### PR TITLE
feat: Add seller conventional intake questionnaire (Phase 3)

### DIFF
--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "seller",
+  "ownership_status": "conventional",
+  "title": "Property Questionnaire",
+  "description": "Answer these questions to determine which documents are required for this listing.",
+  "sections": [
+    {
+      "id": "property_details",
+      "title": "Property Details",
+      "questions": [
+        {
+          "id": "built_before_1978",
+          "type": "boolean",
+          "label": "Was the property built before 1978?",
+          "help_text": "Lead-based paint disclosure is required for properties built before 1978.",
+          "required": true
+        },
+        {
+          "id": "has_hoa",
+          "type": "boolean",
+          "label": "Is the property subject to an owner's association?",
+          "help_text": "This includes HOAs, POAs, and any mandatory membership associations.",
+          "required": true
+        },
+        {
+          "id": "special_districts",
+          "type": "boolean",
+          "label": "Is the property located in any special districts (MUD, PID, etc.)?",
+          "help_text": "Municipal Utility Districts, Public Improvement Districts, or similar.",
+          "required": true
+        },
+        {
+          "id": "flood_hazard",
+          "type": "boolean",
+          "label": "Is the property in a Flood Hazard Area?",
+          "help_text": "Check FEMA flood maps if unsure.",
+          "required": true
+        },
+        {
+          "id": "referral_fee",
+          "type": "boolean",
+          "label": "Will another party get a referral fee from you for this transaction?",
+          "help_text": "If you're paying a referral fee to another agent or broker.",
+          "required": true
+        },
+        {
+          "id": "has_survey",
+          "type": "select",
+          "label": "Does your seller have a copy of their survey?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not Sure"}
+          ],
+          "help_text": "A T-47.1 affidavit may be required if no survey is available.",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "listing-agreement",
+      "name": "Residential Real Estate Listing Agreement",
+      "always": true,
+      "reason": "Required for all seller transactions"
+    },
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required for all seller transactions"
+    },
+    {
+      "slug": "sellers-disclosure",
+      "name": "Seller's Disclosure Notice",
+      "always": true,
+      "reason": "Required for all seller transactions"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Required for all seller transactions"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Addendum for Seller's Disclosure of Information on Lead-Based Paint",
+      "condition": {"field": "built_before_1978", "equals": true},
+      "reason": "Property built before 1978"
+    },
+    {
+      "slug": "hoa-addendum",
+      "name": "Addendum for Property Subject to Mandatory Membership in Owners' Association",
+      "condition": {"field": "has_hoa", "equals": true},
+      "reason": "Property subject to owner's association"
+    },
+    {
+      "slug": "water-district",
+      "name": "Information About On-Site Sewer Facility",
+      "condition": {"field": "special_districts", "equals": true},
+      "reason": "Property in special district (MUD, PID, etc.)"
+    },
+    {
+      "slug": "flood-hazard",
+      "name": "Information About Special Flood Hazard Areas",
+      "condition": {"field": "flood_hazard", "equals": true},
+      "reason": "Property in flood hazard area"
+    },
+    {
+      "slug": "referral-agreement",
+      "name": "Referral Agreement",
+      "condition": {"field": "referral_fee", "equals": true},
+      "reason": "Referral fee will be paid"
+    },
+    {
+      "slug": "t47-affidavit",
+      "name": "T-47.1 Residential Real Property Affidavit",
+      "condition": {"field": "has_survey", "in": ["no", "not_sure"]},
+      "reason": "Seller does not have survey or is unsure"
+    }
+  ]
+}
+

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -1,0 +1,116 @@
+# services/intake_service.py
+"""
+Intake schema loading and document package generation service.
+"""
+
+import json
+import os
+from pathlib import Path
+
+# Path to intake schemas
+SCHEMAS_DIR = Path(__file__).parent.parent / 'intake_schemas'
+
+
+def get_intake_schema(transaction_type: str, ownership_status: str = None) -> dict:
+    """
+    Load the intake schema for a given transaction type and ownership status.
+    
+    Args:
+        transaction_type: e.g., 'seller', 'buyer'
+        ownership_status: e.g., 'conventional', 'builder' (optional)
+    
+    Returns:
+        The schema dict or None if not found
+    """
+    # Build the schema filename
+    if ownership_status:
+        filename = f"{transaction_type}_{ownership_status}.json"
+    else:
+        filename = f"{transaction_type}.json"
+    
+    schema_path = SCHEMAS_DIR / filename
+    
+    if not schema_path.exists():
+        return None
+    
+    with open(schema_path, 'r') as f:
+        return json.load(f)
+
+
+def evaluate_document_rules(schema: dict, intake_data: dict) -> list:
+    """
+    Evaluate document rules against intake answers to determine required documents.
+    
+    Args:
+        schema: The intake schema with document_rules
+        intake_data: The user's answers
+    
+    Returns:
+        List of document dicts with slug, name, reason
+    """
+    required_docs = []
+    
+    for rule in schema.get('document_rules', []):
+        include = False
+        reason = rule.get('reason', '')
+        
+        if rule.get('always'):
+            include = True
+        elif 'condition' in rule:
+            condition = rule['condition']
+            field_value = intake_data.get(condition['field'])
+            
+            if 'equals' in condition:
+                include = field_value == condition['equals']
+            elif 'in' in condition:
+                include = field_value in condition['in']
+            elif 'not_equals' in condition:
+                include = field_value != condition['not_equals']
+        
+        if include:
+            required_docs.append({
+                'slug': rule['slug'],
+                'name': rule['name'],
+                'reason': reason,
+                'always': rule.get('always', False)
+            })
+    
+    return required_docs
+
+
+def validate_intake_data(schema: dict, intake_data: dict) -> tuple:
+    """
+    Validate that all required questions have been answered.
+    
+    Args:
+        schema: The intake schema
+        intake_data: The user's answers
+    
+    Returns:
+        Tuple of (is_valid, list of missing field ids)
+    """
+    missing = []
+    
+    for section in schema.get('sections', []):
+        for question in section.get('questions', []):
+            if question.get('required', False):
+                field_id = question['id']
+                value = intake_data.get(field_id)
+                
+                # Check if value is provided (not None and not empty string)
+                if value is None or value == '':
+                    missing.append(field_id)
+    
+    return (len(missing) == 0, missing)
+
+
+def get_question_labels(schema: dict) -> dict:
+    """
+    Get a mapping of question IDs to their labels for display.
+    """
+    labels = {}
+    for section in schema.get('sections', []):
+        for question in section.get('questions', []):
+            labels[question['id']] = question['label']
+    return labels
+

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -118,7 +118,7 @@
                 </div>
                 {% endif %}
                 
