### PR TITLE
fix: include 'generated' status in send_all_for_signature filter

### DIFF
--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -1213,11 +1213,11 @@ def send_all_for_signature(id):
     if transaction.created_by_id != current_user.id:
         abort(403)
     
-    # Get documents with specialized forms that are filled
+    # Get documents with specialized forms that are filled or generated (previewed)
     specialized_slugs = get_specialized_slugs()
     documents = transaction.documents.filter(
         TransactionDocument.template_slug.in_(specialized_slugs),
-        TransactionDocument.status.in_(['filled', 'draft'])
+        TransactionDocument.status.in_(['filled', 'draft', 'generated'])
     ).order_by(TransactionDocument.created_at).all()
     
     if not documents:

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -1198,12 +1198,13 @@ def preview_all_documents(id):
 @transactions_required
 def send_all_for_signature(id):
     """
-    Send all filled documents as a single envelope to DocuSeal.
-    Creates a combined submission with all documents.
+    Send all filled documents for signature.
+    Each document is sent as a separate submission to handle different submitter roles.
     """
     from services.docuseal_service import (
-        create_multi_doc_submission,
+        create_submission,
         build_docuseal_fields,
+        get_template_submitter_roles,
         DocuSealError,
         DOCUSEAL_MOCK_MODE
     )
@@ -1227,109 +1228,152 @@ def send_all_for_signature(id):
     # Get participants
     participants = transaction.participants.all()
     
-    # Build submitters list
-    submitters = []
-    
-    # Primary seller
+    # Get key participants
     seller = next((p for p in participants if p.role == 'seller' and p.is_primary), None)
-    if seller and seller.display_email:
-        submitters.append({
-            'role': 'Seller',
-            'email': seller.display_email,
-            'name': seller.display_name
-        })
-    
-    # Listing agent as Broker
     listing_agent = next((p for p in participants if p.role == 'listing_agent'), None)
-    if listing_agent and listing_agent.display_email:
-        submitters.append({
-            'role': 'Broker',
-            'email': listing_agent.display_email,
-            'name': listing_agent.display_name
-        })
+    buyer = next((p for p in participants if p.role == 'buyer' and p.is_primary), None)
     
-    if not submitters:
-        flash('No signers found. Please ensure seller and agent have email addresses.', 'error')
+    if not seller or not seller.display_email:
+        flash('No seller with email found. Please add seller contact information.', 'error')
         return redirect(url_for('transactions.preview_all_documents', id=id))
     
     # Build agent data for field population
     agent_data = {
         'name': f"{current_user.first_name} {current_user.last_name}",
         'email': current_user.email,
-        'license_number': getattr(current_user, 'license_number', ''),
-        'phone': getattr(current_user, 'phone', '')
+        'license_number': getattr(current_user, 'license_number', '') or '',
+        'phone': getattr(current_user, 'phone', '') or ''
     }
     
-    # Build documents list for multi-doc submission
-    doc_list = []
-    for doc in documents:
-        doc_list.append({
-            'template_slug': doc.template_slug,
-            'template_name': doc.template_name,
-            'field_data': doc.field_data or {},
-            'agent_data': agent_data
-        })
+    sent_count = 0
+    errors = []
     
