### PR TITLE
fix: Decode HTML entities in Company Updates excerpts

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from dotenv import load_dotenv
 load_dotenv()  # Load .env file before any other imports
 
 import warnings
+import html
 from sqlalchemy.exc import SAWarning
 warnings.filterwarnings('ignore', category=SAWarning, message='.*relationship .* will copy column .*')
 
@@ -34,8 +35,9 @@ def create_app():
     login_manager.init_app(app)
     login_manager.login_view = 'auth.login'
 
-    # Add abs filter for templates
+    # Add custom filters for templates
     app.jinja_env.filters['abs'] = abs
+    app.jinja_env.filters['unescape'] = html.unescape
 
     # Initialize Flask-Mail
     mail = Mail()

--- a/routes/company_updates.py
+++ b/routes/company_updates.py
@@ -8,6 +8,7 @@ from flask_login import login_required, current_user
 from models import db, CompanyUpdate
 from datetime import datetime
 import re
+import html
 
 company_updates_bp = Blueprint('company_updates', __name__)
 
@@ -26,6 +27,8 @@ def generate_excerpt(content, max_length=200):
     """Generate a plain text excerpt from HTML content."""
     # Remove HTML tags
     text = re.sub(r'<[^>]+>', '', content)
+    # Decode HTML entities (like &nbsp; &amp; etc.)
+    text = html.unescape(text)
     # Normalize whitespace
     text = ' '.join(text.split())
     # Truncate

--- a/templates/company_updates/list.html
+++ b/templates/company_updates/list.html
@@ -122,7 +122,7 @@
                             </h2>
                             
                             <p class="text-slate-600 leading-relaxed mb-4">
-                                {{ update.excerpt }}
+                                {{ update.excerpt | unescape }}
                             </p>
                             
                             <span class="inline-flex items-center text-blue-600 font-medium text-sm group-hover:text-blue-700">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -126,7 +126,7 @@
                         <div class="flex items-center gap-2 text-white min-w-0">
                             <span class="font-semibold truncate">{{ latest_update.title }}</span>
                             <span class="hidden sm:inline text-white/70">—</span>
-                            <span class="hidden sm:inline text-white/80 text-sm truncate">{{ latest_update.excerpt[:60] }}{% if latest_update.excerpt|length > 60 %}...{% endif %}</span>
+                            <span class="hidden sm:inline text-white/80 text-sm truncate">{{ (latest_update.excerpt | unescape)[:60] }}{% if latest_update.excerpt|length > 60 %}...{% endif %}</span>
                         </div>
                     </div>
                     


### PR DESCRIPTION
- Add html.unescape() to generate_excerpt function for new posts
- Add 'unescape' Jinja filter for displaying existing excerpts
- Apply filter to list template and dashboard teaser

Fixes &nbsp; and other HTML entities showing as raw text.