### PR TITLE
feat: DocuSeal dynamic role handling and HOA addendum field mapping

### DIFF
--- a/docuseal_mappings/hoa-addendum.yml
+++ b/docuseal_mappings/hoa-addendum.yml
@@ -7,17 +7,28 @@
 # DocuSeal Template URL: https://docuseal.com/d/b3S4Ryi2HCjoh4
 #
 # Document: Addendum for Property Subject to Mandatory Membership in
-#           Owners' Association (TXR Form)
+#           Owners' Association (TREC Form)
 #
 # Submitters (signers):
-#   - Seller (primary seller)
-#   - Buyer (in actual transaction - for listing phase, agent fills as preview)
+#   - Seller (primary seller) - has all pre-filled fields + signature
+#   - Seller 2 (co-seller, optional) - only signature fields, omit if no 2nd seller
 #
 # ACTUAL DOCUSEAL FIELDS (as of 2026-01-04):
-#   Seller: Street address, Association name & phone, Days after effective date,
-#           Seller pays title company cost, Seller signature, Seller date
-#   Buyer:  Option, Days after effective date, Buyer requires updated resale certificate,
-#           Buyer does not require updated resale certificate, Buyer signature, Buyer date
+#   Seller role:
+#     - Street address (text)
+#     - Association name & phone (text)
+#     - 1. Days after effective date (number) - for Option 1
+#     - 2. Days after effective date (number) - for Option 2
+#     - Seller signature 1 (signature)
+#     - Signature date 1 (date)
+#     - Option 1, Option 2, Option 3, Option 4 (text) - use "X" for selected
+#     - Buyer does, Buyer does not (text) - resale cert checkboxes, use "X"
+#     - C. Buyer paid transfer fee (number)
+#     - D. Buyer pays (text) - two fields for section D
+#
+#   Seller 2 role:
+#     - Signature Field 2 (signature)
+#     - Signature date 2 (date)
 #
 # HOW TO UPDATE:
 #   1. View fields at: /transactions/admin/docuseal/template/2469165
@@ -29,47 +40,72 @@ template_id: 2469165
 template_name: "HOA Addendum"
 template_slug: "hoa-addendum"
 
-# What roles does this template use? (for code to know which submitter types)
-# Options: seller, buyer, broker
+# What roles does this template use?
+# Seller 2 is optional - only include in submission if there's a 2nd seller
 submitter_roles:
   - Seller
-  - Buyer
+  - Seller 2
 
 # =============================================================================
 # FIELD MAPPINGS - SELLER FIELDS
 # Format: crm_field: docuseal_field
-# These fields go to the Seller submitter
+# These fields go to the Seller submitter (all pre-filled, read-only except signatures)
+# 
+# Form field names come from hoa_addendum_fields.html
 # =============================================================================
 field_mappings:
 
-  # Property address (combined into one field in DocuSeal)
-  property_address: "Street address"
-  
-  # HOA info (combined into one field in DocuSeal)
-  hoa_name_phone: "Association name & phone"
-  
-  # Days for seller to deliver documents
-  seller_delivery_days: "Days after effective date"
-  
-  # Seller pays title company cost checkbox
-  seller_pays_title_cost: "Seller pays title company cost"
+  # Section C - Fees and Deposits (form uses buyer_fee_cap)
+  buyer_fee_cap: "C. Buyer paid transfer fee"
 
 
 # =============================================================================
-# BUYER FORM FIELDS
-# These fields go to the Buyer submitter (in listing phase, agent fills these)
+# CONDITIONAL FIELD MAPPINGS
+# These fields are only sent if a condition is met
+# Format: condition_field -> { condition_value -> { form_field: docuseal_field } }
 # =============================================================================
-buyer_form_fields:
+conditional_fields:
+  # Days fields depend on which option is selected
+  doc_responsibility:
+    seller:
+      seller_delivery_days: "1. Days after effective date"
+    buyer:
+      buyer_delivery_days: "2. Days after effective date"
+
+
+# =============================================================================
+# COMPUTED OPTION FIELDS
+# The form uses doc_responsibility radio with values: seller, buyer, already_received, not_required
+# These map to DocuSeal Options 1-4. Also handles require_updated_resale and additional_doc_fee_paid_by.
+# These are computed in build_docuseal_fields based on form values.
+# =============================================================================
+option_transforms:
+  # doc_responsibility value -> which Option gets X
+  doc_responsibility:
+    seller: "Option 1"           # Seller delivers docs
+    buyer: "Option 2"            # Buyer delivers docs
+    already_received: "Option 3" # Buyer already has docs
+    not_required: "Option 4"     # Buyer doesn't need docs
   
