### PR TITLE
feat: add Seller's Estimated Net Proceeds form (TXR-1935)

### DIFF
--- a/docuseal_mappings/seller-net-proceeds.yml
+++ b/docuseal_mappings/seller-net-proceeds.yml
@@ -1,0 +1,131 @@
+# =============================================================================
+# SELLER'S ESTIMATED NET PROCEEDS - DocuSeal Field Mapping
+# =============================================================================
+# This file maps CRM form fields to DocuSeal template fields.
+# Template ID: TBD (set when template is uploaded to DocuSeal)
+# Form: TXR-1935
+# =============================================================================
+
+template_id: null  # Set this after uploading template to DocuSeal
+template_name: "Seller's Estimated Net Proceeds"
+template_slug: "seller-net-proceeds"
+
+submitter_roles:
+  - Seller
+  - Broker
+
+field_mappings:
+  seller_name: "Seller"
+  property_address: "Address"
+  closing_date: "Anticipated Closing Date"
+  annual_property_taxes: "Estimated Annual Property Taxes"
+  annual_maintenance_fees: "Estimated Annual Maintenance Fees"
+  financing_conventional: "Conventional"
+  financing_va: "VA"
+  financing_fha: "FHA"
+  financing_usda: "USDA"
+  financing_reverse: "Reverse Mortgage"
+  financing_assumption: "Assumption"
+  financing_owner: "Owner"
+  financing_cash: "Cash"
+  attorneys_fees: "Attorney's Fees / Doc. Prep."
+  brokers_fee_percent: "Brokers' Fees Percent"
+  brokers_fee: "Brokers' Fees"
+  condo_transfer_fee: "Condo. Transfer Fee"
+  courier_fees: "Courier & Express Mail Fees"
+  escrow_fee: "Escrow Fee (one-half)"
+  prorated_taxes: "Taxes Prorated"
+  prorated_interest: "Interest (Assumptions)"
+  prorated_maintenance: "Maintenance Fees"
+  assessments: "Assessments"
+  rents: "Rents"
+  recording_fees: "Recording Fees"
+  repairs_buyer: "Repairs Required by Buyer"
+  repairs_lender: "Repairs Required by Lender"
+  residential_service: "Residential Service Contract"
+  seller_allowances: "Seller Allowances or FHA/VA Nonallowables"
+  survey_fee: "Survey Fee"
+  tax_cert_fee: "Tax Certificate Fee"
+  title_policy: "Title Policy - Owner's"
+  wiring_fees: "Wiring Fees"
+  custom_label_1: "Custom Cost Label 1"
+  custom_amount_1: "Custom Cost Amount 1"
+  custom_label_2: "Custom Cost Label 2"
+  custom_amount_2: "Custom Cost Amount 2"
+  custom_label_3: "Custom Cost Label 3"
+  custom_amount_3: "Custom Cost Amount 3"
+  custom_label_4: "Custom Cost Label 4"
+  custom_amount_4: "Custom Cost Amount 4"
+  total_costs: "Total Estimated Costs"
+  sales_price: "Sales Price"
+  less_costs: "Less Estimated Costs"
+  loan_payoff: "Less Estimated Loan Payoff"
+  net_proceeds: "Estimated Net Proceeds"
+  unused_insurance: "Estimated Unused Insurance"
+  escrow_balance: "Estimated Escrow Balance"
+  total_refunds: "Total Estimated Refunds"
+  prepared_by: "Prepared by"
+
+transforms:
+  checkbox_fields:
+    - financing_conventional
+    - financing_va
+    - financing_fha
+    - financing_usda
+    - financing_reverse
+    - financing_assumption
+    - financing_owner
+    - financing_cash
+  currency_fields:
+    - annual_property_taxes
+    - annual_maintenance_fees
+    - attorneys_fees
+    - brokers_fee
+    - condo_transfer_fee
+    - courier_fees
+    - escrow_fee
+    - prorated_taxes
+    - prorated_interest
+    - prorated_maintenance
+    - assessments
+    - rents
+    - recording_fees
+    - repairs_buyer
+    - repairs_lender
+    - residential_service
+    - seller_allowances
+    - survey_fee
+    - tax_cert_fee
+    - title_policy
+    - wiring_fees
+    - custom_amount_1
+    - custom_amount_2
+    - custom_amount_3
+    - custom_amount_4
+    - total_costs
+    - sales_price
+    - less_costs
+    - loan_payoff
+    - net_proceeds
+    - unused_insurance
+    - escrow_balance
+    - total_refunds
+  date_fields:
+    - closing_date
+  percentage_fields:
+    - brokers_fee_percent
+
+broker_form_fields:
+  prepared_by: "Prepared by"
+
+agent_fields:
+  - prepared_by
+
+computed_fields:
+  - prorated_taxes
+  - brokers_fee
+  - total_costs
+  - less_costs
+  - net_proceeds
+  - total_refunds
+

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -818,6 +818,15 @@ def document_form(id, doc_id):
             prefill_data=prefill_data
         )
     
+    if doc.template_slug == 'seller-net-proceeds':
+        return render_template(
+            'transactions/seller_net_proceeds_form.html',
+            transaction=transaction,
+            document=doc,
+            participants=participants,
+            prefill_data=prefill_data
+        )
+    
     # Default generic form
     return render_template(
         'transactions/document_form.html',

--- a/services/document_registry.py
+++ b/services/document_registry.py
@@ -126,6 +126,14 @@ DOCUMENT_REGISTRY: Dict[str, DocumentConfig] = {
         icon='fa-water',
         sort_order=3,
     ),
+    'seller-net-proceeds': DocumentConfig(
+        slug='seller-net-proceeds',
+        name="Seller's Estimated Net Proceeds",
+        partial_template='transactions/partials/seller_net_proceeds_fields.html',
+        color='emerald',
+        icon='fa-calculator',
+        sort_order=4,
+    ),
     # Future documents - uncomment and create partials/YAMLs as needed:
     #
     # 'sellers-disclosure': DocumentConfig(

--- a/services/docuseal_service.py
+++ b/services/docuseal_service.py
@@ -60,7 +60,7 @@ TEMPLATE_MAP = {
     'flood-hazard': None,
     'water-district': None,
     't47-affidavit': None,
-    'sellers-net': None,
+    'seller-net-proceeds': None,
     'referral-agreement': None,
 }
 
@@ -87,6 +87,12 @@ DOCUMENT_FORMS = {
         'form_template': 'transactions/flood_hazard_form.html',
         'template_id': None,  # Set when DocuSeal template is created
         'description': 'Information About Special Flood Hazard Areas'
+    },
+    'seller-net-proceeds': {
+        'name': "Seller's Estimated Net Proceeds",
+        'form_template': 'transactions/seller_net_proceeds_form.html',
+        'template_id': None,  # Set when DocuSeal template is created
+        'description': 'TXR-1935 Seller\'s Estimated Net Proceeds'
     },
 }
 

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -940,7 +940,7 @@
                             </optgroup>
                             <optgroup label="Other Documents">
                                 <option value="wire-fraud-warning" data-name="Wire Fraud Warning">Wire Fraud Warning</option>
-                                <option value="sellers-net" data-name="Seller's Estimated Net Proceeds">Seller's Estimated Net Proceeds</option>
+                                <option value="seller-net-proceeds" data-name="Seller's Estimated Net Proceeds">Seller's Estimated Net Proceeds</option>
                                 <option value="referral-agreement" data-name="Referral Agreement">Referral Agreement</option>
                                 <option value="custom" data-name="">Custom Document</option>
                             </optgroup>

