### PR TITLE
refactor: YAML-driven document generation system

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,6 +78,18 @@ def create_app():
     app.register_blueprint(company_updates_bp)
     app.register_blueprint(transactions_bp)
 
+    # Load and validate document definitions on startup
+    # This ensures all YAML configs are valid before the app starts
+    with app.app_context():
+        from services.documents import DocumentLoader
+        try:
+            DocumentLoader.load_all()
+            app.logger.info(f"Loaded {len(DocumentLoader.all())} document definitions")
+        except Exception as e:
+            app.logger.error(f"Failed to load document definitions: {e}")
+            # Don't fail startup - old system still works as fallback
+            # raise
+
     return app
 
 app = create_app()

--- a/documents/flood-hazard.yml
+++ b/documents/flood-hazard.yml
@@ -1,0 +1,75 @@
+# =============================================================================
+# FLOOD HAZARD INFORMATION
+# =============================================================================
+# Information About Special Flood Hazard Areas
+# 
+# This is a form-driven document with a custom UI for data entry.
+# =============================================================================
+
+schema_version: "1.0"
+slug: flood-hazard
+name: "Flood Hazard Information"
+docuseal_template_id: 2489522
+type: form-driven
+
+display:
+  color: "#06B6D4"
+  icon: "fas fa-water"
+  sort_order: 3
+
+form:
+  template: flood_hazard_form.html
+  partial: flood_hazard_fields.html
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Seller 2
+# =============================================================================
+
+roles:
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Property address is repeated in 3 places in this document
+# =============================================================================
+
+fields:
+  # Property address fields
+  - field_key: property_address_1
+    docuseal_field: "Property address 1"
+    role_key: seller
+    source: form.property_address
+
+  - field_key: property_address_2
+    docuseal_field: "Property address 2"
+    role_key: seller
+    source: form.property_address
+
+  - field_key: property_address_3
+    docuseal_field: "Property address 3"
+    role_key: seller
+    source: form.property_address
+
+  # Signature fields - handled by DocuSeal
+  - field_key: seller_signature
+    docuseal_field: "Seller Signature"
+    role_key: seller
+    source: null
+
+  - field_key: seller_2_signature
+    docuseal_field: "Seller 2 Signature"
+    role_key: seller_2
+    source: null
+

--- a/documents/hoa-addendum.yml
+++ b/documents/hoa-addendum.yml
@@ -1,0 +1,92 @@
+# =============================================================================
+# HOA ADDENDUM
+# =============================================================================
+# Addendum for Property Subject to Mandatory Membership in Owners' Association
+# TREC Form
+# 
+# This is a form-driven document with a custom UI for data entry.
+# =============================================================================
+
+schema_version: "1.0"
+slug: hoa-addendum
+name: "HOA Addendum"
+docuseal_template_id: 2469165
+type: form-driven
+
+display:
+  color: "#8B5CF6"
+  icon: "fas fa-building"
+  sort_order: 2
+
+form:
+  template: hoa_addendum_form.html
+  partial: hoa_addendum_fields.html
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Seller 2
+# Both sellers sign the HOA addendum
+# =============================================================================
+
+roles:
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Form fields from hoa_addendum_fields.html
+# Note: Computed fields (combining multiple form values) are handled separately
+# =============================================================================
+
+fields:
+  # Property address (computed from multiple fields in old system)
+  - field_key: street_address
+    docuseal_field: "Street address"
+    role_key: seller
+    source: form.property_address
+
+  # HOA information
+  - field_key: association_info
+    docuseal_field: "Association name & phone"
+    role_key: seller
+    source: form.hoa_name
+
+  # Section A - Document delivery options
+  - field_key: option_1_days
+    docuseal_field: "1. Days after effective date"
+    role_key: seller
+    source: form.seller_delivery_days
+
+  - field_key: option_2_days
+    docuseal_field: "2. Days after effective date"
+    role_key: seller
+    source: form.buyer_delivery_days
+
+  # Section C - Fees
+  - field_key: buyer_fee_cap
+    docuseal_field: "C. Buyer paid transfer fee"
+    role_key: seller
+    source: form.buyer_fee_cap
+    transform: currency
+
+  # Signature fields - handled by DocuSeal
+  - field_key: seller_signature
+    docuseal_field: "Seller signature 1"
+    role_key: seller
+    source: null
+
+  - field_key: seller_2_signature
+    docuseal_field: "Signature Field 2"
+    role_key: seller_2
+    source: null
+

--- a/documents/iabs.yml
+++ b/documents/iabs.yml
@@ -1,0 +1,121 @@
+# =============================================================================
+# IABS (Information About Brokerage Services)
+# =============================================================================
+# TXR-2501 - Required disclosure document for Texas real estate transactions
+# 
+# This is a PDF-preview document - no custom form UI.
+# Agent/supervisor fields are auto-populated from the user's profile.
+# Sellers provide initials and date during e-signature.
+# =============================================================================
+
+schema_version: "1.0"
+slug: iabs
+name: "Information About Brokerage Services"
+docuseal_template_id: 2508644
+type: pdf-preview
+
+display:
+  color: "#6B7280"
+  icon: "fas fa-info-circle"
+  sort_order: 10
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Broker, Seller, Agent, Seller 2
+# 
+# - Broker: Pre-filled in DocuSeal template (brokerage info)
+# - Agent: Auto-filled from user profile (agent/supervisor info)
+# - Seller/Seller 2: Provide initials and date during e-signature
+# =============================================================================
+
+roles:
+  - role_key: agent
+    docuseal_role: Agent
+    email_source: user.email
+    name_source: user.full_name
+
+  - role_key: broker
+    docuseal_role: Broker
+    email_source: user.email
+    name_source: user.full_name
+
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# All fields belong to the "agent" role and are auto-populated from the
+# user's profile. Seller fields are left null (manual entry during signing).
+# =============================================================================
+
+fields:
+  # Agent information (from user profile)
+  - field_key: agent_name
+    docuseal_field: "Sales Agent Name"
+    role_key: agent
+    source: user.full_name
+
+  - field_key: agent_license
+    docuseal_field: "Sales Agent License number"
+    role_key: agent
+    source: user.license_number
+
+  - field_key: agent_email
+    docuseal_field: "Sales Agent email"
+    role_key: agent
+    source: user.email
+
+  - field_key: agent_phone
+    docuseal_field: "Sales Agent Phone Number"
+    role_key: agent
+    source: user.phone
+    transform: phone
+
+  # Supervisor information (from user profile)
+  - field_key: supervisor_name
+    docuseal_field: "Supervisor of Agent Name"
+    role_key: agent
+    source: user.licensed_supervisor
+
+  - field_key: supervisor_license
+    docuseal_field: "Supervisor of agent license number"
+    role_key: agent
+    source: user.licensed_supervisor_license
+
+  - field_key: supervisor_email
+    docuseal_field: "Supervisor of agent email"
+    role_key: agent
+    source: user.licensed_supervisor_email
+
+  - field_key: supervisor_phone
+    docuseal_field: "Supervisor of agent Phone number"
+    role_key: agent
+    source: user.licensed_supervisor_phone
+    transform: phone
+
+  # Seller initials - filled during e-signature (no source = manual)
+  - field_key: seller_initials
+    docuseal_field: "Seller 1 Initials"
+    role_key: seller
+    source: null
+
+  - field_key: seller_2_initials
+    docuseal_field: "Seller 2 Initials"
+    role_key: seller_2
+    source: null
+
+  - field_key: buyer_tenant_initials
+    docuseal_field: "Buyer/Tenant/Seller/Landlord initials"
+    role_key: seller
+    source: null
+

--- a/documents/listing-agreement.yml
+++ b/documents/listing-agreement.yml
@@ -1,0 +1,113 @@
+# =============================================================================
+# LISTING AGREEMENT
+# =============================================================================
+# Residential Real Estate Listing Agreement - Exclusive Right to Sell
+# 
+# This is a form-driven document with a custom UI for data entry.
+# Form data is stored in TransactionDocument.field_data and mapped
+# to DocuSeal fields for e-signature.
+# =============================================================================
+
+schema_version: "1.0"
+slug: listing-agreement
+name: "Listing Agreement"
+docuseal_template_id: 2468023
+type: form-driven
+
+display:
+  color: "#F97316"
+  icon: "fas fa-file-contract"
+  sort_order: 1
+
+form:
+  template: listing_agreement_form.html
+  partial: listing_agreement_fields.html
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Seller 2
+# Both sellers sign the listing agreement
+# =============================================================================
+
+roles:
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Form fields are stored in TransactionDocument.field_data
+# Map them to DocuSeal template fields here
+# 
+# Note: This is a placeholder - fields will be added as the form is built out
+# =============================================================================
+
+fields:
+  # Property information
+  - field_key: property_address
+    docuseal_field: "Property Address"
+    role_key: seller
+    source: form.property_address
+
+  - field_key: legal_description
+    docuseal_field: "Legal Description"
+    role_key: seller
+    source: form.legal_description
+
+  - field_key: list_price
+    docuseal_field: "List Price"
+    role_key: seller
+    source: form.list_price
+    transform: currency
+
+  # Commission
+  - field_key: commission_rate
+    docuseal_field: "Commission Rate"
+    role_key: seller
+    source: form.commission_rate
+    transform: percent
+
+  # Listing period
+  - field_key: listing_begin_date
+    docuseal_field: "Listing Begin Date"
+    role_key: seller
+    source: form.listing_begin_date
+    transform: date_short
+
+  - field_key: listing_end_date
+    docuseal_field: "Listing End Date"
+    role_key: seller
+    source: form.listing_end_date
+    transform: date_short
+
+  # Seller information (Seller 1)
+  - field_key: seller_1_name
+    docuseal_field: "Seller 1 Name"
+    role_key: seller
+    source: transaction.primary_seller.display_name
+
+  - field_key: seller_1_email
+    docuseal_field: "Seller 1 Email"
+    role_key: seller
+    source: transaction.primary_seller.display_email
+
+  # Seller information (Seller 2) - optional
+  - field_key: seller_2_name
+    docuseal_field: "Seller 2 Name"
+    role_key: seller_2
+    source: transaction.sellers[1].display_name
+
+  - field_key: seller_2_email
+    docuseal_field: "Seller 2 Email"
+    role_key: seller_2
+    source: transaction.sellers[1].display_email
+

