### PR TITLE
feat: listing form improvements and transaction UI enhancements

### DIFF
--- a/docuseal_mappings/listing-agreement.yml
+++ b/docuseal_mappings/listing-agreement.yml
@@ -82,8 +82,7 @@ field_mappings:
   # SECTION 5: BROKER COMPENSATION
   # ---------------------------------------------------------------------------
   offer_buyer_agent_comp: "Broker comp method"  # Radio: "percent" or "flat"
-  total_commission_percent: "Commission percent"
-  total_commission_flat: "Flat fee amount"
+  total_commission: "Total commission"  # Free form text: e.g., "6%", "$5,000", or "$5,000 + 3%"
   buyer_agent_percent: "Compensation percent"
   buyer_agent_flat: "Compensation flat fee"
   
@@ -179,9 +178,12 @@ transforms:
   # Currency fields - will have commas/$ stripped
   currency_fields:
     - list_price
-    - total_commission_flat
     - buyer_agent_flat
     - listing_only_flat
+  
+  # Free form text fields (not processed as currency)
+  freeform_fields:
+    - total_commission
 
   # Date fields - will be converted to MM/DD/YYYY
   date_fields:

--- a/models.py
+++ b/models.py
@@ -407,8 +407,8 @@ class Transaction(db.Model):
     ownership_status = db.Column(db.String(50))
     
     # Transaction status
-    # Values: draft, active, pending, under_contract, closed, cancelled
-    status = db.Column(db.String(50), default='draft')
+    # Values: preparing_to_list, active, under_contract, closed, cancelled
+    status = db.Column(db.String(50), default='preparing_to_list')
     
     # Key dates
     expected_close_date = db.Column(db.Date)
@@ -498,6 +498,15 @@ class TransactionParticipant(db.Model):
         if self.user and self.user.email:
             return self.user.email
         return self.email
+    
+    @property
+    def display_phone(self):
+        """Get phone from contact, user, or phone field."""
+        if self.contact and self.contact.phone:
+            return self.contact.phone
+        if self.user and self.user.phone:
+            return self.user.phone
+        return self.phone
     
     def __repr__(self):
         return f'<TransactionParticipant {self.role}: {self.display_name}>'

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -179,7 +179,7 @@ def create_transaction():
             zip_code=zip_code,
             county=county,
             ownership_status=ownership_status,
-            status='draft'
+            status='preparing_to_list'
         )
         db.session.add(transaction)
         db.session.flush()  # Get the transaction ID
@@ -521,7 +521,7 @@ def update_status(id):
     data = request.get_json()
     new_status = data.get('status')
     
-    valid_statuses = ['draft', 'active', 'pending', 'under_contract', 'closed', 'cancelled']
+    valid_statuses = ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled']
     if new_status not in valid_statuses:
         return jsonify({'success': False, 'error': 'Invalid status'}), 400
     

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -42,20 +42,20 @@
     /* Status dropdown styling */
     .status-dropdown {
         position: relative;
-        z-index: 100;
+        z-index: 1000;
     }
 
     .status-dropdown-menu {
         position: absolute;
         top: 100%;
-        right: 0;
+        left: 0;
         margin-top: 0.5rem;
         background: white;
         border-radius: 0.75rem;
         box-shadow: 0 10px 40px rgba(0,0,0,0.15);
         border: 1px solid #e2e8f0;
-        z-index: 100;
-        min-width: 180px;
+        z-index: 1001;
+        min-width: 200px;
         opacity: 0;
         visibility: hidden;
         transform: translateY(-10px);
@@ -92,12 +92,10 @@
         transition: all 0.2s ease-out;
     }
 
