### PR TITLE
feat: DocuSeal e-signature integration with preview, send, void & resend

### DIFF
--- a/docuseal_mappings/listing-agreement.yml
+++ b/docuseal_mappings/listing-agreement.yml
@@ -1,0 +1,233 @@
+# =============================================================================
+# LISTING AGREEMENT - DocuSeal Field Mapping
+# =============================================================================
+# This file maps CRM form fields to DocuSeal template fields.
+#
+# Template ID: 2468023
+# DocuSeal Template: "listing agreement"
+# Total DocuSeal Fields: 130
+#
+# Submitters (signers):
+#   - Seller (uuid: c8a354a2-cb65-4f46-98f0-3852299989ef)
+#   - Broker (uuid: 02ee5cd7-ccec-46ee-820a-6c6d91247cb9)
+#
+# HOW TO UPDATE:
+#   1. View fields at: /transactions/admin/docuseal/template/2468023
+#   2. Match your CRM form field to the DocuSeal field name
+#   3. Run a test submission to verify
+# =============================================================================
+
+template_id: 2468023
+template_name: "Listing Agreement"
+template_slug: "listing-agreement"
+
+# =============================================================================
+# FIELD MAPPINGS
+# Format: crm_field: docuseal_field
+# NOTE: CRM form saves fields WITHOUT the 'field_' prefix
+# =============================================================================
+field_mappings:
+
+  # ---------------------------------------------------------------------------
+  # SECTION 1: PARTIES - Seller Information
+  # ---------------------------------------------------------------------------
+  seller_legal_name: "Seller name"
+  seller_phone: "Seller phone"
+  seller_email: "Seller email/fax"
+  # NOTE: DocuSeal also has:
+  #   - "Seller company" - for LLC/Trust owners
+  #   - "Seller address" - seller's mailing address
+  #   - "City, State, Zip" - seller's city/state/zip
+  #   - "Seller alternate email/fax" - secondary contact
+
+  # ---------------------------------------------------------------------------
+  # SECTION 1: PARTIES - Property Address
+  # ---------------------------------------------------------------------------
+  property_address: "Property address/zip"
+  property_city: "City"
+  property_county: "County"
+  # NOTE: DocuSeal has "Property name" - for named estates/farms
+
+  # ---------------------------------------------------------------------------
+  # SECTION 2: PROPERTY DETAILS - Legal Description
+  # ---------------------------------------------------------------------------
+  legal_lot: "Lot number"
+  legal_block: "Block number"
+  legal_subdivision: "Subdivision"
+  # NOTE: DocuSeal has "Additional description" - for metes & bounds
+
+  # ---------------------------------------------------------------------------
+  # SECTION 2: PROPERTY DETAILS - Exclusions & HOA
+  # ---------------------------------------------------------------------------
+  exclusions: "Items to remove"
+  has_hoa: "Hoa membership"  # Radio: "yes" or "no"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 3: LISTING PRICE
+  # ---------------------------------------------------------------------------
+  list_price: "Listing price"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 4: LISTING TERM
+  # ---------------------------------------------------------------------------
+  listing_start_date: "Listing start date"
+  listing_end_date: "Listing end date"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 5: BROKER COMPENSATION
+  # ---------------------------------------------------------------------------
+  offer_buyer_agent_comp: "Broker comp method"  # Radio: "percent" or "flat"
+  total_commission_percent: "Commission percent"
+  total_commission_flat: "Flat fee amount"
+  buyer_agent_percent: "Compensation percent"
+  buyer_agent_flat: "Compensation flat fee"
+  
+  # Section 5B uses same DocuSeal fields as Section 5A
+  listing_only_percent: "Commission percent"
+  listing_only_flat: "Flat fee amount"
+  
+  authorize_buyer_expense_disclosure: "Disclosure auth"  # Radio: "yes" or "no"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 6: PROTECTION PERIOD
+  # NOTE: These fields may be unnamed in DocuSeal - needs verification
+  # ---------------------------------------------------------------------------
+  # protection_period_days: ???
+  # compensation_county: ???
+
+  # ---------------------------------------------------------------------------
+  # SECTION 7: MLS & MARKETING
+  # NOTE: These are BROKER fields - moved to broker_form_fields section below
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # SECTION 8: ACCESS & SHOWINGS  
+  # NOTE: These are BROKER fields - moved to broker_form_fields section below
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # SECTION 9: INTERMEDIARY
+  # NOTE: These are BROKER fields - moved to broker_form_fields section below
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # SECTION 10: INTERNET DISPLAY
+  # NOTE: DocuSeal uses different option values - needs transformation
+  # ---------------------------------------------------------------------------
+  # internet_display: "Online display"  # Options: "No listing", "Hide address"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 11: FINANCING OPTIONS
+  # NOTE: DocuSeal uses single radio, our form uses checkboxes - needs special handling
+  # ---------------------------------------------------------------------------
+  # financing_*: "Financing options"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 12: SELLER REPRESENTATIONS
+  # ---------------------------------------------------------------------------
+  liens_explanation: "Known liens"
+  delinquencies_explanation: "Other encumbrances"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 13: SPECIAL PROVISIONS
+  # ---------------------------------------------------------------------------
+  special_provisions: "Special provisions text"
+
+  # ---------------------------------------------------------------------------
+  # SECTION 14: FIRPTA
+  # ---------------------------------------------------------------------------
+  is_foreign_seller: "Foreign status"  # Radio: "yes" or "no"
+
+
+# =============================================================================
+# VALUE TRANSFORMS
+# These fields require value transformation before sending to DocuSeal
+# =============================================================================
+transforms:
+
+  # Radio button mappings (our value -> DocuSeal value)
+  radio_mappings:
+    has_hoa:
+      "yes": "yes"
+      "no": "no"
+    authorize_buyer_expense_disclosure:
+      "yes": "yes"
+      "no": "no"
+    authorize_lockbox:
+      "yes": "yes"
+      "no": "no"
+    authorize_intermediary:
+      "yes": "yes"
+      "no": "no"
+    is_foreign_seller:
+      "yes": "yes"
+      "no": "no"
+      "not_sure": "yes"  # Treat "not sure" as yes for FIRPTA purposes
+    enter_mls:
+      "yes": "yes"
+      "no": "no"
+      "delayed": "delay"  # Map our 'delayed' to DocuSeal's 'delay'
+    offer_buyer_agent_comp:
+      "yes": "percent"
+      "no": "flat"
+
+  # Currency fields - will have commas/$ stripped
+  currency_fields:
+    - list_price
+    - total_commission_flat
+    - buyer_agent_flat
+    - listing_only_flat
+
+  # Date fields - will be converted to MM/DD/YYYY
+  date_fields:
+    - listing_start_date
+    - listing_end_date
+
+
+# =============================================================================
+# BROKER FORM FIELDS
+# These are form fields that belong to the BROKER submitter (not Seller)
+# Format: crm_field: docuseal_field
+# =============================================================================
+broker_form_fields:
+  # Section 7: MLS & Marketing
+  enter_mls: "Mls filing"  # Radio: "yes", "early", "delay", "no"
+  mls_delay_days: "Delay days"
+  mls_delay_reason: "Purpose of delay"
+  
+  # Section 8: Access & Showings
+  authorize_lockbox: "Keybox auth"  # Radio: "yes" or "no"
+  
+  # Section 9: Intermediary
+  authorize_intermediary: "Intermediary"  # Radio: "yes" or "no"
+
+
+# =============================================================================
+# BROKER/AGENT FIELDS
+# These are auto-populated from the logged-in agent, not the form
+# =============================================================================
+agent_fields:
+  - docuseal_field: "Broker printed name"
+    source: "agent.name"
+  - docuseal_field: "Broker associate printed name"
+    source: "agent.name"
+  - docuseal_field: "Broker license number"
+    source: "agent.license_number"
+  - docuseal_field: "Broker associate license"
+    source: "agent.license_number"
+  - docuseal_field: "Broker email/fax"
+    source: "agent.email"
+  # Optional: Broker address if we have it
+  # - docuseal_field: "Broker address line"
+  #   source: "brokerage.address"
+
+
+# =============================================================================
+# COMPUTED FIELDS
+# Fields that combine or transform multiple form values
+# =============================================================================
+computed_fields:
+  # Combine address + zip for the full property address field
+  - docuseal_field: "Property address/zip"
+    template: "{property_address}, {property_zip}"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sendgrid==6.10.0
 requests==2.31.0
 psycopg2-binary>=2.9.9
 itsdangerous>=2.1.2