--- a/documents/schema/v1.0.json
+++ b/documents/schema/v1.0.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "document-definition-v1.0",
+  "title": "Document Definition",
+  "description": "Schema for document definitions that drive the document generation system",
+  "type": "object",
+  "required": ["schema_version", "slug", "name", "docuseal_template_id", "type", "display", "roles", "fields"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "Schema version (e.g., '1.0')"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Stable identifier, kebab-case"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Display name for the document"
+    },
+    "docuseal_template_id": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "DocuSeal template ID"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["form-driven", "pdf-preview"],
+      "description": "Document type"
+    },
+    "display": {
+      "type": "object",
+      "required": ["color", "icon", "sort_order"],
+      "properties": {
+        "color": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$",
+          "description": "Hex color code"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Font Awesome icon class"
+        },
+        "sort_order": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Display order (lower = first)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "form": {
+      "type": "object",
+      "required": ["template", "partial"],
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "Form template filename"
+        },
+        "partial": {
+          "type": "string",
+          "description": "Form partial filename"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Required for form-driven documents"
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["role_key", "docuseal_role", "email_source", "name_source"],
+        "properties": {
+          "role_key": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$",
+            "description": "Stable internal identifier, snake_case"
+          },
+          "docuseal_role": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact DocuSeal role name"
+          },
+          "email_source": {
+            "type": "string",
+            "description": "Source path for email"
+          },
+          "name_source": {
+            "type": "string",
+            "description": "Source path for display name"
+          },
+          "optional": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip if source resolves to null"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["field_key", "docuseal_field", "role_key"],
+        "properties": {
+          "field_key": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$",
+            "description": "Stable internal identifier, snake_case"
+          },
+          "docuseal_field": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact DocuSeal field name"
+          },
+          "role_key": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$",
+            "description": "Role this field belongs to"
+          },
+          "source": {
+            "type": ["string", "null"],
+            "description": "Data source path (null = manual entry)"
+          },
+          "transform": {
+            "type": "string",
+            "description": "Optional transform function name"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "type": { "const": "form-driven" } }
+      },
+      "then": {
+        "required": ["form"]
+      }
+    }
+  ]
+}
+

--- a/documents/seller-net-proceeds.yml
+++ b/documents/seller-net-proceeds.yml
@@ -1,0 +1,109 @@
+# =============================================================================
+# SELLER'S ESTIMATED NET PROCEEDS
+# =============================================================================
+# Seller's Estimated Net Proceeds worksheet
+# Calculates expected proceeds from sale after all deductions
+# 
+# This is a form-driven document with a custom UI for data entry.
+# =============================================================================
+
+schema_version: "1.0"
+slug: seller-net-proceeds
+name: "Seller's Estimated Net Proceeds"
+docuseal_template_id: 2490157
+type: form-driven
+
+display:
+  color: "#10B981"
+  icon: "fas fa-calculator"
+  sort_order: 4
+
+form:
+  template: seller_net_proceeds_form.html
+  partial: seller_net_proceeds_fields.html
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Seller 2
+# =============================================================================
+
+roles:
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Financial calculation fields from seller_net_proceeds_fields.html
+# =============================================================================
+
+fields:
+  # Property information
+  - field_key: property_address
+    docuseal_field: "Property Address"
+    role_key: seller
+    source: form.property_address
+
+  # Financial fields
+  - field_key: sales_price
+    docuseal_field: "Sales Price"
+    role_key: seller
+    source: form.sales_price
+    transform: currency
+
+  - field_key: first_mortgage
+    docuseal_field: "First Mortgage"
+    role_key: seller
+    source: form.first_mortgage
+    transform: currency
+
+  - field_key: second_mortgage
+    docuseal_field: "Second Mortgage"
+    role_key: seller
+    source: form.second_mortgage
+    transform: currency
+
+  - field_key: commission
+    docuseal_field: "Commission"
+    role_key: seller
+    source: form.commission
+    transform: currency
+
+  - field_key: title_insurance
+    docuseal_field: "Title Insurance"
+    role_key: seller
+    source: form.title_insurance
+    transform: currency
+
+  - field_key: closing_costs
+    docuseal_field: "Closing Costs"
+    role_key: seller
+    source: form.closing_costs
+    transform: currency
+
+  - field_key: estimated_net
+    docuseal_field: "Estimated Net Proceeds"
+    role_key: seller
+    source: form.estimated_net
+    transform: currency
+
+  # Signature fields - handled by DocuSeal
+  - field_key: seller_signature
+    docuseal_field: "Seller Signature"
+    role_key: seller
+    source: null
+
+  - field_key: seller_2_signature
+    docuseal_field: "Seller 2 Signature"
+    role_key: seller_2
+    source: null
+

--- a/models.py
+++ b/models.py
@@ -446,6 +446,19 @@ class Transaction(db.Model):
             parts.append(self.zip_code)
         return ', '.join(parts)
     
+    @property
+    def primary_seller(self):
+        """Get the primary seller participant (for document field resolution)."""
+        return next(
+            (p for p in self.participants.all() if p.role == 'seller' and p.is_primary),
+            None
+        )
+    
+    @property
+    def sellers(self):
+        """Get all seller participants as a list (for document field resolution)."""
+        return [p for p in self.participants.all() if p.role == 'seller']
+    
     def __repr__(self):
         return f'<Transaction {self.id}: {self.street_address}>'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ requests==2.31.0
 psycopg2-binary>=2.9.9
 itsdangerous>=2.1.2
 PyYAML>=6.0
+jsonschema>=4.0.0
+pytest>=7.0.0

--- a/services/documents/__init__.py
+++ b/services/documents/__init__.py
@@ -1,0 +1,75 @@
+"""
+Document Generation System
+
+A configuration-driven system for generating and managing documents.
+Documents are defined in YAML files and processed through a pipeline
+of resolution, role building, and DocuSeal integration.
+
+Usage:
+    from services.documents import DocumentLoader, FieldResolver, RoleBuilder, DocuSealClient
+    
+    # On app startup
+    DocumentLoader.load_all()
+    
+    # When processing a document
+    definition = DocumentLoader.get('listing-agreement')
+    context = build_context(user, transaction, form_data)
+    fields = FieldResolver.resolve(definition, context)
+    submitters = RoleBuilder.build(definition, fields, context)
+    result = DocuSealClient.create_submission(definition.docuseal_template_id, submitters)
+"""
+
+from .types import (
+    DocumentType,
+    DisplayConfig,
+    FormConfig,
+    RoleDefinition,
+    FieldDefinition,
+    DocumentDefinition,
+    ResolvedField,
+    Submitter
+)
+
+from .exceptions import (
+    DocumentError,
+    ConfigurationError,
+    ValidationError,
+    ResolutionError,
+    DocuSealAPIError
+)
+
+from .loader import DocumentLoader
+from .field_resolver import FieldResolver
+from .role_builder import RoleBuilder
+from .docuseal_client import DocuSealClient
+from .transforms import TRANSFORMS, apply_transform, register_transform
+
+__all__ = [
+    # Types
+    'DocumentType',
+    'DisplayConfig',
+    'FormConfig',
+    'RoleDefinition',
+    'FieldDefinition',
+    'DocumentDefinition',
+    'ResolvedField',
+    'Submitter',
+    
+    # Exceptions
+    'DocumentError',
+    'ConfigurationError',
+    'ValidationError',
+    'ResolutionError',
+    'DocuSealAPIError',
+    
+    # Services
+    'DocumentLoader',
+    'FieldResolver',
+    'RoleBuilder',
+    'DocuSealClient',
+    
+    # Transforms
+    'TRANSFORMS',
+    'apply_transform',
+    'register_transform',
+]

