### PR TITLE
refactor: extract shared TodoManager class from dashboard and user_todo

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,4 +1,11 @@
-// Joke of the Day - Fetch from external APIs
+/**
+ * Dashboard JavaScript
+ * - Joke of the Day functionality
+ * - Dashboard Todo List (uses shared TodoManager class)
+ */
+
+// ==================== Joke of the Day ====================
+
 async function fetchDadJoke() {
     const response = await fetch('https://icanhazdadjoke.com/', {
         headers: { 'Accept': 'application/json' }
@@ -29,250 +36,25 @@ async function displayRandomJoke() {
     }
 }
 
-// Dashboard Todo List Management
+// ==================== Dashboard Todo List ====================
+
 document.addEventListener('DOMContentLoaded', function() {
     // Load joke of the day
     displayRandomJoke();
-    // Elements
-    const newTodoInput = document.getElementById('dashboardNewTodoInput');
-    const addTodoBtn = document.getElementById('dashboardAddTodoBtn');
-    const activeTodoList = document.getElementById('dashboardActiveTodoList');
-    let todos = [];
-    let completedTodos = [];
+    
+    // Check if we're on the dashboard with todo elements
+    const activeList = document.getElementById('dashboardActiveTodoList');
+    if (!activeList) return; // Not on dashboard or no todo section
 
-    console.log('Dashboard todo initialization started');
-    console.log('Found elements:', {
-        newTodoInput: !!newTodoInput,
-        addTodoBtn: !!addTodoBtn,
-        activeTodoList: !!activeTodoList
+    // Initialize TodoManager for dashboard
+    // Dashboard uses a simpler config - no completed list, no counts
+    const dashboardTodos = new TodoManager({
+        templateId: 'todoItemTemplate',
+        activeListId: 'dashboardActiveTodoList',
+        inputId: 'dashboardNewTodoInput',
+        addBtnId: 'dashboardAddTodoBtn'
     });
 
-    // Load initial todos
-    loadTodos();
-
-    // Event Listeners
-    if (addTodoBtn) {
-        addTodoBtn.addEventListener('click', addTodo);
-    }
-
-    if (newTodoInput) {
-        newTodoInput.addEventListener('keypress', function(e) {
-            if (e.key === 'Enter') {
-                addTodo();
-            }
-        });
-    }
-
-    // Functions
-    function loadTodos() {
-        console.log('Loading todos...');
-        fetch('/api/user_todos/get')
-            .then(response => response.json())
-            .then(data => {
-                console.log('Received todos:', data);
-                todos = data.active || [];
-                completedTodos = data.completed || [];
-                renderTodos();
-                updateEmptyState();
-            })
-            .catch(error => {
-                console.error('Error loading todos:', error);
-                updateEmptyState();
-            });
-    }
-
-    function updateEmptyState() {
-        if (!activeTodoList) {
-            console.error('No active todo list element found');
-            return;
-        }
-
-        // Remove existing empty state if it exists
-        const existingEmptyState = activeTodoList.querySelector('.empty-state');
-        if (existingEmptyState) {
-            existingEmptyState.remove();
-        }
-
-        // Add empty state if no todos
-        if (todos.length === 0) {
-            console.log('No todos found, showing empty state');
-            const emptyState = document.createElement('li');
-            emptyState.className = 'empty-state text-center py-8 text-gray-500 italic bg-gray-50/50 rounded-lg';
-            emptyState.textContent = 'No active tasks. Add one above!';
-            activeTodoList.appendChild(emptyState);
-        }
-    }
-
-    function renderTodos() {
-        if (!activeTodoList) {
-            console.error('No active todo list element found during render');
-            return;
-        }
-        
-        console.log('Rendering todos:', todos);
-        activeTodoList.innerHTML = '';
-        todos.forEach((todo, index) => {
-            const li = createTodoElement(todo, index);
-            activeTodoList.appendChild(li);
-        });
-    }
-
-    function createTodoElement(todoText, index) {
-        const template = document.getElementById('todoItemTemplate');
-        if (!template) {
-            console.error('Todo item template not found');
-            return document.createElement('li');
-        }
-
-        const clone = template.content.cloneNode(true);
-        const li = clone.querySelector('li');
-        const todoTextElement = clone.querySelector('.todo-text');
-        const editContainer = clone.querySelector('.todo-edit-container');
-        const editInput = clone.querySelector('.todo-edit-input');
-        const checkbox = clone.querySelector('.todo-checkbox');
-        const deleteBtn = clone.querySelector('.delete-todo');
-
-        // Set todo text
-        todoTextElement.textContent = todoText;
-        editInput.value = todoText;
-
-        // Add transition styles
-        li.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
-        li.style.opacity = '0';
-        li.style.transform = 'translateX(20px)';
-
-        // Double click to edit
-        todoTextElement.addEventListener('dblclick', function() {
-            startEditing(li);
-        });
-
-        // Handle edit input
-        editInput.addEventListener('blur', function() {
-            finishEditing(li, index);
-        });
-
-        editInput.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter') {
-                finishEditing(li, index);
-            } else if (e.key === 'Escape') {
-                cancelEditing(li);
-            }
-        });
-
-        // Prevent click events from bubbling up when editing
-        editContainer.addEventListener('click', function(e) {
-            e.stopPropagation();
-        });
-
-        // Handle checkbox
-        checkbox.addEventListener('change', function() {
-            li.style.opacity = '0';
-            li.style.transform = 'translateX(20px)';
-            
-            setTimeout(() => {
-                completeTodo(index);
-            }, 300);
-        });
-
-        // Handle delete
-        deleteBtn.addEventListener('click', function() {
-            li.style.opacity = '0';
-            li.style.transform = 'translateX(20px)';
-            
-            setTimeout(() => {
-                deleteTodo(index);
-            }, 300);
-        });
-
-        // Trigger animation after creation
-        setTimeout(() => {
-            li.style.opacity = '1';
-            li.style.transform = 'translateX(0)';
-        }, 50);
-
-        return li;
-    }
-
-    function startEditing(todoItem) {
-        const textElement = todoItem.querySelector('.todo-text');
-        const editContainer = todoItem.querySelector('.todo-edit-container');
-        const editInput = todoItem.querySelector('.todo-edit-input');
-        
-        // Hide text, show input
-        textElement.classList.add('hidden');
-        editContainer.classList.remove('hidden');
-        
-        // Focus and select text
-        editInput.focus();
-        editInput.select();
-    }
-
-    function cancelEditing(todoItem) {
-        const textElement = todoItem.querySelector('.todo-text');
-        const editContainer = todoItem.querySelector('.todo-edit-container');
-        
-        // Hide input, show text
-        textElement.classList.remove('hidden');
-        editContainer.classList.add('hidden');
-    }
-
-    function finishEditing(li, index) {
-        const textElement = li.querySelector('.todo-text');
-        const editContainer = li.querySelector('.todo-edit-container');
-        const editInput = li.querySelector('.todo-edit-input');
-        const newText = editInput.value.trim();
-        
-        if (newText && newText !== todos[index]) {
-            console.log('Updating todo text at index:', index);
-            todos[index] = newText;
-            textElement.textContent = newText;
-            saveTodos();
-        }
-        
-        // Hide input, show text
-        textElement.classList.remove('hidden');
-        editContainer.classList.add('hidden');
-    }
-
-    function addTodo() {
-        const text = newTodoInput.value.trim();
-        if (!text) return;
-
-        console.log('Adding new todo:', text);
-        todos.push(text);
-        saveTodos();
-        newTodoInput.value = '';
-    }
-
-    function completeTodo(index) {
-        console.log('Completing todo at index:', index);
-        const completedTodo = todos.splice(index, 1)[0];
-        completedTodos.push(completedTodo); // Add to completed todos
-        saveTodos();
-    }
-
-    function deleteTodo(index) {
-        console.log('Deleting todo at index:', index);
-        todos.splice(index, 1);
-        saveTodos();
-    }
-
-    function saveTodos() {
-        console.log('Saving todos:', { active: todos, completed: completedTodos });
-        fetch('/api/user_todos/save', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                active: todos,
-                completed: completedTodos // Now including completed todos in the save
-            })
-        })
-        .then(response => response.json())
-        .then(() => {
-            loadTodos(); // Reload to ensure sync
-        })
-        .catch(error => console.error('Error saving todos:', error));
-    }
-}); 
+    // Make it accessible for debugging if needed
+    window.dashboardTodos = dashboardTodos;
+});

