### PR TITLE
feat: add joke of the day to dashboard header

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,5 +1,38 @@
+// Joke of the Day - Fetch from external APIs
+async function fetchDadJoke() {
+    const response = await fetch('https://icanhazdadjoke.com/', {
+        headers: { 'Accept': 'application/json' }
+    });
+    const data = await response.json();
+    return data.joke;
+}
+
+async function fetchJokeAPI() {
+    const response = await fetch('https://v2.jokeapi.dev/joke/Pun,Misc?type=single&blacklistFlags=nsfw,religious,political,racist,sexist,explicit');
+    const data = await response.json();
+    if (data.error) throw new Error('JokeAPI error');
+    return data.joke;
+}
+
+async function displayRandomJoke() {
+    const jokeText = document.getElementById('joke-text');
+    if (!jokeText) return; // Not on dashboard page
+    
+    try {
+        // Randomly pick which API to use
+        const useIcanhazdadjoke = Math.random() < 0.5;
+        const joke = useIcanhazdadjoke ? await fetchDadJoke() : await fetchJokeAPI();
+        jokeText.textContent = joke;
+    } catch (error) {
+        // Fallback if APIs fail
+        jokeText.textContent = "Why did the real estate agent bring a ladder? To reach new heights in sales!";
+    }
+}
+
 // Dashboard Todo List Management
 document.addEventListener('DOMContentLoaded', function() {
+    // Load joke of the day
+    displayRandomJoke();
     // Elements
     const newTodoInput = document.getElementById('dashboardNewTodoInput');
     const addTodoBtn = document.getElementById('dashboardAddTodoBtn');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -77,6 +77,20 @@
                     <p class="text-slate-500 mt-1 font-medium">Welcome back, {{ current_user.first_name }}</p>
                 </div>
             </div>
+            
+            <!-- Joke of the Day (inline) -->
+            <div id="joke-container" class="hidden md:flex flex-1 justify-center">
+                <div class="relative group inline-flex items-center px-5 py-2.5 bg-gradient-to-r from-amber-50 via-orange-50 to-yellow-50 rounded-xl shadow-md border border-amber-200/60 hover:shadow-lg transition-all duration-300">
+                    <div class="absolute inset-0 bg-gradient-to-r from-amber-100/50 via-orange-100/50 to-yellow-100/50 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div class="relative flex items-center">
+                        <div class="w-8 h-8 bg-gradient-to-br from-amber-400 to-orange-500 rounded-lg flex items-center justify-center shadow-sm mr-3">
+                            <i class="fas fa-lightbulb text-white text-sm"></i>
+                        </div>
+                        <p id="joke-text" class="text-slate-700 italic font-medium text-sm max-w-md">Loading a laugh...</p>
+                    </div>
+                </div>
+            </div>
+            
             <button 
                 onclick="showDailyTodoModal()"
                 class="group relative overflow-hidden px-5 py-2.5 rounded-xl bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-indigo-600 hover:via-purple-600 hover:to-pink-600 text-white shadow-lg hover:shadow-xl transition-all duration-300 ease-in-out transform hover:-translate-y-1 hover:scale-105 active:scale-95"


### PR DESCRIPTION
- Fetch random jokes from icanhazdadjoke and JokeAPI on each dashboard load
- Display joke inline between Dashboard title and Daily To-Do button
- Apply content filtering to JokeAPI (blacklist nsfw, religious, political, etc)
- Styled with amber/orange gradient and lightbulb icon to match dashboard theme
- Includes fallback joke if APIs fail