-    try:
-        # Create combined submission
-        result = create_multi_doc_submission(
-            documents=doc_list,
-            submitters=submitters,
-            transaction_id=transaction.id,
-            send_email=True,
-            message={
-                'subject': f'Documents Ready for Signature - {transaction.street_address}',
-                'body': f'Please review and sign the documents for {transaction.full_address}. Click here to sign: {{{{submitter.link}}}}'
-            }
-        )
-        
-        submission_id = result.get('id')
-        
-        # Update all documents with the combined submission ID
-        for i, doc in enumerate(documents):
+    for doc in documents:
+        try:
+            # Get the roles this template needs
+            template_roles = get_template_submitter_roles(doc.template_slug)
+            
+            # Build submitters based on template's required roles
+            doc_submitters = []
+            
+            if 'Seller' in template_roles and seller and seller.display_email:
+                seller_fields = build_docuseal_fields(
+                    doc.field_data or {},
+                    doc.template_slug,
+                    agent_data=None,
+                    submitter_role='Seller'
+                )
+                doc_submitters.append({
+                    'role': 'Seller',
+                    'email': seller.display_email,
+                    'name': seller.display_name,
+                    'fields': seller_fields
+                })
+            
+            if 'Broker' in template_roles:
+                broker_email = listing_agent.display_email if listing_agent else current_user.email
+                broker_name = listing_agent.display_name if listing_agent else f"{current_user.first_name} {current_user.last_name}"
+                broker_fields = build_docuseal_fields(
+                    doc.field_data or {},
+                    doc.template_slug,
+                    agent_data,
+                    submitter_role='Broker'
+                )
+                doc_submitters.append({
+                    'role': 'Broker',
+                    'email': broker_email,
+                    'name': broker_name,
+                    'fields': broker_fields
+                })
+            
+            if 'Buyer' in template_roles:
+                # For seller documents with Buyer role (like HOA addendum), 
+                # use listing agent as placeholder if no buyer exists yet
+                buyer_email = buyer.display_email if buyer and buyer.display_email else current_user.email
+                buyer_name = buyer.display_name if buyer and buyer.display_name else f"{current_user.first_name} {current_user.last_name}"
+                buyer_fields = build_docuseal_fields(
+                    doc.field_data or {},
+                    doc.template_slug,
+                    agent_data=None,
+                    submitter_role='Buyer'
+                )
+                doc_submitters.append({
+                    'role': 'Buyer',
+                    'email': buyer_email,
+                    'name': buyer_name,
+                    'fields': buyer_fields
+                })
+            
+            if not doc_submitters:
+                errors.append(f"{doc.template_name}: No valid submitters found")
+                continue
+            
+            # Create submission for this document
+            result = create_submission(
+                template_slug=doc.template_slug,
+                submitters=doc_submitters,
+                field_values=None,  # Fields are in submitters
+                send_email=True,
+                message={
+                    'subject': f'{doc.template_name} Ready for Signature - {transaction.street_address}',
+                    'body': f'Please review and sign {doc.template_name} for {transaction.full_address}. Click here to sign: {{{{submitter.link}}}}'
+                }
+            )
+            
+            submission_id = result.get('id')
+            
+            # Update document
             doc.status = 'sent'
             doc.docuseal_submission_id = str(submission_id)
             doc.sent_at = datetime.utcnow()
             
-            # Create signature records for each signer on each document
+            # Create signature records
             for submitter_data in result.get('submitters', []):
                 # Find matching participant
                 participant = None
-                if submitter_data.get('role') == 'Seller':
-                    participant = next((p for p in participants if p.role == 'seller' and p.is_primary), None)
-                elif submitter_data.get('role') == 'Broker':
-                    participant = next((p for p in participants if p.role == 'listing_agent'), None)
+                role = submitter_data.get('role')
+                if role == 'Seller':
+                    participant = seller
+                elif role == 'Broker':
+                    participant = listing_agent
+                elif role == 'Buyer':
+                    participant = buyer
                 
                 signature = DocumentSignature(
                     document_id=doc.id,
                     participant_id=participant.id if participant else None,
                     signer_email=submitter_data.get('email', ''),
                     signer_name=submitter_data.get('name', ''),
-                    signer_role=submitter_data.get('role', 'Signer'),
+                    signer_role=role or 'Signer',
                     status='sent',
                     docuseal_submitter_slug=submitter_data.get('slug', ''),
                     sent_at=datetime.utcnow()
                 )
                 db.session.add(signature)
-        
-        db.session.commit()
-        
-        doc_count = len(documents)
-        signer_count = len(submitters)
-        
+            
+            sent_count += 1
+            
+        except DocuSealError as e:
+            errors.append(f"{doc.template_name}: {str(e)}")
+        except Exception as e:
+            errors.append(f"{doc.template_name}: Unexpected error - {str(e)}")
+    
+    db.session.commit()
+    
+    # Flash results
+    if sent_count > 0:
         if DOCUSEAL_MOCK_MODE:
-            flash(f'[MOCK MODE] {doc_count} document(s) sent as one envelope to {signer_count} signer(s). Submission ID: {submission_id}', 'success')
+            flash(f'[MOCK MODE] {sent_count} document(s) sent for signature!', 'success')
         else:
-            flash(f'{doc_count} document(s) sent as one envelope to {signer_count} signer(s) for signature!', 'success')
-        
+            flash(f'{sent_count} document(s) sent for signature!', 'success')
+    
+    if errors:
+        for error in errors:
+            flash(f'Error: {error}', 'error')
+    
+    if sent_count > 0:
         return redirect(url_for('transactions.view_transaction', id=id))
-        
-    except DocuSealError as e:
-        flash(f'Error sending documents: {str(e)}', 'error')
-        return redirect(url_for('transactions.preview_all_documents', id=id))
-    except Exception as e:
-        db.session.rollback()
-        flash(f'Unexpected error: {str(e)}', 'error')
+    else:
         return redirect(url_for('transactions.preview_all_documents', id=id))
 
 


### PR DESCRIPTION
After preview, documents have status='generated'. The send_all function was filtering only for 'filled' and 'draft', causing 'no docs generated' error even when documents were previewed and ready.