--- a/templates/transactions/partials/seller_net_proceeds_fields.html
+++ b/templates/transactions/partials/seller_net_proceeds_fields.html
@@ -1,0 +1,161 @@
+{# 
+Seller's Estimated Net Proceeds Form Fields Partial
+TXR-1935 - Seller's Estimated Net Proceeds
+
+This partial creates a document-style form UI that mimics the actual TXR form layout.
+Includes real-time calculations for prorated taxes, broker fees, and totals.
+
+Variables expected: prefill_data (dict), doc (optional - for field prefixing in combined view)
+#}
+
+{% set field_prefix = 'doc_' ~ (doc.id if doc else 'snp') ~ '_field_' %}
+{% set doc_id = doc.id if doc else 'snp' %}
+
+<!-- ============================================================== -->
+<!-- SELLER'S ESTIMATED NET PROCEEDS - DOCUMENT STYLE -->
+<!-- ============================================================== -->
+<style>
+    .snp-document { background: #fff; border-radius: 0.75rem; box-shadow: 0 2px 12px rgba(0,0,0,0.05); border: 1px solid #e2e8f0; margin-bottom: 1.5rem; overflow: hidden; }
+    .snp-header { background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%); color: white; padding: 1rem 1.25rem; text-align: center; }
+    .snp-header h2 { font-size: 1.125rem; font-weight: 700; letter-spacing: 0.05em; margin: 0; }
+    .snp-body { padding: 1.25rem 1.5rem; }
+    .snp-disclaimer { font-size: 0.75rem; font-style: italic; color: #64748b; text-align: center; margin-bottom: 1rem; padding-bottom: 0.75rem; border-bottom: 1px solid #f1f5f9; }
+    .snp-form-row { display: flex; align-items: center; margin-bottom: 0.625rem; gap: 0.5rem; }
+    .snp-form-row label { font-size: 0.8125rem; font-weight: 500; color: #333; white-space: nowrap; }
+    .snp-form-row input.snp-field { border: none; border-bottom: 2px solid #3b82f6; background: #f8fafc; padding: 0.25rem 0.375rem; font-size: 0.8125rem; flex: 1; min-width: 100px; transition: all 0.2s; }
+    .snp-form-row input.snp-field:focus { outline: none; background: #eff6ff; border-bottom-color: #1d4ed8; }
+    .snp-form-row input.snp-field[readonly] { background: #f1f5f9; border-bottom-color: #94a3b8; color: #64748b; }
+    /* Money input wrapper for SNP form */
+    .snp-money-wrapper { display: flex; align-items: center; border: 1.5px solid #e2e8f0; border-radius: 0.375rem; background: #fff; overflow: hidden; min-width: 95px; transition: all 0.2s; }
+    .snp-money-wrapper:focus-within { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1); }
+    .snp-money-wrapper.calculated { background: #f1f5f9; border-color: #cbd5e1; }
+    .snp-money-wrapper .snp-dollar { padding: 0.2rem 0 0.2rem 0.375rem; color: #94a3b8; font-size: 0.75rem; font-weight: 500; background: #f8fafc; }
+    .snp-money-wrapper.calculated .snp-dollar { background: #f1f5f9; color: #94a3b8; }
+    .snp-money-wrapper .snp-money-input { width: 100%; padding: 0.2rem 0.375rem 0.2rem 0.25rem; border: none; font-size: 0.75rem; text-align: right; background: transparent; }
+    .snp-money-wrapper .snp-money-input:focus { outline: none; }
+    .snp-money-wrapper .snp-money-input[readonly] { color: #64748b; font-weight: 600; }
+    .snp-two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-top: 1rem; }
+    @media (max-width: 768px) { .snp-two-col { grid-template-columns: 1fr; gap: 1rem; } }
+    .snp-section-box { border: 1.5px solid #e2e8f0; border-radius: 0.625rem; padding: 0.875rem; background: #fafbfc; }
+    .snp-section-title { font-size: 0.875rem; font-weight: 700; color: #1e293b; margin-bottom: 0.625rem; padding-bottom: 0.5rem; border-bottom: 2px solid #334155; }
+    .snp-cost-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.375rem; font-size: 0.75rem; }
+    .snp-cost-row label { color: #475569; flex: 1; }
+    .snp-cost-row .snp-percent-input { width: 40px; padding: 0.2rem; border: 1.5px solid #e2e8f0; border-radius: 0.25rem; font-size: 0.75rem; text-align: center; margin-right: 0.25rem; }
+    .snp-cost-row .snp-percent-input:focus { outline: none; border-color: #3b82f6; }
+    .snp-custom-row { display: flex; align-items: center; gap: 0.375rem; margin-bottom: 0.375rem; }
+    .snp-custom-row .snp-custom-label { flex: 1; padding: 0.25rem; border: none; border-bottom: 1.5px dashed #cbd5e1; font-size: 0.75rem; background: transparent; transition: all 0.2s; }
+    .snp-custom-row .snp-custom-label:focus { outline: none; border-bottom-color: #3b82f6; border-bottom-style: solid; }
+    .snp-custom-row .snp-custom-label::placeholder { color: #94a3b8; font-style: italic; }
+    .snp-total-row { display: flex; justify-content: space-between; align-items: center; padding-top: 0.625rem; margin-top: 0.625rem; border-top: 2px solid #334155; font-weight: 700; font-size: 0.8125rem; }
+    .snp-total-row .snp-money-wrapper { background: #f1f5f9; border-color: #94a3b8; border-width: 2px; min-width: 100px; }
+    .snp-total-row .snp-money-wrapper .snp-dollar { background: #f1f5f9; color: #64748b; font-weight: 700; }
+    .snp-total-row .snp-money-wrapper .snp-money-input { font-size: 0.8125rem; font-weight: 700; color: #475569; }
+    .snp-net-proceeds-row { display: flex; justify-content: space-between; align-items: center; padding: 0.625rem; margin-top: 0.75rem; background: linear-gradient(135deg, #ecfdf5, #d1fae5); border: 2px solid #10b981; border-radius: 0.5rem; }
+    .snp-net-proceeds-row label { font-weight: 700; font-size: 0.875rem; color: #065f46; }
+    .snp-net-proceeds-row .snp-money-wrapper { background: white; border: 2px solid #059669; border-radius: 0.375rem; min-width: 110px; }
+    .snp-net-proceeds-row .snp-money-wrapper .snp-dollar { background: white; color: #059669; font-weight: 700; font-size: 0.875rem; }
+    .snp-net-proceeds-row .snp-money-wrapper .snp-money-input { font-size: 0.9375rem; font-weight: 700; color: #059669; }
+    .snp-financing-group { display: flex; flex-wrap: wrap; gap: 0.375rem; margin-top: 0.375rem; }
+    .snp-financing-option { display: flex; align-items: center; gap: 0.375rem; padding: 0.375rem 0.625rem; background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 0.375rem; cursor: pointer; transition: all 0.15s; }
+    .snp-financing-option:hover { background: #f1f5f9; border-color: #cbd5e1; }
+    .snp-financing-option:has(input:checked) { background: #eff6ff; border-color: #3b82f6; }
+    .snp-financing-option input[type="checkbox"] { width: 0.875rem; height: 0.875rem; accent-color: #3b82f6; cursor: pointer; }
+    .snp-financing-option span { font-size: 0.75rem; color: #475569; font-weight: 500; }
+    .snp-financing-option:has(input:checked) span { color: #1d4ed8; }
+    .snp-prepared-by { margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #e2e8f0; font-size: 0.8125rem; color: #475569; }
+    .snp-note-text { font-size: 0.6875rem; color: #64748b; font-style: italic; margin-top: 0.5rem; }
+    .snp-parentheses::before { content: '('; font-weight: 600; color: #dc2626; margin-right: 2px; }
+    .snp-parentheses::after { content: ')'; font-weight: 600; color: #dc2626; margin-left: 2px; }
+</style>
+
+<div class="snp-document" id="snpDocument_{{ doc_id }}">
+    <div class="snp-header"><h2>SELLER'S ESTIMATED NET PROCEEDS</h2></div>
+    <div class="snp-body">
+        <p class="snp-disclaimer">The figures below are estimates. Actual costs and proceeds will vary. Estimates are not guaranteed.</p>
+
+        <div class="snp-form-row"><label>Seller:</label><input type="text" name="{{ field_prefix }}seller_name" class="snp-field" value="{{ prefill_data.get('seller_name', '') }}" readonly></div>
+        <div class="snp-form-row"><label>Address:</label><input type="text" name="{{ field_prefix }}property_address" class="snp-field" value="{{ prefill_data.get('property_address', '') }}" readonly></div>
+        <div class="snp-form-row"><label>Anticipated Closing Date:</label><input type="date" name="{{ field_prefix }}closing_date" id="snp_closingDate_{{ doc_id }}" class="snp-field" style="max-width: 150px;" value="{{ prefill_data.get('closing_date', '') }}" onchange="snpRecalculateAll('{{ doc_id }}')"></div>
+        <div class="snp-form-row"><label>Est. Annual Property Taxes:</label><div class="snp-money-wrapper" style="max-width: 120px;"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}annual_property_taxes" id="snp_annualTaxes_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('annual_property_taxes', '') }}" placeholder="0.00" oninput="snpFormatMoney(this); snpRecalculateAll('{{ doc_id }}')"></div></div>
+        <div class="snp-form-row"><label>Est. Annual Maintenance Fees:</label><div class="snp-money-wrapper" style="max-width: 120px;"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}annual_maintenance_fees" class="snp-money-input" value="{{ prefill_data.get('annual_maintenance_fees', '') }}" placeholder="0.00" oninput="snpFormatMoney(this)"></div></div>
+
+        <div style="margin: 0.75rem 0;"><label style="font-size: 0.8125rem; font-weight: 500; color: #333;">Buyer's Anticipated Financing:</label>
+            <div class="snp-financing-group">
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_conventional" value="1" {{ 'checked' if prefill_data.get('financing_conventional') else '' }}><span>Conventional</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_va" value="1" {{ 'checked' if prefill_data.get('financing_va') else '' }}><span>VA</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_fha" value="1" {{ 'checked' if prefill_data.get('financing_fha') else '' }}><span>FHA</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_usda" value="1" {{ 'checked' if prefill_data.get('financing_usda') else '' }}><span>USDA</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_reverse" value="1" {{ 'checked' if prefill_data.get('financing_reverse') else '' }}><span>Reverse Mtg</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_assumption" value="1" {{ 'checked' if prefill_data.get('financing_assumption') else '' }}><span>Assumption</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_owner" value="1" {{ 'checked' if prefill_data.get('financing_owner') else '' }}><span>Owner</span></label>
+                <label class="snp-financing-option"><input type="checkbox" name="{{ field_prefix }}financing_cash" value="1" {{ 'checked' if prefill_data.get('financing_cash') else '' }}><span>Cash</span></label>
+            </div>
+        </div>
+
+        <div class="snp-two-col">
+            <!-- Left: Estimated Costs -->
+            <div class="snp-section-box">
+                <div class="snp-section-title">Estimated Costs</div>
+                <div class="snp-cost-row"><label>Attorney's Fees / Doc. Prep.</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}attorneys_fees" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('attorneys_fees', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Brokers' Fees</label><input type="text" name="{{ field_prefix }}brokers_fee_percent" id="snp_brokerPercent_{{ doc_id }}" class="snp-percent-input" value="{{ prefill_data.get('brokers_fee_percent', '') }}" placeholder="%" oninput="snpCalculateBrokersFee('{{ doc_id }}')"><span style="font-size:0.65rem;color:#64748b;">%</span><div class="snp-money-wrapper calculated"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}brokers_fee" id="snp_brokerFee_{{ doc_id }}" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('brokers_fee', '') }}" placeholder="0" readonly></div></div>
+                <div class="snp-cost-row"><label>Condo. Transfer Fee</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}condo_transfer_fee" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('condo_transfer_fee', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Courier & Express Mail</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}courier_fees" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('courier_fees', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Escrow Fee (one-half)</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}escrow_fee" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('escrow_fee', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div style="font-size:0.75rem;color:#475569;font-weight:500;margin:0.375rem 0 0.125rem;">Prorations*:</div>
+                <div class="snp-cost-row" style="margin-left:0.5rem;"><label>Taxes <span id="snp_proratedDays_{{ doc_id }}" style="font-size:0.65rem;color:#64748b;">(___ days)</span></label><div class="snp-money-wrapper calculated"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}prorated_taxes" id="snp_proratedTaxes_{{ doc_id }}" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('prorated_taxes', '') }}" placeholder="0" readonly></div></div>
+                <div class="snp-cost-row" style="margin-left:0.5rem;"><label>Interest (Assumptions)**</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}prorated_interest" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('prorated_interest', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row" style="margin-left:0.5rem;"><label>Maintenance Fees</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}prorated_maintenance" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('prorated_maintenance', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row" style="margin-left:0.5rem;"><label>Assessments</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}assessments" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('assessments', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row" style="margin-left:0.5rem;"><label>Rents</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}rents" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('rents', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Recording Fees</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}recording_fees" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('recording_fees', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Repairs Required by Buyer</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}repairs_buyer" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('repairs_buyer', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Repairs Required by Lender</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}repairs_lender" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('repairs_lender', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Residential Service Contract</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}residential_service" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('residential_service', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Seller Allowances / FHA/VA</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}seller_allowances" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('seller_allowances', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Survey Fee</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}survey_fee" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('survey_fee', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Tax Certificate Fee</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}tax_cert_fee" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('tax_cert_fee', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Title Policy - Owner's</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}title_policy" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('title_policy', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-cost-row"><label>Wiring Fees</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}wiring_fees" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('wiring_fees', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-custom-row"><input type="text" name="{{ field_prefix }}custom_label_1" class="snp-custom-label" value="{{ prefill_data.get('custom_label_1', '') }}" placeholder="Other..."><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}custom_amount_1" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('custom_amount_1', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-custom-row"><input type="text" name="{{ field_prefix }}custom_label_2" class="snp-custom-label" value="{{ prefill_data.get('custom_label_2', '') }}" placeholder="Other..."><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}custom_amount_2" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('custom_amount_2', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-custom-row"><input type="text" name="{{ field_prefix }}custom_label_3" class="snp-custom-label" value="{{ prefill_data.get('custom_label_3', '') }}" placeholder="Other..."><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}custom_amount_3" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('custom_amount_3', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-custom-row"><input type="text" name="{{ field_prefix }}custom_label_4" class="snp-custom-label" value="{{ prefill_data.get('custom_label_4', '') }}" placeholder="Other..."><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}custom_amount_4" class="snp-money-input snp-cost-input-{{ doc_id }}" value="{{ prefill_data.get('custom_amount_4', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateCosts('{{ doc_id }}')"></div></div>
+                <div class="snp-total-row"><label>Total Estimated Costs</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}total_costs" id="snp_totalCosts_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('total_costs', '') }}" readonly></div></div>
+            </div>
+
+            <!-- Right: Proceeds -->
+            <div>
+                <div class="snp-section-box" style="margin-bottom:0.75rem;">
+                    <div class="snp-section-title">Estimated Proceeds to Seller:</div>
+                    <div class="snp-cost-row"><label>Sales Price</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}sales_price" id="snp_salesPrice_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('sales_price', prefill_data.get('list_price', '')) }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateAll('{{ doc_id }}')"></div></div>
+                    <div class="snp-cost-row"><label>Less Estimated Costs</label><span class="snp-parentheses"><div class="snp-money-wrapper calculated"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}less_costs" id="snp_lessCosts_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('less_costs', '') }}" readonly></div></span></div>
+                    <div class="snp-cost-row"><label>Less Estimated Loan Payoff</label><span class="snp-parentheses"><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}loan_payoff" id="snp_loanPayoff_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('loan_payoff', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateNetProceeds('{{ doc_id }}')"></div></span></div>
+                    <div class="snp-net-proceeds-row"><label>Estimated Net Proceeds:</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}net_proceeds" id="snp_netProceeds_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('net_proceeds', '') }}" readonly></div></div>
+                </div>
+                <div class="snp-section-box">
+                    <div class="snp-section-title">After Closing Refunds</div>
+                    <div class="snp-cost-row"><label>Estimated Unused Insurance</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}unused_insurance" class="snp-money-input snp-refund-input-{{ doc_id }}" value="{{ prefill_data.get('unused_insurance', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateRefunds('{{ doc_id }}')"></div></div>
+                    <div class="snp-cost-row"><label>Estimated Escrow Balance</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}escrow_balance" class="snp-money-input snp-refund-input-{{ doc_id }}" value="{{ prefill_data.get('escrow_balance', '') }}" placeholder="0" oninput="snpFormatMoney(this); snpRecalculateRefunds('{{ doc_id }}')"></div></div>
+                    <div class="snp-total-row"><label>Total Estimated Refunds:</label><div class="snp-money-wrapper"><span class="snp-dollar">$</span><input type="text" name="{{ field_prefix }}total_refunds" id="snp_totalRefunds_{{ doc_id }}" class="snp-money-input" value="{{ prefill_data.get('total_refunds', '') }}" readonly></div></div>
+                </div>
+            </div>
+        </div>
+
+        <p class="snp-note-text">* Prorations are calculated through the closing date. ** Interest is prorated only in assumption transactions.</p>
+        <div class="snp-prepared-by"><strong>Prepared by:</strong> {{ current_user.first_name }} {{ current_user.last_name }}<input type="hidden" name="{{ field_prefix }}prepared_by" value="{{ current_user.first_name }} {{ current_user.last_name }}"></div>
+    </div>
+</div>
+
+<script>
+function snpFormatMoney(input) { let v=input.value.replace(/[^0-9.]/g,''); const p=v.split('.'); if(p.length>2)v=p[0]+'.'+p.slice(1).join(''); if(v){const n=parseFloat(v); if(!isNaN(n))input.value=n.toLocaleString('en-US',{minimumFractionDigits:v.includes('.')?2:0,maximumFractionDigits:2});} }
+function snpParseMoney(s) { return s?parseFloat(s.replace(/[$,]/g,''))||0:0; }
+function snpFormatAsMoney(n) { return n.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}); }
+function snpRecalculateAll(id) { snpCalculateProratedTaxes(id); snpCalculateBrokersFee(id); snpRecalculateCosts(id); snpRecalculateRefunds(id); snpRecalculateNetProceeds(id); }
+function snpCalculateProratedTaxes(id) { const cd=document.getElementById('snp_closingDate_'+id)?.value; const at=snpParseMoney(document.getElementById('snp_annualTaxes_'+id)?.value); if(!cd||!at){const tf=document.getElementById('snp_proratedTaxes_'+id);const df=document.getElementById('snp_proratedDays_'+id);if(tf)tf.value='';if(df)df.textContent='(___ days)';return;} const c=new Date(cd);const y=new Date(c.getFullYear(),0,1);const d=Math.ceil((c-y)/(1000*60*60*24))+1;const dr=at/365;const pa=dr*d;const df=document.getElementById('snp_proratedDays_'+id);if(df)df.textContent='('+d+' days)';const tf=document.getElementById('snp_proratedTaxes_'+id);if(tf)tf.value=snpFormatAsMoney(pa);snpRecalculateCosts(id); }
+function snpCalculateBrokersFee(id) { const ps=document.getElementById('snp_brokerPercent_'+id)?.value; const sp=snpParseMoney(document.getElementById('snp_salesPrice_'+id)?.value); const ff=document.getElementById('snp_brokerFee_'+id); if(!ps||!sp){if(ff)ff.value='';snpRecalculateCosts(id);return;} const p=parseFloat(ps)||0;const f=(sp*p)/100;if(ff)ff.value=snpFormatAsMoney(f);snpRecalculateCosts(id); }
+function snpRecalculateCosts(id) { const ci=document.querySelectorAll('.snp-cost-input-'+id); let t=0; ci.forEach(i=>{t+=snpParseMoney(i.value);}); const tf=document.getElementById('snp_totalCosts_'+id); const lf=document.getElementById('snp_lessCosts_'+id); if(tf)tf.value=snpFormatAsMoney(t); if(lf)lf.value=snpFormatAsMoney(t); snpRecalculateNetProceeds(id); }
+function snpRecalculateRefunds(id) { const ri=document.querySelectorAll('.snp-refund-input-'+id); let t=0; ri.forEach(i=>{t+=snpParseMoney(i.value);}); const tf=document.getElementById('snp_totalRefunds_'+id); if(tf)tf.value=snpFormatAsMoney(t); }
+function snpRecalculateNetProceeds(id) { const sp=snpParseMoney(document.getElementById('snp_salesPrice_'+id)?.value); const lc=snpParseMoney(document.getElementById('snp_lessCosts_'+id)?.value); const lp=snpParseMoney(document.getElementById('snp_loanPayoff_'+id)?.value); const np=sp-lc-lp; const nf=document.getElementById('snp_netProceeds_'+id); if(nf)nf.value=snpFormatAsMoney(np); }
+document.addEventListener('DOMContentLoaded',function(){document.querySelectorAll('[id^="snpDocument_"]').forEach(function(d){const id=d.id.replace('snpDocument_','');snpRecalculateAll(id);});});
+</script>
+

--- a/templates/transactions/seller_net_proceeds_form.html
+++ b/templates/transactions/seller_net_proceeds_form.html
@@ -1,0 +1,1471 @@
+{% extends "base.html" %}
+
+{% block title %}Seller's Estimated Net Proceeds - {{ transaction.street_address }} - TechnolOG{% endblock %}
+
+{% block content %}
+<style>
+    /* Document-style form styling */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    /* Document container - modern paper look */
+    .document-container {
+        background: #fff;
+        border-radius: 1rem;
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 10px 30px -5px rgba(0, 0, 0, 0.08);
+        border: 1px solid #e2e8f0;
+        max-width: 850px;
+        margin: 0 auto;
+    }
+
+    .document-header {
+        background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
+        color: white;
+        padding: 1.5rem 2rem;
+        border-radius: 1rem 1rem 0 0;
+        text-align: center;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .document-header::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: radial-gradient(circle at 30% 50%, rgba(255,255,255,0.1) 0%, transparent 50%);
+        pointer-events: none;
+    }
+
+    .document-header h1 {
+        font-size: 1.375rem;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        margin: 0;
+        text-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    }
+
+    .document-header .subtitle {
+        font-size: 0.75rem;
+        opacity: 0.85;
+        margin-top: 0.375rem;
+        letter-spacing: 0.025em;
+    }
+
+    .document-body {
+        padding: 1.75rem 2rem 2rem;
+    }
+
+    .disclaimer-text {
+        font-size: 0.8125rem;
+        font-style: italic;
+        color: #64748b;
+        text-align: center;
+        margin-bottom: 1.75rem;
+        padding-bottom: 1.25rem;
+        border-bottom: 1px solid #f1f5f9;
+    }
+
+    /* Form layout sections */
+    .form-row {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0.75rem;
+        gap: 0.5rem;
+    }
+
+    .form-row label {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #333;
+        white-space: nowrap;
+    }
+
+    .form-row .field-line {
+        flex: 1;
+        border-bottom: 1.5px solid #ccc;
+        min-height: 1.75rem;
+        display: flex;
+        align-items: flex-end;
+    }
+
+    .form-row input.doc-field {
+        border: none;
+        border-bottom: 2px solid #3b82f6;
+        background: #f8fafc;
+        padding: 0.375rem 0.5rem;
+        font-size: 0.875rem;
+        width: 100%;
+        transition: all 0.2s;
+    }
+
+    .form-row input.doc-field:focus {
+        outline: none;
+        background: #eff6ff;
+        border-bottom-color: #1d4ed8;
+    }
+
+    .form-row input.doc-field[readonly] {
+        background: #f1f5f9;
+        border-bottom-color: #94a3b8;
+        color: #64748b;
+    }
+
+    .form-row input.doc-field.calculated {
+        background: #ecfdf5;
+        border-bottom-color: #10b981;
+        color: #065f46;
+        font-weight: 600;
+    }
+
+    /* Two-column sections */
+    .two-column-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2rem;
+        margin-top: 1.5rem;
+    }
+
+    @media (max-width: 768px) {
+        .two-column-section {
+            grid-template-columns: 1fr;
+            gap: 1.5rem;
+        }
+    }
+
+    .section-box {
+        border: 1.5px solid #e2e8f0;
+        border-radius: 0.75rem;
+        padding: 1.25rem;
+        background: #fafbfc;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    }
+
+    .section-title {
+        font-size: 0.9375rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-bottom: 1rem;
+        padding-bottom: 0.625rem;
+        border-bottom: 2px solid #334155;
+        letter-spacing: 0.01em;
+    }
+
+    /* Cost row - label on left, amount on right */
+    .cost-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5rem;
+        font-size: 0.8125rem;
+    }
+
+    .cost-row label {
+        color: #475569;
+        flex: 1;
+    }
+
+    .cost-row .percent-input {
+        width: 45px;
+        padding: 0.25rem;
+        border: 1.5px solid #ccc;
+        border-radius: 0.25rem;
+        font-size: 0.8125rem;
+        text-align: center;
+        margin-right: 0.25rem;
+    }
+
+    .cost-row .percent-input:focus {
+        outline: none;
+        border-color: #3b82f6;
+    }
+
+    /* Money field wrapper with $ prefix */
+    .money-field-wrapper {
+        display: flex;
+        align-items: center;
+        max-width: 150px;
+        background: #f8fafc;
+        border-bottom: 2px solid #3b82f6;
+        transition: all 0.2s;
+    }
+
+    .money-field-wrapper:focus-within {
+        background: #eff6ff;
+        border-bottom-color: #1d4ed8;
+    }
+
+    .money-prefix {
+        padding: 0.375rem 0 0.375rem 0.5rem;
+        color: #64748b;
+        font-size: 0.875rem;
+        font-weight: 500;
+    }
+
+    .money-field-wrapper .doc-field.money-field {
+        border: none;
+        background: transparent;
+        padding: 0.375rem 0.5rem 0.375rem 0.25rem;
+        width: 100%;
+    }
+
+    .money-field-wrapper .doc-field.money-field:focus {
+        outline: none;
+        background: transparent;
+    }
+
+    /* Money input wrapper for cost rows */
+    .money-input-wrapper {
+        display: flex;
+        align-items: center;
+        border: 1.5px solid #e2e8f0;
+        border-radius: 0.375rem;
+        background: #fff;
+        overflow: hidden;
+        transition: all 0.2s;
+        min-width: 110px;
+    }
+
+    .money-input-wrapper:focus-within {
+        border-color: #3b82f6;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
+    .money-input-wrapper .dollar-sign {
+        padding: 0.25rem 0 0.25rem 0.5rem;
+        color: #94a3b8;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        background: #f8fafc;
+    }
+
+    .money-input-wrapper.calculated {
+        background: #f1f5f9;
+        border-color: #cbd5e1;
+    }
+
+    .money-input-wrapper.calculated .dollar-sign {
+        background: #f1f5f9;
+        color: #94a3b8;
+    }
+
+    .cost-row .money-input {
+        width: 100%;
+        padding: 0.3rem 0.5rem 0.3rem 0.25rem;
+        border: none;
+        font-size: 0.8125rem;
+        text-align: right;
+        background: transparent;
+    }
+
+    .cost-row .money-input:focus {
+        outline: none;
+    }
+
+    .cost-row .money-input[readonly] {
+        background: transparent;
+        color: #64748b;
+        font-weight: 600;
+    }
+
+    .cost-row .money-input.calculated {
+        background: transparent;
+        color: #64748b;
+        font-weight: 600;
+        cursor: not-allowed;
+    }
+
+    /* Custom row - user adds their own */
+    .custom-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .custom-row .custom-label-input {
+        flex: 1;
+        padding: 0.3rem 0.5rem;
+        border: none;
+        border-bottom: 1.5px dashed #cbd5e1;
+        font-size: 0.8125rem;
+        background: transparent;
+        transition: all 0.2s;
+    }
+
+    .custom-row .custom-label-input:focus {
+        outline: none;
+        border-bottom-color: #3b82f6;
+        border-bottom-style: solid;
+        background: #f8fafc;
+    }
+
+    .custom-row .custom-label-input::placeholder {
+        color: #94a3b8;
+        font-style: italic;
+    }
+
+    .custom-row .money-input-wrapper {
+        min-width: 110px;
+    }
+
+    .custom-row .money-input {
+        width: 100%;
+        padding: 0.3rem 0.5rem 0.3rem 0.25rem;
+        border: none;
+        font-size: 0.8125rem;
+        text-align: right;
+        background: transparent;
+    }
+
+    /* Total row */
+    .total-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding-top: 0.75rem;
+        margin-top: 0.75rem;
+        border-top: 2px solid #334155;
+        font-weight: 700;
+        font-size: 0.9375rem;
+    }
+
+    .total-row .money-input-wrapper.total-wrapper {
+        background: #f1f5f9;
+        border-color: #94a3b8;
+        border-width: 2px;
+        min-width: 120px;
+    }
+
+    .total-row .money-input-wrapper.total-wrapper .dollar-sign {
+        background: #f1f5f9;
+        color: #64748b;
+        font-weight: 700;
+    }
+
+    .total-row .money-input {
+        width: 100%;
+        padding: 0.375rem 0.5rem 0.375rem 0.25rem;
+        border: none;
+        font-size: 0.9375rem;
+        text-align: right;
+        font-weight: 700;
+        background: transparent;
+        color: #475569;
+    }
+
+    /* Proceeds section styling */
+    .proceeds-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5rem;
+        font-size: 0.875rem;
+    }
+
+    .proceeds-row label {
+        color: #1e293b;
+        font-weight: 500;
+    }
+
+    .proceeds-row .parentheses {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
+    .proceeds-row .parentheses::before {
+        content: '(';
+        font-weight: 600;
+        color: #dc2626;
+    }
+
+    .proceeds-row .parentheses::after {
+        content: ')';
+        font-weight: 600;
+        color: #dc2626;
+    }
+
+    /* Proceeds section money wrapper - match cost-row styling */
+    .proceeds-row .money-input-wrapper {
+        min-width: 110px;
+    }
+
+    .proceeds-row .money-input-wrapper .money-input {
+        width: 100%;
+        padding: 0.3rem 0.5rem 0.3rem 0.25rem;
+        border: none;
+        font-size: 0.8125rem;
+        text-align: right;
+        background: transparent;
+    }
+
+    .proceeds-row .money-input-wrapper .money-input:focus {
+        outline: none;
+    }
+
+    .proceeds-row .money-input-wrapper.calculated .money-input {
+        color: #64748b;
+        font-weight: 600;
+    }
+
+    /* Net proceeds total - prominent styling */
+    .net-proceeds-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.875rem 1rem;
+        margin-top: 1rem;
+        background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+        border: 2px solid #10b981;
+        border-radius: 0.5rem;
+    }
+
+    .net-proceeds-row label {
+        font-weight: 700;
+        font-size: 1rem;
+        color: #065f46;
+    }
+
+    .net-proceeds-row .money-input-wrapper.net-proceeds-wrapper {
+        background: white;
+        border: 2px solid #059669;
+        border-radius: 0.375rem;
+        min-width: 140px;
+    }
+
+    .net-proceeds-row .money-input-wrapper .dollar-sign {
+        background: white;
+        color: #059669;
+        font-weight: 700;
+        font-size: 1rem;
+        padding: 0.5rem 0 0.5rem 0.625rem;
+    }
+
+    .net-proceeds-row .money-input {
+        width: 100%;
+        padding: 0.5rem 0.625rem 0.5rem 0.25rem;
+        border: none;
+        font-size: 1.125rem;
+        text-align: right;
+        font-weight: 700;
+        background: transparent;
+        color: #059669;
+    }
+
+    /* Checkbox group for financing */
+    .financing-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.625rem;
+    }
+
+    .financing-option {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.875rem;
+        background: #f8fafc;
+        border: 1.5px solid #e2e8f0;
+        border-radius: 0.5rem;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .financing-option:hover {
+        background: #f1f5f9;
+        border-color: #cbd5e1;
+    }
+
+    .financing-option:has(input:checked) {
+        background: #eff6ff;
+        border-color: #3b82f6;
+    }
+
+    .financing-option input[type="checkbox"] {
+        width: 1rem;
+        height: 1rem;
+        accent-color: #3b82f6;
+        cursor: pointer;
+    }
+
+    .financing-option span {
+        font-size: 0.8125rem;
+        color: #475569;
+        font-weight: 500;
+    }
+
+    .financing-option:has(input:checked) span {
+        color: #1d4ed8;
+    }
+
+    /* Prepared by section */
+    .prepared-by-section {
+        margin-top: 1.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid #e2e8f0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .prepared-by-section label {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #475569;
+    }
+
+    .prepared-by-section .agent-name {
+        font-size: 0.875rem;
+        color: #1e293b;
+        font-weight: 600;
+    }
+
+    /* Notes section */
+    .notes-section {
+        margin-top: 1rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    .notes-section .note-text {
+        font-size: 0.75rem;
+        color: #64748b;
+        font-style: italic;
+    }
+
+    /* Floating action bar */
+    .floating-action-bar {
+        position: fixed;
+        bottom: 1.5rem;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(255, 255, 255, 0.95);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        padding: 0.75rem 1rem;
+        border-radius: 1rem;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.8);
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+    }
+
+    .premium-btn {
+        transition: all 0.2s ease-out;
+        border-radius: 0.625rem;
+        font-weight: 500;
+    }
+
+    .premium-btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.12);
+    }
+
+    .premium-btn:active {
+        transform: translateY(0);
+    }
+
+    .form-bottom-spacer {
+        height: 100px;
+    }
+
+    /* Progress bar */
+    .progress-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: #f1f5f9;
+        z-index: 1000;
+    }
+
+    .progress-bar-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #1e3a5f 0%, #3b82f6 50%, #10b981 100%);
+        transition: width 0.3s ease-out;
+        border-radius: 0 3px 3px 0;
+    }
+
+    /* Sales price warning modal */
+    .modal-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1000;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .modal-overlay.show {
+        display: flex;
+    }
+
+    .modal-content {
+        background: white;
+        padding: 1.5rem;
+        border-radius: 1rem;
+        max-width: 400px;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+    }
+
+    .modal-content h3 {
+        color: #f59e0b;
+        margin-bottom: 0.75rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .modal-content p {
+        color: #475569;
+        font-size: 0.9375rem;
+        margin-bottom: 1rem;
+    }
+
+    .modal-buttons {
+        display: flex;
+        gap: 0.75rem;
+        justify-content: flex-end;
+    }
+
+    .modal-buttons button {
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .modal-buttons .btn-cancel {
+        background: #f1f5f9;
+        border: 1px solid #e2e8f0;
+        color: #64748b;
+    }
+
+    .modal-buttons .btn-confirm {
+        background: #f59e0b;
+        border: none;
+        color: white;
+    }
+
+    .modal-buttons .btn-confirm:hover {
+        background: #d97706;
+    }
+</style>
+
+<!-- Progress Bar -->
+<div class="progress-bar">
+    <div class="progress-bar-fill" id="progressFill" style="width: 0%"></div>
+</div>
+
+<!-- Sales Price Warning Modal -->
+<div class="modal-overlay" id="salesPriceModal">
+    <div class="modal-content">
+        <h3><i class="fas fa-exclamation-triangle"></i> Change Sales Price?</h3>
+        <p>This value is different from the sales price on the transaction record. Are you sure you want to use a different amount for this estimate?</p>
+        <div class="modal-buttons">
+            <button class="btn-cancel" onclick="cancelSalesPriceChange()">Cancel</button>
+            <button class="btn-confirm" onclick="confirmSalesPriceChange()">Yes, Update It</button>
+        </div>
+    </div>
+</div>
+
+<!-- Premium gradient background -->
+<div class="min-h-full bg-gradient-to-br from-slate-100 via-white to-blue-50/30">
+    <div class="p-4 md:p-6">
+        <!-- Back Link -->
+        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+           class="inline-flex items-center text-slate-500 hover:text-blue-600 text-sm mb-4 transition-colors animate-fade-in-up max-w-[850px] mx-auto block">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Transaction
+        </a>
+
+        <!-- Main Form -->
+        <form id="netProceedsForm" method="POST" action="{{ url_for('transactions.save_document_form', id=transaction.id, doc_id=document.id) }}">
+            <div class="document-container animate-fade-in-up">
+                <!-- Document Header -->
+                <div class="document-header">
+                    <h1>SELLER'S ESTIMATED NET PROCEEDS</h1>
+                    <div class="subtitle">TXR-1935 • Texas Association of REALTORS®</div>
+                </div>
+
+                <div class="document-body">
+                    <p class="disclaimer-text">
+                        The figures below are estimates. Actual costs and proceeds will vary. Estimates are not guaranteed.
+                    </p>
+
+                    <!-- Seller Name -->
+                    <div class="form-row">
+                        <label>Seller:</label>
+                        <div class="field-line">
+                            <input type="text" name="field_seller_name" class="doc-field" 
+                                   value="{{ prefill_data.get('seller_name', '') }}" readonly>
+                        </div>
+                    </div>
+
+                    <!-- Address -->
+                    <div class="form-row">
+                        <label>Address:</label>
+                        <div class="field-line">
+                            <input type="text" name="field_property_address" class="doc-field" 
+                                   value="{{ prefill_data.get('property_address', '') }}" readonly>
+                        </div>
+                    </div>
+
+                    <!-- Anticipated Closing Date -->
+                    <div class="form-row">
+                        <label>Anticipated Closing Date:</label>
+                        <div class="field-line" style="max-width: 180px;">
+                            <input type="date" name="field_closing_date" id="closingDate" class="doc-field"
+                                   value="{{ prefill_data.get('closing_date', '') }}"
+                                   onchange="recalculateAll()">
+                        </div>
+                    </div>
+
+                    <!-- Estimated Annual Property Taxes -->
+                    <div class="form-row">
+                        <label>Estimated Annual Property Taxes:</label>
+                        <div class="money-field-wrapper">
+                            <span class="money-prefix">$</span>
+                            <input type="text" name="field_annual_property_taxes" id="annualPropertyTaxes" class="doc-field money-field"
+                                   value="{{ prefill_data.get('annual_property_taxes', '') }}"
+                                   placeholder="0.00"
+                                   oninput="formatMoney(this); recalculateAll()">
+                        </div>
+                    </div>
+
+                    <!-- Estimated Annual Maintenance Fees -->
+                    <div class="form-row">
+                        <label>Estimated Annual Maintenance Fees:</label>
+                        <div class="money-field-wrapper">
+                            <span class="money-prefix">$</span>
+                            <input type="text" name="field_annual_maintenance_fees" id="annualMaintenanceFees" class="doc-field money-field"
+                                   value="{{ prefill_data.get('annual_maintenance_fees', '') }}"
+                                   placeholder="0.00"
+                                   oninput="formatMoney(this)">
+                        </div>
+                    </div>
+
+                    <!-- Buyer's Anticipated Financing -->
+                    <div style="margin-top: 1rem; margin-bottom: 1rem;">
+                        <label style="font-size: 0.875rem; font-weight: 500; color: #333;">Buyer's Anticipated Financing:</label>
+                        <div class="financing-group">
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_conventional" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_conventional') else '' }}>
+                                <span>Conventional</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_va" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_va') else '' }}>
+                                <span>VA</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_fha" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_fha') else '' }}>
+                                <span>FHA</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_usda" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_usda') else '' }}>
+                                <span>USDA</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_reverse" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_reverse') else '' }}>
+                                <span>Reverse Mortgage</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_assumption" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_assumption') else '' }}>
+                                <span>Assumption</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_owner" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_owner') else '' }}>
+                                <span>Owner</span>
+                            </label>
+                            <label class="financing-option">
+                                <input type="checkbox" name="field_financing_cash" value="1"
+                                       {{ 'checked' if prefill_data.get('financing_cash') else '' }}>
+                                <span>Cash</span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- Two Column Layout: Estimated Costs & Proceeds -->
+                    <div class="two-column-section">
+                        <!-- Left Column: Estimated Costs -->
+                        <div class="section-box">
+                            <div class="section-title">Estimated Costs</div>
+                            
+                            <div class="cost-row">
+                                <label>Attorney's Fees / Doc. Prep.</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_attorneys_fees" class="money-input cost-input"
+                                           value="{{ prefill_data.get('attorneys_fees', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Brokers' Fees</label>
+                                <input type="text" name="field_brokers_fee_percent" id="brokersFeePercent" class="percent-input"
+                                       value="{{ prefill_data.get('brokers_fee_percent', '') }}"
+                                       placeholder="%" oninput="calculateBrokersFee()">
+                                <span style="font-size: 0.75rem; color: #64748b;">%</span>
+                                <div class="money-input-wrapper calculated">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_brokers_fee" id="brokersFee" class="money-input calculated cost-input"
+                                           value="{{ prefill_data.get('brokers_fee', '') }}"
+                                           placeholder="0" readonly>
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Condo. Transfer Fee</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_condo_transfer_fee" class="money-input cost-input"
+                                           value="{{ prefill_data.get('condo_transfer_fee', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Courier & Express Mail Fees</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_courier_fees" class="money-input cost-input"
+                                           value="{{ prefill_data.get('courier_fees', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Escrow Fee (one-half)</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_escrow_fee" class="money-input cost-input"
+                                           value="{{ prefill_data.get('escrow_fee', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div style="font-size: 0.8125rem; color: #475569; font-weight: 500; margin: 0.5rem 0 0.25rem;">Prorations*:</div>
+                            
+                            <div class="cost-row" style="margin-left: 0.75rem;">
+                                <label>Taxes <span id="proratedDays" style="font-size: 0.75rem; color: #64748b;">Prorated for ___ days</span></label>
+                                <div class="money-input-wrapper calculated">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_prorated_taxes" id="proratedTaxes" class="money-input calculated cost-input"
+                                           value="{{ prefill_data.get('prorated_taxes', '') }}"
+                                           placeholder="0" readonly>
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row" style="margin-left: 0.75rem;">
+                                <label>Interest (Assumptions)**</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_prorated_interest" class="money-input cost-input"
+                                           value="{{ prefill_data.get('prorated_interest', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row" style="margin-left: 0.75rem;">
+                                <label>Maintenance Fees</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_prorated_maintenance" class="money-input cost-input"
+                                           value="{{ prefill_data.get('prorated_maintenance', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row" style="margin-left: 0.75rem;">
+                                <label>Assessments</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_assessments" class="money-input cost-input"
+                                           value="{{ prefill_data.get('assessments', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row" style="margin-left: 0.75rem;">
+                                <label>Rents</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_rents" class="money-input cost-input"
+                                           value="{{ prefill_data.get('rents', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Recording Fees</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_recording_fees" class="money-input cost-input"
+                                           value="{{ prefill_data.get('recording_fees', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Repairs Required by Buyer</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_repairs_buyer" class="money-input cost-input"
+                                           value="{{ prefill_data.get('repairs_buyer', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Repairs Required by Lender</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_repairs_lender" class="money-input cost-input"
+                                           value="{{ prefill_data.get('repairs_lender', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Residential Service Contract</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_residential_service" class="money-input cost-input"
+                                           value="{{ prefill_data.get('residential_service', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Seller Allowances or FHA/VA Nonallowables (Para. 12)</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_seller_allowances" class="money-input cost-input"
+                                           value="{{ prefill_data.get('seller_allowances', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Survey Fee</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_survey_fee" class="money-input cost-input"
+                                           value="{{ prefill_data.get('survey_fee', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Tax Certificate Fee</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_tax_cert_fee" class="money-input cost-input"
+                                           value="{{ prefill_data.get('tax_cert_fee', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Title Policy - Owner's</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_title_policy" class="money-input cost-input"
+                                           value="{{ prefill_data.get('title_policy', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="cost-row">
+                                <label>Wiring Fees</label>
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_wiring_fees" class="money-input cost-input"
+                                           value="{{ prefill_data.get('wiring_fees', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <!-- 4 Custom rows -->
+                            <div class="custom-row">
+                                <input type="text" name="field_custom_label_1" class="custom-label-input"
+                                       value="{{ prefill_data.get('custom_label_1', '') }}"
+                                       placeholder="Other...">
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_custom_amount_1" class="money-input cost-input"
+                                           value="{{ prefill_data.get('custom_amount_1', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="custom-row">
+                                <input type="text" name="field_custom_label_2" class="custom-label-input"
+                                       value="{{ prefill_data.get('custom_label_2', '') }}"
+                                       placeholder="Other...">
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_custom_amount_2" class="money-input cost-input"
+                                           value="{{ prefill_data.get('custom_amount_2', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="custom-row">
+                                <input type="text" name="field_custom_label_3" class="custom-label-input"
+                                       value="{{ prefill_data.get('custom_label_3', '') }}"
+                                       placeholder="Other...">
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_custom_amount_3" class="money-input cost-input"
+                                           value="{{ prefill_data.get('custom_amount_3', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="custom-row">
+                                <input type="text" name="field_custom_label_4" class="custom-label-input"
+                                       value="{{ prefill_data.get('custom_label_4', '') }}"
+                                       placeholder="Other...">
+                                <div class="money-input-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_custom_amount_4" class="money-input cost-input"
+                                           value="{{ prefill_data.get('custom_amount_4', '') }}"
+                                           placeholder="0" oninput="formatMoney(this); recalculateCosts()">
+                                </div>
+                            </div>
+                            
+                            <div class="total-row">
+                                <label>Total Estimated Costs</label>
+                                <div class="money-input-wrapper total-wrapper">
+                                    <span class="dollar-sign">$</span>
+                                    <input type="text" name="field_total_costs" id="totalCosts" class="money-input" 
+                                           value="{{ prefill_data.get('total_costs', '') }}"
+                                           readonly>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Right Column: Estimated Proceeds to Seller -->
+                        <div>
+                            <div class="section-box" style="margin-bottom: 1rem;">
+                                <div class="section-title">Estimated Proceeds to Seller:</div>
+                                
+                                <div class="proceeds-row">
+                                    <label>Sales Price</label>
+                                    <div class="money-input-wrapper proceeds-money">
+                                        <span class="dollar-sign">$</span>
+                                        <input type="text" name="field_sales_price" id="salesPrice" class="money-input"
+                                               value="{{ prefill_data.get('sales_price', prefill_data.get('list_price', '')) }}"
+                                               placeholder="0"
+                                               onfocus="checkSalesPriceEdit(this)"
+                                               oninput="formatMoney(this); recalculateAll()">
+                                    </div>
+                                    <input type="hidden" id="originalSalesPrice" value="{{ prefill_data.get('list_price', '') }}">
+                                </div>
+                                
+                                <div class="proceeds-row">
+                                    <label>Less Estimated Costs</label>
+                                    <div class="parentheses">
+                                        <div class="money-input-wrapper calculated">
+                                            <span class="dollar-sign">$</span>
+                                            <input type="text" name="field_less_costs" id="lessCosts" class="money-input calculated"
+                                                   value="{{ prefill_data.get('less_costs', '') }}"
+                                                   readonly>
+                                        </div>
+                                    </div>
+                                </div>
+                                
+                                <div class="proceeds-row">
+                                    <label>Less Estimated Loan Payoff</label>
+                                    <div class="parentheses">
+                                        <div class="money-input-wrapper">
+                                            <span class="dollar-sign">$</span>
+                                            <input type="text" name="field_loan_payoff" id="loanPayoff" class="money-input"
+                                                   value="{{ prefill_data.get('loan_payoff', '') }}"
+                                                   placeholder="0"
+                                                   oninput="formatMoney(this); recalculateNetProceeds()">
+                                        </div>
+                                    </div>
+                                </div>
+                                
+                                <div class="net-proceeds-row">
+                                    <label>Estimated Net Proceeds:</label>
+                                    <div class="money-input-wrapper net-proceeds-wrapper">
+                                        <span class="dollar-sign">$</span>
+                                        <input type="text" name="field_net_proceeds" id="netProceeds" class="money-input"
+                                               value="{{ prefill_data.get('net_proceeds', '') }}"
+                                               readonly>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <!-- After Closing Refunds -->
+                            <div class="section-box">
+                                <div class="section-title">After Closing Refunds</div>
+                                
+                                <div class="cost-row">
+                                    <label>Estimated Unused Insurance</label>
+                                    <div class="money-input-wrapper">
+                                        <span class="dollar-sign">$</span>
+                                        <input type="text" name="field_unused_insurance" class="money-input refund-input"
+                                               value="{{ prefill_data.get('unused_insurance', '') }}"
+                                               placeholder="0" oninput="formatMoney(this); recalculateRefunds()">
+                                    </div>
+                                </div>
+                                
+                                <div class="cost-row">
+                                    <label>Estimated Escrow Balance</label>
+                                    <div class="money-input-wrapper">
+                                        <span class="dollar-sign">$</span>
+                                        <input type="text" name="field_escrow_balance" class="money-input refund-input"
+                                               value="{{ prefill_data.get('escrow_balance', '') }}"
+                                               placeholder="0" oninput="formatMoney(this); recalculateRefunds()">
+                                    </div>
+                                </div>
+                                
+                                <div class="total-row">
+                                    <label>Total Estimated Refunds:</label>
+                                    <div class="money-input-wrapper total-wrapper">
+                                        <span class="dollar-sign">$</span>
+                                        <input type="text" name="field_total_refunds" id="totalRefunds" class="money-input"
+                                               value="{{ prefill_data.get('total_refunds', '') }}"
+                                               readonly>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Notes Section -->
+                    <div class="notes-section">
+                        <p class="note-text">
+                            <strong>Note:</strong> Seller may be required to pay some costs directly to the service providers before closing.
+                        </p>
+                        <p class="note-text" style="margin-top: 0.5rem;">
+                            * Prorations are calculated through the closing date.<br>
+                            ** Interest is prorated only in assumption transactions.
+                        </p>
+                    </div>
+
+                    <!-- Prepared By -->
+                    <div class="prepared-by-section">
+                        <label>Prepared by:</label>
+                        <span class="agent-name">{{ current_user.first_name }} {{ current_user.last_name }}</span>
+                        <input type="hidden" name="field_prepared_by" value="{{ current_user.first_name }} {{ current_user.last_name }}">
+                    </div>
+                </div>
+            </div>
+
+            <!-- Spacer for floating action bar -->
+            <div class="form-bottom-spacer"></div>
+        </form>
+        
+        <!-- Floating Action Bar -->
+        <div class="floating-action-bar">
+            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+               class="premium-btn px-5 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-lg transition-colors">
+                Cancel
+            </a>
+            <div class="w-px h-8 bg-slate-200"></div>
+            <button type="submit" form="netProceedsForm" name="submit_action" value="save" 
+                    class="premium-btn px-5 py-2.5 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg flex items-center gap-2 transition-colors">
+                <i class="fas fa-save text-slate-500"></i>
+                Save Draft
+            </button>
+            <button type="button" onclick="saveAndPreview()" 
+                    class="premium-btn px-5 py-2.5 text-sm font-medium text-white bg-gradient-to-r from-blue-600 to-emerald-600 hover:from-blue-700 hover:to-emerald-700 rounded-lg flex items-center gap-2 shadow-sm transition-colors">
+                <i class="fas fa-check-circle"></i>
+                Save & Continue
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- Toast Notification -->
+<div id="toast" class="fixed bottom-6 right-6 z-50 hidden">
+    <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-2xl shadow-2xl border border-slate-200">
+        <i id="toastIcon" class="fas fa-info-circle text-blue-500"></i>
+        <span id="toastMessage" class="text-sm font-medium text-slate-700"></span>
+    </div>
+</div>
+
+<script>
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+let salesPriceEditAllowed = false;
+let pendingSalesPriceValue = '';
+
+document.addEventListener('DOMContentLoaded', function() {
+    recalculateAll();
+    updateProgress();
+    
+    // Add input listeners for progress tracking
+    document.querySelectorAll('input').forEach(el => {
+        el.addEventListener('change', updateProgress);
+        el.addEventListener('input', updateProgress);
+    });
+});
+
+// =============================================================================
+// MONEY FORMATTING
+// =============================================================================
+
+function formatMoney(input) {
+    // Remove all non-numeric except decimal
+    let value = input.value.replace(/[^0-9.]/g, '');
+    
+    // Ensure only one decimal point
+    const parts = value.split('.');
+    if (parts.length > 2) {
+        value = parts[0] + '.' + parts.slice(1).join('');
+    }
+    
+    // Parse and format
+    if (value) {
+        const num = parseFloat(value);
+        if (!isNaN(num)) {
+            // Format with commas, keeping decimal if present
+            const formatted = num.toLocaleString('en-US', {
+                minimumFractionDigits: value.includes('.') ? 2 : 0,
+                maximumFractionDigits: 2
+            });
+            input.value = formatted;
+        }
+    }
+}
+
+function parseMoneyValue(str) {
+    if (!str) return 0;
+    // Remove $ and commas, then parse
+    const cleaned = str.replace(/[$,]/g, '');
+    return parseFloat(cleaned) || 0;
+}
+
+function formatAsMoney(num) {
+    return num.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+}
+
+// =============================================================================
+// SALES PRICE EDIT WARNING
+// =============================================================================
+
+function checkSalesPriceEdit(input) {
+    const original = document.getElementById('originalSalesPrice').value;
+    if (original && !salesPriceEditAllowed) {
+        input.blur();
+        pendingSalesPriceValue = input.value;
+        document.getElementById('salesPriceModal').classList.add('show');
+    }
+}
+
+function cancelSalesPriceChange() {
+    document.getElementById('salesPriceModal').classList.remove('show');
+    document.getElementById('salesPrice').value = pendingSalesPriceValue;
+}
+
+function confirmSalesPriceChange() {
+    document.getElementById('salesPriceModal').classList.remove('show');
+    salesPriceEditAllowed = true;
+    document.getElementById('salesPrice').focus();
+}
+
+// =============================================================================
+// CALCULATIONS
+// =============================================================================
+
+function recalculateAll() {
+    calculateProratedTaxes();
+    calculateBrokersFee();
+    recalculateCosts();
+    recalculateRefunds();
+    recalculateNetProceeds();
+    updateProgress();
+}
+
+function calculateProratedTaxes() {
+    const closingDateStr = document.getElementById('closingDate').value;
+    const annualTaxes = parseMoneyValue(document.getElementById('annualPropertyTaxes').value);
+    
+    if (!closingDateStr || !annualTaxes) {
+        document.getElementById('proratedTaxes').value = '';
+        document.getElementById('proratedDays').textContent = 'Prorated for ___ days';
+        return;
+    }
+    
+    // Calculate days from Jan 1 to closing date
+    const closingDate = new Date(closingDateStr);
+    const yearStart = new Date(closingDate.getFullYear(), 0, 1); // January 1
+    const diffTime = closingDate - yearStart;
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1; // +1 to include closing day
+    
+    // Calculate prorated taxes
+    const dailyRate = annualTaxes / 365;
+    const proratedAmount = dailyRate * diffDays;
+    
+    document.getElementById('proratedDays').textContent = `Prorated for ${diffDays} days`;
+    document.getElementById('proratedTaxes').value = formatAsMoney(proratedAmount);
+    
+    recalculateCosts();
+}
+
+function calculateBrokersFee() {
+    const percentStr = document.getElementById('brokersFeePercent').value;
+    const salesPrice = parseMoneyValue(document.getElementById('salesPrice').value);
+    
+    if (!percentStr || !salesPrice) {
+        document.getElementById('brokersFee').value = '';
+        recalculateCosts();
+        return;
+    }
+    
+    const percent = parseFloat(percentStr) || 0;
+    const fee = (salesPrice * percent) / 100;
+    
+    document.getElementById('brokersFee').value = formatAsMoney(fee);
+    recalculateCosts();
+}
+
+function recalculateCosts() {
+    const costInputs = document.querySelectorAll('.cost-input');
+    let total = 0;
+    
+    costInputs.forEach(input => {
+        total += parseMoneyValue(input.value);
+    });
+    
+    document.getElementById('totalCosts').value = formatAsMoney(total);
+    document.getElementById('lessCosts').value = formatAsMoney(total);
+    
+    recalculateNetProceeds();
+}
+
+function recalculateRefunds() {
+    const refundInputs = document.querySelectorAll('.refund-input');
+    let total = 0;
+    
+    refundInputs.forEach(input => {
+        total += parseMoneyValue(input.value);
+    });
+    
+    document.getElementById('totalRefunds').value = formatAsMoney(total);
+}
+
+function recalculateNetProceeds() {
+    const salesPrice = parseMoneyValue(document.getElementById('salesPrice').value);
+    const lessCosts = parseMoneyValue(document.getElementById('lessCosts').value);
+    const loanPayoff = parseMoneyValue(document.getElementById('loanPayoff').value);
+    
+    const netProceeds = salesPrice - lessCosts - loanPayoff;
+    
+    document.getElementById('netProceeds').value = formatAsMoney(netProceeds);
+}
+
+// =============================================================================
+// PROGRESS TRACKING
+// =============================================================================
+
+function updateProgress() {
+    const form = document.getElementById('netProceedsForm');
+    const allInputs = form.querySelectorAll('input:not([type="hidden"]):not([readonly])');
+    let filledCount = 0;
+    let totalCount = 0;
+    
+    allInputs.forEach(input => {
+        if (input.type === 'checkbox') {
+            // Don't count checkboxes toward progress
+        } else if (input.value && input.value.trim()) {
+            filledCount++;
+            totalCount++;
+        } else {
+            totalCount++;
+        }
+    });
+    
+    const progress = totalCount > 0 ? Math.min((filledCount / totalCount) * 100, 100) : 0;
+    document.getElementById('progressFill').style.width = progress + '%';
+}
+
+// =============================================================================
+// FORM SUBMISSION
+// =============================================================================
+
+function showToast(message, type = 'info') {
+    const toast = document.getElementById('toast');
+    const icon = document.getElementById('toastIcon');
+    document.getElementById('toastMessage').textContent = message;
+    
+    icon.className = 'fas';
+    if (type === 'success') {
+        icon.classList.add('fa-check-circle', 'text-green-500');
+    } else if (type === 'error') {
+        icon.classList.add('fa-exclamation-circle', 'text-red-500');
+    } else if (type === 'warning') {
+        icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
+    } else {
+        icon.classList.add('fa-info-circle', 'text-blue-500');
+    }
+    
+    toast.classList.remove('hidden');
+    setTimeout(() => toast.classList.add('hidden'), 4000);
+}
+
+function saveAndPreview() {
+    const form = document.getElementById('netProceedsForm');
+    const formData = new FormData(form);
+    
+    showToast('Saving document...', 'info');
+    
+    fetch(form.action, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => {
+        if (response.ok) {
+            showToast('Opening preview...', 'success');
+            setTimeout(() => {
+                window.location.href = "{{ url_for('transactions.document_preview', id=transaction.id, doc_id=document.id) }}";
+            }, 500);
+        } else {
+            showToast('Error saving form. Please try again.', 'error');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        showToast('Error saving form. Please try again.', 'error');
+    });
+}
+</script>
+{% endblock %}
+


### PR DESCRIPTION
- Create document-style form UI mimicking actual TXR form layout
- Add real-time calculations for prorated taxes, broker fees, and totals
- Auto-populate seller name, address, and sales price from transaction
- Add financing type checkboxes and custom cost line items
- Style money fields with $ prefix inside input boxes
- Create partial template for Fill All Documents view
- Add DocuSeal mapping configuration
- Register document in document registry and routing