--- a/static/js/todo-manager.js
+++ b/static/js/todo-manager.js
@@ -1,0 +1,492 @@
+/**
+ * TodoManager - Shared todo list management class
+ * Used by both dashboard.js and user_todo.js to eliminate code duplication
+ */
+class TodoManager {
+    /**
+     * @param {Object} config - Configuration options
+     * @param {string} config.templateId - ID of the todo item template element
+     * @param {string} config.activeListId - ID of the active todos list element
+     * @param {string} [config.completedListId] - ID of the completed todos list (optional)
+     * @param {string} [config.inputId] - ID of the new todo input element
+     * @param {string} [config.addBtnId] - ID of the add todo button
+     * @param {string} [config.activeCountId] - ID of active count display element
+     * @param {string} [config.completedCountId] - ID of completed count display element
+     * @param {Function} [config.onSave] - Callback after saving todos
+     * @param {Function} [config.onLoad] - Callback after loading todos
+     */
+    constructor(config) {
+        this.config = config;
+        this.todos = [];
+        this.completedTodos = [];
+        
+        // Cache DOM elements
+        this.template = document.getElementById(config.templateId);
+        this.activeList = document.getElementById(config.activeListId);
+        this.completedList = config.completedListId ? document.getElementById(config.completedListId) : null;
+        this.input = config.inputId ? document.getElementById(config.inputId) : null;
+        this.addBtn = config.addBtnId ? document.getElementById(config.addBtnId) : null;
+        this.activeCountEl = config.activeCountId ? document.getElementById(config.activeCountId) : null;
+        this.completedCountEl = config.completedCountId ? document.getElementById(config.completedCountId) : null;
+        
+        this.init();
+    }
+
+    /**
+     * Initialize the todo manager
+     */
+    init() {
+        this.bindEvents();
+        this.loadTodos();
+    }
+
+    /**
+     * Bind event listeners for input and add button
+     */
+    bindEvents() {
+        if (this.addBtn) {
+            this.addBtn.addEventListener('click', () => this.addTodo());
+        }
+        
+        if (this.input) {
+            this.input.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    this.addTodo();
+                }
+            });
+        }
+    }
+
+    // ==================== API Methods ====================
+
+    /**
+     * Load todos from the server
+     */
+    async loadTodos() {
+        try {
+            const response = await fetch('/api/user_todos/get');
+            const data = await response.json();
+            
+            this.todos = data.active || [];
+            this.completedTodos = data.completed || [];
+            
+            this.render();
+            this.updateCounts();
+            this.updateEmptyStates();
+            
+            if (this.config.onLoad) {
+                this.config.onLoad(this.todos, this.completedTodos);
+            }
+        } catch (error) {
+            console.error('Error loading todos:', error);
+            this.updateEmptyStates();
+        }
+    }
+
+    /**
+     * Save todos to the server
+     */
+    async saveTodos() {
+        try {
+            await fetch('/api/user_todos/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    active: this.todos,
+                    completed: this.completedTodos
+                })
+            });
+            
+            if (this.config.onSave) {
+                this.config.onSave(this.todos, this.completedTodos);
+            }
+        } catch (error) {
+            console.error('Error saving todos:', error);
+        }
+    }
+
+    /**
+     * Sync todos from DOM (useful after drag-drop reordering)
+     */
+    syncFromDOM() {
+        this.todos = [];
+        this.completedTodos = [];
+
+        if (this.activeList) {
+            this.activeList.querySelectorAll('.todo-text').forEach(el => {
+                if (!el.closest('.empty-state') && !el.closest('.text-center')) {
+                    this.todos.push(el.textContent);
+                }
+            });
+        }
+
+        if (this.completedList) {
+            this.completedList.querySelectorAll('.todo-text').forEach(el => {
+                if (!el.closest('.empty-state') && !el.closest('.text-center')) {
+                    this.completedTodos.push(el.textContent);
+                }
+            });
+        }
+    }
+
+    // ==================== CRUD Operations ====================
+
+    /**
+     * Add a new todo from the input field
+     */
+    addTodo() {
+        if (!this.input) return;
+        
+        const text = this.input.value.trim();
+        if (!text) return;
+
+        this.todos.push(text);
+        this.input.value = '';
+        
+        // Add to DOM
+        if (this.activeList) {
+            const element = this.createTodoElement(text, false);
+            this.activeList.appendChild(element);
+        }
+        
+        this.saveTodos();
+        this.updateCounts();
+        this.updateEmptyStates();
+    }
+
+    /**
+     * Complete a todo at the given index
+     * @param {number} index - Index in the todos array
+     */
+    completeTodo(index) {
+        const completedTodo = this.todos.splice(index, 1)[0];
+        this.completedTodos.push(completedTodo);
+        this.saveTodos();
+        this.updateCounts();
+        this.updateEmptyStates();
+    }
+
+    /**
+     * Uncomplete a todo (move from completed to active)
+     * @param {number} index - Index in the completedTodos array
+     */
+    uncompleteTodo(index) {
+        const todo = this.completedTodos.splice(index, 1)[0];
+        this.todos.push(todo);
+        this.saveTodos();
+        this.updateCounts();
+        this.updateEmptyStates();
+    }
+
+    /**
+     * Delete a todo
+     * @param {number} index - Index in the array
+     * @param {boolean} [isCompleted=false] - Whether it's from completed list
+     */
+    deleteTodo(index, isCompleted = false) {
+        if (isCompleted) {
+            this.completedTodos.splice(index, 1);
+        } else {
+            this.todos.splice(index, 1);
+        }
+        this.saveTodos();
+        this.updateCounts();
+        this.updateEmptyStates();
+    }
+
+    /**
+     * Update a todo's text
+     * @param {number} index - Index in the array
+     * @param {string} newText - New text for the todo
+     * @param {boolean} [isCompleted=false] - Whether it's from completed list
+     */
+    updateTodo(index, newText, isCompleted = false) {
+        if (isCompleted) {
+            this.completedTodos[index] = newText;
+        } else {
+            this.todos[index] = newText;
+        }
+        this.saveTodos();
+    }
+
+    // ==================== DOM Creation ====================
+
+    /**
+     * Create a todo element from the template
+     * @param {string} text - Todo text
+     * @param {boolean} [completed=false] - Whether this is a completed todo
+     * @returns {HTMLElement} The created todo element
+     */
+    createTodoElement(text, completed = false) {
+        if (!this.template) {
+            console.error('Todo item template not found');
+            return document.createElement('li');
+        }
+
+        const clone = this.template.content.cloneNode(true);
+        const todoItem = clone.querySelector('li') || clone.querySelector('.todo-item');
+        const todoText = clone.querySelector('.todo-text');
+        const editContainer = clone.querySelector('.todo-edit-container');
+        const editInput = clone.querySelector('.todo-edit-input');
+        const checkbox = clone.querySelector('.todo-checkbox');
+        const deleteBtn = clone.querySelector('.delete-todo');
+
+        // Set content
+        todoText.textContent = text;
+        editInput.value = text;
+        if (checkbox) checkbox.checked = completed;
+
+        // Setup transitions
+        todoItem.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+        todoItem.style.opacity = '0';
+        todoItem.style.transform = 'translateX(20px)';
+
+        // Bind events
+        this.bindTodoEvents(todoItem, todoText, editContainer, editInput, checkbox, deleteBtn);
+
+        // Animate in
+        setTimeout(() => {
+            todoItem.style.opacity = '1';
+            todoItem.style.transform = 'translateX(0)';
+        }, 50);
+
+        return todoItem;
+    }
+
+    /**
+     * Bind event listeners to a todo element
+     */
+    bindTodoEvents(todoItem, todoText, editContainer, editInput, checkbox, deleteBtn) {
+        // Double-click to edit
+        todoText.addEventListener('dblclick', () => {
+            this.startEditing(todoItem);
+        });
+
+        // Edit input events
+        if (editContainer) {
+            editContainer.addEventListener('click', (e) => e.stopPropagation());
+        }
+
+        if (editInput) {
+            editInput.addEventListener('blur', () => {
+                this.stopEditing(todoItem, true);
+            });
+
+            editInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    this.stopEditing(todoItem, true);
+                } else if (e.key === 'Escape') {
+                    this.stopEditing(todoItem, false);
+                }
+            });
+        }
+
+        // Checkbox (complete/uncomplete)
+        if (checkbox) {
+            checkbox.addEventListener('change', () => {
+                this.handleCheckboxChange(todoItem, checkbox.checked);
+            });
+        }
+
+        // Delete button
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', () => {
+                this.handleDelete(todoItem);
+            });
+        }
+    }
+
+    /**
+     * Handle checkbox change (complete/uncomplete)
+     */
+    handleCheckboxChange(todoItem, isChecked) {
+        const index = this.getItemIndex(todoItem);
+        const isInCompleted = this.completedList && this.completedList.contains(todoItem);
+
+        // Animate out
+        todoItem.style.opacity = '0';
+        todoItem.style.transform = 'translateX(20px)';
+
+        setTimeout(() => {
+            if (isChecked && !isInCompleted) {
+                // Moving to completed
+                if (this.completedList) {
+                    todoItem.remove();
+                    this.completedList.appendChild(todoItem);
+                    todoItem.style.opacity = '1';
+                    todoItem.style.transform = 'translateX(0)';
+                }
+                this.syncFromDOM();
+                this.saveTodos();
+            } else if (!isChecked && isInCompleted) {
+                // Moving back to active
+                todoItem.remove();
+                this.activeList.appendChild(todoItem);
+                todoItem.style.opacity = '1';
+                todoItem.style.transform = 'translateX(0)';
+                this.syncFromDOM();
+                this.saveTodos();
+            } else {
+                // Simple complete (no completed list - like dashboard)
+                todoItem.remove();
+                this.syncFromDOM();
+                this.saveTodos();
+            }
+            this.updateCounts();
+            this.updateEmptyStates();
+        }, 300);
+    }
+
+    /**
+     * Handle delete button click
+     */
+    handleDelete(todoItem) {
+        todoItem.style.opacity = '0';
+        todoItem.style.transform = 'translateX(20px)';
+
+        setTimeout(() => {
+            todoItem.remove();
+            this.syncFromDOM();
+            this.saveTodos();
+            this.updateCounts();
+            this.updateEmptyStates();
+        }, 300);
+    }
+
+    /**
+     * Get the index of a todo item in its list
+     */
+    getItemIndex(todoItem) {
+        const parent = todoItem.parentElement;
+        const items = Array.from(parent.querySelectorAll('.todo-item'));
+        return items.indexOf(todoItem);
+    }
+
+    // ==================== Editing ====================
+
+    /**
+     * Start editing a todo item
+     */
+    startEditing(todoItem) {
+        const textElement = todoItem.querySelector('.todo-text');
+        const editContainer = todoItem.querySelector('.todo-edit-container');
+        const editInput = todoItem.querySelector('.todo-edit-input');
+
+        textElement.classList.add('hidden');
+        editContainer.classList.remove('hidden');
+        editInput.focus();
+        editInput.select();
+    }
+
+    /**
+     * Stop editing a todo item
+     * @param {boolean} save - Whether to save the changes
+     */
+    stopEditing(todoItem, save) {
+        const textElement = todoItem.querySelector('.todo-text');
+        const editContainer = todoItem.querySelector('.todo-edit-container');
+        const editInput = todoItem.querySelector('.todo-edit-input');
+
+        if (save && editInput.value.trim() !== '') {
+            const newText = editInput.value.trim();
+            if (newText !== textElement.textContent) {
+                textElement.textContent = newText;
+                this.syncFromDOM();
+                this.saveTodos();
+            }
+        }
+
+        textElement.classList.remove('hidden');
+        editContainer.classList.add('hidden');
+    }
+
+    // ==================== Rendering ====================
+
+    /**
+     * Render all todos to the DOM
+     */
+    render() {
+        if (this.activeList) {
+            this.activeList.innerHTML = '';
+            this.todos.forEach((text) => {
+                const element = this.createTodoElement(text, false);
+                this.activeList.appendChild(element);
+            });
+        }
+
+        if (this.completedList) {
+            this.completedList.innerHTML = '';
+            this.completedTodos.forEach((text) => {
+                const element = this.createTodoElement(text, true);
+                this.completedList.appendChild(element);
+            });
+        }
+    }
+
+    /**
+     * Update task count displays
+     */
+    updateCounts() {
+        if (this.activeCountEl) {
+            const count = this.todos.length;
+            this.activeCountEl.textContent = `${count} ${count === 1 ? 'task' : 'tasks'}`;
+        }
+
+        if (this.completedCountEl) {
+            const count = this.completedTodos.length;
+            this.completedCountEl.textContent = `${count} completed`;
+        }
+    }
+
+    /**
+     * Update empty state messages
+     */
+    updateEmptyStates() {
+        this.updateListEmptyState(this.activeList, this.todos.length, 'No active tasks. Add one above!');
+        
+        if (this.completedList) {
+            this.updateListEmptyState(this.completedList, this.completedTodos.length, 'No completed tasks yet');
+        }
+    }
+
+    /**
+     * Update empty state for a specific list
+     */
+    updateListEmptyState(list, itemCount, message) {
+        if (!list) return;
+
+        // Remove existing empty state
+        const existing = list.querySelector('.empty-state');
+        if (existing) existing.remove();
+
+        // Add empty state if no items
+        if (itemCount === 0) {
+            const emptyState = document.createElement('li');
+            emptyState.className = 'empty-state text-center py-8 text-gray-500 italic bg-gray-50/50 rounded-lg';
+            emptyState.textContent = message;
+            list.appendChild(emptyState);
+        }
+    }
+
+    // ==================== Utilities ====================
+
+    /**
+     * Get current todos
+     */
+    getTodos() {
+        return { active: this.todos, completed: this.completedTodos };
+    }
+
+    /**
+     * Refresh from server
+     */
+    refresh() {
+        this.loadTodos();
+    }
+}
+
+// Export for module usage (if needed in future)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = TodoManager;
+}
+