+PyYAML>=6.0

--- a/services/docuseal_service.py
+++ b/services/docuseal_service.py
@@ -3,30 +3,54 @@
 DocuSeal Integration Service
 
 This service handles all DocuSeal API interactions for e-signatures.
-Currently uses mock implementations - swap in real API calls when ready.
+Supports both test (sandbox) and production modes via environment variables.
 
-To enable real integration:
-1. Sign up at https://console.docuseal.com/api
-2. Add DOCUSEAL_API_KEY to .env
-3. Set DOCUSEAL_MOCK_MODE=False in .env
-4. Upload templates to DocuSeal and update TEMPLATE_MAP
+Configuration:
+- DOCUSEAL_API_KEY_TEST: API key for test/sandbox mode
+- DOCUSEAL_API_KEY_PROD: API key for production
+- DOCUSEAL_MODE: 'test' or 'prod' (defaults to 'test')
+
+Field Mappings:
+- Stored in YAML files at: docuseal_mappings/<template-slug>.yml
+- Each template has its own mapping file
+- See docuseal_mappings/listing-agreement.yml for format example
 """
 
 import os
 import json
+import requests
+import logging
+import yaml
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
 import uuid
+from pathlib import Path
 
-# Configuration
-DOCUSEAL_API_KEY = os.environ.get('DOCUSEAL_API_KEY', '')
-DOCUSEAL_API_URL = os.environ.get('DOCUSEAL_API_URL', 'https://api.docuseal.com')
-DOCUSEAL_MOCK_MODE = os.environ.get('DOCUSEAL_MOCK_MODE', 'True').lower() == 'true'
+logger = logging.getLogger(__name__)
+
+# Path to mapping files
+MAPPINGS_DIR = Path(__file__).parent.parent / 'docuseal_mappings'
+
+# Configuration - supports test and production modes
+DOCUSEAL_MODE = os.environ.get('DOCUSEAL_MODE', 'test').lower()
+DOCUSEAL_API_KEY_TEST = os.environ.get('DOCUSEAL_API_KEY_TEST', '')
+DOCUSEAL_API_KEY_PROD = os.environ.get('DOCUSEAL_API_KEY_PROD', '')
+
+# Select the appropriate API key based on mode
+if DOCUSEAL_MODE == 'prod':
+    DOCUSEAL_API_KEY = DOCUSEAL_API_KEY_PROD
+    DOCUSEAL_API_URL = 'https://api.docuseal.com'
+else:
+    DOCUSEAL_API_KEY = DOCUSEAL_API_KEY_TEST
+    DOCUSEAL_API_URL = 'https://api.docuseal.com'  # Same URL for test mode, different key
+
+# Mock mode is now controlled by whether we have a valid API key
+DOCUSEAL_MOCK_MODE = not bool(DOCUSEAL_API_KEY)
 
 # Map our template slugs to DocuSeal template IDs
-# Update these after uploading templates to DocuSeal
+# NOTE: Template IDs may differ between test and production environments
 TEMPLATE_MAP = {
-    'listing-agreement': None,  # DocuSeal template ID
+    'listing-agreement': 2468023,  # Listing Agreement template
     'iabs': None,
     'sellers-disclosure': None,
     'wire-fraud-warning': None,
@@ -39,6 +63,281 @@ TEMPLATE_MAP = {
     'referral-agreement': None,
 }
 
+# =============================================================================
+# FIELD MAPPING LOADER
+# =============================================================================
+# Field mappings are stored in YAML files at: docuseal_mappings/<template-slug>.yml
+# This keeps the service code clean and makes mappings easier to maintain.
+# 
+# Each YAML file contains:
+#   - template_id: DocuSeal template ID
+#   - field_mappings: Dict mapping our form fields to DocuSeal fields
+#   - transforms: Rules for value transformation (radio mappings, currency, dates)
+#   - agent_fields: Fields to populate from logged-in agent
+#   - computed_fields: Fields that combine multiple form values
+# =============================================================================
+
+# Cache for loaded mappings
+_mapping_cache: Dict[str, Dict[str, Any]] = {}
+
+
+def load_field_mapping(template_slug: str) -> Optional[Dict[str, Any]]:
+    """
+    Load field mapping from YAML file for a template.
+    
+    Args:
+        template_slug: Template identifier (e.g., 'listing-agreement')
+        
+    Returns:
+        Dict with field_mappings, transforms, agent_fields, etc.
+        Returns None if no mapping file exists.
+    """
+    # Check cache first
+    if template_slug in _mapping_cache:
+        return _mapping_cache[template_slug]
+    
+    # Load from YAML file
+    mapping_file = MAPPINGS_DIR / f"{template_slug}.yml"
+    
+    if not mapping_file.exists():
+        logger.warning(f"No field mapping file found: {mapping_file}")
+        return None
+    
+    try:
+        with open(mapping_file, 'r') as f:
+            mapping = yaml.safe_load(f)
+        
+        # Cache it
+        _mapping_cache[template_slug] = mapping
+        logger.info(f"Loaded field mapping for {template_slug}")
+        return mapping
+        
+    except Exception as e:
+        logger.error(f"Error loading field mapping for {template_slug}: {e}")
+        return None
+
+
+def get_field_mappings(template_slug: str) -> Dict[str, str]:
+    """Get just the field mappings dict from a template's YAML config."""
+    mapping = load_field_mapping(template_slug)
+    if mapping:
+        return mapping.get('field_mappings', {})
+    return {}
+
+
+def get_mapping_file_path(template_slug: str) -> str:
+    """Get the path to the mapping file for a template (for display in admin)."""
+    return str(MAPPINGS_DIR / f"{template_slug}.yml")
+
+def _format_date(date_str: str) -> str:
+    """Convert date to MM/DD/YYYY format for DocuSeal."""
+    if not date_str:
+        return ''
+    try:
+        # Handle YYYY-MM-DD format from HTML date inputs
+        if isinstance(date_str, str) and '-' in date_str:
+            d = datetime.strptime(date_str, '%Y-%m-%d')
+            return d.strftime('%m/%d/%Y')
+        return date_str
+    except:
+        return date_str
+
+
+def _format_currency(value: Any) -> str:
+    """Strip currency formatting ($, commas) for DocuSeal number fields."""
+    if not value:
+        return ''
+    return str(value).replace(',', '').replace('$', '').strip()
+
+
+def _apply_transform(value: Any, field_name: str, transforms: Dict[str, Any]) -> str:
+    """
+    Apply transformation rules from YAML config to a field value.
+    
+    Handles:
+    - radio_mappings: Map our values to DocuSeal values
+    - currency_fields: Strip $ and commas
+    - date_fields: Convert to MM/DD/YYYY
+    """
+    if not transforms:
+        return str(value) if value else ''
+    
+    # Check if it's a currency field
+    currency_fields = transforms.get('currency_fields', [])
+    if field_name in currency_fields:
+        return _format_currency(value)
+    
+    # Check if it's a date field
+    date_fields = transforms.get('date_fields', [])
+    if field_name in date_fields:
+        return _format_date(value)
+    
+    # Check for radio mapping
+    radio_mappings = transforms.get('radio_mappings', {})
+    if field_name in radio_mappings:
+        mapping = radio_mappings[field_name]
+        str_value = str(value).lower() if value else ''
+        return mapping.get(str_value, str(value) if value else '')
+    
+    # No transformation needed
+    return str(value) if value else ''
+
+
+def build_docuseal_fields(form_data: Dict[str, Any], template_slug: str, agent_data: Dict[str, Any] = None, submitter_role: str = None) -> List[Dict[str, Any]]:
+    """
+    Convert CRM form data to DocuSeal fields format.
+    
+    Loads field mappings from YAML file at: docuseal_mappings/<template_slug>.yml
+    
+    Args:
+        form_data: Dict of form field names to values (from TransactionDocument.field_data)
+        template_slug: The template being filled (e.g., 'listing-agreement')
+        agent_data: Optional dict with agent info (name, email, license_number, phone)
+        submitter_role: Optional role filter - 'Seller' returns only seller fields, 
+                       'Broker' returns only broker/agent fields, None returns all
+    
+    Returns:
+        List of dicts with 'name' and 'default_value' for DocuSeal API
+    """
+    fields = []
+    
+    # Load mapping from YAML file
+    mapping = load_field_mapping(template_slug)
+    if not mapping:
+        logger.warning(f"No field mapping found for template: {template_slug}")
+        return fields
+    
+    # For Broker submitter, return agent_fields + broker_form_fields
+    if submitter_role == 'Broker':
+        transforms = mapping.get('transforms', {})
+        
+        # 1. Add agent auto-fill fields
+        agent_field_configs = mapping.get('agent_fields', [])
+        if agent_data and agent_field_configs:
+            for config in agent_field_configs:
+                docuseal_name = config.get('docuseal_field')
+                source = config.get('source', '')
+                
+                if docuseal_name and source:
+                    parts = source.split('.')
+                    if len(parts) == 2 and parts[0] == 'agent':
+                        value = agent_data.get(parts[1], '')
+                        if value:
+                            fields.append({
+                                'name': docuseal_name,
+                                'default_value': str(value)
+                            })
+        elif agent_data and not agent_field_configs:
+            # Fallback standard agent fields
+            standard_agent_fields = [
+                ('Broker printed name', agent_data.get('name', '')),
+                ('Broker associate printed name', agent_data.get('name', '')),
+                ('Broker license number', agent_data.get('license_number', '')),
+                ('Broker associate license', agent_data.get('license_number', '')),
+                ('Broker email/fax', agent_data.get('email', '')),
+            ]
+            for docuseal_name, value in standard_agent_fields:
+                if value:
+                    fields.append({
+                        'name': docuseal_name,
+                        'default_value': str(value)
+                    })
+        
+        # 2. Add broker form fields (form data that goes to Broker submitter)
+        broker_form_fields = mapping.get('broker_form_fields', {})
+        for form_field, docuseal_field in broker_form_fields.items():
+            if not docuseal_field:
+                continue
+            if form_field in form_data and form_data[form_field]:
+                value = form_data[form_field]
+                transformed_value = _apply_transform(value, form_field, transforms)
+                if transformed_value:
+                    fields.append({
+                        'name': docuseal_field,
+                        'default_value': transformed_value
+                    })
+        
+        logger.info(f"Built {len(fields)} DocuSeal Broker fields")
+        return fields
+    
+    # For Seller submitter or no filter, return form-based fields
+    field_map = mapping.get('field_mappings', {})
+    transforms = mapping.get('transforms', {})
+    
+    # Map form fields to DocuSeal fields
+    for form_field, docuseal_field in field_map.items():
+        if not docuseal_field:
+            continue  # Skip fields mapped to null
+            
+        if form_field in form_data and form_data[form_field]:
+            value = form_data[form_field]
+            
+            # Apply transformation if needed
+            transformed_value = _apply_transform(value, form_field, transforms)
+            
+            if transformed_value:  # Only add non-empty values
+                fields.append({
+                    'name': docuseal_field,
+                    'default_value': transformed_value
+                })
+    
+    # Handle computed fields (fields that combine multiple form values)
+    computed_fields = mapping.get('computed_fields', [])
+    for computed in computed_fields:
+        docuseal_name = computed.get('docuseal_field')
+        template = computed.get('template', '')
+        
+        if docuseal_name and template:
+            try:
+                # Simple template substitution using format
+                computed_value = template.format(**form_data)
+                if computed_value and computed_value != template:  # Only add if substitution worked
+                    fields.append({
+                        'name': docuseal_name,
+                        'default_value': computed_value
+                    })
+            except KeyError:
+                pass  # Missing form field, skip this computed field
+    
+    # Add agent/broker fields if provided (only when not filtering for Seller)
+    if submitter_role != 'Seller':
+        agent_field_configs = mapping.get('agent_fields', [])
+        if agent_data and agent_field_configs:
+            for config in agent_field_configs:
+                docuseal_name = config.get('docuseal_field')
+                source = config.get('source', '')
+                
+                if docuseal_name and source:
+                    # Parse source like "agent.name" or "agent.license_number"
+                    parts = source.split('.')
+                    if len(parts) == 2 and parts[0] == 'agent':
+                        value = agent_data.get(parts[1], '')
+                        if value:
+                            fields.append({
+                                'name': docuseal_name,
+                                'default_value': str(value)
+                            })
+        
+        # Fallback: Add standard agent fields if no config specified
+        elif agent_data and not agent_field_configs:
+            standard_agent_fields = [
+                ('Broker printed name', agent_data.get('name', '')),
+                ('Broker associate printed name', agent_data.get('name', '')),
+                ('Broker license number', agent_data.get('license_number', '')),
+                ('Broker associate license', agent_data.get('license_number', '')),
+                ('Broker email/fax', agent_data.get('email', '')),
+            ]
+            for docuseal_name, value in standard_agent_fields:
+                if value:
+                    fields.append({
+                        'name': docuseal_name,
+                        'default_value': str(value)
+                    })
+    
+    role_label = f" for {submitter_role}" if submitter_role else ""
+    logger.info(f"Built {len(fields)} DocuSeal fields{role_label} from form data for {template_slug}")
+    return fields
+
 # Mock storage for development (in-memory)
 _mock_submissions = {}
 _mock_events = []
