### PR TITLE
fix: Add horizontal scrolling to contact list table

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1038,9 +1038,9 @@ function clearSort() {
         {% endfor %}
     </div>
 
-    <!-- Desktop Table View - Premium Styling with Full Width -->
-    <div class="border-2 border-slate-200 rounded-2xl overflow-hidden hidden md:block shadow-lg bg-white">
-        <table class="premium-table w-full">
+    <!-- Desktop Table View - Premium Styling with Full Width and Horizontal Scroll -->
+    <div class="border-2 border-slate-200 rounded-2xl overflow-x-auto hidden md:block shadow-lg bg-white">
+        <table class="premium-table w-full min-w-[1200px]">
             <thead class="text-sm border-b-2 border-slate-200">
                 <tr>
                     <th class="w-8 px-4 py-4">


### PR DESCRIPTION
- Change overflow-hidden to overflow-x-auto on table container
- Add min-width of 1200px to table to ensure consistent layout
- Allows horizontal scrolling on smaller screens instead of cutting off columns