### PR TITLE
Feat/transaction list detail improvements

### DIFF
--- a/routes/contacts.py
+++ b/routes/contacts.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request, abort, Response, jsonify, current_app
 from flask_login import login_required, current_user
-from models import db, Contact, ContactGroup, User
+from models import db, Contact, ContactGroup, User, Transaction, TransactionParticipant
 from forms import ContactForm
 import csv
 from io import StringIO
@@ -111,12 +111,18 @@ def view_contact(contact_id):
     user_tz = get_user_timezone()
     now = datetime.now(user_tz)
 
+    # Get related transactions via TransactionParticipant
+    related_transactions = Transaction.query.join(TransactionParticipant).filter(
+        TransactionParticipant.contact_id == contact.id
+    ).order_by(Transaction.created_at.desc()).all()
+
     return render_template('view_contact.html', 
                          contact=contact, 
                          all_groups=all_groups,
                          next_contact=next_contact,
                          prev_contact=prev_contact,
-                         now=now)
+                         now=now,
+                         related_transactions=related_transactions)
 
 
 @contacts_bp.route('/contacts/create', methods=['GET', 'POST'])

--- a/templates/transactions/create.html
+++ b/templates/transactions/create.html
@@ -3,165 +3,382 @@
 {% block title %}New Transaction - TechnolOG{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-6 max-w-3xl">
-    <!-- Header -->
-    <div class="mb-6">
-        <a href="{{ url_for('transactions.list_transactions') }}" class="text-gray-500 hover:text-gray-700 text-sm">
-            <i class="fas fa-arrow-left mr-1"></i>Back to Transactions
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    .animate-fade-in-up-delay-1 {
+        animation: fadeInUp 0.6s ease-out 0.1s forwards;
+        opacity: 0;
+    }
+
+    .animate-fade-in-up-delay-2 {
+        animation: fadeInUp 0.6s ease-out 0.2s forwards;
+        opacity: 0;
+    }
+
+    .animate-fade-in-up-delay-3 {
+        animation: fadeInUp 0.6s ease-out 0.3s forwards;
+        opacity: 0;
+    }
+
+    /* Premium card styling */
+    .premium-card {
+        background: white;
+        border-radius: 1rem;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        transition: all 0.2s ease-out;
+    }
+
+    .premium-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+
+    /* Premium button */
+    .premium-btn {
+        transition: all 0.2s ease-out;
+        border-radius: 0.75rem;
+    }
+
+    .premium-btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Premium input styling */
+    .premium-input {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+    }
+
+    .premium-input:focus {
+        border-color: #f97316;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+        outline: none;
+    }
+
+    .premium-input::placeholder {
+        color: #94a3b8;
+    }
+
+    /* Type card styling */
+    .type-card {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        transition: all 0.2s ease-out;
+        background: white;
+    }
+
+    .type-card:hover {
+        border-color: #cbd5e1;
+        background: #f8fafc;
+    }
+
+    .type-card.selected {
+        border-color: #f97316;
+        background: linear-gradient(to bottom, rgba(249, 115, 22, 0.05), rgba(249, 115, 22, 0.1));
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+    }
+
+    .type-icon {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.625rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 0.5rem;
+    }
+
+    .type-seller .type-icon { background: linear-gradient(135deg, #f97316, #ea580c); }
+    .type-buyer .type-icon { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+    .type-landlord .type-icon { background: linear-gradient(135deg, #06b6d4, #0891b2); }
+    .type-tenant .type-icon { background: linear-gradient(135deg, #10b981, #059669); }
+    .type-default .type-icon { background: linear-gradient(135deg, #6366f1, #4f46e5); }
+
+    /* Ownership card styling */
+    .ownership-card {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        transition: all 0.2s ease-out;
+        background: white;
+    }
+
+    .ownership-card:hover {
+        border-color: #cbd5e1;
+        background: #f8fafc;
+    }
+
+    .ownership-card.selected {
+        border-color: #f97316;
+        background: linear-gradient(to bottom, rgba(249, 115, 22, 0.05), rgba(249, 115, 22, 0.1));
+    }
+
+    /* Contact chip */
+    .contact-chip {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        background: linear-gradient(to right, #f8fafc, #f1f5f9);
+        border: 1px solid #e2e8f0;
+        border-radius: 0.75rem;
+        transition: all 0.2s ease-out;
+    }
+
+    .contact-chip:hover {
+        background: linear-gradient(to right, #f1f5f9, #e2e8f0);
+    }
+
+    /* Search results dropdown */
+    .search-results {
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.75rem;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.12);
+        overflow: hidden;
+    }
+
+    .search-result-item {
+        padding: 0.75rem 1rem;
+        transition: all 0.15s ease-out;
+        cursor: pointer;
+        border-bottom: 1px solid #f1f5f9;
+    }
+
+    .search-result-item:last-child {
+        border-bottom: none;
+    }
+
+    .search-result-item:hover {
+        background: linear-gradient(to right, rgba(249, 115, 22, 0.05), rgba(249, 115, 22, 0.1));
+    }
+
+    /* Step number */
+    .step-number {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.5rem;
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 0.875rem;
+        flex-shrink: 0;
+    }
+</style>
+
+<!-- Premium gradient background -->
+<div class="min-h-full bg-gradient-to-br from-slate-50 via-white to-orange-50/30">
+    <div class="p-4 md:p-6 max-w-3xl mx-auto">
+        <!-- Back Link -->
+        <a href="{{ url_for('transactions.list_transactions') }}" 
+           class="inline-flex items-center text-slate-500 hover:text-orange-600 text-sm mb-4 transition-colors animate-fade-in-up">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Transactions
         </a>
-        <h1 class="text-2xl font-bold text-gray-800 mt-2">Create New Transaction</h1>
-    </div>
-
-    <!-- Form -->
-    <form method="POST" action="{{ url_for('transactions.create_transaction') }}" class="space-y-6">
-        <!-- Step 1: Select Contacts -->
-        <div class="bg-white rounded-lg shadow-sm p-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-600 text-sm font-bold mr-2">1</span>
-                Select Client(s)
-            </h2>
-            
-            <!-- Contact Search -->
-            <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2">Search Contacts</label>
-                <input type="text" 
-                       id="contactSearch" 
-                       placeholder="Type to search contacts..."
-                       class="input input-bordered w-full"
-                       autocomplete="off">
-                <div id="contactSearchResults" class="mt-2 bg-white border rounded-lg shadow-lg hidden max-h-48 overflow-y-auto"></div>
+        
+        <!-- Header Section -->
+        <div class="flex items-center space-x-4 mb-6 animate-fade-in-up">
+            <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-500 to-orange-600 items-center justify-center shadow-lg flex-shrink-0">
+                <i class="fas fa-plus text-white text-xl"></i>
             </div>
-
-            <!-- Selected Contacts -->
-            <div id="selectedContacts" class="space-y-2">
-                <p class="text-sm text-gray-500" id="noContactsMessage">No contacts selected yet.</p>
+            <div>
+                <h1 class="text-2xl md:text-3xl font-bold text-slate-800">Create New Transaction</h1>
+                <p class="text-slate-500 mt-1">Set up a new real estate transaction</p>
             </div>
         </div>
 
-        <!-- Step 2: Transaction Type -->
-        <div class="bg-white rounded-lg shadow-sm p-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-600 text-sm font-bold mr-2">2</span>
-                Transaction Type
-            </h2>
-            
-            <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                {% for tt in transaction_types %}
-                <label class="cursor-pointer">
-                    <input type="radio" name="transaction_type_id" value="{{ tt.id }}" 
-                           class="hidden peer" required>
-                    <div class="p-4 border-2 rounded-lg text-center transition-all
-                                peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                hover:border-gray-300">
-                        <div class="text-2xl mb-1">
-                            {% if tt.name == 'seller' %}🏠
-                            {% elif tt.name == 'buyer' %}🔑
-                            {% elif tt.name == 'landlord' %}🏢
-                            {% elif tt.name == 'tenant' %}📋
-                            {% else %}🤝{% endif %}
+        <!-- Form -->
+        <form method="POST" action="{{ url_for('transactions.create_transaction') }}">
+            <!-- Step 1: Select Contacts -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-1">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="step-number">1</div>
+                    <h2 class="text-lg font-bold text-slate-800">Select Client(s)</h2>
+                </div>
+                
+                <!-- Contact Search -->
+                <div class="mb-4 relative">
+                    <label class="block text-sm font-medium text-slate-700 mb-2">Search Contacts</label>
+                    <div class="relative">
+                        <input type="text" 
+                               id="contactSearch" 
+                               placeholder="Type to search contacts..."
+                               class="premium-input w-full"
+                               style="padding-left: 2.5rem;"
+                               autocomplete="off">
+                        <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
+                    </div>
+                    <div id="contactSearchResults" class="search-results mt-2 hidden max-h-48 overflow-y-auto absolute left-0 right-0 z-10"></div>
+                </div>
+
+                <!-- Selected Contacts -->
+                <div id="selectedContacts" class="space-y-2">
+                    <p class="text-sm text-slate-500 flex items-center gap-2" id="noContactsMessage">
+                        <i class="fas fa-info-circle text-slate-400"></i>
+                        No contacts selected yet.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Step 2: Transaction Type -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-2">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="step-number">2</div>
+                    <h2 class="text-lg font-bold text-slate-800">Transaction Type</h2>
+                </div>
+                
+                <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                    {% for tt in transaction_types %}
+                    <label class="cursor-pointer">
+                        <input type="radio" name="transaction_type_id" value="{{ tt.id }}" 
+                               class="hidden peer" required>
+                        <div class="type-card peer-checked:selected p-4 text-center
+                                    {% if tt.name == 'seller' %}type-seller
+                                    {% elif tt.name == 'buyer' %}type-buyer
+                                    {% elif tt.name == 'landlord' %}type-landlord
+                                    {% elif tt.name == 'tenant' %}type-tenant
+                                    {% else %}type-default{% endif %}">
+                            <div class="type-icon mx-auto">
+                                {% if tt.name == 'seller' %}
+                                <i class="fas fa-home text-white"></i>
+                                {% elif tt.name == 'buyer' %}
+                                <i class="fas fa-key text-white"></i>
+                                {% elif tt.name == 'landlord' %}
+                                <i class="fas fa-building text-white"></i>
+                                {% elif tt.name == 'tenant' %}
+                                <i class="fas fa-file-signature text-white"></i>
+                                {% else %}
+                                <i class="fas fa-handshake text-white"></i>
+                                {% endif %}
+                            </div>
+                            <div class="font-semibold text-slate-800 text-sm">{{ tt.display_name }}</div>
                         </div>
-                        <div class="font-medium text-gray-800">{{ tt.display_name }}</div>
-                    </div>
-                </label>
-                {% endfor %}
+                    </label>
+                    {% endfor %}
+                </div>
             </div>
-        </div>
 
-        <!-- Step 3: Property Address -->
-        <div class="bg-white rounded-lg shadow-sm p-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-600 text-sm font-bold mr-2">3</span>
-                Property Address
-            </h2>
-            
-            <div class="space-y-4">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Street Address *</label>
-                    <input type="text" name="street_address" required
-                           class="input input-bordered w-full"
-                           placeholder="123 Main St">
+            <!-- Step 3: Property Address -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-3">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="step-number">3</div>
+                    <h2 class="text-lg font-bold text-slate-800">Property Address</h2>
                 </div>
                 
-                <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                    <div class="col-span-2 sm:col-span-2">
-                        <label class="block text-sm font-medium text-gray-700 mb-1">City</label>
-                        <input type="text" name="city"
-                               class="input input-bordered w-full"
-                               placeholder="Austin">
-                    </div>
+                <div class="space-y-4">
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">State</label>
-                        <input type="text" name="state" value="TX"
-                               class="input input-bordered w-full">
+                        <label class="block text-sm font-medium text-slate-700 mb-2">Street Address <span class="text-red-500">*</span></label>
+                        <input type="text" name="street_address" required
+                               class="premium-input w-full"
+                               placeholder="123 Main St">
                     </div>
+                    
+                    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                        <div class="col-span-2 sm:col-span-2">
+                            <label class="block text-sm font-medium text-slate-700 mb-2">City</label>
+                            <input type="text" name="city"
+                                   class="premium-input w-full"
+                                   placeholder="Austin">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-slate-700 mb-2">State</label>
+                            <input type="text" name="state" value="TX"
+                                   class="premium-input w-full">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-slate-700 mb-2">ZIP</label>
+                            <input type="text" name="zip_code"
+                                   class="premium-input w-full"
+                                   placeholder="78701">
+                        </div>
+                    </div>
+                    
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">ZIP</label>
-                        <input type="text" name="zip_code"
-                               class="input input-bordered w-full"
-                               placeholder="78701">
+                        <label class="block text-sm font-medium text-slate-700 mb-2">County</label>
+                        <input type="text" name="county"
+                               class="premium-input w-full"
+                               placeholder="Travis">
                     </div>
+                </div>
+            </div>
+
+            <!-- Step 4: Ownership Status (Seller Only) -->
+            <div id="ownershipSection" class="premium-card p-6 mb-6 hidden animate-fade-in-up">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="step-number">4</div>
+                    <h2 class="text-lg font-bold text-slate-800">Ownership Status</h2>
                 </div>
                 
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">County</label>
-                    <input type="text" name="county"
-                           class="input input-bordered w-full"
-                           placeholder="Travis">
+                <div class="grid grid-cols-2 gap-3">
+                    <label class="cursor-pointer">
+                        <input type="radio" name="ownership_status" value="conventional" class="hidden peer">
+                        <div class="ownership-card peer-checked:selected p-4 text-center">
+                            <div class="w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center mx-auto mb-2">
+                                <i class="fas fa-home text-slate-600"></i>
+                            </div>
+                            <div class="font-semibold text-slate-800 text-sm">Conventional / Resale</div>
+                        </div>
+                    </label>
+                    <label class="cursor-pointer">
+                        <input type="radio" name="ownership_status" value="builder" class="hidden peer">
+                        <div class="ownership-card peer-checked:selected p-4 text-center">
+                            <div class="w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center mx-auto mb-2">
+                                <i class="fas fa-hard-hat text-slate-600"></i>
+                            </div>
+                            <div class="font-semibold text-slate-800 text-sm">Builder / New Construction</div>
+                        </div>
+                    </label>
+                    <label class="cursor-pointer">
+                        <input type="radio" name="ownership_status" value="reo" class="hidden peer">
+                        <div class="ownership-card peer-checked:selected p-4 text-center">
+                            <div class="w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center mx-auto mb-2">
+                                <i class="fas fa-bank text-slate-600"></i>
+                            </div>
+                            <div class="font-semibold text-slate-800 text-sm">REO / Foreclosure</div>
+                        </div>
+                    </label>
+                    <label class="cursor-pointer">
+                        <input type="radio" name="ownership_status" value="short_sale" class="hidden peer">
+                        <div class="ownership-card peer-checked:selected p-4 text-center">
+                            <div class="w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center mx-auto mb-2">
+                                <i class="fas fa-hand-holding-usd text-slate-600"></i>
+                            </div>
+                            <div class="font-semibold text-slate-800 text-sm">Short Sale</div>
+                        </div>
+                    </label>
                 </div>
             </div>
-        </div>
 
-        <!-- Step 4: Ownership Status (Seller Only) -->
-        <div id="ownershipSection" class="bg-white rounded-lg shadow-sm p-6 hidden">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 text-blue-600 text-sm font-bold mr-2">4</span>
-                Ownership Status
-            </h2>
-            
-            <div class="grid grid-cols-2 gap-3">
-                <label class="cursor-pointer">
-                    <input type="radio" name="ownership_status" value="conventional" class="hidden peer">
-                    <div class="p-3 border-2 rounded-lg text-center transition-all
-                                peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                hover:border-gray-300">
-                        <div class="font-medium text-gray-800">Conventional / Resale</div>
-                    </div>
-                </label>
-                <label class="cursor-pointer">
-                    <input type="radio" name="ownership_status" value="builder" class="hidden peer">
-                    <div class="p-3 border-2 rounded-lg text-center transition-all
-                                peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                hover:border-gray-300">
-                        <div class="font-medium text-gray-800">Builder / New Construction</div>
-                    </div>
-                </label>
-                <label class="cursor-pointer">
-                    <input type="radio" name="ownership_status" value="reo" class="hidden peer">
-                    <div class="p-3 border-2 rounded-lg text-center transition-all
-                                peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                hover:border-gray-300">
-                        <div class="font-medium text-gray-800">REO / Foreclosure</div>
-                    </div>
-                </label>
-                <label class="cursor-pointer">
-                    <input type="radio" name="ownership_status" value="short_sale" class="hidden peer">
-                    <div class="p-3 border-2 rounded-lg text-center transition-all
-                                peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                hover:border-gray-300">
-                        <div class="font-medium text-gray-800">Short Sale</div>
-                    </div>
-                </label>
+            <!-- Submit Actions -->
+            <div class="flex flex-col sm:flex-row justify-end gap-3 animate-fade-in-up-delay-3">
+                <a href="{{ url_for('transactions.list_transactions') }}" 
+                   class="premium-btn px-6 py-3 text-sm font-medium text-slate-700 bg-white border-2 border-slate-200 hover:bg-slate-50 text-center">
+                    Cancel
+                </a>
+                <button type="submit" 
+                        class="premium-btn px-6 py-3 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 shadow-md flex items-center justify-center gap-2">
+                    <i class="fas fa-plus"></i>
+                    Create Transaction
+                </button>
             </div>
-        </div>
-
-        <!-- Submit -->
-        <div class="flex justify-end gap-3">
-            <a href="{{ url_for('transactions.list_transactions') }}" class="btn btn-ghost">Cancel</a>
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-plus mr-2"></i>Create Transaction
-            </button>
-        </div>
-    </form>
+        </form>
+    </div>
 </div>
 
 <script>
@@ -190,17 +407,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(res => res.json())
                 .then(contacts => {
                     if (contacts.length === 0) {
-                        searchResults.innerHTML = '<div class="p-3 text-gray-500">No contacts found</div>';
+                        searchResults.innerHTML = '<div class="p-4 text-slate-500 text-sm text-center">No contacts found</div>';
                     } else {
-                        searchResults.innerHTML = contacts
-                            .filter(c => !selectedContactIds.has(c.id))
-                            .map(c => `
-                                <div class="p-3 hover:bg-gray-50 cursor-pointer border-b last:border-0"
-                                     data-contact='${JSON.stringify(c)}'>
-                                    <div class="font-medium">${c.name}</div>
-                                    <div class="text-sm text-gray-500">${c.email || 'No email'}</div>
+                        const filtered = contacts.filter(c => !selectedContactIds.has(c.id));
+                        if (filtered.length === 0) {
+                            searchResults.innerHTML = '<div class="p-4 text-slate-500 text-sm text-center">All matching contacts already selected</div>';
+                        } else {
+                            searchResults.innerHTML = filtered.map(c => `
+                                <div class="search-result-item" data-contact='${JSON.stringify(c)}'>
+                                    <div class="font-medium text-slate-800">${c.name}</div>
+                                    <div class="text-sm text-slate-500">${c.email || 'No email'}</div>
                                 </div>
-                            `).join('') || '<div class="p-3 text-gray-500">All matching contacts already selected</div>';
+                            `).join('');
+                        }
                     }
                     searchResults.classList.remove('hidden');
                 });
@@ -232,15 +451,20 @@ document.addEventListener('DOMContentLoaded', function() {
         noContactsMessage.classList.add('hidden');
         
         const contactEl = document.createElement('div');
-        contactEl.className = 'flex items-center justify-between p-3 bg-gray-50 rounded-lg';
+        contactEl.className = 'contact-chip';
         contactEl.dataset.contactId = contact.id;
         contactEl.innerHTML = `
             <input type="hidden" name="contact_ids" value="${contact.id}">
-            <div>
-                <div class="font-medium text-gray-800">${contact.name}</div>
-                <div class="text-sm text-gray-500">${contact.email || ''} ${contact.phone || ''}</div>
+            <div class="flex items-center gap-3">
+                <div class="w-9 h-9 rounded-full bg-gradient-to-br from-indigo-100 to-indigo-200 flex items-center justify-center flex-shrink-0">
+                    <span class="text-indigo-600 font-semibold text-sm">${contact.name.substring(0, 2).toUpperCase()}</span>
+                </div>
+                <div>
+                    <div class="font-medium text-slate-800">${contact.name}</div>
+                    <div class="text-sm text-slate-500">${contact.email || ''} ${contact.phone || ''}</div>
+                </div>
             </div>
-            <button type="button" class="btn btn-ghost btn-sm text-red-500 remove-contact">
+            <button type="button" class="p-2 rounded-lg text-slate-400 hover:text-red-500 hover:bg-red-50 transition-all remove-contact">
                 <i class="fas fa-times"></i>
             </button>
         `;
@@ -266,7 +490,7 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('input[name="transaction_type_id"]').forEach(radio => {
         radio.addEventListener('change', function() {
             // Find the transaction type name by looking at the label text
-            const label = this.closest('label').querySelector('.font-medium').textContent.trim();
+            const label = this.closest('label').querySelector('.font-semibold').textContent.trim();
             if (label.includes('Seller')) {
                 ownershipSection.classList.remove('hidden');
             } else {
@@ -274,7 +498,22 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+
+    // Update visual selection state for type cards
+    document.querySelectorAll('input[name="transaction_type_id"]').forEach(radio => {
+        radio.addEventListener('change', function() {
+            document.querySelectorAll('.type-card').forEach(card => card.classList.remove('selected'));
+            this.closest('label').querySelector('.type-card').classList.add('selected');
+        });
+    });
+
+    // Update visual selection state for ownership cards
+    document.querySelectorAll('input[name="ownership_status"]').forEach(radio => {
+        radio.addEventListener('change', function() {
+            document.querySelectorAll('.ownership-card').forEach(card => card.classList.remove('selected'));
+            this.closest('label').querySelector('.ownership-card').classList.add('selected');
+        });
+    });
 });
 </script>
 {% endblock %}
-

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -163,10 +163,19 @@
 <div class="min-h-full bg-gradient-to-br from-slate-50 via-white to-orange-50/30">
     <div class="p-4 md:p-6 max-w-7xl mx-auto">
         <!-- Back Link -->
+        {% set ref = request.args.get('ref') %}
+        {% set contact_id = request.args.get('contact_id') %}
+        {% if ref == 'contact' and contact_id %}
+        <a href="{{ url_for('contacts.view_contact', contact_id=contact_id) }}" 
+           class="inline-flex items-center text-slate-500 hover:text-orange-600 text-sm mb-4 transition-colors animate-fade-in-up">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Contact
+        </a>
+        {% else %}
         <a href="{{ url_for('transactions.list_transactions') }}" 
            class="inline-flex items-center text-slate-500 hover:text-orange-600 text-sm mb-4 transition-colors animate-fade-in-up">
             <i class="fas fa-arrow-left mr-2"></i>Back to Transactions
         </a>
+        {% endif %}
         
         <!-- Header Section -->
         <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6 animate-fade-in-up relative z-50">

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -31,6 +31,8 @@
         border: 1px solid #e2e8f0;
         box-shadow: 0 1px 3px rgba(0,0,0,0.05);
         transition: all 0.2s ease-out;
+        position: relative;
+        z-index: 1;
     }
 
     .premium-card:hover {
@@ -167,7 +169,7 @@
         </a>
         
         <!-- Header Section -->
-        <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6 animate-fade-in-up">
+        <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6 animate-fade-in-up relative z-50">
             <div class="flex items-start space-x-4">
                 <!-- Property Icon -->
                 <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-500 to-orange-600 items-center justify-center shadow-lg flex-shrink-0">

--- a/templates/transactions/document_form.html
+++ b/templates/transactions/document_form.html
@@ -3,257 +3,488 @@
 {% block title %}{{ document.template_name }} - {{ transaction.street_address }} - TechnolOG{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-6 max-w-4xl">
-    <!-- Header -->
-    <div class="mb-6">
-        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" class="text-gray-500 hover:text-gray-700 text-sm">
-            <i class="fas fa-arrow-left mr-1"></i>Back to Transaction
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    .animate-fade-in-up-delay-1 {
+        animation: fadeInUp 0.6s ease-out 0.1s forwards;
+        opacity: 0;
+    }
+
+    .animate-fade-in-up-delay-2 {
+        animation: fadeInUp 0.6s ease-out 0.2s forwards;
+        opacity: 0;
+    }
+
+    .animate-fade-in-up-delay-3 {
+        animation: fadeInUp 0.6s ease-out 0.3s forwards;
+        opacity: 0;
+    }
+
+    /* Premium card styling */
+    .premium-card {
+        background: white;
+        border-radius: 1rem;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        transition: all 0.2s ease-out;
+    }
+
+    .premium-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+
+    /* Premium button */
+    .premium-btn {
+        transition: all 0.2s ease-out;
+        border-radius: 0.75rem;
+    }
+
+    .premium-btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Premium input styling */
+    .premium-input {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.625rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+        width: 100%;
+    }
+
+    .premium-input:focus {
+        border-color: #f97316;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+        outline: none;
+    }
+
+    .premium-input::placeholder {
+        color: #94a3b8;
+    }
+
+    .premium-input[readonly] {
+        background-color: #f1f5f9;
+        color: #64748b;
+        cursor: not-allowed;
+    }
+
+    .premium-input[readonly]:focus {
+        border-color: #e2e8f0;
+        box-shadow: none;
+    }
+
+    /* Premium textarea */
+    .premium-textarea {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.625rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+        width: 100%;
+        resize: vertical;
+        min-height: 100px;
+    }
+
+    .premium-textarea:focus {
+        border-color: #f97316;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+        outline: none;
+    }
+
+    /* Section icon */
+    .section-icon {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.625rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+    }
+
+    /* Status badge */
+    .status-badge {
+        padding: 0.375rem 0.875rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.025em;
+    }
+
+    .status-pending { background: #f1f5f9; color: #64748b; }
+    .status-filled { background: #dbeafe; color: #1e40af; }
+    .status-sent { background: #fef3c7; color: #92400e; }
+    .status-signed { background: #dcfce7; color: #166534; }
+
+    /* Input with icon */
+    .input-with-icon {
+        position: relative;
+    }
+
+    .input-icon-left {
+        position: absolute;
+        left: 0.875rem;
+        top: 50%;
+        transform: translateY(-50%);
+        color: #64748b;
+        font-size: 0.875rem;
+        pointer-events: none;
+    }
+
+    .input-icon-right {
+        position: absolute;
+        right: 0.875rem;
+        top: 50%;
+        transform: translateY(-50%);
+        color: #64748b;
+        font-size: 0.875rem;
+        pointer-events: none;
+    }
+
+    .input-padded-left {
+        padding-left: 2rem;
+    }
+
+    .input-padded-right {
+        padding-right: 2rem;
+    }
+
+    /* Form label */
+    .form-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #475569;
+        margin-bottom: 0.5rem;
+    }
+
+    /* Form group */
+    .form-group {
+        margin-bottom: 0;
+    }
+</style>
+
+<!-- Premium gradient background -->
+<div class="min-h-full bg-gradient-to-br from-slate-50 via-white to-orange-50/30">
+    <div class="p-4 md:p-6 max-w-4xl mx-auto">
+        <!-- Back Link -->
+        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+           class="inline-flex items-center text-slate-500 hover:text-orange-600 text-sm mb-4 transition-colors animate-fade-in-up">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Transaction
         </a>
-        <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mt-2 gap-4">
-            <div>
-                <h1 class="text-2xl font-bold text-gray-800">{{ document.template_name }}</h1>
-                <p class="text-gray-500">{{ transaction.street_address }}</p>
+        
+        <!-- Header Section -->
+        <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6 animate-fade-in-up">
+            <div class="flex items-start space-x-4">
+                <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-emerald-500 to-emerald-600 items-center justify-center shadow-lg flex-shrink-0">
+                    <i class="fas fa-file-alt text-white text-xl"></i>
+                </div>
+                <div>
+                    <h1 class="text-2xl md:text-3xl font-bold text-slate-800">{{ document.template_name }}</h1>
+                    <p class="text-slate-500 mt-1">{{ transaction.street_address }}</p>
+                </div>
             </div>
-            <div class="flex gap-2">
-                <span class="badge badge-{{ 'secondary' if document.status == 'filled' else 'ghost' }} badge-lg">
-                    {{ document.status|title }}
-                </span>
-            </div>
+            <span class="status-badge status-{{ document.status }}">
+                {{ document.status|title }}
+            </span>
         </div>
+
+        <!-- Document Form -->
+        <form id="documentForm" method="POST" action="{{ url_for('transactions.save_document_form', id=transaction.id, doc_id=document.id) }}">
+            
+            <!-- Property Information Section -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-1">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="section-icon bg-gradient-to-br from-blue-500 to-blue-600">
+                        <i class="fas fa-home text-white text-sm"></i>
+                    </div>
+                    <h2 class="text-lg font-bold text-slate-800">Property Information</h2>
+                </div>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="md:col-span-2 form-group">
+                        <label class="form-label">Street Address</label>
+                        <input type="text" name="field_property_address" 
+                               value="{{ prefill_data.get('property_address', '') }}"
+                               class="premium-input" readonly>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">City</label>
+                        <input type="text" name="field_property_city" 
+                               value="{{ prefill_data.get('property_city', '') }}"
+                               class="premium-input" readonly>
+                    </div>
+                    <div class="grid grid-cols-2 gap-3">
+                        <div class="form-group">
+                            <label class="form-label">State</label>
+                            <input type="text" name="field_property_state" 
+                                   value="{{ prefill_data.get('property_state', 'TX') }}"
+                                   class="premium-input" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">ZIP</label>
+                            <input type="text" name="field_property_zip" 
+                                   value="{{ prefill_data.get('property_zip', '') }}"
+                                   class="premium-input" readonly>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">County</label>
+                        <input type="text" name="field_property_county" 
+                               value="{{ prefill_data.get('property_county', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Legal Description</label>
+                        <input type="text" name="field_legal_description" 
+                               value="{{ prefill_data.get('legal_description', '') }}"
+                               class="premium-input" placeholder="Lot/Block/Survey">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Seller Information Section -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-1">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="section-icon bg-gradient-to-br from-green-500 to-green-600">
+                        <i class="fas fa-user text-white text-sm"></i>
+                    </div>
+                    <h2 class="text-lg font-bold text-slate-800">Seller Information</h2>
+                </div>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-group">
+                        <label class="form-label">Seller Name</label>
+                        <input type="text" name="field_seller_name" 
+                               value="{{ prefill_data.get('seller_name', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Co-Seller Name</label>
+                        <input type="text" name="field_co_seller_name" 
+                               value="{{ prefill_data.get('co_seller_name', '') }}"
+                               class="premium-input" placeholder="If applicable">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Seller Email</label>
+                        <input type="email" name="field_seller_email" 
+                               value="{{ prefill_data.get('seller_email', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Seller Phone</label>
+                        <input type="tel" name="field_seller_phone" 
+                               value="{{ prefill_data.get('seller_phone', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="md:col-span-2 form-group">
+                        <label class="form-label">Seller Mailing Address</label>
+                        <input type="text" name="field_seller_mailing_address" 
+                               value="{{ prefill_data.get('seller_mailing_address', '') }}"
+                               class="premium-input" placeholder="If different from property">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Agent/Broker Information Section -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-2">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="section-icon bg-gradient-to-br from-purple-500 to-purple-600">
+                        <i class="fas fa-briefcase text-white text-sm"></i>
+                    </div>
+                    <h2 class="text-lg font-bold text-slate-800">Agent/Broker Information</h2>
+                </div>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-group">
+                        <label class="form-label">Listing Agent</label>
+                        <input type="text" name="field_agent_name" 
+                               value="{{ prefill_data.get('agent_name', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Agent License #</label>
+                        <input type="text" name="field_agent_license" 
+                               value="{{ prefill_data.get('agent_license', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Agent Email</label>
+                        <input type="email" name="field_agent_email" 
+                               value="{{ prefill_data.get('agent_email', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Agent Phone</label>
+                        <input type="tel" name="field_agent_phone" 
+                               value="{{ prefill_data.get('agent_phone', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Broker Name</label>
+                        <input type="text" name="field_broker_name" 
+                               value="{{ prefill_data.get('broker_name', 'Origen Realty') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Broker License #</label>
+                        <input type="text" name="field_broker_license" 
+                               value="{{ prefill_data.get('broker_license', '') }}"
+                               class="premium-input">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Listing Terms Section (for Listing Agreement) -->
+            {% if 'listing' in document.template_slug.lower() %}
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-2">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="section-icon bg-gradient-to-br from-orange-500 to-orange-600">
+                        <i class="fas fa-file-contract text-white text-sm"></i>
+                    </div>
+                    <h2 class="text-lg font-bold text-slate-800">Listing Terms</h2>
+                </div>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-group">
+                        <label class="form-label">List Price</label>
+                        <div class="input-with-icon">
+                            <span class="input-icon-left">$</span>
+                            <input type="text" name="field_list_price" 
+                                   value="{{ prefill_data.get('list_price', '') }}"
+                                   class="premium-input input-padded-left" placeholder="0.00">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Commission Rate</label>
+                        <div class="input-with-icon">
+                            <input type="text" name="field_commission_rate" 
+                                   value="{{ prefill_data.get('commission_rate', '') }}"
+                                   class="premium-input input-padded-right" placeholder="6">
+                            <span class="input-icon-right">%</span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Listing Start Date</label>
+                        <input type="date" name="field_listing_start_date" 
+                               value="{{ prefill_data.get('listing_start_date', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Listing End Date</label>
+                        <input type="date" name="field_listing_end_date" 
+                               value="{{ prefill_data.get('listing_end_date', '') }}"
+                               class="premium-input">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Buyer's Agent Commission</label>
+                        <div class="input-with-icon">
+                            <input type="text" name="field_buyers_agent_commission" 
+                                   value="{{ prefill_data.get('buyers_agent_commission', '') }}"
+                                   class="premium-input input-padded-right" placeholder="3">
+                            <span class="input-icon-right">%</span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">MLS #</label>
+                        <input type="text" name="field_mls_number" 
+                               value="{{ prefill_data.get('mls_number', '') }}"
+                               class="premium-input" placeholder="Will be assigned">
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            <!-- Additional Notes Section -->
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-3">
+                <div class="flex items-center gap-3 mb-5">
+                    <div class="section-icon bg-gradient-to-br from-amber-500 to-amber-600">
+                        <i class="fas fa-sticky-note text-white text-sm"></i>
+                    </div>
+                    <h2 class="text-lg font-bold text-slate-800">Additional Notes</h2>
+                </div>
+                
+                <div>
+                    <textarea name="field_notes" 
+                              class="premium-textarea" rows="4"
+                              placeholder="Any additional notes or special conditions...">{{ prefill_data.get('notes', '') }}</textarea>
+                </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex flex-col sm:flex-row justify-between items-stretch sm:items-center gap-4 animate-fade-in-up-delay-3">
+                <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+                   class="premium-btn px-6 py-3 text-sm font-medium text-slate-700 bg-white border-2 border-slate-200 hover:bg-slate-50 text-center order-3 sm:order-1">
+                    Cancel
+                </a>
+                <div class="flex flex-col sm:flex-row gap-3 order-1 sm:order-2">
+                    <button type="submit" name="action" value="save" 
+                            class="premium-btn px-6 py-3 text-sm font-medium text-slate-700 bg-white border-2 border-slate-200 hover:bg-slate-50 flex items-center justify-center gap-2">
+                        <i class="fas fa-save text-slate-500"></i>
+                        Save Draft
+                    </button>
+                    <button type="button" onclick="saveAndPreview()" 
+                            class="premium-btn px-6 py-3 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 shadow-md flex items-center justify-center gap-2">
+                        <i class="fas fa-eye"></i>
+                        Save & Preview
+                    </button>
+                </div>
+            </div>
+        </form>
     </div>
-
-    <!-- Document Form -->
-    <form id="documentForm" method="POST" action="{{ url_for('transactions.save_document_form', id=transaction.id, doc_id=document.id) }}">
-        <!-- Property Information Section -->
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <i class="fas fa-home text-blue-500 mr-2"></i>Property Information
-            </h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="md:col-span-2">
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Street Address</label>
-                    <input type="text" name="field_property_address" 
-                           value="{{ prefill_data.get('property_address', '') }}"
-                           class="input input-bordered w-full" readonly>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">City</label>
-                    <input type="text" name="field_property_city" 
-                           value="{{ prefill_data.get('property_city', '') }}"
-                           class="input input-bordered w-full" readonly>
-                </div>
-                <div class="grid grid-cols-2 gap-2">
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">State</label>
-                        <input type="text" name="field_property_state" 
-                               value="{{ prefill_data.get('property_state', 'TX') }}"
-                               class="input input-bordered w-full" readonly>
-                    </div>
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">ZIP</label>
-                        <input type="text" name="field_property_zip" 
-                               value="{{ prefill_data.get('property_zip', '') }}"
-                               class="input input-bordered w-full" readonly>
-                    </div>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">County</label>
-                    <input type="text" name="field_property_county" 
-                           value="{{ prefill_data.get('property_county', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Legal Description</label>
-                    <input type="text" name="field_legal_description" 
-                           value="{{ prefill_data.get('legal_description', '') }}"
-                           class="input input-bordered w-full" placeholder="Lot/Block/Survey">
-                </div>
-            </div>
-        </div>
-
-        <!-- Seller Information Section -->
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <i class="fas fa-user text-green-500 mr-2"></i>Seller Information
-            </h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Seller Name</label>
-                    <input type="text" name="field_seller_name" 
-                           value="{{ prefill_data.get('seller_name', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Co-Seller Name</label>
-                    <input type="text" name="field_co_seller_name" 
-                           value="{{ prefill_data.get('co_seller_name', '') }}"
-                           class="input input-bordered w-full" placeholder="If applicable">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Seller Email</label>
-                    <input type="email" name="field_seller_email" 
-                           value="{{ prefill_data.get('seller_email', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Seller Phone</label>
-                    <input type="tel" name="field_seller_phone" 
-                           value="{{ prefill_data.get('seller_phone', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div class="md:col-span-2">
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Seller Mailing Address</label>
-                    <input type="text" name="field_seller_mailing_address" 
-                           value="{{ prefill_data.get('seller_mailing_address', '') }}"
-                           class="input input-bordered w-full" placeholder="If different from property">
-                </div>
-            </div>
-        </div>
-
-        <!-- Agent/Broker Information Section -->
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <i class="fas fa-briefcase text-purple-500 mr-2"></i>Agent/Broker Information
-            </h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Listing Agent</label>
-                    <input type="text" name="field_agent_name" 
-                           value="{{ prefill_data.get('agent_name', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Agent License #</label>
-                    <input type="text" name="field_agent_license" 
-                           value="{{ prefill_data.get('agent_license', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Agent Email</label>
-                    <input type="email" name="field_agent_email" 
-                           value="{{ prefill_data.get('agent_email', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Agent Phone</label>
-                    <input type="tel" name="field_agent_phone" 
-                           value="{{ prefill_data.get('agent_phone', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Broker Name</label>
-                    <input type="text" name="field_broker_name" 
-                           value="{{ prefill_data.get('broker_name', 'Origen Realty') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Broker License #</label>
-                    <input type="text" name="field_broker_license" 
-                           value="{{ prefill_data.get('broker_license', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-            </div>
-        </div>
-
-        <!-- Listing Terms Section (for Listing Agreement) -->
-        {% if 'listing' in document.template_slug.lower() %}
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <i class="fas fa-file-contract text-orange-500 mr-2"></i>Listing Terms
-            </h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">List Price</label>
-                    <div class="relative">
-                        <span class="absolute left-3 top-3 text-gray-500">$</span>
-                        <input type="text" name="field_list_price" 
-                               value="{{ prefill_data.get('list_price', '') }}"
-                               class="input input-bordered w-full pl-7" placeholder="0.00">
-                    </div>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Commission Rate</label>
-                    <div class="relative">
-                        <input type="text" name="field_commission_rate" 
-                               value="{{ prefill_data.get('commission_rate', '') }}"
-                               class="input input-bordered w-full pr-7" placeholder="6">
-                        <span class="absolute right-3 top-3 text-gray-500">%</span>
-                    </div>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Listing Start Date</label>
-                    <input type="date" name="field_listing_start_date" 
-                           value="{{ prefill_data.get('listing_start_date', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Listing End Date</label>
-                    <input type="date" name="field_listing_end_date" 
-                           value="{{ prefill_data.get('listing_end_date', '') }}"
-                           class="input input-bordered w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Buyer's Agent Commission</label>
-                    <div class="relative">
-                        <input type="text" name="field_buyers_agent_commission" 
-                               value="{{ prefill_data.get('buyers_agent_commission', '') }}"
-                               class="input input-bordered w-full pr-7" placeholder="3">
-                        <span class="absolute right-3 top-3 text-gray-500">%</span>
-                    </div>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">MLS #</label>
-                    <input type="text" name="field_mls_number" 
-                           value="{{ prefill_data.get('mls_number', '') }}"
-                           class="input input-bordered w-full" placeholder="Will be assigned">
-                </div>
-            </div>
-        </div>
-        {% endif %}
-
-        <!-- Additional Notes Section -->
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">
-                <i class="fas fa-sticky-note text-yellow-500 mr-2"></i>Additional Notes
-            </h2>
-            <div>
-                <textarea name="field_notes" 
-                          class="textarea textarea-bordered w-full" rows="4"
-                          placeholder="Any additional notes or special conditions...">{{ prefill_data.get('notes', '') }}</textarea>
-            </div>
-        </div>
-
-        <!-- Actions -->
-        <div class="flex flex-col sm:flex-row justify-between items-center gap-4 bg-white rounded-lg shadow-sm p-4">
-            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
-               class="btn btn-ghost w-full sm:w-auto">
-                Cancel
-            </a>
-            <div class="flex gap-2 w-full sm:w-auto">
-                <button type="submit" name="action" value="save" class="btn btn-outline flex-1 sm:flex-none">
-                    <i class="fas fa-save mr-2"></i>Save Draft
-                </button>
-                <button type="button" onclick="saveAndPreview()" class="btn btn-primary flex-1 sm:flex-none">
-                    <i class="fas fa-eye mr-2"></i>Save & Preview
-                </button>
-            </div>
-        </div>
-    </form>
 </div>
 
-<!-- Coming Soon Toast -->
-<div id="comingSoonToast" class="toast toast-end hidden">
-    <div class="alert alert-info">
-        <i class="fas fa-info-circle"></i>
-        <span>PDF preview coming soon with DocuSeal integration!</span>
+<!-- Toast Notification -->
+<div id="toast" class="fixed bottom-6 right-6 z-50 hidden">
+    <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-2xl shadow-2xl border border-slate-200">
+        <i id="toastIcon" class="fas fa-info-circle text-blue-500"></i>
+        <span id="toastMessage" class="text-sm font-medium text-slate-700"></span>
     </div>
 </div>
 
 <script>
+function showToast(message, type = 'info') {
+    const toast = document.getElementById('toast');
+    const icon = document.getElementById('toastIcon');
+    document.getElementById('toastMessage').textContent = message;
+    
+    icon.className = 'fas';
+    if (type === 'success') {
+        icon.classList.add('fa-check-circle', 'text-green-500');
+    } else if (type === 'error') {
+        icon.classList.add('fa-exclamation-circle', 'text-red-500');
+    } else if (type === 'warning') {
+        icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
+    } else {
+        icon.classList.add('fa-info-circle', 'text-blue-500');
+    }
+    
+    toast.classList.remove('hidden');
+    setTimeout(() => toast.classList.add('hidden'), 4000);
+}
+
 function saveAndPreview() {
     // Save the form first
     const form = document.getElementById('documentForm');
     const formData = new FormData(form);
+    
+    showToast('Saving document...', 'info');
     
     fetch(form.action, {
         method: 'POST',
@@ -261,21 +492,17 @@ function saveAndPreview() {
     })
     .then(response => {
         if (response.ok) {
-            // Show coming soon toast for preview
-            const toast = document.getElementById('comingSoonToast');
-            toast.classList.remove('hidden');
+            showToast('PDF preview coming soon with DocuSeal integration!', 'info');
             setTimeout(() => {
-                toast.classList.add('hidden');
-                // Redirect back to transaction
                 window.location.href = "{{ url_for('transactions.view_transaction', id=transaction.id) }}";
             }, 2000);
         } else {
-            alert('Error saving form. Please try again.');
+            showToast('Error saving form. Please try again.', 'error');
         }
     })
     .catch(error => {
         console.error('Error:', error);
-        alert('Error saving form. Please try again.');
+        showToast('Error saving form. Please try again.', 'error');
     });
 }
 
@@ -296,4 +523,3 @@ document.querySelectorAll('input[name*="price"], input[name*="commission"]').for
 });
 </script>
 {% endblock %}
-

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -3,116 +3,359 @@
 {% block title %}Property Questionnaire - {{ transaction.street_address }} - TechnolOG{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-6 max-w-3xl">
-    <!-- Header -->
-    <div class="mb-6">
-        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" class="text-gray-500 hover:text-gray-700 text-sm">
-            <i class="fas fa-arrow-left mr-1"></i>Back to Transaction
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    .animate-fade-in-up-delay-1 {
+        animation: fadeInUp 0.6s ease-out 0.1s forwards;
+        opacity: 0;
+    }
+
+    .animate-fade-in-up-delay-2 {
+        animation: fadeInUp 0.6s ease-out 0.2s forwards;
+        opacity: 0;
+    }
+
+    /* Premium card styling */
+    .premium-card {
+        background: white;
+        border-radius: 1rem;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        transition: all 0.2s ease-out;
+    }
+
+    .premium-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+
+    /* Premium button */
+    .premium-btn {
+        transition: all 0.2s ease-out;
+        border-radius: 0.75rem;
+    }
+
+    .premium-btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Premium input styling */
+    .premium-input {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+        width: 100%;
+    }
+
+    .premium-input:focus {
+        border-color: #f97316;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+        outline: none;
+    }
+
+    .premium-input::placeholder {
+        color: #94a3b8;
+    }
+
+    /* Premium textarea */
+    .premium-textarea {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+        width: 100%;
+        resize: vertical;
+        min-height: 80px;
+    }
+
+    .premium-textarea:focus {
+        border-color: #f97316;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+        outline: none;
+    }
+
+    /* Yes/No toggle cards - compact professional style */
+    .toggle-card {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.5rem;
+        transition: all 0.15s ease-out;
+        background: white;
+        padding: 0.5rem 1.25rem;
+        text-align: center;
+        cursor: pointer;
+        font-size: 0.875rem;
+    }
+
+    .toggle-card:hover {
+        border-color: #cbd5e1;
+        background: #f8fafc;
+    }
+
+    .toggle-card.selected-yes {
+        border-color: #22c55e;
+        background: #f0fdf4;
+        box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.1);
+    }
+
+    .toggle-card.selected-yes .toggle-icon {
+        color: #16a34a;
+    }
+
+    .toggle-card.selected-yes .toggle-text {
+        color: #166534;
+        font-weight: 600;
+    }
+
+    .toggle-card.selected-no {
+        border-color: #f87171;
+        background: #fef2f2;
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+    }
+
+    .toggle-card.selected-no .toggle-icon {
+        color: #dc2626;
+    }
+
+    .toggle-card.selected-no .toggle-text {
+        color: #991b1b;
+        font-weight: 600;
+    }
+
+    /* Option pill cards */
+    .option-pill {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        transition: all 0.2s ease-out;
+        background: white;
+        padding: 0.625rem 1rem;
+        cursor: pointer;
+        font-size: 0.875rem;
+    }
+
+    .option-pill:hover {
+        border-color: #cbd5e1;
+        background: #f8fafc;
+    }
+
+    .option-pill.selected {
+        border-color: #f97316;
+        background: linear-gradient(to bottom, rgba(249, 115, 22, 0.05), rgba(249, 115, 22, 0.1));
+        color: #c2410c;
+        font-weight: 500;
+    }
+
+    /* Question item styling */
+    .question-item {
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid #f1f5f9;
+    }
+
+    .question-item:last-child {
+        padding-bottom: 0;
+        border-bottom: none;
+    }
+
+    /* Section icon */
+    .section-icon {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.625rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    /* Progress indicator */
+    .progress-bar {
+        height: 4px;
+        background: #e2e8f0;
+        border-radius: 2px;
+        overflow: hidden;
+    }
+
+    .progress-bar-fill {
+        height: 100%;
+        background: linear-gradient(to right, #f97316, #ea580c);
+        transition: width 0.3s ease-out;
+    }
+</style>
+
+<!-- Premium gradient background -->
+<div class="min-h-full bg-gradient-to-br from-slate-50 via-white to-orange-50/30">
+    <div class="p-4 md:p-6 max-w-3xl mx-auto">
+        <!-- Back Link -->
+        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+           class="inline-flex items-center text-slate-500 hover:text-orange-600 text-sm mb-4 transition-colors animate-fade-in-up">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Transaction
         </a>
-        <h1 class="text-2xl font-bold text-gray-800 mt-2">{{ schema.title }}</h1>
-        <p class="text-gray-500">{{ transaction.street_address }}</p>
-        <p class="text-sm text-gray-400 mt-1">{{ schema.description }}</p>
-    </div>
+        
+        <!-- Header Section -->
+        <div class="flex items-start space-x-4 mb-6 animate-fade-in-up">
+            <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-purple-500 to-purple-600 items-center justify-center shadow-lg flex-shrink-0">
+                <i class="fas fa-clipboard-list text-white text-xl"></i>
+            </div>
+            <div class="flex-1">
+                <h1 class="text-2xl md:text-3xl font-bold text-slate-800">{{ schema.title }}</h1>
+                <p class="text-slate-600 mt-1">{{ transaction.street_address }}</p>
+                <p class="text-sm text-slate-500 mt-1">{{ schema.description }}</p>
+            </div>
+        </div>
 
-    <!-- Questionnaire Form -->
-    <form id="intakeForm" method="POST" action="{{ url_for('transactions.save_intake', id=transaction.id) }}">
-        {% for section in schema.sections %}
-        <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-            <h2 class="text-lg font-semibold text-gray-800 mb-4">{{ section.title }}</h2>
-            
-            <div class="space-y-6">
-                {% for question in section.questions %}
-                <div class="question-item" data-question-id="{{ question.id }}">
-                    <label class="block text-sm font-medium text-gray-700 mb-2">
-                        {{ question.label }}
-                        {% if question.required %}<span class="text-red-500">*</span>{% endif %}
-                    </label>
-                    
-                    {% if question.help_text %}
-                    <p class="text-xs text-gray-500 mb-2">{{ question.help_text }}</p>
-                    {% endif %}
-                    
-                    {% if question.type == 'boolean' %}
-                    <!-- Yes/No Toggle -->
-                    <div class="flex gap-3">
-                        <label class="cursor-pointer flex-1">
-                            <input type="radio" name="{{ question.id }}" value="true" 
-                                   class="hidden peer"
-                                   {% if intake_data.get(question.id) == true %}checked{% endif %}>
-                            <div class="p-3 border-2 rounded-lg text-center transition-all
-                                        peer-checked:border-green-500 peer-checked:bg-green-50
-                                        hover:border-gray-300">
-                                <i class="fas fa-check text-green-500 mr-1"></i> Yes
-                            </div>
-                        </label>
-                        <label class="cursor-pointer flex-1">
-                            <input type="radio" name="{{ question.id }}" value="false" 
-                                   class="hidden peer"
-                                   {% if intake_data.get(question.id) == false %}checked{% endif %}>
-                            <div class="p-3 border-2 rounded-lg text-center transition-all
-                                        peer-checked:border-red-500 peer-checked:bg-red-50
-                                        hover:border-gray-300">
-                                <i class="fas fa-times text-red-500 mr-1"></i> No
-                            </div>
-                        </label>
+        <!-- Progress Bar -->
+        <div class="premium-card p-4 mb-6 animate-fade-in-up">
+            <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium text-slate-700">Questionnaire Progress</span>
+                <span class="text-sm text-slate-500" id="progressText">0% Complete</span>
+            </div>
+            <div class="progress-bar">
+                <div class="progress-bar-fill" id="progressBarFill" style="width: 0%"></div>
+            </div>
+        </div>
+
+        <!-- Questionnaire Form -->
+        <form id="intakeForm" method="POST" action="{{ url_for('transactions.save_intake', id=transaction.id) }}">
+            {% for section in schema.sections %}
+            <div class="premium-card p-6 mb-6 animate-fade-in-up-delay-1">
+                <div class="flex items-center gap-3 mb-6">
+                    <div class="section-icon bg-gradient-to-br 
+                        {% if loop.index == 1 %}from-blue-500 to-blue-600
+                        {% elif loop.index == 2 %}from-emerald-500 to-emerald-600
+                        {% elif loop.index == 3 %}from-purple-500 to-purple-600
+                        {% elif loop.index == 4 %}from-amber-500 to-amber-600
+                        {% else %}from-slate-500 to-slate-600{% endif %}">
+                        <i class="fas 
+                            {% if loop.index == 1 %}fa-home
+                            {% elif loop.index == 2 %}fa-shield-alt
+                            {% elif loop.index == 3 %}fa-tools
+                            {% elif loop.index == 4 %}fa-file-contract
+                            {% else %}fa-list{% endif %} text-white text-sm"></i>
                     </div>
-                    
-                    {% elif question.type == 'select' %}
-                    <!-- Select Dropdown or Radio Buttons -->
-                    <div class="flex flex-wrap gap-2">
-                        {% for option in question.options %}
-                        <label class="cursor-pointer">
-                            <input type="radio" name="{{ question.id }}" value="{{ option.value }}" 
-                                   class="hidden peer"
-                                   {% if intake_data.get(question.id) == option.value %}checked{% endif %}>
-                            <div class="px-4 py-2 border-2 rounded-lg text-center transition-all
-                                        peer-checked:border-blue-500 peer-checked:bg-blue-50
-                                        hover:border-gray-300">
-                                {{ option.label }}
-                            </div>
-                        </label>
-                        {% endfor %}
-                    </div>
-                    
-                    {% elif question.type == 'text' %}
-                    <!-- Text Input -->
-                    <input type="text" name="{{ question.id }}" 
-                           value="{{ intake_data.get(question.id, '') }}"
-                           class="input input-bordered w-full">
-                    
-                    {% elif question.type == 'textarea' %}
-                    <!-- Textarea -->
-                    <textarea name="{{ question.id }}" 
-                              class="textarea textarea-bordered w-full" rows="3">{{ intake_data.get(question.id, '') }}</textarea>
-                    {% endif %}
+                    <h2 class="text-lg font-bold text-slate-800">{{ section.title }}</h2>
                 </div>
-                {% endfor %}
+                
+                <div class="space-y-6">
+                    {% for question in section.questions %}
+                    <div class="question-item" data-question-id="{{ question.id }}">
+                        <label class="block text-sm font-medium text-slate-700 mb-2">
+                            {{ question.label }}
+                            {% if question.required %}<span class="text-red-500 ml-1">*</span>{% endif %}
+                        </label>
+                        
+                        {% if question.help_text %}
+                        <p class="text-xs text-slate-500 mb-3 flex items-start gap-2">
+                            <i class="fas fa-info-circle text-slate-400 mt-0.5"></i>
+                            {{ question.help_text }}
+                        </p>
+                        {% endif %}
+                        
+                        {% if question.type == 'boolean' %}
+                        <!-- Yes/No Toggle -->
+                        <div class="inline-flex gap-2">
+                            <label class="cursor-pointer">
+                                <input type="radio" name="{{ question.id }}" value="true" 
+                                       class="hidden toggle-input"
+                                       {% if intake_data.get(question.id) == true %}checked{% endif %}>
+                                <div class="toggle-card flex items-center justify-center gap-1.5 {% if intake_data.get(question.id) == true %}selected-yes{% endif %}">
+                                    <i class="fas fa-check toggle-icon text-slate-400 text-xs"></i>
+                                    <span class="toggle-text text-slate-600">Yes</span>
+                                </div>
+                            </label>
+                            <label class="cursor-pointer">
+                                <input type="radio" name="{{ question.id }}" value="false" 
+                                       class="hidden toggle-input"
+                                       {% if intake_data.get(question.id) == false %}checked{% endif %}>
+                                <div class="toggle-card flex items-center justify-center gap-1.5 {% if intake_data.get(question.id) == false %}selected-no{% endif %}">
+                                    <i class="fas fa-times toggle-icon text-slate-400 text-xs"></i>
+                                    <span class="toggle-text text-slate-600">No</span>
+                                </div>
+                            </label>
+                        </div>
+                        
+                        {% elif question.type == 'select' %}
+                        <!-- Select Options -->
+                        <div class="flex flex-wrap gap-2">
+                            {% for option in question.options %}
+                            <label class="cursor-pointer">
+                                <input type="radio" name="{{ question.id }}" value="{{ option.value }}" 
+                                       class="hidden peer"
+                                       {% if intake_data.get(question.id) == option.value %}checked{% endif %}>
+                                <div class="option-pill peer-checked:selected">
+                                    {{ option.label }}
+                                </div>
+                            </label>
+                            {% endfor %}
+                        </div>
+                        
+                        {% elif question.type == 'text' %}
+                        <!-- Text Input -->
+                        <input type="text" name="{{ question.id }}" 
+                               value="{{ intake_data.get(question.id, '') }}"
+                               class="premium-input">
+                        
+                        {% elif question.type == 'textarea' %}
+                        <!-- Textarea -->
+                        <textarea name="{{ question.id }}" 
+                                  class="premium-textarea" rows="3">{{ intake_data.get(question.id, '') }}</textarea>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
             </div>
-        </div>
-        {% endfor %}
+            {% endfor %}
 
-        <!-- Actions -->
-        <div class="flex justify-between items-center">
-            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
-               class="btn btn-ghost">
-                Cancel
-            </a>
-            <div class="flex gap-3">
-                <button type="submit" name="action" value="save" class="btn btn-outline">
-                    <i class="fas fa-save mr-2"></i>Save Draft
-                </button>
-                <button type="button" onclick="saveAndGenerate()" class="btn btn-primary">
-                    <i class="fas fa-file-alt mr-2"></i>Save & Generate Documents
-                </button>
+            <!-- Actions -->
+            <div class="flex flex-col sm:flex-row justify-between items-stretch sm:items-center gap-4 animate-fade-in-up-delay-2">
+                <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+                   class="premium-btn px-6 py-3 text-sm font-medium text-slate-700 bg-white border-2 border-slate-200 hover:bg-slate-50 text-center order-3 sm:order-1">
+                    Cancel
+                </a>
+                <div class="flex flex-col sm:flex-row gap-3 order-1 sm:order-2">
+                    <button type="submit" name="action" value="save" 
+                            class="premium-btn px-6 py-3 text-sm font-medium text-slate-700 bg-white border-2 border-slate-200 hover:bg-slate-50 flex items-center justify-center gap-2">
+                        <i class="fas fa-save text-slate-500"></i>
+                        Save Draft
+                    </button>
+                    <button type="button" onclick="saveAndGenerate()" 
+                            class="premium-btn px-6 py-3 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 shadow-md flex items-center justify-center gap-2">
+                        <i class="fas fa-file-alt"></i>
+                        Save & Generate Documents
+                    </button>
+                </div>
             </div>
-        </div>
-    </form>
+        </form>
+    </div>
+</div>
+
+<!-- Toast Notification -->
+<div id="toast" class="fixed bottom-6 right-6 z-50 hidden">
+    <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-2xl shadow-2xl border border-slate-200">
+        <i id="toastIcon" class="fas fa-info-circle text-blue-500"></i>
+        <span id="toastMessage" class="text-sm font-medium text-slate-700"></span>
+    </div>
 </div>
 
 <script>
 function saveAndGenerate() {
     const form = document.getElementById('intakeForm');
     const formData = new FormData(form);
+    
+    showToast('Saving questionnaire...', 'info');
     
     // First save the intake data
     fetch('{{ url_for("transactions.save_intake", id=transaction.id) }}', {
@@ -121,6 +364,7 @@ function saveAndGenerate() {
     })
     .then(response => {
         if (response.ok) {
+            showToast('Generating documents...', 'success');
             // Then generate the document package
             const generateForm = document.createElement('form');
             generateForm.method = 'POST';
@@ -128,26 +372,113 @@ function saveAndGenerate() {
             document.body.appendChild(generateForm);
             generateForm.submit();
         } else {
-            alert('Error saving questionnaire. Please try again.');
+            showToast('Error saving questionnaire. Please try again.', 'error');
         }
     })
     .catch(error => {
         console.error('Error:', error);
-        alert('Error saving questionnaire. Please try again.');
+        showToast('Error saving questionnaire. Please try again.', 'error');
     });
 }
 
-// Auto-save on change (optional - for better UX)
-let saveTimeout;
-document.querySelectorAll('input, textarea, select').forEach(el => {
-    el.addEventListener('change', () => {
-        clearTimeout(saveTimeout);
-        saveTimeout = setTimeout(() => {
-            // Could implement auto-save here
-            console.log('Answer changed');
-        }, 1000);
+function showToast(message, type = 'info') {
+    const toast = document.getElementById('toast');
+    const icon = document.getElementById('toastIcon');
+    document.getElementById('toastMessage').textContent = message;
+    
+    icon.className = 'fas';
+    if (type === 'success') {
+        icon.classList.add('fa-check-circle', 'text-green-500');
+    } else if (type === 'error') {
+        icon.classList.add('fa-exclamation-circle', 'text-red-500');
+    } else if (type === 'warning') {
+        icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
+    } else {
+        icon.classList.add('fa-info-circle', 'text-blue-500');
+    }
+    
+    toast.classList.remove('hidden');
+    setTimeout(() => toast.classList.add('hidden'), 4000);
+}
+
+// Progress tracking and visual feedback
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('intakeForm');
+    const questions = form.querySelectorAll('.question-item');
+    const progressBar = document.getElementById('progressBarFill');
+    const progressText = document.getElementById('progressText');
+    
+    function updateProgress() {
+        let answered = 0;
+        let total = questions.length;
+        
+        questions.forEach(q => {
+            const inputs = q.querySelectorAll('input, textarea');
+            let hasValue = false;
+            inputs.forEach(input => {
+                if (input.type === 'radio' && input.checked) hasValue = true;
+                if ((input.type === 'text' || input.tagName === 'TEXTAREA') && input.value.trim()) hasValue = true;
+            });
+            if (hasValue) answered++;
+        });
+        
+        const percent = Math.round((answered / total) * 100);
+        progressBar.style.width = percent + '%';
+        progressText.textContent = percent + '% Complete';
+    }
+    
+    // Update progress on any input change
+    form.querySelectorAll('input, textarea').forEach(el => {
+        el.addEventListener('change', updateProgress);
+        el.addEventListener('input', updateProgress);
+    });
+    
+    // Initial progress calculation
+    updateProgress();
+    
+    // Handle toggle (Yes/No) selection
+    document.querySelectorAll('.toggle-input').forEach(input => {
+        input.addEventListener('change', function() {
+            const container = this.closest('.question-item');
+            
+            // Clear all toggle states in this question
+            container.querySelectorAll('.toggle-card').forEach(card => {
+                card.classList.remove('selected-yes', 'selected-no');
+            });
+            
+            // Apply the selected state
+            const card = this.closest('label').querySelector('.toggle-card');
+            if (this.value === 'true') {
+                card.classList.add('selected-yes');
+            } else {
+                card.classList.add('selected-no');
+            }
+        });
+    });
+    
+    // Handle option pill selection
+    document.querySelectorAll('.option-pill').forEach(pill => {
+        const input = pill.closest('label').querySelector('input');
+        if (input && input.checked) {
+            pill.classList.add('selected');
+        }
+    });
+    
+    document.querySelectorAll('input[type="radio"]:not(.toggle-input)').forEach(radio => {
+        radio.addEventListener('change', function() {
+            const container = this.closest('.question-item');
+            
+            // Update option pills
+            container.querySelectorAll('.option-pill').forEach(pill => {
+                pill.classList.remove('selected');
+            });
+            
+            const pill = this.closest('label')?.querySelector('.option-pill');
+            if (pill) {
+                pill.classList.add('selected');
+            }
+        });
     });
 });
 </script>
 {% endblock %}
-

--- a/templates/view_contact.html
+++ b/templates/view_contact.html
@@ -622,9 +622,98 @@
                 </div>
             </div>
 
-            <!-- Side Container - Related Tasks -->
-            <div class="lg:w-96 animate-fade-in-up-delay-3">
-                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden sticky top-24 premium-card">
+            <!-- Side Container - Related Tasks & Transactions -->
+            <div class="lg:w-96 space-y-6 animate-fade-in-up-delay-3">
+                <!-- Related Transactions Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-orange-500 to-amber-600 flex items-center justify-center">
+                                    <i class="fas fa-file-contract text-white text-sm"></i>
+                                </div>
+                                <h2 class="text-lg font-semibold text-slate-800">Related Transactions</h2>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="divide-y divide-slate-100 max-h-80 overflow-y-auto">
+                        {% for tx in related_transactions %}
+                        <a href="{{ url_for('transactions.view_transaction', id=tx.id, ref='contact', contact_id=contact.id) }}" 
+                           class="block p-4 hover:bg-slate-50 transition-colors duration-150 group">
+                            <div class="flex items-start space-x-3">
+                                <!-- Type Indicator -->
+                                <div class="flex-shrink-0">
+                                    <div class="w-9 h-9 rounded-lg flex items-center justify-center shadow-sm
+                                        {% if tx.transaction_type.name == 'seller' %}bg-gradient-to-br from-orange-400 to-orange-500
+                                        {% elif tx.transaction_type.name == 'buyer' %}bg-gradient-to-br from-purple-400 to-purple-500
+                                        {% elif tx.transaction_type.name == 'landlord' %}bg-gradient-to-br from-cyan-400 to-cyan-500
+                                        {% elif tx.transaction_type.name == 'tenant' %}bg-gradient-to-br from-green-400 to-green-500
+                                        {% else %}bg-gradient-to-br from-indigo-400 to-indigo-500{% endif %} text-white">
+                                        {% if tx.transaction_type.name == 'seller' %}
+                                        <i class="fas fa-home text-xs"></i>
+                                        {% elif tx.transaction_type.name == 'buyer' %}
+                                        <i class="fas fa-key text-xs"></i>
+                                        {% elif tx.transaction_type.name == 'landlord' %}
+                                        <i class="fas fa-building text-xs"></i>
+                                        {% elif tx.transaction_type.name == 'tenant' %}
+                                        <i class="fas fa-file-signature text-xs"></i>
+                                        {% else %}
+                                        <i class="fas fa-handshake text-xs"></i>
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                <!-- Transaction Content -->
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex items-center space-x-2">
+                                        <span class="text-sm font-medium text-slate-800 group-hover:text-orange-600 truncate transition-colors duration-150">
+                                            {{ tx.street_address }}
+                                        </span>
+                                    </div>
+                                    <div class="mt-1 flex items-center flex-wrap gap-2 text-xs">
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                                            {% if tx.transaction_type.name == 'seller' %}bg-orange-100 text-orange-700
+                                            {% elif tx.transaction_type.name == 'buyer' %}bg-purple-100 text-purple-700
+                                            {% elif tx.transaction_type.name == 'landlord' %}bg-cyan-100 text-cyan-700
+                                            {% elif tx.transaction_type.name == 'tenant' %}bg-green-100 text-green-700
+                                            {% else %}bg-indigo-100 text-indigo-700{% endif %}">
+                                            {{ tx.transaction_type.display_name }}
+                                        </span>
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                                            {% if tx.status == 'draft' %}bg-slate-100 text-slate-600
+                                            {% elif tx.status == 'active' %}bg-green-100 text-green-700
+                                            {% elif tx.status == 'pending' %}bg-amber-100 text-amber-700
+                                            {% elif tx.status == 'under_contract' %}bg-blue-100 text-blue-700
+                                            {% elif tx.status == 'closed' %}bg-indigo-100 text-indigo-700
+                                            {% else %}bg-red-100 text-red-700{% endif %}">
+                                            {{ tx.status|replace('_', ' ')|title }}
+                                        </span>
+                                    </div>
+                                    <div class="mt-1 text-xs text-slate-500">
+                                        {{ tx.created_at.strftime('%b %d, %Y') }}
+                                    </div>
+                                </div>
+
+                                <!-- Arrow -->
+                                <div class="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                                    <i class="fas fa-chevron-right text-slate-400 text-sm"></i>
+                                </div>
+                            </div>
+                        </a>
+                        {% else %}
+                        <div class="p-8 text-center">
+                            <div class="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
+                                <i class="fas fa-file-contract text-slate-400 text-xl"></i>
+                            </div>
+                            <p class="text-slate-500 text-sm">No transactions</p>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <!-- Related Tasks Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
                         <div class="flex items-center justify-between">
                             <div class="flex items-center gap-3">
@@ -658,7 +747,7 @@
                     </div>
 
                     <!-- Task Lists -->
-                    <div id="pendingTasks" class="divide-y divide-slate-100 max-h-[calc(100vh-300px)] overflow-y-auto">
+                    <div id="pendingTasks" class="divide-y divide-slate-100 max-h-80 overflow-y-auto">
                         {% for task in contact.tasks|selectattr('status', 'equalto', 'pending')|sort(attribute='due_date') %}
                         <div class="p-4 hover:bg-slate-50 transition-colors duration-150">
                             <div class="flex items-start space-x-3">
@@ -718,7 +807,7 @@
                         {% endfor %}
                     </div>
 
-                    <div id="completedTasks" class="hidden divide-y divide-slate-100 max-h-[calc(100vh-300px)] overflow-y-auto">
+                    <div id="completedTasks" class="hidden divide-y divide-slate-100 max-h-80 overflow-y-auto">
                         {% for task in contact.tasks|selectattr('status', 'equalto', 'completed')|sort(attribute='completed_at', reverse=true) %}
                         <div class="p-4 hover:bg-slate-50 transition-colors duration-150">
                             <div class="flex items-start space-x-3">


### PR DESCRIPTION
Changes Made:
1. Updated routes/contacts.py
Added imports for Transaction and TransactionParticipant models
Query for related transactions via the TransactionParticipant relationship
Pass related_transactions to the template
2. Updated templates/view_contact.html
Added a new Related Transactions card in the sidebar above Related Tasks
Shows transaction type icon with gradient colors matching the transaction list page
Displays property address, transaction type badge, status badge, and creation date
Clickable rows link to the transaction detail page with ref=contact&contact_id=X params
Empty state with icon when no transactions
Consistent premium styling matching the Related Tasks card
3. Updated templates/transactions/detail.html
Added logic to check for ref=contact and contact_id query parameters
When coming from a contact, the back button says "Back to Contact" and links to that contact
Otherwise, defaults to "Back to Transactions" as before
The Related Transactions section follows the same premium design as the Related Tasks section with:
Gradient icon badges for transaction types
Type and status badges with appropriate colors
Hover effects and smooth transitions
Arrow indicator on hover
Scrollable container for many transactions