@@ -49,6 +348,14 @@ class DocuSealError(Exception):
     pass
 
 
+def _get_headers() -> Dict[str, str]:
+    """Get headers for DocuSeal API requests."""
+    return {
+        'X-Auth-Token': DOCUSEAL_API_KEY,
+        'Content-Type': 'application/json'
+    }
+
+
 def get_template_id(slug: str) -> Optional[int]:
     """Get DocuSeal template ID for a document slug."""
     return TEMPLATE_MAP.get(slug)
@@ -57,6 +364,60 @@ def get_template_id(slug: str) -> Optional[int]:
 def is_template_ready(slug: str) -> bool:
     """Check if a template has been uploaded to DocuSeal."""
     return TEMPLATE_MAP.get(slug) is not None
+
+
+# =============================================================================
+# TEMPLATE MANAGEMENT
+# =============================================================================
+
+def get_template(template_id: int) -> Dict[str, Any]:
+    """
+    Fetch template details from DocuSeal including all fields.
+    
+    Returns template info with:
+    - fields: List of field definitions (name, type, required, submitter_uuid)
+    - submitters: List of submitter roles (name, uuid)
+    - documents: List of attached documents
+    """
+    if DOCUSEAL_MOCK_MODE:
+        return _mock_get_template(template_id)
+    
+    try:
+        response = requests.get(
+            f"{DOCUSEAL_API_URL}/templates/{template_id}",
+            headers=_get_headers()
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error(f"DocuSeal get_template error: {e}")
+        raise DocuSealError(f"Failed to fetch template: {e}")
+
+
+def get_template_fields(template_id: int) -> List[Dict[str, Any]]:
+    """
+    Get just the fields from a template.
+    
+    Returns list of field dicts with:
+    - name: Field name (used for pre-filling)
+    - type: Field type (text, signature, date, checkbox, etc.)
+    - required: Whether field is required
+    - submitter_uuid: Which signer this field belongs to
+    """
+    template = get_template(template_id)
+    return template.get('fields', [])
+
+
+def get_template_submitters(template_id: int) -> List[Dict[str, Any]]:
+    """
+    Get the submitter roles defined in a template.
+    
+    Returns list of submitter dicts with:
+    - name: Role name (e.g., "Seller", "Listing Agent")
+    - uuid: Unique identifier for this role
+    """
+    template = get_template(template_id)
+    return template.get('submitters', [])
 
 
 # =============================================================================
@@ -75,8 +436,8 @@ def create_submission(
     
     Args:
         template_slug: Our internal template identifier
-        submitters: List of signers with role, email, name
-        field_values: Pre-filled field values
+        submitters: List of signers with role, email, name, and optional fields[]
+        field_values: Pre-filled field values (applied to all submitters if not in submitter.fields)
         send_email: Whether to send email invitations
         message: Custom email subject/body
     
@@ -86,30 +447,54 @@ def create_submission(
     if DOCUSEAL_MOCK_MODE:
         return _mock_create_submission(template_slug, submitters, field_values, send_email)
     
-    # Real API implementation
+    # Get template ID
     template_id = get_template_id(template_slug)
     if not template_id:
         raise DocuSealError(f"Template not configured for slug: {template_slug}")
     
-    # TODO: Implement real DocuSeal API call
-    # import requests
-    # response = requests.post(
-    #     f"{DOCUSEAL_API_URL}/submissions",
-    #     headers={
-    #         "X-Auth-Token": DOCUSEAL_API_KEY,
-    #         "Content-Type": "application/json"
-    #     },
-    #     json={
-    #         "template_id": template_id,
-    #         "send_email": send_email,
-    #         "submitters": submitters,
-    #         "fields": field_values or {},
-    #         "message": message
-    #     }
-    # )
-    # return response.json()
+    # Build the request payload
+    payload = {
+        "template_id": template_id,
+        "send_email": send_email,
+        "submitters": submitters
+    }
     
-    raise DocuSealError("Real API not implemented. Set DOCUSEAL_MOCK_MODE=True")
+    # Add custom message if provided
+    if message:
+        payload["message"] = message
+    
+    logger.info(f"Creating DocuSeal submission for template {template_id} ({template_slug})")
+    logger.debug(f"Submitters: {[s.get('email') for s in submitters]}")
+    
+    try:
+        response = requests.post(
+            f"{DOCUSEAL_API_URL}/submissions",
+            headers=_get_headers(),
+            json=payload
+        )
+        response.raise_for_status()
+        result = response.json()
+        
+        # DocuSeal returns a list of submitters, each with their own id and slug
+        # We need to normalize this to a dict with 'id' and 'submitters' keys
+        if isinstance(result, list):
+            # Get submission_id from first submitter (all share the same submission)
+            submission_id = result[0].get('submission_id') if result else None
+            normalized_result = {
+                'id': submission_id,
+                'submitters': result
+            }
+            logger.info(f"DocuSeal submission created: {submission_id} with {len(result)} submitters")
+            return normalized_result
+        
+        logger.info(f"DocuSeal submission created: {result.get('id')}")
+        return result
+        
+    except requests.exceptions.RequestException as e:
+        logger.error(f"DocuSeal create_submission error: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            logger.error(f"Response: {e.response.text}")
+        raise DocuSealError(f"Failed to create submission: {e}")
 
 
 def get_submission(submission_id: str) -> Dict[str, Any]:
@@ -117,8 +502,16 @@ def get_submission(submission_id: str) -> Dict[str, Any]:
     if DOCUSEAL_MOCK_MODE:
         return _mock_get_submission(submission_id)
     
-    # TODO: Real API call
-    raise DocuSealError("Real API not implemented")
+    try:
+        response = requests.get(
+            f"{DOCUSEAL_API_URL}/submissions/{submission_id}",
+            headers=_get_headers()
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error(f"DocuSeal get_submission error: {e}")
+        raise DocuSealError(f"Failed to get submission: {e}")
 
 
 def get_submission_status(submission_id: str) -> str:
@@ -129,6 +522,99 @@ def get_submission_status(submission_id: str) -> str:
     """
     submission = get_submission(submission_id)
     return submission.get('status', 'pending')
+
+
+def resend_signature_emails(submission_id: str, submitter_ids: List[int] = None, message: Dict[str, str] = None) -> Dict[str, Any]:
+    """
+    Resend signature request emails to submitters who haven't completed signing.
+    
+    Uses the DocuSeal Update Submitter API with send_email=true.
+    
+    Args:
+        submission_id: The DocuSeal submission ID
+        submitter_ids: Optional list of specific submitter IDs to resend to.
+                      If None, resends to all pending submitters.
+        message: Optional custom message with 'subject' and 'body' keys.
+                Body can include {{submitter.link}} for the signing link.
+    
+    Returns:
+        Dict with 'success', 'resent_count', and 'submitters' list
+    """
+    if DOCUSEAL_MOCK_MODE:
+        return {
+            'success': True,
+            'resent_count': 1,
+            'submitters': [{'id': 1, 'email': 'mock@example.com', 'status': 'sent'}],
+            'message': 'Emails resent (mock mode)'
+        }
+    
+    try:
+        # Get current submission to find pending submitters
+        submission = get_submission(submission_id)
+        submitters = submission.get('submitters', [])
+        
+        resent = []
+        for submitter in submitters:
+            # Skip if submitter already completed
+            if submitter.get('status') == 'completed':
+                continue
+            
+            # Skip if we're targeting specific submitter IDs and this isn't one
+            if submitter_ids and submitter.get('id') not in submitter_ids:
+                continue
+            
+            submitter_id = submitter.get('id')
+            if not submitter_id:
+                continue
+            
+            # Build update payload
+            update_payload = {
+                'send_email': True
+            }
+            
+            # Add custom message if provided
+            if message:
+                update_payload['message'] = {
+                    'subject': message.get('subject', 'Reminder: Document Ready for Signature'),
+                    'body': message.get('body', 'Please sign the document at your earliest convenience. Click here to sign: {{submitter.link}}')
+                }
+            
+            # Call the Update Submitter API
+            headers = {
+                'X-Auth-Token': DOCUSEAL_API_KEY,
+                'Content-Type': 'application/json'
+            }
+            
+            response = requests.put(
+                f"{DOCUSEAL_API_URL}/submitters/{submitter_id}",
+                headers=headers,
+                json=update_payload
+            )
+            response.raise_for_status()
+            
+            result = response.json()
+            resent.append({
+                'id': result.get('id'),
+                'email': result.get('email'),
+                'name': result.get('name'),
+                'status': result.get('status'),
+                'sent_at': result.get('sent_at')
+            })
+            
+            logger.info(f"Resent signature email to submitter {submitter_id}: {result.get('email')}")
+        
+        return {
+            'success': True,
+            'resent_count': len(resent),
+            'submitters': resent,
+            'message': f'Successfully resent emails to {len(resent)} submitter(s)'
+        }
+        
+    except requests.RequestException as e:
+        logger.error(f"DocuSeal resend_signature_emails error: {e}")
+        if hasattr(e, 'response') and e.response is not None:
+            logger.error(f"Response: {e.response.text}")
+        raise DocuSealError(f"Failed to resend signature emails: {e}")
 
 
 def get_signing_url(submission_id: str, submitter_slug: str) -> str:
@@ -155,21 +641,44 @@ def get_signed_document_urls(submission_id: str) -> List[Dict[str, str]]:
     if DOCUSEAL_MOCK_MODE:
         return _mock_get_signed_documents(submission_id)
     
-    # TODO: Real API call
-    raise DocuSealError("Real API not implemented")
+    try:
+        submission = get_submission(submission_id)
+        documents = []
+        
+        # Extract document URLs from submission
+        for doc in submission.get('documents', []):
+            documents.append({
+                'name': doc.get('filename', 'document.pdf'),
+                'url': doc.get('url', '')
+            })
+        
+        return documents
+    except Exception as e:
+        logger.error(f"DocuSeal get_signed_document_urls error: {e}")
+        raise DocuSealError(f"Failed to get signed documents: {e}")
 
 
 # =============================================================================
-# TEMPLATE MANAGEMENT
+# TEMPLATE LISTING
 # =============================================================================
 
-def list_templates() -> List[Dict[str, Any]]:
+def list_templates(limit: int = 100) -> List[Dict[str, Any]]:
     """List all templates in DocuSeal account."""
     if DOCUSEAL_MOCK_MODE:
         return _mock_list_templates()
     
-    # TODO: Real API call
-    raise DocuSealError("Real API not implemented")
+    try:
+        response = requests.get(
+            f"{DOCUSEAL_API_URL}/templates",
+            headers=_get_headers(),
+            params={'limit': limit}
+        )
+        response.raise_for_status()
+        result = response.json()
+        return result.get('data', [])
+    except requests.exceptions.RequestException as e:
+        logger.error(f"DocuSeal list_templates error: {e}")
+        raise DocuSealError(f"Failed to list templates: {e}")
 
 
 def upload_template(file_path: str, name: str) -> Dict[str, Any]:
@@ -182,8 +691,8 @@ def upload_template(file_path: str, name: str) -> Dict[str, Any]:
     if DOCUSEAL_MOCK_MODE:
         return _mock_upload_template(name)
     
-    # TODO: Real API call with multipart form data
-    raise DocuSealError("Real API not implemented")
+    # Real implementation would use multipart form upload
+    raise DocuSealError("Template upload should be done via DocuSeal web interface")
 
 
 # =============================================================================
@@ -294,6 +803,25 @@ def _mock_list_templates() -> List[Dict[str, Any]]:
     ]
 
 
+def _mock_get_template(template_id: int) -> Dict[str, Any]:
+    """Mock implementation of get_template."""
+    return {
+        'id': template_id,
+        'name': 'Listing Agreement',
+        'fields': [
+            {'uuid': 'f1', 'name': 'Seller Name', 'type': 'text', 'required': True},
+            {'uuid': 'f2', 'name': 'Property Address', 'type': 'text', 'required': True},
+            {'uuid': 'f3', 'name': 'Listing Price', 'type': 'text', 'required': True},
+            {'uuid': 'f4', 'name': 'Seller Signature', 'type': 'signature', 'required': True},
+        ],
+        'submitters': [
+            {'name': 'Seller', 'uuid': 's1'},
+            {'name': 'Listing Agent', 'uuid': 's2'},
+        ],
+        'documents': []
+    }
+
+
 def _mock_upload_template(name: str) -> Dict[str, Any]:
     """Mock implementation of upload_template."""
     return {
@@ -370,21 +898,14 @@ def build_submitters_from_participants(participants, transaction) -> List[Dict[s
             })
             break
     
-    # Get co-seller if exists
-    for p in participants:
-        if p.role == 'co_seller':
-            submitters.append({
-                'role': 'Co-Seller',
-                'email': p.display_email,
-                'name': p.display_name
-            })
-            break
+    # NOTE: Co-seller would need a separate DocuSeal template role
+    # For now, only primary seller signs as "Seller"
     
-    # Get listing agent
+    # Get listing agent - maps to "Broker" in DocuSeal
     for p in participants:
         if p.role == 'listing_agent':
             submitters.append({
-                'role': 'Listing Agent',
+                'role': 'Broker',  # DocuSeal uses "Broker" not "Listing Agent"
                 'email': p.display_email,
                 'name': p.display_name
             })

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -448,6 +448,16 @@
                                             <i class="fas fa-clock w-5"></i>
                                             <span class="ml-2">Check Status</span>
                                         </button>
+                                        <button onclick="resendDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-green-600 hover:bg-green-50 transition-colors">
+                                            <i class="fas fa-envelope w-5"></i>
+                                            <span class="ml-2">Resend Email</span>
+                                        </button>
+                                        <button onclick="voidDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-amber-600 hover:bg-amber-50 transition-colors">
+                                            <i class="fas fa-undo w-5"></i>
+                                            <span class="ml-2">Void & Re-edit</span>
+                                        </button>
                                         <button onclick="simulateSignature({{ doc.id }})" 
                                                 class="w-full flex items-center px-4 py-2.5 text-sm text-orange-600 hover:bg-orange-50 transition-colors">
                                             <i class="fas fa-magic w-5"></i>
@@ -1034,6 +1044,47 @@ function checkSignatureStatus(docId) {
             showToast('Error: ' + data.error, 'error');
         }
     });
+}
+
+function voidDocument(docId) {
+    if (!confirm('Void this document? This will clear the current signature request and allow you to edit and resend.')) return;
+    
+    showToast('Voiding document...', 'info');
+    
+    fetch(`/transactions/${transactionId}/documents/${docId}/void`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.success) {
+            showToast('Document voided! You can now edit and resend.', 'success');
+            setTimeout(() => location.reload(), 1500);
+        } else {
+            showToast('Error: ' + data.error, 'error');
+        }
+    })
+    .catch(err => showToast('Error: ' + err.message, 'error'));
+}
+
+function resendDocument(docId) {
+    if (!confirm('Resend signature request emails to signers who haven\'t completed signing?')) return;
+    
+    showToast('Resending emails...', 'info');
+    
+    fetch(`/transactions/${transactionId}/documents/${docId}/resend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.success) {
+            showToast(`Reminder emails sent to ${data.resent_count} signer(s)!`, 'success');
+        } else {
+            showToast('Error: ' + data.error, 'error');
+        }
+    })
+    .catch(err => showToast('Error: ' + err.message, 'error'));
 }
 
 function simulateSignature(docId) {

--- a/templates/transactions/document_preview.html
+++ b/templates/transactions/document_preview.html
@@ -1,0 +1,309 @@
+{% extends "base.html" %}
+
+{% block title %}Preview: {{ document.template_name }} - {{ transaction.street_address }}{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+    <!-- Header -->
+    <div class="bg-white border-b border-slate-200 sticky top-0 z-40">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <!-- Back button and title -->
+                <div class="flex items-center gap-4">
+                    <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
+                       class="flex items-center gap-2 text-slate-600 hover:text-slate-800 transition-colors">
+                        <i class="fas fa-arrow-left"></i>
+                        <span class="hidden sm:inline">Back to Form</span>
+                    </a>
+                    <div class="h-6 w-px bg-slate-200"></div>
+                    <div>
+                        <h1 class="text-lg font-semibold text-slate-800">{{ document.template_name }}</h1>
+                        <p class="text-xs text-slate-500">{{ transaction.street_address }}</p>
+                    </div>
+                </div>
+                
+                <!-- Action buttons -->
+                <div class="flex items-center gap-3">
+                    <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
+                       class="px-4 py-2 text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors flex items-center gap-2">
+                        <i class="fas fa-edit"></i>
+                        Edit Form
+                    </a>
+                    <button onclick="confirmAndSend()" 
+                            class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all flex items-center gap-2">
+                        <i class="fas fa-paper-plane"></i>
+                        Send for Signature
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Preview info banner -->
+    <div class="bg-blue-50 border-b border-blue-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center gap-3 text-blue-800">
+                <i class="fas fa-eye text-blue-500"></i>
+                <p class="text-sm">
+                    <strong>Preview Mode:</strong> 
+                    Review the document below. When ready, click "Send for Signature" to email it to signers.
+                    {% if mock_mode %}
+                    <span class="ml-2 px-2 py-0.5 text-xs bg-amber-100 text-amber-700 rounded-full">Test Mode</span>
+                    {% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
+    
+    <!-- DocuSeal Embed Container -->
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div class="bg-white rounded-2xl shadow-lg border border-slate-200 overflow-hidden">
+            <!-- Document preview header -->
+            <div class="bg-slate-50 border-b border-slate-200 px-6 py-4">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-xl bg-orange-100 flex items-center justify-center">
+                            <i class="fas fa-file-signature text-orange-600"></i>
+                        </div>
+                        <div>
+                            <h2 class="font-semibold text-slate-800">{{ document.template_name }}</h2>
+                            <p class="text-xs text-slate-500">Scroll through to review all pages</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2 text-sm text-slate-500">
+                        <i class="fas fa-info-circle"></i>
+                        <span>Fields are pre-filled from your form</span>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- DocuSeal Form Embed -->
+            <div id="docuseal-container" class="relative" style="min-height: 800px;">
+                {% if mock_mode %}
+                <!-- Mock mode placeholder -->
+                <div class="absolute inset-0 flex items-center justify-center bg-slate-50">
+                    <div class="text-center p-8">
+                        <div class="w-20 h-20 rounded-full bg-amber-100 flex items-center justify-center mx-auto mb-4">
+                            <i class="fas fa-file-alt text-4xl text-amber-500"></i>
+                        </div>
+                        <h3 class="text-xl font-semibold text-slate-800 mb-2">Mock Preview Mode</h3>
+                        <p class="text-slate-600 max-w-md mb-6">
+                            DocuSeal is running in test mode. In production, the actual document would be displayed here 
+                            with all your filled-in data.
+                        </p>
+                        <div class="bg-white rounded-xl border border-slate-200 p-6 max-w-sm mx-auto text-left">
+                            <h4 class="font-medium text-slate-700 mb-3">Document Summary:</h4>
+                            <ul class="space-y-2 text-sm text-slate-600">
+                                <li class="flex items-center gap-2">
+                                    <i class="fas fa-check-circle text-green-500"></i>
+                                    Form data saved
+                                </li>
+                                <li class="flex items-center gap-2">
+                                    <i class="fas fa-check-circle text-green-500"></i>
+                                    Ready for signature
+                                </li>
+                                <li class="flex items-center gap-2">
+                                    <i class="fas fa-user text-blue-500"></i>
+                                    Template: {{ document.template_name }}
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                {% else %}
+                <!-- Real DocuSeal embed -->
+                <script src="https://cdn.docuseal.com/js/form.js"></script>
+                <docuseal-form
+                    id="docusealPreviewForm"
+                    data-src="{{ embed_src }}"
+                    data-preview="true">
+                    <style>
+                        /* Hide the submit button for preview - agent shouldn't complete here */
+                        .submit-form-button { display: none !important; }
+                        .completed-form { display: none !important; }
+                        /* Make the form read-only looking */
+                        .form-container { pointer-events: auto; }
+                    </style>
+                </docuseal-form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    
+    <!-- Floating action bar for mobile -->
+    <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 p-4 sm:hidden z-50">
+        <div class="flex gap-3">
+            <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
+               class="flex-1 px-4 py-3 text-center text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors">
+                <i class="fas fa-edit mr-2"></i>Edit
+            </a>
+            <button onclick="confirmAndSend()" 
+                    class="flex-1 px-4 py-3 text-center text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all">
+                <i class="fas fa-paper-plane mr-2"></i>Send
+            </button>
+        </div>
+    </div>
+    
+    <!-- Add padding for mobile action bar -->
+    <div class="h-20 sm:hidden"></div>
+</div>
+
+<!-- Confirmation Modal -->
+<div id="sendModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" onclick="closeModal()"></div>
+    <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 relative animate-fade-in-up">
+            <button onclick="closeModal()" class="absolute top-4 right-4 text-slate-400 hover:text-slate-600">
+                <i class="fas fa-times"></i>
+            </button>
+            
+            <div class="text-center mb-6">
+                <div class="w-16 h-16 rounded-full bg-orange-100 flex items-center justify-center mx-auto mb-4">
+                    <i class="fas fa-paper-plane text-2xl text-orange-600"></i>
+                </div>
+                <h3 class="text-xl font-bold text-slate-800">Send for Signature?</h3>
+                <p class="text-slate-600 mt-2">
+                    This will send the document to all signers via email. They will receive a link to review and sign.
+                </p>
+            </div>
+            
+            <!-- Signers list -->
+            <div class="bg-slate-50 rounded-xl p-4 mb-6">
+                <h4 class="text-sm font-medium text-slate-700 mb-3">Signers:</h4>
+                <div id="signersList" class="space-y-2">
+                    <!-- Populated by JS -->
+                </div>
+            </div>
+            
+            <div class="flex gap-3">
+                <button onclick="closeModal()" 
+                        class="flex-1 px-4 py-3 text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors">
+                    Cancel
+                </button>
+                <button onclick="sendForSignature()" 
+                        id="confirmSendBtn"
+                        class="flex-1 px-4 py-3 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all flex items-center justify-center gap-2">
+                    <i class="fas fa-paper-plane"></i>
+                    Send Now
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+@keyframes fade-in-up {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+.animate-fade-in-up {
+    animation: fade-in-up 0.3s ease-out forwards;
+}
+</style>
+
+<script>
+const transactionId = {{ transaction.id }};
+const documentId = {{ document.id }};
+
+function confirmAndSend() {
+    // Show modal with signer info
+    const modal = document.getElementById('sendModal');
+    const signersList = document.getElementById('signersList');
+    
+    // Fetch signers from transaction participants
+    fetch(`/transactions/api/${transactionId}/signers`)
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.signers && data.signers.length > 0) {
+                signersList.innerHTML = data.signers.map(s => `
+                    <div class="flex items-center gap-3 text-sm">
+                        <div class="w-8 h-8 rounded-full bg-slate-200 flex items-center justify-center">
+                            <i class="fas fa-user text-slate-500"></i>
+                        </div>
+                        <div>
+                            <div class="font-medium text-slate-800">${s.name}</div>
+                            <div class="text-slate-500">${s.email} • ${s.role}</div>
+                        </div>
+                    </div>
+                `).join('');
+            } else {
+                signersList.innerHTML = `
+                    <div class="text-sm text-amber-600">
+                        <i class="fas fa-exclamation-triangle mr-2"></i>
+                        No signers found. Add participants with email addresses.
+                    </div>
+                `;
+            }
+        })
+        .catch(() => {
+            signersList.innerHTML = `
+                <div class="text-sm text-slate-500">
+                    Loading signers...
+                </div>
+            `;
+        });
+    
+    modal.classList.remove('hidden');
+}
+
+function closeModal() {
+    document.getElementById('sendModal').classList.add('hidden');
+}
+
+function sendForSignature() {
+    const btn = document.getElementById('confirmSendBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Sending...';
+    
+    fetch(`/transactions/${transactionId}/documents/${documentId}/send`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(resp => resp.json())
+    .then(data => {
+        if (data.success) {
+            // Show success and redirect
+            closeModal();
+            showToast('Document sent for signature!', 'success');
+            setTimeout(() => {
+                window.location.href = `/transactions/${transactionId}`;
+            }, 1500);
+        } else {
+            showToast(data.error || 'Failed to send document', 'error');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-paper-plane"></i> Send Now';
+        }
+    })
+    .catch(err => {
+        showToast('Network error. Please try again.', 'error');
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fas fa-paper-plane"></i> Send Now';
+    });
+}
+
+function showToast(message, type) {
+    // Simple toast notification
+    const toast = document.createElement('div');
+    toast.className = `fixed bottom-24 sm:bottom-6 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
+        type === 'success' ? 'bg-green-600 text-white' : 
+        type === 'error' ? 'bg-red-600 text-white' : 
+        'bg-slate-800 text-white'
+    }`;
+    toast.innerHTML = `
+        <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
+        <span>${message}</span>
+    `;
+    document.body.appendChild(toast);
+    
+    setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateY(20px)';
+        toast.style.transition = 'all 0.3s ease-out';
+        setTimeout(() => toast.remove(), 300);
+    }, 3000);
+}
+</script>
+{% endblock %}
+

--- a/templates/transactions/listing_agreement_form.html
+++ b/templates/transactions/listing_agreement_form.html
@@ -1296,7 +1296,7 @@
                 Cancel
             </a>
             <div class="w-px h-8 bg-slate-200"></div>
-            <button type="submit" form="listingAgreementForm" name="action" value="save" 
+            <button type="submit" form="listingAgreementForm" name="submit_action" value="save" 
                     class="premium-btn px-5 py-2.5 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg flex items-center gap-2 transition-colors">
                 <i class="fas fa-save text-slate-500"></i>
                 Save Draft
@@ -1588,10 +1588,11 @@ function saveAndPreview() {
     })
     .then(response => {
         if (response.ok) {
-            showToast('Document saved successfully!', 'success');
+            showToast('Opening preview...', 'success');
             setTimeout(() => {
-                window.location.href = "{{ url_for('transactions.view_transaction', id=transaction.id) }}";
-            }, 1500);
+                // Redirect to preview page instead of transaction view
+                window.location.href = "{{ url_for('transactions.document_preview', id=transaction.id, doc_id=document.id) }}";
+            }, 500);
         } else {
             showToast('Error saving form. Please try again.', 'error');
         }


### PR DESCRIPTION
- Add document preview page with DocuSeal embed before sending
- Implement field mapping from YAML files (docuseal_mappings/)
- Send documents for signature with proper submitter role assignment
- Add void & re-edit feature to cancel and restart signature flow
- Add resend email feature using DocuSeal Update Submitter API
- Fix submitter field assignment (Seller vs Broker fields)
- Include signing link in email body with {{submitter.link}}
- Add PyYAML dependency for field mapping configuration