--- a/static/js/user_todo.js
+++ b/static/js/user_todo.js
@@ -1,257 +1,97 @@
+/**
+ * User Todo Page JavaScript
+ * Full-featured todo list with active/completed sections and drag-drop reordering
+ * Uses shared TodoManager class with SortableJS integration
+ */
+
 document.addEventListener('DOMContentLoaded', function() {
-    // DOM Elements
-    const addTodoBtn = document.getElementById('addTodoBtn');
-    const newTodoInput = document.getElementById('newTodoInput');
-    const activeTodoList = document.getElementById('activeTodoList');
-    const completedTodoList = document.getElementById('completedTodoList');
-    const todoItemTemplate = document.getElementById('todoItemTemplate');
-    const activeTodoCount = document.getElementById('activeTodoCount');
-    const completedTodoCount = document.getElementById('completedTodoCount');
+    // Check if we're on the todo page
+    const activeList = document.getElementById('activeTodoList');
+    const completedList = document.getElementById('completedTodoList');
+    if (!activeList) return;
 
-    // Function to update task counts
-    function updateTaskCounts() {
-        const activeCount = activeTodoList.children.length;
-        const completedCount = completedTodoList.children.length;
-        
-        activeTodoCount.textContent = `${activeCount} ${activeCount === 1 ? 'task' : 'tasks'}`;
-        completedTodoCount.textContent = `${completedCount} ${completedCount === 1 ? 'completed' : 'completed'}`;
-        
-        // Add empty state message if no tasks
-        if (activeCount === 0) {
-            const emptyState = document.createElement('li');
-            emptyState.className = 'text-center py-8 text-gray-500 italic bg-gray-50/50 rounded-lg';
-            emptyState.textContent = 'No active tasks. Add one above!';
-            activeTodoList.appendChild(emptyState);
-        } else {
-            const emptyState = activeTodoList.querySelector('.text-center.py-8');
-            if (emptyState) {
-                emptyState.remove();
-            }
-        }
-        
-        if (completedCount === 0) {
-            const emptyState = document.createElement('li');
-            emptyState.className = 'text-center py-8 text-gray-500 italic bg-gray-50/50 rounded-lg';
-            emptyState.textContent = 'No completed tasks yet';
-            completedTodoList.appendChild(emptyState);
-        } else {
-            const emptyState = completedTodoList.querySelector('.text-center.py-8');
-            if (emptyState) {
-                emptyState.remove();
-            }
-        }
-    }
-
-    // Initialize SortableJS for both lists
-    const activeListSortable = new Sortable(activeTodoList, {
-        animation: 150,
-        ghostClass: 'bg-gray-100',
-        chosenClass: 'opacity-70',
-        dragClass: 'shadow-lg',
-        group: 'todos',
-        handle: '.drag-handle',
-        onEnd: function(evt) {
-            saveTodoOrder();
+    // Initialize TodoManager with full configuration
+    const todoManager = new TodoManager({
+        templateId: 'todoItemTemplate',
+        activeListId: 'activeTodoList',
+        completedListId: 'completedTodoList',
+        inputId: 'newTodoInput',
+        addBtnId: 'addTodoBtn',
+        activeCountId: 'activeTodoCount',
+        completedCountId: 'completedTodoCount',
+        onSave: () => {
+            // Update counts after any save
+            updateTaskCounts();
+        },
+        onLoad: () => {
+            // Initialize sortable after todos are loaded
+            initializeSortable();
             updateTaskCounts();
         }
     });
 
-    const completedListSortable = new Sortable(completedTodoList, {
-        animation: 150,
-        ghostClass: 'bg-gray-100',
-        chosenClass: 'opacity-70',
-        dragClass: 'shadow-lg',
-        group: 'todos',
-        handle: '.drag-handle',
-        onEnd: function(evt) {
-            saveTodoOrder();
-            updateTaskCounts();
+    // Make accessible for debugging
+    window.todoManager = todoManager;
+
+    /**
+     * Initialize SortableJS for drag-drop reordering
+     */
+    function initializeSortable() {
+        if (typeof Sortable === 'undefined') {
+            console.warn('SortableJS not loaded');
+            return;
         }
-    });
 
-    // Todo Functions
-    function createTodoElement(todoText, completed = false) {
-        const clone = todoItemTemplate.content.cloneNode(true);
-        const todoItem = clone.querySelector('.todo-item');
-        const todoTextElement = clone.querySelector('.todo-text');
-        const todoEditContainer = clone.querySelector('.todo-edit-container');
-        const todoEditInput = clone.querySelector('.todo-edit-input');
-        const checkbox = clone.querySelector('.todo-checkbox');
-        const deleteBtn = clone.querySelector('.delete-todo');
-
-        todoTextElement.textContent = todoText;
-        todoEditInput.value = todoText;
-        checkbox.checked = completed;
-
-        // Add event listeners
-        checkbox.addEventListener('change', function() {
-            const targetList = checkbox.checked ? completedTodoList : activeTodoList;
-            const sourceList = checkbox.checked ? activeTodoList : completedTodoList;
-            
-            todoItem.style.opacity = '0';
-            todoItem.style.transform = 'translateX(20px)';
-            
-            setTimeout(() => {
-                sourceList.removeChild(todoItem);
-                targetList.appendChild(todoItem);
-                todoItem.style.opacity = '1';
-                todoItem.style.transform = 'translateX(0)';
-                saveTodoOrder();
+        // Active list sortable
+        new Sortable(activeList, {
+            animation: 150,
+            ghostClass: 'bg-gray-100',
+            chosenClass: 'opacity-70',
+            dragClass: 'shadow-lg',
+            group: 'todos',
+            handle: '.drag-handle',
+            onEnd: function() {
+                todoManager.syncFromDOM();
+                todoManager.saveTodos();
                 updateTaskCounts();
-            }, 300);
-        });
-
-        deleteBtn.addEventListener('click', function() {
-            todoItem.style.opacity = '0';
-            todoItem.style.transform = 'translateX(20px)';
-            
-            setTimeout(() => {
-                todoItem.remove();
-                saveTodoOrder();
-                updateTaskCounts();
-            }, 300);
-        });
-
-        // Edit mode event listeners
-        todoTextElement.addEventListener('dblclick', function(e) {
-            e.preventDefault();
-            startEditing(todoItem);
-        });
-
-        // Prevent click events from bubbling up when editing
-        todoEditContainer.addEventListener('click', function(e) {
-            e.stopPropagation();
-        });
-
-        todoEditInput.addEventListener('click', function(e) {
-            e.stopPropagation();
-        });
-
-        todoEditInput.addEventListener('keydown', function(e) {
-            e.stopPropagation();
-            if (e.key === 'Enter') {
-                stopEditing(todoItem, true);
-            } else if (e.key === 'Escape') {
-                stopEditing(todoItem, false);
             }
         });
 
-        todoEditInput.addEventListener('blur', function() {
-            stopEditing(todoItem, true);
-        });
-
-        // Add transition styles
-        todoItem.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
-        todoItem.style.opacity = '0';
-        todoItem.style.transform = 'translateX(20px)';
-
-        // Trigger animation after append
-        setTimeout(() => {
-            todoItem.style.opacity = '1';
-            todoItem.style.transform = 'translateX(0)';
-        }, 50);
-
-        return todoItem;
-    }
-
-    function startEditing(todoItem) {
-        const textElement = todoItem.querySelector('.todo-text');
-        const editContainer = todoItem.querySelector('.todo-edit-container');
-        const editInput = todoItem.querySelector('.todo-edit-input');
-        
-        // Hide text, show input
-        textElement.classList.add('hidden');
-        editContainer.classList.remove('hidden');
-        
-        // Just focus the input without selecting text
-        editInput.focus();
-    }
-
-    function stopEditing(todoItem, save) {
-        const textElement = todoItem.querySelector('.todo-text');
-        const editContainer = todoItem.querySelector('.todo-edit-container');
-        const editInput = todoItem.querySelector('.todo-edit-input');
-        
-        if (save && editInput.value.trim() !== '') {
-            textElement.textContent = editInput.value.trim();
-            saveTodoOrder();
-        }
-        
-        // Hide input, show text
-        textElement.classList.remove('hidden');
-        editContainer.classList.add('hidden');
-    }
-
-    function saveTodoOrder() {
-        const todos = {
-            active: [],
-            completed: []
-        };
-
-        activeTodoList.querySelectorAll('.todo-text').forEach(todo => {
-            if (!todo.closest('.text-center')) {  // Skip empty state message
-                todos.active.push(todo.textContent);
-            }
-        });
-
-        completedTodoList.querySelectorAll('.todo-text').forEach(todo => {
-            if (!todo.closest('.text-center')) {  // Skip empty state message
-                todos.completed.push(todo.textContent);
-            }
-        });
-
-        fetch('/api/user_todos/save', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(todos)
-        });
-    }
-
-    function loadTodos() {
-        fetch('/api/user_todos/get')
-            .then(response => response.json())
-            .then(todos => {
-                // Clear existing todos
-                activeTodoList.innerHTML = '';
-                completedTodoList.innerHTML = '';
-
-                // Add active todos
-                todos.active.forEach(todo => {
-                    activeTodoList.appendChild(createTodoElement(todo, false));
-                });
-
-                // Add completed todos
-                todos.completed.forEach(todo => {
-                    completedTodoList.appendChild(createTodoElement(todo, true));
-                });
-
-                // Update counts after loading
-                updateTaskCounts();
+        // Completed list sortable
+        if (completedList) {
+            new Sortable(completedList, {
+                animation: 150,
+                ghostClass: 'bg-gray-100',
+                chosenClass: 'opacity-70',
+                dragClass: 'shadow-lg',
+                group: 'todos',
+                handle: '.drag-handle',
+                onEnd: function() {
+                    todoManager.syncFromDOM();
+                    todoManager.saveTodos();
+                    updateTaskCounts();
+                }
             });
-    }
-
-    // Event Listeners
-    function addNewTodo() {
-        const todoText = newTodoInput.value.trim();
-        if (todoText) {
-            const todoElement = createTodoElement(todoText);
-            activeTodoList.appendChild(todoElement);
-            newTodoInput.value = '';
-            saveTodoOrder();
-            updateTaskCounts();
         }
     }
 
-    addTodoBtn.addEventListener('click', addNewTodo);
-    
-    newTodoInput.addEventListener('keypress', function(e) {
-        if (e.key === 'Enter') {
-            addNewTodo();
-        }
-    });
+    /**
+     * Update task count displays
+     * Overrides TodoManager's updateCounts for custom formatting
+     */
+    function updateTaskCounts() {
+        const activeCount = activeList.querySelectorAll('.todo-item').length;
+        const completedCount = completedList ? completedList.querySelectorAll('.todo-item').length : 0;
 
-    // Load initial todos
-    loadTodos();
-}); 
+        const activeCountEl = document.getElementById('activeTodoCount');
+        const completedCountEl = document.getElementById('completedTodoCount');
+
+        if (activeCountEl) {
+            activeCountEl.textContent = `${activeCount} ${activeCount === 1 ? 'task' : 'tasks'}`;
+        }
+
+        if (completedCountEl) {
+            completedCountEl.textContent = `${completedCount} ${completedCount === 1 ? 'completed' : 'completed'}`;
+        }
+    }
+});

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,6 +2,7 @@
 
 {% block head_scripts %}
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="{{ url_for('static', filename='js/todo-manager.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
 <style>
     /* Premium animations from action_plan */

--- a/templates/user_todo.html
+++ b/templates/user_todo.html
@@ -124,5 +124,6 @@
 
 {% block head_scripts %}
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="{{ url_for('static', filename='js/todo-manager.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/user_todo.js') }}" defer></script>
 {% endblock %} 


### PR DESCRIPTION
- Create reusable TodoManager class in static/js/todo-manager.js
- Simplify dashboard.js from 278 to 55 lines
- Simplify user_todo.js from 257 to 90 lines
- Eliminate duplicated todo CRUD, editing, and rendering logic
- Add TodoManager script to dashboard.html and user_todo.html templates