-  # Radio option for document responsibility
-  doc_responsibility: "Option"
+  # For Option 3 (already_received), require_updated_resale determines:
+  require_updated_resale:
+    "yes": "Buyer does"          # Buyer requires updated resale cert
+    "no": "Buyer does not"       # Buyer does not require
   
-  # Days for buyer side
-  buyer_delivery_days: "Days after effective date"
-  
-  # Resale certificate checkboxes
-  require_updated_resale_yes: "Buyer requires updated resale certificate"
-  require_updated_resale_no: "Buyer does not require updated resale certificate"
+  # additional_doc_fee_paid_by determines section D
+  additional_doc_fee_paid_by:
+    buyer: "D. Buyer pays"
+    seller: "D. Seller pays"
+
+
+# =============================================================================
+# SELLER 2 FIELDS
+# These fields go to the Seller 2 submitter (second seller)
+# Note: Signature and date are handled automatically by DocuSeal
+# =============================================================================
+seller_2_fields: {}
+  # Seller 2 only has signature fields which are handled by DocuSeal
+  # No pre-filled fields needed
 
 
 # =============================================================================
@@ -78,16 +114,9 @@ buyer_form_fields:
 # =============================================================================
 transforms:
 
-  # Radio button mappings (our value -> DocuSeal value)
-  radio_mappings:
-    doc_responsibility:
-      "A": "A"
-      "B": "B"
-      "C": "C"
-      "D": "D"
-    
   # Currency fields - will have commas/$ stripped
-  currency_fields: []
+  currency_fields:
+    - buyer_fee_cap
 
   # Date fields - will be converted to MM/DD/YYYY
   date_fields: []

--- a/docuseal_mappings/listing-agreement.yml
+++ b/docuseal_mappings/listing-agreement.yml
@@ -82,7 +82,8 @@ field_mappings:
   # SECTION 5: BROKER COMPENSATION
   # ---------------------------------------------------------------------------
   offer_buyer_agent_comp: "Broker comp method"  # Radio: "percent" or "flat"
-  total_commission: "Total commission"  # Free form text: e.g., "6%", "$5,000", or "$5,000 + 3%"
+  # TODO: Update this to match the actual DocuSeal field name for commission
+  # total_commission: "Total commission"  # Commented out - field doesn't exist in DocuSeal yet
   buyer_agent_percent: "Compensation percent"
   buyer_agent_flat: "Compensation flat fee"
   

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -729,6 +729,18 @@ function handleDocResponsibility(value, container) {
     toggleConditional('buyerDaysSection', value === 'buyer', container);
     toggleConditional('updatedResaleSection', value === 'already_received', container);
     toggleConditional('notRequiredWarning', value === 'not_required', container);
+    
+    // Clear sub-option fields when their parent option is deselected
+    if (value !== 'already_received') {
+        // Clear the require_updated_resale radio buttons within this container
+        const searchRoot = container || document;
+        searchRoot.querySelectorAll('input[name*="require_updated_resale"]').forEach(radio => {
+            radio.checked = false;
+            // Also remove the 'selected' class from option cards
+            const card = radio.closest('.option-card');
+            if (card) card.classList.remove('selected');
+        });
+    }
 }
 
 // =============================================================================

--- a/templates/transactions/hoa_addendum_form.html
+++ b/templates/transactions/hoa_addendum_form.html
@@ -756,6 +756,18 @@ function handleDocResponsibility(value) {
     document.getElementById('updatedResaleSection').classList.remove('show');
     document.getElementById('notRequiredWarning').classList.remove('show');
     
+    // Clear sub-option fields when their parent option is deselected
+    // This ensures values don't persist when hidden
+    if (value !== 'already_received') {
+        // Clear the require_updated_resale radio buttons
+        document.querySelectorAll('input[name="field_require_updated_resale"]').forEach(radio => {
+            radio.checked = false;
+            // Also remove the 'selected' class from option cards
+            const card = radio.closest('.option-card');
+            if (card) card.classList.remove('selected');
+        });
+    }
+    
     // Show the appropriate section
     switch(value) {
         case 'seller':


### PR DESCRIPTION
- Add dynamic submitter role handling based on template YAML config
- Templates now define their own roles (Seller, Seller 2, Broker, etc.)
- Only submitters matching template roles are sent to DocuSeal API
- Add support for Seller 2 (co-seller) with automatic inclusion when present
- Add checkbox_to_x transform for text fields simulating checkboxes
- Add option_transforms for radio group to DocuSeal field mapping
- Add conditional_fields for context-dependent field inclusion
- Update HOA addendum YAML with proper field mappings
- Fix form JS to clear sub-option fields when parent option changes
- Add debug logging for DocuSeal API troubleshooting
- Comment out missing 'Total commission' field in listing agreement YAML