--- a/services/documents/docuseal_client.py
+++ b/services/documents/docuseal_client.py
@@ -1,0 +1,337 @@
+"""
+DocuSeal Client
+
+Thin wrapper around the DocuSeal API for document submissions.
+Handles authentication, request building, and error handling.
+
+This is a simplified, focused client that only does what's needed
+for the document generation system. For complex operations, use
+the existing docuseal_service.py (which will eventually be deprecated).
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .types import Submitter
+from .exceptions import DocuSealAPIError
+
+logger = logging.getLogger(__name__)
+
+# Configuration from environment
+DOCUSEAL_MODE = os.environ.get('DOCUSEAL_MODE', 'test').lower()
+DOCUSEAL_API_KEY_TEST = os.environ.get('DOCUSEAL_API_KEY_TEST', '')
+DOCUSEAL_API_KEY_PROD = os.environ.get('DOCUSEAL_API_KEY_PROD', '')
+
+# Select API key based on mode
+if DOCUSEAL_MODE == 'prod':
+    DOCUSEAL_API_KEY = DOCUSEAL_API_KEY_PROD
+else:
+    DOCUSEAL_API_KEY = DOCUSEAL_API_KEY_TEST
+
+DOCUSEAL_API_URL = 'https://api.docuseal.com'
+DOCUSEAL_MOCK_MODE = not bool(DOCUSEAL_API_KEY)
+
+# Request timeout
+DEFAULT_TIMEOUT = 30
+
+
+class DocuSealClient:
+    """
+    Client for DocuSeal API operations.
+    
+    Provides methods for:
+        - Creating submissions (send for signature)
+        - Creating preview submissions (no email)
+        - Getting template information
+    """
+    
+    @classmethod
+    def is_mock_mode(cls) -> bool:
+        """Check if running in mock mode (no API key)."""
+        return DOCUSEAL_MOCK_MODE
+    
+    @classmethod
+    def _get_headers(cls) -> Dict[str, str]:
+        """Get request headers with auth."""
+        return {
+            'X-Auth-Token': DOCUSEAL_API_KEY,
+            'Content-Type': 'application/json'
+        }
+    
+    @classmethod
+    def get_template(cls, template_id: int) -> Dict[str, Any]:
+        """
+        Fetch template details from DocuSeal.
+        
+        Returns:
+            Template data with fields, submitters, etc.
+        """
+        if DOCUSEAL_MOCK_MODE:
+            return cls._mock_template(template_id)
+        
+        try:
+            response = requests.get(
+                f"{DOCUSEAL_API_URL}/templates/{template_id}",
+                headers=cls._get_headers(),
+                timeout=DEFAULT_TIMEOUT
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise DocuSealAPIError(
+                f"Failed to fetch template {template_id}: {e}",
+                status_code=getattr(e.response, 'status_code', None) if hasattr(e, 'response') else None
+            )
+    
+    @classmethod
+    def get_template_roles(cls, template_id: int) -> List[str]:
+        """
+        Get the submitter role names from a template.
+        
+        Returns:
+            List of role names (e.g., ['Seller', 'Broker', 'Seller 2'])
+        """
+        template = cls.get_template(template_id)
+        submitters = template.get('submitters', [])
+        return [s.get('name', '') for s in submitters]
+    
+    @classmethod
+    def create_submission(
+        cls,
+        template_id: int,
+        submitters: List[Submitter],
+        send_email: bool = True,
+        message: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Create a submission to send document for signature.
+        
+        Args:
+            template_id: DocuSeal template ID
+            submitters: List of Submitter objects
+            send_email: Whether to send email invitations
+            message: Optional custom message with 'subject' and 'body'
+            
+        Returns:
+            Submission data with ID and submitter details
+        """
+        if DOCUSEAL_MOCK_MODE:
+            return cls._mock_submission(template_id, submitters)
+        
+        payload = {
+            'template_id': template_id,
+            'send_email': send_email,
+            'submitters': [s.to_dict() for s in submitters]
+        }
+        
+        if message:
+            payload['message'] = message
+        
+        try:
+            response = requests.post(
+                f"{DOCUSEAL_API_URL}/submissions",
+                headers=cls._get_headers(),
+                json=payload,
+                timeout=DEFAULT_TIMEOUT
+            )
+            response.raise_for_status()
+            
+            result = response.json()
+            
+            # DocuSeal returns a list of submitter results
+            if isinstance(result, list):
+                return {
+                    'id': result[0].get('submission_id') if result else None,
+                    'submitters': result
+                }
+            
+            return result
+            
+        except requests.exceptions.RequestException as e:
+            error_body = None
+            status_code = None
+            
+            if hasattr(e, 'response') and e.response is not None:
+                status_code = e.response.status_code
+                try:
+                    error_body = e.response.text
+                except Exception:
+                    pass
+            
+            logger.error(f"DocuSeal submission failed: {e}")
+            if error_body:
+                logger.error(f"Response body: {error_body}")
+            
+            raise DocuSealAPIError(
+                f"Failed to create submission: {e}",
+                status_code=status_code,
+                response_body=error_body
+            )
+    
+    @classmethod
+    def create_preview_submission(
+        cls,
+        template_id: int,
+        submitters: List[Submitter]
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Create a preview submission (no email sent).
+        
+        Returns the first submitter's embed info for displaying the preview.
+        
+        Args:
+            template_id: DocuSeal template ID
+            submitters: List of Submitter objects
+            
+        Returns:
+            Dict with 'slug' and 'embed_src' for embedding, or None in mock mode
+        """
+        if DOCUSEAL_MOCK_MODE:
+            return None
+        
+        try:
+            result = cls.create_submission(
+                template_id=template_id,
+                submitters=submitters,
+                send_email=False
+            )
+            
+            # Get the first submitter's embed info
+            submitter_results = result.get('submitters', [])
+            if submitter_results:
+                first = submitter_results[0]
+                return {
+                    'slug': first.get('slug', ''),
+                    'embed_src': first.get('embed_src', f"https://docuseal.com/s/{first.get('slug', '')}")
+                }
+            
+            return None
+            
+        except DocuSealAPIError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating preview submission: {e}")
+            return None
+    
+    @classmethod
+    def merge_templates(
+        cls,
+        template_ids: List[int],
+        name: str,
+        roles: Optional[List[str]] = None,
+        external_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Merge multiple templates into one combined template.
+        
+        Args:
+            template_ids: List of template IDs to merge
+            name: Name for the merged template
+            roles: Optional unified roles for the merged template
+            external_id: Optional external ID for tracking
+            
+        Returns:
+            Merged template data with new template ID
+        """
+        if DOCUSEAL_MOCK_MODE:
+            return cls._mock_merged_template(template_ids, name)
+        
+        payload = {
+            'template_ids': template_ids,
+            'name': name
+        }
+        
+        if roles:
+            payload['submitters'] = [{'name': role} for role in roles]
+        
+        if external_id:
+            payload['external_id'] = external_id
+        
+        try:
+            response = requests.post(
+                f"{DOCUSEAL_API_URL}/templates/merge",
+                headers=cls._get_headers(),
+                json=payload,
+                timeout=DEFAULT_TIMEOUT
+            )
+            response.raise_for_status()
+            return response.json()
+            
+        except requests.exceptions.RequestException as e:
+            error_body = None
+            status_code = None
+            
+            if hasattr(e, 'response') and e.response is not None:
+                status_code = e.response.status_code
+                try:
+                    error_body = e.response.text
+                except Exception:
+                    pass
+            
+            logger.error(f"DocuSeal merge templates failed: {e}")
+            if error_body:
+                logger.error(f"Response body: {error_body}")
+            
+            raise DocuSealAPIError(
+                f"Failed to merge templates: {e}",
+                status_code=status_code,
+                response_body=error_body
+            )
+    
+    @classmethod
+    def _mock_template(cls, template_id: int) -> Dict[str, Any]:
+        """Return mock template data for testing."""
+        return {
+            'id': template_id,
+            'name': f'Mock Template {template_id}',
+            'submitters': [
+                {'name': 'Seller', 'uuid': 'mock-seller-uuid'},
+                {'name': 'Broker', 'uuid': 'mock-broker-uuid'}
+            ],
+            'fields': []
+        }
+    
+    @classmethod
+    def _mock_merged_template(cls, template_ids: List[int], name: str) -> Dict[str, Any]:
+        """Return mock merged template data for testing."""
+        return {
+            'id': 99999,
+            'name': name,
+            'submitters': [
+                {'name': 'Seller', 'uuid': 'mock-seller-uuid'},
+                {'name': 'Broker', 'uuid': 'mock-broker-uuid'}
+            ],
+            'fields': [],
+            'source_template_ids': template_ids
+        }
+    
+    @classmethod
+    def _mock_submission(
+        cls,
+        template_id: int,
+        submitters: List[Submitter]
+    ) -> Dict[str, Any]:
+        """Return mock submission data for testing."""
+        import uuid
+        
+        submitter_results = []
+        for i, sub in enumerate(submitters):
+            mock_slug = f"mock-{uuid.uuid4().hex[:8]}"
+            submitter_results.append({
+                'id': i + 1,
+                'submission_id': 12345,
+                'email': sub.email,
+                'role': sub.role,
+                'slug': mock_slug,
+                'embed_src': f"https://docuseal.com/s/{mock_slug}",
+                'status': 'pending'
+            })
+        
+        return {
+            'id': 12345,
+            'submitters': submitter_results
+        }
+

--- a/services/documents/exceptions.py
+++ b/services/documents/exceptions.py
@@ -1,0 +1,57 @@
+"""
+Document System Exceptions
+
+Custom exceptions for document configuration and processing errors.
+"""
+
+
+class DocumentError(Exception):
+    """Base exception for all document system errors."""
+    pass
+
+
+class ConfigurationError(DocumentError):
+    """
+    Raised when document configuration is invalid.
+    
+    This includes YAML syntax errors, schema validation failures,
+    and referential integrity issues (e.g., field references unknown role).
+    """
+    pass
+
+
+class ValidationError(DocumentError):
+    """
+    Raised when a single document definition fails validation.
+    
+    Contains details about what specifically failed.
+    """
+    def __init__(self, message: str, document_slug: str = None, field: str = None):
+        self.document_slug = document_slug
+        self.field = field
+        super().__init__(message)
+
+
+class ResolutionError(DocumentError):
+    """
+    Raised when field resolution fails.
+    
+    This can happen when a source path is invalid or
+    required data is missing.
+    """
+    def __init__(self, message: str, source_path: str = None):
+        self.source_path = source_path
+        super().__init__(message)
+
+
+class DocuSealAPIError(DocumentError):
+    """
+    Raised when DocuSeal API calls fail.
+    
+    Wraps the underlying API error with context.
+    """
+    def __init__(self, message: str, status_code: int = None, response_body: str = None):
+        self.status_code = status_code
+        self.response_body = response_body
+        super().__init__(message)
+

--- a/services/documents/field_resolver.py
+++ b/services/documents/field_resolver.py
@@ -1,0 +1,274 @@
+"""
+Field Resolver
+
+Resolves field values from data sources using source path expressions.
+Supports dot notation for object properties and bracket notation for arrays.
+
+Source path syntax:
+    user.email              -> context['user'].email
+    user.full_name          -> f"{context['user'].first_name} {context['user'].last_name}"
+    transaction.property_address -> context['transaction'].property_address
+    transaction.sellers[0].email -> context['transaction'].sellers[0].email
+    form.list_price         -> context['form']['list_price']
+    null                    -> None (manual entry)
+"""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from .types import DocumentDefinition, FieldDefinition, ResolvedField
+from .transforms import apply_transform
+from .exceptions import ResolutionError
+
+logger = logging.getLogger(__name__)
+
+
+class FieldResolver:
+    """
+    Resolves field definitions to actual values using a data context.
+    
+    The context is a dict containing:
+        - 'user': Current User object
+        - 'transaction': Transaction object
+        - 'form': Dict of form field values (from TransactionDocument.field_data)
+    """
+    
+    # Pattern for bracket notation: name[index]
+    BRACKET_PATTERN = re.compile(r'^([a-zA-Z_][a-zA-Z0-9_]*)\[(\d+)\]$')
+    
+    @classmethod
+    def resolve(
+        cls,
+        definition: DocumentDefinition,
+        context: Dict[str, Any]
+    ) -> List[ResolvedField]:
+        """
+        Resolve all fields in a document definition.
+        
+        Args:
+            definition: The document definition
+            context: Dict with 'user', 'transaction', 'form' keys
+            
+        Returns:
+            List of ResolvedField objects with values populated
+        """
+        resolved = []
+        
+        for field_def in definition.fields:
+            try:
+                resolved_field = cls.resolve_field(field_def, context)
+                resolved.append(resolved_field)
+            except ResolutionError as e:
+                logger.warning(f"Failed to resolve field {field_def.field_key}: {e}")
+                # Create a field with None value
+                resolved.append(ResolvedField(
+                    field_key=field_def.field_key,
+                    docuseal_field=field_def.docuseal_field,
+                    role_key=field_def.role_key,
+                    value=None,
+                    is_manual=field_def.source is None
+                ))
+        
+        return resolved
+    
+    @classmethod
+    def resolve_field(
+        cls,
+        field_def: FieldDefinition,
+        context: Dict[str, Any]
+    ) -> ResolvedField:
+        """
+        Resolve a single field definition.
+        
+        Args:
+            field_def: The field definition
+            context: Dict with data sources
+            
+        Returns:
+            ResolvedField with value populated
+        """
+        # Manual entry fields have no source
+        if field_def.source is None:
+            return ResolvedField(
+                field_key=field_def.field_key,
+                docuseal_field=field_def.docuseal_field,
+                role_key=field_def.role_key,
+                value=None,
+                is_manual=True
+            )
+        
+        # Resolve the source path
+        raw_value = cls.resolve_path(field_def.source, context)
+        
+        # Apply transform if specified
+        transformed_value = apply_transform(raw_value, field_def.transform)
+        
+        return ResolvedField(
+            field_key=field_def.field_key,
+            docuseal_field=field_def.docuseal_field,
+            role_key=field_def.role_key,
+            value=transformed_value if transformed_value else None,
+            is_manual=False
+        )
+    
+    @classmethod
+    def resolve_path(cls, source_path: str, context: Dict[str, Any]) -> Any:
+        """
+        Resolve a source path to a value.
+        
+        Args:
+            source_path: Path like "user.email" or "transaction.sellers[0].name"
+            context: Dict containing data sources
+            
+        Returns:
+            The resolved value, or None if not found
+        """
+        if not source_path:
+            return None
+        
+        # Split into parts, handling both dot notation and brackets
+        parts = cls._parse_path(source_path)
+        
+        if not parts:
+            return None
+        
+        # Get the root object from context
+        root_key = parts[0]
+        if root_key not in context:
+            logger.debug(f"Root key '{root_key}' not in context")
+            return None
+        
+        # Navigate through the path
+        current = context[root_key]
+        
+        for part in parts[1:]:
+            if current is None:
+                return None
+            
+            current = cls._get_value(current, part)
+        
+        return current
+    
+    @classmethod
+    def _parse_path(cls, path: str) -> List[str]:
+        """
+        Parse a source path into parts.
+        
+        Examples:
+            "user.email" -> ["user", "email"]
+            "transaction.sellers[0].name" -> ["transaction", "sellers[0]", "name"]
+        """
+        # Split by dots, but preserve bracket notation
+        parts = []
+        current = ""
+        in_bracket = False
+        
+        for char in path:
+            if char == '[':
+                in_bracket = True
+                current += char
+            elif char == ']':
+                in_bracket = False
+                current += char
+            elif char == '.' and not in_bracket:
+                if current:
+                    parts.append(current)
+                current = ""
+            else:
+                current += char
+        
+        if current:
+            parts.append(current)
+        
+        return parts
+    
+    @classmethod
+    def _get_value(cls, obj: Any, part: str) -> Any:
+        """
+        Get a value from an object by property name or index.
+        
+        Handles:
+            - Object attributes (getattr)
+            - Dict keys
+            - List/tuple indices via bracket notation
+            - Special computed properties (full_name)
+        """
+        # Check for bracket notation: sellers[0]
+        bracket_match = cls.BRACKET_PATTERN.match(part)
+        if bracket_match:
+            attr_name = bracket_match.group(1)
+            index = int(bracket_match.group(2))
+            
+            # Get the list/collection first
+            collection = cls._get_attr_or_key(obj, attr_name)
+            if collection is None:
+                return None
+            
+            # Access by index
+            try:
+                # Handle SQLAlchemy query objects
+                if hasattr(collection, 'all'):
+                    collection = collection.all()
+                
+                if isinstance(collection, (list, tuple)) and 0 <= index < len(collection):
+                    return collection[index]
+                return None
+            except (IndexError, TypeError):
+                return None
+        
+        # Handle special computed properties
+        if part == 'full_name':
+            return cls._get_full_name(obj)
+        
+        # Standard attribute/key access
+        return cls._get_attr_or_key(obj, part)
+    
+    @classmethod
+    def _get_attr_or_key(cls, obj: Any, key: str) -> Any:
+        """Get a value by attribute or dict key."""
+        # Try as dict key first (for form data)
+        if isinstance(obj, dict):
+            return obj.get(key)
+        
+        # Try as attribute
+        if hasattr(obj, key):
+            value = getattr(obj, key)
+            # Handle callable relationships (SQLAlchemy)
+            if callable(value) and not isinstance(value, type):
+                try:
+                    return value()
+                except TypeError:
+                    return value
+            return value
+        
+        return None
+    
+    @classmethod
+    def _get_full_name(cls, obj: Any) -> Optional[str]:
+        """
+        Compute full_name from first_name and last_name.
+        
+        This is a common computed property for User and Participant objects.
+        """
+        first = cls._get_attr_or_key(obj, 'first_name') or ''
+        last = cls._get_attr_or_key(obj, 'last_name') or ''
+        
+        # Also try display_name for participants
+        if not first and not last:
+            display = cls._get_attr_or_key(obj, 'display_name')
+            if display:
+                return display
+        
+        full = f"{first} {last}".strip()
+        return full if full else None
+    
+    @classmethod
+    def resolve_single(cls, source_path: str, context: Dict[str, Any]) -> Any:
+        """
+        Convenience method to resolve a single source path.
+        
+        Useful for resolving role email/name sources.
+        """
+        return cls.resolve_path(source_path, context)
+

--- a/services/documents/loader.py
+++ b/services/documents/loader.py
@@ -1,0 +1,280 @@
+"""
+Document Loader
+
+Loads, validates, and caches document definitions from YAML files.
+Validates all documents on startup and fails fast if any are invalid.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import yaml
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+from .types import DocumentDefinition, DocumentType
+from .exceptions import ConfigurationError, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# Paths
+DOCUMENTS_DIR = Path(__file__).parent.parent.parent / 'documents'
+SCHEMA_DIR = DOCUMENTS_DIR / 'schema'
+
+
+class DocumentLoader:
+    """
+    Singleton loader for document definitions.
+    
+    Loads all YAML files from the documents/ directory on startup,
+    validates them against the JSON schema, and caches them for
+    fast lookup during request handling.
+    
+    Usage:
+        # On app startup
+        DocumentLoader.load_all()
+        
+        # During request handling
+        definition = DocumentLoader.get('listing-agreement')
+    """
+    
+    _definitions: Dict[str, DocumentDefinition] = {}
+    _schemas: Dict[str, dict] = {}
+    _validated: bool = False
+    
+    @classmethod
+    def load_all(cls) -> None:
+        """
+        Load and validate all document definitions.
+        
+        Called at app startup. If any document fails validation,
+        raises ConfigurationError with all errors listed.
+        """
+        cls._definitions.clear()
+        errors = []
+        
+        # Load schema(s)
+        cls._load_schemas()
+        
+        # Find all YAML files
+        if not DOCUMENTS_DIR.exists():
+            logger.warning(f"Documents directory not found: {DOCUMENTS_DIR}")
+            return
+        
+        yaml_files = list(DOCUMENTS_DIR.glob('*.yml')) + list(DOCUMENTS_DIR.glob('*.yaml'))
+        
+        if not yaml_files:
+            logger.warning(f"No document definitions found in {DOCUMENTS_DIR}")
+            return
+        
+        # Load and validate each file
+        for yaml_file in yaml_files:
+            try:
+                definition = cls._load_and_validate(yaml_file)
+                
+                # Check for duplicate slugs
+                if definition.slug in cls._definitions:
+                    errors.append(
+                        f"{yaml_file.name}: Duplicate slug '{definition.slug}' "
+                        f"(already defined in another file)"
+                    )
+                    continue
+                
+                cls._definitions[definition.slug] = definition
+                logger.debug(f"Loaded document definition: {definition.slug}")
+                
+            except (ValidationError, yaml.YAMLError) as e:
+                errors.append(f"{yaml_file.name}: {e}")
+            except Exception as e:
+                errors.append(f"{yaml_file.name}: Unexpected error - {e}")
+        
+        if errors:
+            error_msg = "Document configuration errors:\n" + "\n".join(f"  - {e}" for e in errors)
+            logger.error(error_msg)
+            raise ConfigurationError(error_msg)
+        
+        cls._validated = True
+        logger.info(f"Loaded {len(cls._definitions)} document definition(s)")
+    
+    @classmethod
+    def _load_schemas(cls) -> None:
+        """Load JSON schemas for validation."""
+        cls._schemas.clear()
+        
+        if not SCHEMA_DIR.exists():
+            logger.warning(f"Schema directory not found: {SCHEMA_DIR}")
+            return
+        
+        for schema_file in SCHEMA_DIR.glob('v*.json'):
+            try:
+                version = schema_file.stem  # e.g., "v1.0"
+                schema = json.loads(schema_file.read_text())
+                cls._schemas[version] = schema
+                logger.debug(f"Loaded schema: {version}")
+            except Exception as e:
+                logger.error(f"Failed to load schema {schema_file}: {e}")
+    
+    @classmethod
+    def _get_schema(cls, version: str) -> dict:
+        """Get schema for a specific version."""
+        schema_key = f"v{version}"
+        if schema_key not in cls._schemas:
+            raise ValidationError(f"Unknown schema version: {version}")
+        return cls._schemas[schema_key]
+    
+    @classmethod
+    def _load_and_validate(cls, path: Path) -> DocumentDefinition:
+        """Load a YAML file and validate it."""
+        # Parse YAML
+        raw = yaml.safe_load(path.read_text())
+        
+        if not raw:
+            raise ValidationError("Empty document definition")
+        
+        # 1. Schema validation (if jsonschema available)
+        schema_version = raw.get('schema_version', '1.0')
+        if jsonschema and cls._schemas:
+            try:
+                schema = cls._get_schema(schema_version)
+                jsonschema.validate(raw, schema)
+            except jsonschema.ValidationError as e:
+                raise ValidationError(f"Schema validation failed: {e.message}")
+        
+        # 2. Referential integrity checks
+        cls._validate_references(raw)
+        
+        # 3. Additional business rule validation
+        cls._validate_business_rules(raw)
+        
+        # 4. Convert to typed dataclass
+        return DocumentDefinition.from_dict(raw)
+    
+    @classmethod
+    def _validate_references(cls, raw: dict) -> None:
+        """Validate that fields reference valid roles."""
+        role_keys: Set[str] = {r['role_key'] for r in raw.get('roles', [])}
+        
+        for field in raw.get('fields', []):
+            field_key = field.get('field_key', 'unknown')
+            ref_role = field.get('role_key')
+            
+            if ref_role not in role_keys:
+                raise ValidationError(
+                    f"Field '{field_key}' references unknown role '{ref_role}'. "
+                    f"Available roles: {sorted(role_keys)}"
+                )
+    
+    @classmethod
+    def _validate_business_rules(cls, raw: dict) -> None:
+        """Validate business-specific rules."""
+        doc_type = raw.get('type')
+        
+        # Form-driven documents must have form config
+        if doc_type == 'form-driven' and 'form' not in raw:
+            raise ValidationError(
+                "Form-driven documents must have a 'form' section with template and partial"
+            )
+        
+        # Check for unique role_keys
+        role_keys = [r['role_key'] for r in raw.get('roles', [])]
+        if len(role_keys) != len(set(role_keys)):
+            duplicates = [k for k in role_keys if role_keys.count(k) > 1]
+            raise ValidationError(f"Duplicate role_keys: {set(duplicates)}")
+        
+        # Check for unique field_keys
+        field_keys = [f['field_key'] for f in raw.get('fields', [])]
+        if len(field_keys) != len(set(field_keys)):
+            duplicates = [k for k in field_keys if field_keys.count(k) > 1]
+            raise ValidationError(f"Duplicate field_keys: {set(duplicates)}")
+        
+        # Validate source path syntax (bracket notation for arrays)
+        for field in raw.get('fields', []):
+            source = field.get('source')
+            if source and cls._has_invalid_array_syntax(source):
+                raise ValidationError(
+                    f"Field '{field.get('field_key')}' has invalid source syntax: '{source}'. "
+                    f"Use bracket notation for arrays (e.g., 'sellers[0]' not 'sellers.0')"
+                )
+        
+        for role in raw.get('roles', []):
+            for source_key in ['email_source', 'name_source']:
+                source = role.get(source_key)
+                if source and cls._has_invalid_array_syntax(source):
+                    raise ValidationError(
+                        f"Role '{role.get('role_key')}' has invalid {source_key} syntax: '{source}'. "
+                        f"Use bracket notation for arrays (e.g., 'sellers[0]' not 'sellers.0')"
+                    )
+    
+    @classmethod
+    def _has_invalid_array_syntax(cls, source: str) -> bool:
+        """Check if source uses dot notation for array indices (invalid)."""
+        import re
+        # Match patterns like .0. or .1. or .0 at end (but not [0])
+        # This catches sellers.0.email but not sellers[0].email
+        return bool(re.search(r'\.\d+(?:\.|$)', source))
+    
+    @classmethod
+    def get(cls, slug: str) -> Optional[DocumentDefinition]:
+        """
+        Get a document definition by slug.
+        
+        Returns None if not found.
+        """
+        return cls._definitions.get(slug)
+    
+    @classmethod
+    def get_or_raise(cls, slug: str) -> DocumentDefinition:
+        """
+        Get a document definition by slug, raising if not found.
+        """
+        definition = cls.get(slug)
+        if not definition:
+            raise ValidationError(f"Unknown document slug: {slug}")
+        return definition
+    
+    @classmethod
+    def all(cls) -> List[DocumentDefinition]:
+        """Get all loaded document definitions."""
+        return list(cls._definitions.values())
+    
+    @classmethod
+    def all_slugs(cls) -> List[str]:
+        """Get all loaded document slugs."""
+        return list(cls._definitions.keys())
+    
+    @classmethod
+    def get_by_type(cls, doc_type: DocumentType) -> List[DocumentDefinition]:
+        """Get all documents of a specific type."""
+        return [d for d in cls._definitions.values() if d.type == doc_type]
+    
+    @classmethod
+    def get_form_driven(cls) -> List[DocumentDefinition]:
+        """Get all form-driven documents."""
+        return cls.get_by_type(DocumentType.FORM_DRIVEN)
+    
+    @classmethod
+    def get_pdf_preview(cls) -> List[DocumentDefinition]:
+        """Get all PDF-preview documents."""
+        return cls.get_by_type(DocumentType.PDF_PREVIEW)
+    
+    @classmethod
+    def get_sorted(cls) -> List[DocumentDefinition]:
+        """Get all documents sorted by display order."""
+        return sorted(cls._definitions.values(), key=lambda d: d.display.sort_order)
+    
+    @classmethod
+    def is_loaded(cls) -> bool:
+        """Check if documents have been loaded and validated."""
+        return cls._validated
+    
+    @classmethod
+    def clear(cls) -> None:
+        """Clear all cached definitions. Mainly for testing."""
+        cls._definitions.clear()
+        cls._validated = False
+

--- a/services/documents/role_builder.py
+++ b/services/documents/role_builder.py
@@ -1,0 +1,206 @@
+"""
+Role Builder
+
+Groups resolved fields by their DocuSeal role and builds
+submitter objects ready for the DocuSeal API.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .types import DocumentDefinition, ResolvedField, RoleDefinition, Submitter
+from .field_resolver import FieldResolver
+
+logger = logging.getLogger(__name__)
+
+
+class RoleBuilder:
+    """
+    Builds DocuSeal submitter objects from document definitions and resolved fields.
+    
+    Takes:
+        - Document definition (roles, fields)
+        - Resolved fields (with values)
+        - Context (for resolving role email/name)
+    
+    Returns:
+        - List of Submitter objects ready for DocuSeal API
+    """
+    
+    @classmethod
+    def build(
+        cls,
+        definition: DocumentDefinition,
+        resolved_fields: List[ResolvedField],
+        context: Dict[str, Any]
+    ) -> List[Submitter]:
+        """
+        Build submitter objects for all roles in the document.
+        
+        Args:
+            definition: Document definition with role configs
+            resolved_fields: List of resolved fields with values
+            context: Data context for resolving role email/name
+            
+        Returns:
+            List of Submitter objects, one per role (excluding optional roles with no data)
+        """
+        submitters = []
+        
+        # Group fields by role_key
+        fields_by_role: Dict[str, List[ResolvedField]] = {}
+        for field in resolved_fields:
+            if field.role_key not in fields_by_role:
+                fields_by_role[field.role_key] = []
+            fields_by_role[field.role_key].append(field)
+        
+        # Build submitter for each role
+        for role_def in definition.roles:
+            submitter = cls._build_submitter(
+                role_def=role_def,
+                fields=fields_by_role.get(role_def.role_key, []),
+                context=context
+            )
+            
+            if submitter:
+                submitters.append(submitter)
+        
+        logger.debug(f"Built {len(submitters)} submitter(s) for {definition.slug}")
+        return submitters
+    
+    @classmethod
+    def _build_submitter(
+        cls,
+        role_def: RoleDefinition,
+        fields: List[ResolvedField],
+        context: Dict[str, Any]
+    ) -> Optional[Submitter]:
+        """
+        Build a single submitter from a role definition.
+        
+        Returns None if the role is optional and has no valid data.
+        """
+        # Resolve email and name from context
+        email = FieldResolver.resolve_single(role_def.email_source, context)
+        name = FieldResolver.resolve_single(role_def.name_source, context)
+        
+        # Skip optional roles with no email
+        if role_def.optional and not email:
+            logger.debug(f"Skipping optional role '{role_def.role_key}' (no email)")
+            return None
+        
+        # Use placeholder for preview if no email but role is required
+        if not email:
+            logger.warning(f"No email for required role '{role_def.role_key}', using placeholder")
+            email = "placeholder@preview.local"
+            name = name or "Placeholder"
+        
+        # Build DocuSeal field format
+        docuseal_fields = []
+        for field in fields:
+            field_dict = field.to_docuseal_format()
+            if field_dict:  # Skip None (manual fields)
+                docuseal_fields.append(field_dict)
+        
+        return Submitter(
+            role=role_def.docuseal_role,
+            email=email,
+            name=name or email,
+            fields=docuseal_fields
+        )
+    
+    @classmethod
+    def build_for_preview(
+        cls,
+        definition: DocumentDefinition,
+        resolved_fields: List[ResolvedField],
+        context: Dict[str, Any],
+        preview_email: str = None
+    ) -> List[Submitter]:
+        """
+        Build submitters for preview mode.
+        
+        In preview mode, all required roles get the preview email
+        so we can generate a preview submission without sending emails.
+        
+        Args:
+            definition: Document definition
+            resolved_fields: Resolved fields with values
+            context: Data context
+            preview_email: Email to use for all submitters (optional)
+            
+        Returns:
+            List of Submitter objects for preview
+        """
+        submitters = []
+        
+        # Group fields by role_key
+        fields_by_role: Dict[str, List[ResolvedField]] = {}
+        for field in resolved_fields:
+            if field.role_key not in fields_by_role:
+                fields_by_role[field.role_key] = []
+            fields_by_role[field.role_key].append(field)
+        
+        # Build submitter for each role
+        for role_def in definition.roles:
+            # Resolve name for display
+            name = FieldResolver.resolve_single(role_def.name_source, context)
+            
+            # For optional roles, check if we have data
+            if role_def.optional:
+                email = FieldResolver.resolve_single(role_def.email_source, context)
+                if not email:
+                    logger.debug(f"Skipping optional role '{role_def.role_key}' in preview")
+                    continue
+            
+            # Build DocuSeal field format
+            role_fields = fields_by_role.get(role_def.role_key, [])
+            docuseal_fields = []
+            for field in role_fields:
+                field_dict = field.to_docuseal_format()
+                if field_dict:
+                    docuseal_fields.append(field_dict)
+            
+            # Use preview email or resolve from context
+            if preview_email:
+                use_email = preview_email
+            else:
+                use_email = FieldResolver.resolve_single(role_def.email_source, context)
+                if not use_email:
+                    use_email = f"preview-{role_def.role_key}@preview.local"
+            
+            submitters.append(Submitter(
+                role=role_def.docuseal_role,
+                email=use_email,
+                name=name or role_def.docuseal_role,
+                fields=docuseal_fields
+            ))
+        
+        logger.debug(f"Built {len(submitters)} preview submitter(s) for {definition.slug}")
+        return submitters
+    
+    @classmethod
+    def build_for_send(
+        cls,
+        definition: DocumentDefinition,
+        resolved_fields: List[ResolvedField],
+        context: Dict[str, Any]
+    ) -> List[Submitter]:
+        """
+        Build submitters for actual sending (emails will be sent).
+        
+        Unlike preview, this uses actual participant emails and
+        excludes optional roles without valid email addresses.
+        
+        Args:
+            definition: Document definition
+            resolved_fields: Resolved fields with values
+            context: Data context
+            
+        Returns:
+            List of Submitter objects for sending
+        """
+        # For send, we use the standard build which already handles
+        # optional roles correctly (skips them if no email)
+        return cls.build(definition, resolved_fields, context)
+

--- a/services/documents/transforms.py
+++ b/services/documents/transforms.py
@@ -1,0 +1,285 @@
+"""
+Field Transforms
+
+Functions that transform raw values into formatted strings
+for DocuSeal fields. Each transform is registered by name
+and can be referenced in YAML field definitions.
+
+Usage in YAML:
+    - field_key: list_price
+      docuseal_field: "List Price"
+      source: form.list_price
+      transform: currency
+"""
+
+import logging
+import re
+from datetime import datetime, date
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Type alias for transform functions
+TransformFunc = Callable[[Any], str]
+
+
+def transform_currency(value: Any) -> str:
+    """
+    Format a number as US currency.
+    
+    Examples:
+        500000 -> "$500,000.00"
+        1234.5 -> "$1,234.50"
+        "500000" -> "$500,000.00"
+    """
+    if value is None:
+        return ""
+    
+    try:
+        # Handle string input
+        if isinstance(value, str):
+            # Remove existing formatting
+            value = value.replace('$', '').replace(',', '').strip()
+            if not value:
+                return ""
+            value = float(value)
+        
+        return f"${value:,.2f}"
+    except (ValueError, TypeError):
+        logger.warning(f"Could not format as currency: {value}")
+        return str(value) if value else ""
+
+
+def transform_currency_no_cents(value: Any) -> str:
+    """
+    Format a number as US currency without cents.
+    
+    Examples:
+        500000 -> "$500,000"
+        1234.5 -> "$1,235"
+    """
+    if value is None:
+        return ""
+    
+    try:
+        if isinstance(value, str):
+            value = value.replace('$', '').replace(',', '').strip()
+            if not value:
+                return ""
+            value = float(value)
+        
+        return f"${int(round(value)):,}"
+    except (ValueError, TypeError):
+        logger.warning(f"Could not format as currency: {value}")
+        return str(value) if value else ""
+
+
+def transform_percent(value: Any) -> str:
+    """
+    Format a number as a percentage.
+    
+    Examples:
+        6 -> "6%"
+        6.5 -> "6.5%"
+        "6" -> "6%"
+    """
+    if value is None:
+        return ""
+    
+    try:
+        if isinstance(value, str):
+            value = value.replace('%', '').strip()
+            if not value:
+                return ""
+        
+        # Convert and check if it's a whole number
+        num = float(value)
+        if num == int(num):
+            return f"{int(num)}%"
+        return f"{num}%"
+    except (ValueError, TypeError):
+        logger.warning(f"Could not format as percent: {value}")
+        return str(value) if value else ""
+
+
+def transform_date(value: Any) -> str:
+    """
+    Format a date in standard US format.
+    
+    Examples:
+        "2026-01-15" -> "January 15, 2026"
+        datetime(2026, 1, 15) -> "January 15, 2026"
+        date(2026, 1, 15) -> "January 15, 2026"
+    """
+    if value is None:
+        return ""
+    
+    try:
+        if isinstance(value, (datetime, date)):
+            return value.strftime("%B %d, %Y")
+        
+        if isinstance(value, str):
+            if not value.strip():
+                return ""
+            # Try common formats
+            for fmt in ["%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"]:
+                try:
+                    dt = datetime.strptime(value, fmt)
+                    return dt.strftime("%B %d, %Y")
+                except ValueError:
+                    continue
+        
+        logger.warning(f"Could not parse date: {value}")
+        return str(value)
+    except Exception:
+        logger.warning(f"Could not format as date: {value}")
+        return str(value) if value else ""
+
+
+def transform_date_short(value: Any) -> str:
+    """
+    Format a date in short US format.
+    
+    Examples:
+        "2026-01-15" -> "01/15/2026"
+    """
+    if value is None:
+        return ""
+    
+    try:
+        if isinstance(value, (datetime, date)):
+            return value.strftime("%m/%d/%Y")
+        
+        if isinstance(value, str):
+            if not value.strip():
+                return ""
+            for fmt in ["%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"]:
+                try:
+                    dt = datetime.strptime(value, fmt)
+                    return dt.strftime("%m/%d/%Y")
+                except ValueError:
+                    continue
+        
+        return str(value)
+    except Exception:
+        return str(value) if value else ""
+
+
+def transform_phone(value: Any) -> str:
+    """
+    Format a phone number in US format.
+    
+    Examples:
+        "7137254459" -> "(713) 725-4459"
+        7137254459 -> "(713) 725-4459"
+        "(713) 725-4459" -> "(713) 725-4459"
+    """
+    if value is None:
+        return ""
+    
+    # Convert to string and extract digits
+    phone_str = str(value)
+    digits = re.sub(r'\D', '', phone_str)
+    
+    if not digits:
+        return ""
+    
+    # Handle 10-digit US numbers
+    if len(digits) == 10:
+        return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+    
+    # Handle 11-digit with country code
+    if len(digits) == 11 and digits[0] == '1':
+        return f"({digits[1:4]}) {digits[4:7]}-{digits[7:]}"
+    
+    # Return original if can't format
+    return phone_str
+
+
+def transform_uppercase(value: Any) -> str:
+    """Convert to uppercase."""
+    if value is None:
+        return ""
+    return str(value).upper()
+
+
+def transform_lowercase(value: Any) -> str:
+    """Convert to lowercase."""
+    if value is None:
+        return ""
+    return str(value).lower()
+
+
+def transform_titlecase(value: Any) -> str:
+    """Convert to title case."""
+    if value is None:
+        return ""
+    return str(value).title()
+
+
+def transform_trim(value: Any) -> str:
+    """Trim whitespace."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def transform_none(value: Any) -> str:
+    """No transformation - just convert to string."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+# Registry of available transforms
+TRANSFORMS: Dict[str, TransformFunc] = {
+    'currency': transform_currency,
+    'currency_no_cents': transform_currency_no_cents,
+    'percent': transform_percent,
+    'date': transform_date,
+    'date_short': transform_date_short,
+    'phone': transform_phone,
+    'uppercase': transform_uppercase,
+    'lowercase': transform_lowercase,
+    'titlecase': transform_titlecase,
+    'trim': transform_trim,
+    'none': transform_none,
+}
+
+
+def get_transform(name: str) -> Optional[TransformFunc]:
+    """Get a transform function by name."""
+    return TRANSFORMS.get(name)
+
+
+def apply_transform(value: Any, transform_name: Optional[str]) -> str:
+    """
+    Apply a named transform to a value.
+    
+    If transform_name is None or not found, returns str(value).
+    """
+    if value is None:
+        return ""
+    
+    if not transform_name:
+        return str(value)
+    
+    transform_func = get_transform(transform_name)
+    if transform_func:
+        return transform_func(value)
+    
+    logger.warning(f"Unknown transform: {transform_name}")
+    return str(value)
+
+
+def register_transform(name: str, func: TransformFunc) -> None:
+    """
+    Register a custom transform function.
+    
+    Use this to add new transforms without modifying this file:
+        from services.documents.transforms import register_transform
+        register_transform('county_name', my_county_formatter)
+    """
+    TRANSFORMS[name] = func
+    logger.debug(f"Registered transform: {name}")
+

--- a/services/documents/types.py
+++ b/services/documents/types.py
@@ -1,0 +1,215 @@
+"""
+Document System Type Definitions
+
+Dataclasses representing document definitions loaded from YAML.
+These are immutable after loading and validated on startup.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+from enum import Enum
+
+
+class DocumentType(Enum):
+    """Types of documents supported by the system."""
+    FORM_DRIVEN = "form-driven"
+    PDF_PREVIEW = "pdf-preview"
+
+
+@dataclass(frozen=True)
+class DisplayConfig:
+    """Display/UI configuration for a document."""
+    color: str
+    icon: str
+    sort_order: int
+
+
+@dataclass(frozen=True)
+class FormConfig:
+    """Form configuration for form-driven documents."""
+    template: str  # Full template path (e.g., listing_agreement_form.html)
+    partial: str   # Partial template path (e.g., listing_agreement_fields.html)
+
+
+@dataclass(frozen=True)
+class RoleDefinition:
+    """
+    A DocuSeal submitter role definition.
+    
+    Attributes:
+        role_key: Stable internal identifier (snake_case)
+        docuseal_role: Exact role name in DocuSeal template
+        email_source: Source path for email (e.g., "user.email")
+        name_source: Source path for display name (e.g., "user.full_name")
+        optional: If True, skip this role when source resolves to None
+    """
+    role_key: str
+    docuseal_role: str
+    email_source: str
+    name_source: str
+    optional: bool = False
+
+
+@dataclass(frozen=True)
+class FieldDefinition:
+    """
+    A field mapping between data sources and DocuSeal fields.
+    
+    Attributes:
+        field_key: Stable internal identifier (snake_case)
+        docuseal_field: Exact field name in DocuSeal template
+        role_key: Which role this field belongs to
+        source: Data source path (e.g., "user.email", "form.list_price", null for manual)
+        transform: Optional transform function name (e.g., "currency", "date")
+    """
+    field_key: str
+    docuseal_field: str
+    role_key: str
+    source: Optional[str] = None  # None means manual entry in DocuSeal
+    transform: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DocumentDefinition:
+    """
+    Complete definition of a document loaded from YAML.
+    
+    This is the primary data structure that drives the entire
+    document generation system. One YAML file = one DocumentDefinition.
+    """
+    schema_version: str
+    slug: str
+    name: str
+    docuseal_template_id: int
+    type: DocumentType
+    display: DisplayConfig
+    roles: List[RoleDefinition]
+    fields: List[FieldDefinition]
+    form: Optional[FormConfig] = None
+    
+    @property
+    def is_form_driven(self) -> bool:
+        """Check if this document uses a custom form UI."""
+        return self.type == DocumentType.FORM_DRIVEN
+    
+    @property
+    def is_pdf_preview(self) -> bool:
+        """Check if this document uses direct PDF preview."""
+        return self.type == DocumentType.PDF_PREVIEW
+    
+    def get_role(self, role_key: str) -> Optional[RoleDefinition]:
+        """Get a role definition by its key."""
+        return next((r for r in self.roles if r.role_key == role_key), None)
+    
+    def get_fields_for_role(self, role_key: str) -> List[FieldDefinition]:
+        """Get all fields that belong to a specific role."""
+        return [f for f in self.fields if f.role_key == role_key]
+    
+    def get_role_keys(self) -> List[str]:
+        """Get all role keys defined in this document."""
+        return [r.role_key for r in self.roles]
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'DocumentDefinition':
+        """
+        Create a DocumentDefinition from a parsed YAML dict.
+        
+        This handles the conversion from raw dict to typed dataclasses.
+        """
+        # Parse display config
+        display_data = data.get('display', {})
+        display = DisplayConfig(
+            color=display_data.get('color', '#6B7280'),
+            icon=display_data.get('icon', 'fas fa-file'),
+            sort_order=display_data.get('sort_order', 999)
+        )
+        
+        # Parse form config (optional, only for form-driven)
+        form = None
+        if 'form' in data:
+            form_data = data['form']
+            form = FormConfig(
+                template=form_data.get('template', ''),
+                partial=form_data.get('partial', '')
+            )
+        
+        # Parse roles
+        roles = []
+        for role_data in data.get('roles', []):
+            roles.append(RoleDefinition(
+                role_key=role_data['role_key'],
+                docuseal_role=role_data['docuseal_role'],
+                email_source=role_data['email_source'],
+                name_source=role_data['name_source'],
+                optional=role_data.get('optional', False)
+            ))
+        
+        # Parse fields
+        fields = []
+        for field_data in data.get('fields', []):
+            fields.append(FieldDefinition(
+                field_key=field_data['field_key'],
+                docuseal_field=field_data['docuseal_field'],
+                role_key=field_data['role_key'],
+                source=field_data.get('source'),  # Can be None
+                transform=field_data.get('transform')
+            ))
+        
+        return cls(
+            schema_version=data['schema_version'],
+            slug=data['slug'],
+            name=data['name'],
+            docuseal_template_id=data['docuseal_template_id'],
+            type=DocumentType(data['type']),
+            display=display,
+            form=form,
+            roles=tuple(roles),  # Convert to tuple for immutability
+            fields=tuple(fields)
+        )
+
+
+@dataclass
+class ResolvedField:
+    """
+    A field with its value resolved from the data context.
+    
+    This is the intermediate representation between the definition
+    and the final DocuSeal API payload.
+    """
+    field_key: str
+    docuseal_field: str
+    role_key: str
+    value: Optional[str]  # Resolved and transformed value
+    is_manual: bool = False  # True if source was null (manual entry)
+    
+    def to_docuseal_format(self) -> Dict[str, Any]:
+        """Convert to DocuSeal API field format."""
+        if self.is_manual or self.value is None:
+            return None  # Don't include manual/empty fields
+        return {
+            'name': self.docuseal_field,
+            'default_value': str(self.value)
+        }
+
+
+@dataclass
+class Submitter:
+    """
+    A DocuSeal submitter ready for API submission.
+    
+    This is the final representation sent to DocuSeal.
+    """
+    role: str  # DocuSeal role name
+    email: str
+    name: str
+    fields: List[Dict[str, Any]]  # List of {name, default_value}
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to DocuSeal API format."""
+        return {
+            'role': self.role,
+            'email': self.email,
+            'name': self.name,
+            'fields': self.fields
+        }
+

--- a/tests/test_document_definitions.py
+++ b/tests/test_document_definitions.py
@@ -1,0 +1,291 @@
+"""
+Document Definition Test Harness
+
+Validates all document definitions on every test run.
+This ensures configuration errors are caught before deployment.
+
+Run with: python -m pytest tests/test_document_definitions.py -v
+"""
+
+import pytest
+import sys
+from pathlib import Path
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.documents import (
+    DocumentLoader,
+    FieldResolver,
+    RoleBuilder,
+    DocumentType,
+    ConfigurationError
+)
+
+
+class MockUser:
+    """Mock User object for testing field resolution."""
+    id = 1
+    email = "agent@test.com"
+    first_name = "Test"
+    last_name = "Agent"
+    phone = "7135551234"
+    license_number = "TX123456"
+    licensed_supervisor = "Jane Supervisor"
+    licensed_supervisor_license = "TX789012"
+    licensed_supervisor_email = "supervisor@test.com"
+    licensed_supervisor_phone = "7135555678"
+    
+    @property
+    def full_name(self):
+        return f"{self.first_name} {self.last_name}"
+
+
+class MockParticipant:
+    """Mock Participant object for testing."""
+    def __init__(self, role, name, email, is_primary=False):
+        self.role = role
+        self.display_name = name
+        self.display_email = email
+        self.is_primary = is_primary
+        self.first_name = name.split()[0] if name else ""
+        self.last_name = name.split()[-1] if name and len(name.split()) > 1 else ""
+    
+    @property
+    def name(self):
+        return self.display_name
+    
+    @property
+    def email(self):
+        return self.display_email
+
+
+class MockTransaction:
+    """Mock Transaction object for testing."""
+    id = 1
+    property_address = "123 Test St, Houston, TX 77001"
+    
+    @property
+    def primary_seller(self):
+        return MockParticipant("seller", "John Seller", "seller@test.com", is_primary=True)
+    
+    @property
+    def sellers(self):
+        return [
+            self.primary_seller,
+            MockParticipant("seller", "Jane Seller", "seller2@test.com")
+        ]
+    
+    @property
+    def participants(self):
+        return self.sellers
+
+
+def create_mock_context():
+    """Create a mock context with all data sources."""
+    return {
+        'user': MockUser(),
+        'transaction': MockTransaction(),
+        'form': {
+            'list_price': '500000',
+            'commission_rate': '6',
+            'property_address': '123 Test St',
+        }
+    }
+
+
+class TestDocumentLoader:
+    """Test document loading and validation."""
+    
+    def test_load_all_succeeds(self):
+        """All YAML files should load without errors."""
+        # This will raise ConfigurationError if any document is invalid
+        DocumentLoader.load_all()
+        assert DocumentLoader.is_loaded()
+    
+    def test_at_least_one_document_loaded(self):
+        """At least one document definition should be loaded."""
+        DocumentLoader.load_all()
+        assert len(DocumentLoader.all()) >= 1
+    
+    def test_all_slugs_are_unique(self):
+        """All document slugs should be unique."""
+        DocumentLoader.load_all()
+        slugs = DocumentLoader.all_slugs()
+        assert len(slugs) == len(set(slugs))
+
+
+class TestDocumentDefinitions:
+    """Test each document definition individually."""
+    
+    @pytest.fixture(autouse=True)
+    def load_documents(self):
+        """Load all documents before each test."""
+        DocumentLoader.clear()
+        DocumentLoader.load_all()
+    
+    def test_iabs_definition_exists(self):
+        """IABS document should be loaded."""
+        definition = DocumentLoader.get('iabs')
+        assert definition is not None
+        assert definition.slug == 'iabs'
+        assert definition.type == DocumentType.PDF_PREVIEW
+    
+    def test_iabs_has_required_roles(self):
+        """IABS should have agent, broker, seller roles."""
+        definition = DocumentLoader.get('iabs')
+        role_keys = definition.get_role_keys()
+        
+        assert 'agent' in role_keys
+        assert 'broker' in role_keys
+        assert 'seller' in role_keys
+    
+    def test_iabs_has_agent_fields(self):
+        """IABS should have agent/supervisor fields."""
+        definition = DocumentLoader.get('iabs')
+        agent_fields = definition.get_fields_for_role('agent')
+        
+        field_keys = [f.field_key for f in agent_fields]
+        assert 'agent_name' in field_keys
+        assert 'agent_license' in field_keys
+        assert 'supervisor_name' in field_keys
+
+
+class TestFieldResolution:
+    """Test field resolution with mock data."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load documents and create context."""
+        DocumentLoader.clear()
+        DocumentLoader.load_all()
+        self.context = create_mock_context()
+    
+    def test_resolve_user_email(self):
+        """Should resolve user.email from context."""
+        value = FieldResolver.resolve_single('user.email', self.context)
+        assert value == "agent@test.com"
+    
+    def test_resolve_user_full_name(self):
+        """Should resolve user.full_name from context."""
+        value = FieldResolver.resolve_single('user.full_name', self.context)
+        assert value == "Test Agent"
+    
+    def test_resolve_transaction_primary_seller(self):
+        """Should resolve transaction.primary_seller.email."""
+        value = FieldResolver.resolve_single('transaction.primary_seller.email', self.context)
+        assert value == "seller@test.com"
+    
+    def test_resolve_sellers_array(self):
+        """Should resolve transaction.sellers[1].email with bracket notation."""
+        value = FieldResolver.resolve_single('transaction.sellers[1].email', self.context)
+        assert value == "seller2@test.com"
+    
+    def test_resolve_form_data(self):
+        """Should resolve form.list_price from form data."""
+        value = FieldResolver.resolve_single('form.list_price', self.context)
+        assert value == "500000"
+    
+    def test_resolve_null_source_returns_none(self):
+        """Null source path should return None."""
+        value = FieldResolver.resolve_single(None, self.context)
+        assert value is None
+    
+    def test_resolve_missing_path_returns_none(self):
+        """Missing path should return None, not raise."""
+        value = FieldResolver.resolve_single('user.nonexistent_field', self.context)
+        assert value is None
+
+
+class TestRoleBuilding:
+    """Test role building with resolved fields."""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Load documents and create context."""
+        DocumentLoader.clear()
+        DocumentLoader.load_all()
+        self.context = create_mock_context()
+    
+    def test_build_iabs_submitters(self):
+        """Should build submitters for IABS document."""
+        definition = DocumentLoader.get('iabs')
+        fields = FieldResolver.resolve(definition, self.context)
+        submitters = RoleBuilder.build(definition, fields, self.context)
+        
+        # Should have at least agent, broker, seller (seller_2 is optional)
+        assert len(submitters) >= 3
+        
+        roles = [s.role for s in submitters]
+        assert 'Agent' in roles
+        assert 'Broker' in roles
+        assert 'Seller' in roles
+    
+    def test_agent_submitter_has_fields(self):
+        """Agent submitter should have pre-filled fields."""
+        definition = DocumentLoader.get('iabs')
+        fields = FieldResolver.resolve(definition, self.context)
+        submitters = RoleBuilder.build(definition, fields, self.context)
+        
+        agent_submitter = next(s for s in submitters if s.role == 'Agent')
+        
+        # Agent should have fields with values
+        assert len(agent_submitter.fields) > 0
+        
+        # Check a specific field
+        field_names = [f['name'] for f in agent_submitter.fields]
+        assert 'Sales Agent Name' in field_names
+    
+    def test_optional_role_skipped_when_no_data(self):
+        """Optional roles should be skipped when data is missing."""
+        definition = DocumentLoader.get('iabs')
+        
+        # Create context without second seller
+        context = {
+            'user': MockUser(),
+            'transaction': type('MockTx', (), {
+                'primary_seller': MockParticipant("seller", "John", "john@test.com", True),
+                'sellers': [MockParticipant("seller", "John", "john@test.com", True)]  # Only one seller
+            })(),
+            'form': {}
+        }
+        
+        fields = FieldResolver.resolve(definition, context)
+        submitters = RoleBuilder.build(definition, fields, context)
+        
+        # Seller 2 should not be in submitters
+        roles = [s.role for s in submitters]
+        assert 'Seller 2' not in roles
+
+
+class TestTransforms:
+    """Test field value transforms."""
+    
+    def test_currency_transform(self):
+        """Currency transform should format numbers."""
+        from services.documents.transforms import transform_currency
+        
+        assert transform_currency(500000) == "$500,000.00"
+        assert transform_currency("500000") == "$500,000.00"
+        assert transform_currency(1234.5) == "$1,234.50"
+    
+    def test_phone_transform(self):
+        """Phone transform should format 10-digit numbers."""
+        from services.documents.transforms import transform_phone
+        
+        assert transform_phone("7135551234") == "(713) 555-1234"
+        assert transform_phone(7135551234) == "(713) 555-1234"
+        assert transform_phone("(713) 555-1234") == "(713) 555-1234"
+    
+    def test_percent_transform(self):
+        """Percent transform should add % symbol."""
+        from services.documents.transforms import transform_percent
+        
+        assert transform_percent(6) == "6%"
+        assert transform_percent("6.5") == "6.5%"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])
+


### PR DESCRIPTION
Major refactor of the document generation system to use YAML configuration files instead of hard-coded logic, reducing code complexity and making it easy to add new documents without code changes.

## New Architecture

- documents/*.yml - Document definitions (metadata, roles, fields, display)
- services/documents/ - Core document system services:
  - loader.py - Loads and validates YAML definitions with JSON schema
  - field_resolver.py - Resolves field values from data sources
  - role_builder.py - Builds DocuSeal submitters from definitions
  - docuseal_client.py - Thin API wrapper for DocuSeal
  - transforms.py - Value transforms (currency, date, phone, etc.)
  - types.py - Type definitions (DocumentDefinition, Submitter, etc.)

## Routes Migrated

All key document routes now use the new system:
- document_form, fill_all_documents, save_all_documents
- preview_all_documents, document_preview
- send_for_signature, send_all_for_signature
- generate_document_package

## Key Improvements

- Reduced routes/transactions.py by ~300 lines (net 268 lines removed)
- Adding new documents now requires only YAML config (+ optional partial template)
- Centralized field mappings, role definitions, and display configuration
- JSON schema validation on startup catches config errors early
- 19 automated tests for document definitions

## Model Changes

Added helper properties to Transaction model:
- primary_seller - Returns primary seller participant
- sellers - Returns list of all seller participants

These enable clean YAML source paths like:
  transaction.primary_seller.display_email transaction.sellers[1].display_name