-                <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}#intake" 
+                <a href="{{ url_for('transactions.intake_questionnaire', id=transaction.id) }}" 
                    class="btn btn-outline btn-sm w-full">
                     <i class="fas fa-clipboard-list mr-2"></i>
                     {% if transaction.intake_data %}Edit Questionnaire{% else %}Start Questionnaire{% endif %}

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+
+{% block title %}Property Questionnaire - {{ transaction.street_address }} - TechnolOG{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-6 max-w-3xl">
+    <!-- Header -->
+    <div class="mb-6">
+        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" class="text-gray-500 hover:text-gray-700 text-sm">
+            <i class="fas fa-arrow-left mr-1"></i>Back to Transaction
+        </a>
+        <h1 class="text-2xl font-bold text-gray-800 mt-2">{{ schema.title }}</h1>
+        <p class="text-gray-500">{{ transaction.street_address }}</p>
+        <p class="text-sm text-gray-400 mt-1">{{ schema.description }}</p>
+    </div>
+
+    <!-- Questionnaire Form -->
+    <form id="intakeForm" method="POST" action="{{ url_for('transactions.save_intake', id=transaction.id) }}">
+        {% for section in schema.sections %}
+        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+            <h2 class="text-lg font-semibold text-gray-800 mb-4">{{ section.title }}</h2>
+            
+            <div class="space-y-6">
+                {% for question in section.questions %}
+                <div class="question-item" data-question-id="{{ question.id }}">
+                    <label class="block text-sm font-medium text-gray-700 mb-2">
+                        {{ question.label }}
+                        {% if question.required %}<span class="text-red-500">*</span>{% endif %}
+                    </label>
+                    
+                    {% if question.help_text %}
+                    <p class="text-xs text-gray-500 mb-2">{{ question.help_text }}</p>
+                    {% endif %}
+                    
+                    {% if question.type == 'boolean' %}
+                    <!-- Yes/No Toggle -->
+                    <div class="flex gap-3">
+                        <label class="cursor-pointer flex-1">
+                            <input type="radio" name="{{ question.id }}" value="true" 
+                                   class="hidden peer"
+                                   {% if intake_data.get(question.id) == true %}checked{% endif %}>
+                            <div class="p-3 border-2 rounded-lg text-center transition-all
+                                        peer-checked:border-green-500 peer-checked:bg-green-50
+                                        hover:border-gray-300">
+                                <i class="fas fa-check text-green-500 mr-1"></i> Yes
+                            </div>
+                        </label>
+                        <label class="cursor-pointer flex-1">
+                            <input type="radio" name="{{ question.id }}" value="false" 
+                                   class="hidden peer"
+                                   {% if intake_data.get(question.id) == false %}checked{% endif %}>
+                            <div class="p-3 border-2 rounded-lg text-center transition-all
+                                        peer-checked:border-red-500 peer-checked:bg-red-50
+                                        hover:border-gray-300">
+                                <i class="fas fa-times text-red-500 mr-1"></i> No
+                            </div>
+                        </label>
+                    </div>
+                    
+                    {% elif question.type == 'select' %}
+                    <!-- Select Dropdown or Radio Buttons -->
+                    <div class="flex flex-wrap gap-2">
+                        {% for option in question.options %}
+                        <label class="cursor-pointer">
+                            <input type="radio" name="{{ question.id }}" value="{{ option.value }}" 
+                                   class="hidden peer"
+                                   {% if intake_data.get(question.id) == option.value %}checked{% endif %}>
+                            <div class="px-4 py-2 border-2 rounded-lg text-center transition-all
+                                        peer-checked:border-blue-500 peer-checked:bg-blue-50
+                                        hover:border-gray-300">
+                                {{ option.label }}
+                            </div>
+                        </label>
+                        {% endfor %}
+                    </div>
+                    
+                    {% elif question.type == 'text' %}
+                    <!-- Text Input -->
+                    <input type="text" name="{{ question.id }}" 
+                           value="{{ intake_data.get(question.id, '') }}"
+                           class="input input-bordered w-full">
+                    
+                    {% elif question.type == 'textarea' %}
+                    <!-- Textarea -->
+                    <textarea name="{{ question.id }}" 
+                              class="textarea textarea-bordered w-full" rows="3">{{ intake_data.get(question.id, '') }}</textarea>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+
+        <!-- Actions -->
+        <div class="flex justify-between items-center">
+            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+               class="btn btn-ghost">
+                Cancel
+            </a>
+            <div class="flex gap-3">
+                <button type="submit" name="action" value="save" class="btn btn-outline">
+                    <i class="fas fa-save mr-2"></i>Save Draft
+                </button>
+                <button type="button" onclick="saveAndGenerate()" class="btn btn-primary">
+                    <i class="fas fa-file-alt mr-2"></i>Save & Generate Documents
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
+
+<script>
+function saveAndGenerate() {
+    const form = document.getElementById('intakeForm');
+    const formData = new FormData(form);
+    
+    // First save the intake data
+    fetch('{{ url_for("transactions.save_intake", id=transaction.id) }}', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => {
+        if (response.ok) {
+            // Then generate the document package
+            const generateForm = document.createElement('form');
+            generateForm.method = 'POST';
+            generateForm.action = '{{ url_for("transactions.generate_document_package", id=transaction.id) }}';
+            document.body.appendChild(generateForm);
+            generateForm.submit();
+        } else {
+            alert('Error saving questionnaire. Please try again.');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert('Error saving questionnaire. Please try again.');
+    });
+}
+
+// Auto-save on change (optional - for better UX)
+let saveTimeout;
+document.querySelectorAll('input, textarea, select').forEach(el => {
+    el.addEventListener('change', () => {
+        clearTimeout(saveTimeout);
+        saveTimeout = setTimeout(() => {
+            // Could implement auto-save here
+            console.log('Answer changed');
+        }, 1000);
+    });
+});
+</script>
+{% endblock %}
+


### PR DESCRIPTION
- Create intake_schemas/seller_conventional.json with 6 questions and 10 document rules
- Add services/intake_service.py for schema loading and document rule evaluation
- Add intake questionnaire UI with Yes/No toggles and multi-option selects
- Add routes for viewing, saving, and generating document package from intake
- Document rules engine correctly includes/excludes documents based on answers
- Transaction detail shows questionnaire status and saved answers
- Conditional documents display their inclusion reason

Questions covered:
- Built before 1978 (Lead Paint)
- Owner's association (HOA)
- Special districts (MUD, PID)
- Flood hazard area
- Referral fee
- Survey availability (T-47.1)