-    .status-draft { background: #f1f5f9; color: #64748b; }
-    .status-draft:hover { background: #e2e8f0; }
+    .status-preparing_to_list { background: #fef3c7; color: #92400e; }
+    .status-preparing_to_list:hover { background: #fde68a; }
     .status-active { background: #dcfce7; color: #166534; }
     .status-active:hover { background: #bbf7d0; }
-    .status-pending { background: #fef3c7; color: #92400e; }
-    .status-pending:hover { background: #fde68a; }
     .status-under_contract { background: #dbeafe; color: #1e40af; }
     .status-under_contract:hover { background: #bfdbfe; }
     .status-closed { background: #e0e7ff; color: #3730a3; }
@@ -157,6 +155,111 @@
         font-size: 0.875rem;
         text-align: right;
     }
+
+    /* Pizza Tracker Styles */
+    .status-tracker {
+        display: flex;
+        justify-content: space-between;
+        position: relative;
+        padding: 0;
+    }
+    
+    .status-tracker::before {
+        content: '';
+        position: absolute;
+        top: 20px;
+        left: 0;
+        right: 0;
+        height: 4px;
+        background: #e2e8f0;
+        z-index: 0;
+    }
+    
+    .status-tracker-progress {
+        position: absolute;
+        top: 20px;
+        left: 0;
+        height: 4px;
+        background: linear-gradient(90deg, #f97316, #ea580c);
+        z-index: 1;
+        transition: width 0.5s ease-out;
+        border-radius: 2px;
+    }
+    
+    .tracker-step {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        position: relative;
+        z-index: 2;
+        flex: 1;
+    }
+    
+    .tracker-dot {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.875rem;
+        font-weight: 600;
+        transition: all 0.3s ease-out;
+        border: 3px solid white;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    
+    .tracker-dot.completed {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: white;
+    }
+    
+    .tracker-dot.current {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: white;
+        box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2), 0 2px 8px rgba(0,0,0,0.15);
+        animation: pulse-tracker 2s infinite;
+    }
+    
+    .tracker-dot.upcoming {
+        background: #f1f5f9;
+        color: #94a3b8;
+    }
+    
+    .tracker-dot.cancelled {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: white;
+    }
+    
+    @keyframes pulse-tracker {
+        0%, 100% { box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2), 0 2px 8px rgba(0,0,0,0.15); }
+        50% { box-shadow: 0 0 0 8px rgba(249, 115, 22, 0.1), 0 2px 8px rgba(0,0,0,0.15); }
+    }
+    
+    .tracker-label {
+        margin-top: 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-align: center;
+        max-width: 80px;
+    }
+    
+    .tracker-label.completed { color: #16a34a; }
+    .tracker-label.current { color: #ea580c; }
+    .tracker-label.upcoming { color: #94a3b8; }
+    .tracker-label.cancelled { color: #dc2626; }
+
+    /* Prominent header badge */
+    .prominent-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1.25rem;
+        border-radius: 1rem;
+        font-weight: 700;
+        font-size: 0.875rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
 </style>
 
 <!-- Premium gradient background -->
@@ -178,7 +281,7 @@
         {% endif %}
         
         <!-- Header Section -->
-        <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-6 animate-fade-in-up relative z-50">
+        <div class="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4 mb-4 animate-fade-in-up relative z-50">
             <div class="flex items-start space-x-4">
                 <!-- Property Icon -->
                 <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-500 to-orange-600 items-center justify-center shadow-lg flex-shrink-0">
@@ -193,38 +296,107 @@
                 </div>
             </div>
             
-            <!-- Badges & Actions -->
-            <div class="flex flex-wrap items-center gap-3">
-                <!-- Type Badge -->
-                <span class="type-badge type-{{ transaction.transaction_type.name }}">
-                    {{ transaction.transaction_type.display_name }}
-                </span>
-                
-                <!-- Status Dropdown -->
-                <div class="status-dropdown" id="statusDropdown">
-                    <button onclick="toggleStatusDropdown(event)" class="status-badge status-{{ transaction.status }} flex items-center gap-2">
-                        {{ transaction.status|replace('_', ' ')|title }}
-                        <i class="fas fa-chevron-down text-xs opacity-50"></i>
-                    </button>
-                    <div class="status-dropdown-menu p-2" id="statusDropdownMenu">
-                        {% for status in ['draft', 'active', 'pending', 'under_contract', 'closed', 'cancelled'] %}
-                        <button onclick="updateStatus('{{ status }}')"
-                                class="w-full text-left px-4 py-2 text-sm rounded-lg hover:bg-slate-100 transition-colors {% if transaction.status == status %}font-bold text-orange-600{% endif %}">
-                            {{ status|replace('_', ' ')|title }}
-                            {% if transaction.status == status %}<i class="fas fa-check ml-2 text-orange-500"></i>{% endif %}
-                        </button>
-                        {% endfor %}
-                    </div>
-                </div>
+            <!-- Delete Button -->
+            <button onclick="confirmDelete()" 
+                    class="premium-btn px-4 py-2 text-sm border-2 border-red-200 text-red-600 bg-red-50 hover:bg-red-100 flex items-center gap-2">
+                <i class="fas fa-trash-alt"></i>
+                <span class="hidden sm:inline">Delete</span>
+            </button>
+        </div>
 
-                <!-- Delete Button -->
-                <button onclick="confirmDelete()" 
-                        class="premium-btn px-4 py-2 text-sm border-2 border-red-200 text-red-600 bg-red-50 hover:bg-red-100 flex items-center gap-2">
-                    <i class="fas fa-trash-alt"></i>
-                    <span class="hidden sm:inline">Delete</span>
+        <!-- Prominent Type & Status Badges -->
+        <div class="flex flex-wrap items-center gap-4 mb-6 animate-fade-in-up relative" style="z-index: 999;">
+            <!-- Type Badge - More Prominent -->
+            <div class="prominent-badge type-{{ transaction.transaction_type.name }}">
+                <i class="fas fa-{% if transaction.transaction_type.name == 'seller' %}home{% elif transaction.transaction_type.name == 'buyer' %}key{% else %}handshake{% endif %}"></i>
+                {{ transaction.transaction_type.display_name }}
+            </div>
+            
+            <!-- Status Dropdown - More Prominent -->
+            <div class="status-dropdown" id="statusDropdown">
+                {% set status_labels = {
+                    'preparing_to_list': 'Preparing to List',
+                    'active': 'Active',
+                    'under_contract': 'Under Contract',
+                    'closed': 'Closed',
+                    'cancelled': 'Cancelled/Withdrawn'
+                } %}
+                <button onclick="toggleStatusDropdown(event)" class="prominent-badge status-{{ transaction.status }} flex items-center gap-2 cursor-pointer hover:scale-105 transition-transform">
+                    <i class="fas fa-{% if transaction.status == 'closed' %}check-circle{% elif transaction.status == 'cancelled' %}times-circle{% elif transaction.status == 'active' %}broadcast-tower{% elif transaction.status == 'under_contract' %}file-signature{% else %}clipboard-list{% endif %}"></i>
+                    {{ status_labels.get(transaction.status, transaction.status|replace('_', ' ')|title) }}
+                    <i class="fas fa-chevron-down text-xs opacity-50 ml-1"></i>
                 </button>
+                <div class="status-dropdown-menu p-2" id="statusDropdownMenu">
+                    {% for status, label in status_labels.items() %}
+                    <button onclick="updateStatus('{{ status }}')"
+                            class="w-full text-left px-4 py-2 text-sm rounded-lg hover:bg-slate-100 transition-colors {% if transaction.status == status %}font-bold text-orange-600{% endif %}">
+                        {{ label }}
+                        {% if transaction.status == status %}<i class="fas fa-check ml-2 text-orange-500"></i>{% endif %}
+                    </button>
+                    {% endfor %}
+                </div>
             </div>
         </div>
+
+        <!-- Status Progress Tracker (Pizza Tracker) -->
+        {% if transaction.status != 'cancelled' %}
+        <div class="premium-card p-6 mb-6 animate-fade-in-up">
+            {% set statuses = ['preparing_to_list', 'active', 'under_contract', 'closed'] %}
+            {% set status_icons = {
+                'preparing_to_list': 'clipboard-list',
+                'active': 'broadcast-tower',
+                'under_contract': 'file-signature',
+                'closed': 'check-circle'
+            } %}
+            {% set status_labels_tracker = {
+                'preparing_to_list': 'Preparing',
+                'active': 'Active',
+                'under_contract': 'Under Contract',
+                'closed': 'Closed'
+            } %}
+            {% set current_index = statuses.index(transaction.status) if transaction.status in statuses else 0 %}
+            {% set is_final_step = current_index == (statuses|length - 1) %}
+            {# Calculate progress: line extends from left edge to center of current step, or 100% if at final step #}
+            {% set step_width = 100 / statuses|length %}
+            {% set progress_percent = 100 if is_final_step else ((step_width / 2) + (current_index * step_width)) %}
+            
+            <div class="status-tracker">
+                <div class="status-tracker-progress" style="width: {{ progress_percent }}%;"></div>
+                {% for status in statuses %}
+                {% set step_index = loop.index0 %}
+                {% set is_completed = step_index < current_index %}
+                {% set is_current = step_index == current_index %}
+                {% set is_upcoming = step_index > current_index %}
+                {% set is_final_completed = is_current and is_final_step %}
+                <div class="tracker-step">
+                    <div class="tracker-dot {% if is_completed or is_final_completed %}completed{% elif is_current %}current{% else %}upcoming{% endif %}">
+                        {% if is_completed or is_final_completed %}
+                        <i class="fas fa-check"></i>
+                        {% else %}
+                        <i class="fas fa-{{ status_icons[status] }}"></i>
+                        {% endif %}
+                    </div>
+                    <span class="tracker-label {% if is_completed or is_final_completed %}completed{% elif is_current %}current{% else %}upcoming{% endif %}">
+                        {{ status_labels_tracker[status] }}
+                    </span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% else %}
+        <!-- Cancelled Status Banner -->
+        <div class="premium-card p-4 mb-6 animate-fade-in-up bg-red-50 border-red-200">
+            <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+                    <i class="fas fa-times-circle text-red-600"></i>
+                </div>
+                <div>
+                    <span class="font-semibold text-red-800">Transaction Cancelled/Withdrawn</span>
+                    <p class="text-sm text-red-600">This transaction is no longer active</p>
+                </div>
+            </div>
+        </div>
+        {% endif %}
 
         <!-- Main Content Grid -->
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -263,8 +435,15 @@
                         <div class="info-row">
                             <span class="info-label">Current Status</span>
                             <span class="info-value">
+                                {% set detail_status_labels = {
+                                    'preparing_to_list': 'Preparing to List',
+                                    'active': 'Active',
+                                    'under_contract': 'Under Contract',
+                                    'closed': 'Closed',
+                                    'cancelled': 'Cancelled/Withdrawn'
+                                } %}
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium status-{{ transaction.status }}">
-                                    {{ transaction.status|replace('_', ' ')|title }}
+                                    {{ detail_status_labels.get(transaction.status, transaction.status|replace('_', ' ')|title) }}
                                 </span>
                             </span>
                         </div>
@@ -559,10 +738,19 @@
                                 </div>
                                 <div class="text-sm text-slate-500">{{ participant.role|replace('_', ' ')|title }}</div>
                                 {% if participant.display_email %}
-                                <div class="text-xs text-slate-400 truncate mt-0.5">{{ participant.display_email }}</div>
+                                <div class="text-xs text-slate-400 truncate mt-0.5">
+                                    <i class="fas fa-envelope mr-1"></i>{{ participant.display_email }}
+                                </div>
+                                {% endif %}
+                                {% if participant.display_phone %}
+                                <div class="text-xs text-slate-400 truncate mt-0.5">
+                                    <i class="fas fa-phone mr-1"></i>{{ participant.display_phone }}
+                                </div>
                                 {% endif %}
                                 {% if participant.company %}
-                                <div class="text-xs text-slate-400 truncate">{{ participant.company }}</div>
+                                <div class="text-xs text-slate-400 truncate mt-0.5">
+                                    <i class="fas fa-building mr-1"></i>{{ participant.company }}
+                                </div>
                                 {% endif %}
                             </div>
                             <button onclick="removeParticipant({{ participant.id }})"

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -446,6 +446,40 @@
     .form-bottom-spacer {
         height: 100px;
     }
+
+    /* Checkbox group */
+    .checkbox-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 0.75rem;
+    }
+
+    .checkbox-item {
+        display: flex;
+        align-items: center;
+        padding: 0.75rem 1rem;
+        border: 2px solid #e2e8f0;
+        border-radius: 0.625rem;
+        cursor: pointer;
+        transition: all 0.2s ease-out;
+        background: #f8fafc;
+    }
+
+    .checkbox-item:hover {
+        border-color: #cbd5e1;
+    }
+
+    .checkbox-item.checked {
+        border-color: var(--section-color, #f97316);
+        background: #fff7ed;
+    }
+
+    .checkbox-item input[type="checkbox"] {
+        width: 1.125rem;
+        height: 1.125rem;
+        margin-right: 0.75rem;
+        accent-color: var(--section-color, #f97316);
+    }
 </style>
 
 <!-- Progress Bar -->
@@ -745,6 +779,41 @@ function formatCurrency(input) {
         input.value = value;
     }
 }
+
+// =============================================================================
+// DATE CALCULATIONS
+// =============================================================================
+
+function updateEndDateFromStart(startInput) {
+    // Find the corresponding end date input in the same form section
+    const section = startInput.closest('.premium-card') || startInput.closest('.form-section');
+    if (section) {
+        const endInput = section.querySelector('.listing-end-date');
+        if (endInput && startInput.value) {
+            // Only update if end date is empty or hasn't been manually changed
+            if (!endInput.value || endInput.dataset.autoSet === 'true') {
+                const startDate = new Date(startInput.value);
+                // Add 6 months
+                startDate.setMonth(startDate.getMonth() + 6);
+                // Format as YYYY-MM-DD for input[type="date"]
+                const year = startDate.getFullYear();
+                const month = String(startDate.getMonth() + 1).padStart(2, '0');
+                const day = String(startDate.getDate()).padStart(2, '0');
+                endInput.value = `${year}-${month}-${day}`;
+                endInput.dataset.autoSet = 'true';
+            }
+        }
+    }
+}
+
+// Initialize end date listeners to clear auto-set flag when user manually changes
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.listing-end-date').forEach(function(endInput) {
+        endInput.addEventListener('input', function() {
+            this.dataset.autoSet = 'false';
+        });
+    });
+});
 
 // =============================================================================
 // TOAST NOTIFICATIONS

--- a/templates/transactions/list.html
+++ b/templates/transactions/list.html
@@ -109,9 +109,8 @@
         letter-spacing: 0.025em;
     }
 
-    .status-draft { background: #f1f5f9; color: #64748b; }
+    .status-preparing_to_list { background: #fef3c7; color: #92400e; }
     .status-active { background: #dcfce7; color: #166534; }
-    .status-pending { background: #fef3c7; color: #92400e; }
     .status-under_contract { background: #dbeafe; color: #1e40af; }
     .status-closed { background: #e0e7ff; color: #3730a3; }
     .status-cancelled { background: #fee2e2; color: #991b1b; }
@@ -201,12 +200,11 @@
                             onchange="this.form.submit()"
                             class="px-4 py-2.5 bg-slate-50 border-2 border-slate-200 rounded-xl text-sm focus:border-orange-500 focus:ring-0 transition-colors cursor-pointer">
                         <option value="">All Statuses</option>
-                        <option value="draft" {% if status_filter == 'draft' %}selected{% endif %}>Draft</option>
+                        <option value="preparing_to_list" {% if status_filter == 'preparing_to_list' %}selected{% endif %}>Preparing to List</option>
                         <option value="active" {% if status_filter == 'active' %}selected{% endif %}>Active</option>
-                        <option value="pending" {% if status_filter == 'pending' %}selected{% endif %}>Pending</option>
                         <option value="under_contract" {% if status_filter == 'under_contract' %}selected{% endif %}>Under Contract</option>
                         <option value="closed" {% if status_filter == 'closed' %}selected{% endif %}>Closed</option>
-                        <option value="cancelled" {% if status_filter == 'cancelled' %}selected{% endif %}>Cancelled</option>
+                        <option value="cancelled" {% if status_filter == 'cancelled' %}selected{% endif %}>Cancelled/Withdrawn</option>
                     </select>
                 </form>
 
@@ -249,9 +247,16 @@
             {% endfor %}
             {% endif %}
             {% if status_filter %}
+            {% set filter_status_labels = {
+                'preparing_to_list': 'Preparing to List',
+                'active': 'Active',
+                'under_contract': 'Under Contract',
+                'closed': 'Closed',
+                'cancelled': 'Cancelled/Withdrawn'
+            } %}
             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-700 border border-blue-200">
                 <i class="fas fa-circle mr-2 text-blue-500"></i>
-                {{ status_filter|replace('_', ' ')|title }}
+                {{ filter_status_labels.get(status_filter, status_filter|replace('_', ' ')|title) }}
                 <a href="{{ url_for('transactions.list_transactions', type=type_filter, q=search_query) }}" 
                    class="ml-2 text-blue-500 hover:text-blue-700">
                     <i class="fas fa-times"></i>
@@ -309,8 +314,15 @@
                                     </span>
                                 </td>
                                 <td class="px-4 py-4 border-l border-slate-100">
+                                    {% set list_status_labels = {
+                                        'preparing_to_list': 'Preparing to List',
+                                        'active': 'Active',
+                                        'under_contract': 'Under Contract',
+                                        'closed': 'Closed',
+                                        'cancelled': 'Cancelled/Withdrawn'
+                                    } %}
                                     <span class="status-badge status-{{ tx.status }}">
-                                        {{ tx.status|replace('_', ' ')|title }}
+                                        {{ list_status_labels.get(tx.status, tx.status|replace('_', ' ')|title) }}
                                     </span>
                                 </td>
                                 <td class="px-4 py-4 text-slate-500 text-sm border-l border-slate-100">

--- a/templates/transactions/listing_agreement_form.html
+++ b/templates/transactions/listing_agreement_form.html
@@ -685,15 +685,16 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="form-label form-label-required">Listing Start Date</label>
-                        <input type="date" name="field_listing_start_date" 
+                        <input type="date" name="field_listing_start_date" id="listingStartDate"
                                value="{{ prefill_data.get('listing_start_date', '') }}"
-                               class="premium-input">
+                               class="premium-input" onchange="updateEndDate(this)">
                     </div>
                     <div>
                         <label class="form-label form-label-required">Listing End Date</label>
-                        <input type="date" name="field_listing_end_date" 
+                        <input type="date" name="field_listing_end_date" id="listingEndDate"
                                value="{{ prefill_data.get('listing_end_date', '') }}"
                                class="premium-input">
+                        <p class="help-text">Defaults to 6 months from start date</p>
                     </div>
                 </div>
             </div>
@@ -745,22 +746,10 @@
                                 <div>
                                     <label class="form-label form-label-required">Total compensation paid by seller</label>
                                     <p class="text-sm text-slate-600 mb-2">This is the total commission (listing + buyer's agent combined)</p>
-                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                                        <div class="input-group">
-                                            <input type="number" name="field_total_commission_percent" 
-                                                   value="{{ prefill_data.get('total_commission_percent', '') }}"
-                                                   class="premium-input" placeholder="e.g., 6" step="0.01">
-                                            <span class="input-suffix">%</span>
-                                        </div>
-                                        <div class="flex items-center text-slate-400 justify-center">OR</div>
-                                    </div>
-                                    <div class="input-group mt-3">
-                                        <span class="input-prefix">$</span>
-                                        <input type="text" name="field_total_commission_flat" 
-                                               value="{{ prefill_data.get('total_commission_flat', '') }}"
-                                               class="premium-input" placeholder="Flat fee amount"
-                                               oninput="formatCurrency(this)">
-                                    </div>
+                                    <input type="text" name="field_total_commission" 
+                                           value="{{ prefill_data.get('total_commission', '') }}"
+                                           class="premium-input" placeholder="e.g., 6%, $5,000, or $5,000 + 3%">
+                                    <p class="help-text">Enter percentage, flat fee, or combination (e.g., "$5,000 + 3%")</p>
                                 </div>
 
                                 <div>
@@ -1240,7 +1229,7 @@
                     <label class="form-label">Any special provisions or custom terms to include?</label>
                     <textarea name="field_special_provisions" class="premium-textarea" rows="4" 
                               placeholder="Enter any additional terms, conditions, or agreements...">{{ prefill_data.get('special_provisions', '') }}</textarea>
-                    <p class="help-text">This is where you can add any custom agreements not covered elsewhere in the form.</p>
+                    <p class="help-text">Real estate brokers and sales agents are prohibited from practicing law and shall not add to, delete, or modify any provision of this contract unless drafted by a party to this contract or a party's attorney.</p>
                 </div>
             </div>
 
@@ -1551,6 +1540,38 @@ function formatCurrency(input) {
         input.value = value;
     }
 }
+
+// =============================================================================
+// DATE CALCULATIONS
+// =============================================================================
+
+function updateEndDate(startInput) {
+    const endInput = document.getElementById('listingEndDate');
+    if (startInput.value && endInput) {
+        // Only update if end date is empty or hasn't been manually changed
+        if (!endInput.value || endInput.dataset.autoSet === 'true') {
+            const startDate = new Date(startInput.value);
+            // Add 6 months
+            startDate.setMonth(startDate.getMonth() + 6);
+            // Format as YYYY-MM-DD for input[type="date"]
+            const year = startDate.getFullYear();
+            const month = String(startDate.getMonth() + 1).padStart(2, '0');
+            const day = String(startDate.getDate()).padStart(2, '0');
+            endInput.value = `${year}-${month}-${day}`;
+            endInput.dataset.autoSet = 'true';
+        }
+    }
+}
+
+// Clear auto-set flag when user manually changes end date
+document.addEventListener('DOMContentLoaded', function() {
+    const endDateInput = document.getElementById('listingEndDate');
+    if (endDateInput) {
+        endDateInput.addEventListener('input', function() {
+            this.dataset.autoSet = 'false';
+        });
+    }
+});
 
 // =============================================================================
 // FORM SUBMISSION

--- a/templates/transactions/partials/listing_agreement_fields.html
+++ b/templates/transactions/partials/listing_agreement_fields.html
@@ -229,13 +229,14 @@ Variables expected: prefill_data (dict), doc (optional - for field prefixing in 
             <label class="form-label form-label-required">Listing Start Date</label>
             <input type="date" name="{{ field_prefix }}listing_start_date" 
                    value="{{ prefill_data.get('listing_start_date', '') }}"
-                   class="premium-input">
+                   class="premium-input listing-start-date" onchange="updateEndDateFromStart(this)">
         </div>
         <div>
             <label class="form-label form-label-required">Listing End Date</label>
             <input type="date" name="{{ field_prefix }}listing_end_date" 
                    value="{{ prefill_data.get('listing_end_date', '') }}"
-                   class="premium-input">
+                   class="premium-input listing-end-date">
+            <p class="help-text">Defaults to 6 months from start date</p>
         </div>
     </div>
 </div>
@@ -287,22 +288,10 @@ Variables expected: prefill_data (dict), doc (optional - for field prefixing in 
                     <div>
                         <label class="form-label form-label-required">Total compensation paid by seller</label>
                         <p class="text-sm text-slate-600 mb-2">This is the total commission (listing + buyer's agent combined)</p>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                            <div class="input-group">
-                                <input type="number" name="{{ field_prefix }}total_commission_percent" 
-                                       value="{{ prefill_data.get('total_commission_percent', '') }}"
-                                       class="premium-input" placeholder="e.g., 6" step="0.01">
-                                <span class="input-suffix">%</span>
-                            </div>
-                            <div class="flex items-center text-slate-400 justify-center">OR</div>
-                        </div>
-                        <div class="input-group mt-3">
-                            <span class="input-prefix">$</span>
-                            <input type="text" name="{{ field_prefix }}total_commission_flat" 
-                                   value="{{ prefill_data.get('total_commission_flat', '') }}"
-                                   class="premium-input" placeholder="Flat fee amount"
-                                   oninput="formatCurrency(this)">
-                        </div>
+                        <input type="text" name="{{ field_prefix }}total_commission" 
+                               value="{{ prefill_data.get('total_commission', '') }}"
+                               class="premium-input" placeholder="e.g., 6%, $5,000, or $5,000 + 3%">
+                        <p class="help-text">Enter percentage, flat fee, or combination (e.g., "$5,000 + 3%")</p>
                     </div>
 
                     <div>
@@ -782,7 +771,7 @@ Variables expected: prefill_data (dict), doc (optional - for field prefixing in 
         <label class="form-label">Any special provisions or custom terms to include?</label>
         <textarea name="{{ field_prefix }}special_provisions" class="premium-textarea" rows="4" 
                   placeholder="Enter any additional terms, conditions, or agreements...">{{ prefill_data.get('special_provisions', '') }}</textarea>
-        <p class="help-text">This is where you can add any custom agreements not covered elsewhere in the form.</p>
+        <p class="help-text">Real estate brokers and sales agents are prohibited from practicing law and shall not add to, delete, or modify any provision of this contract unless drafted by a party to this contract or a party's attorney.</p>
     </div>
 </div>
 


### PR DESCRIPTION
Listing Agreement Form Changes:
- Section 5A: Changed total compensation to free-form text field (supports ,000 + 3% format)
- Section 4: Auto-calculate end date to 6 months from start date selection
- Section 11: Fixed checkbox styling in fill_all_documents.html to match main form
- Section 13: Updated special provisions help text with legal disclaimer

Transaction Status Updates:
- Changed statuses to: Preparing to List, Active, Under Contract, Closed, Cancelled/Withdrawn
- Updated default status from 'draft' to 'preparing_to_list'
- Updated all status badges, dropdowns, and filters across list and detail views

Transaction Detail Page Enhancements:
- Added pizza tracker status bar showing transaction progress
- Progress bar extends to current step with orange highlight
- Closed status shows green checkmarks and full progress bar
- Cancelled transactions show red warning banner instead of tracker
- Made Transaction Type and Status badges more prominent with icons
- Added phone numbers to participant cards (with icons for email/phone/company)
- Fixed z-index for status dropdown to appear above other UI elements