### PR TITLE
fix: Update last_login at moment of successful login

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -275,6 +275,9 @@ def login():
 
         if user and user.check_password(form.password.data):
             login_user(user)
+            # Update last_login timestamp at the moment of login
+            user.last_login = datetime.utcnow()
+            db.session.commit()
             next_page = request.args.get('next')
             return redirect(next_page) if next_page else redirect(url_for('main.dashboard'))
         else:


### PR DESCRIPTION
Previously last_login was only updated by a before_request handler on the auth blueprint, which meant users who logged in and went straight to the dashboard (main blueprint) never had their last_login updated.

Now last_login is explicitly set at the point of successful login.