### PR TITLE
feat: add conditional field support for document definitions

### DIFF
--- a/documents/hoa-addendum.yml
+++ b/documents/hoa-addendum.yml
@@ -5,6 +5,7 @@
 # TREC Form
 # 
 # This is a form-driven document with a custom UI for data entry.
+# Template ID: 2469165
 # =============================================================================
 
 schema_version: "1.0"
@@ -45,41 +46,129 @@ roles:
 # FIELDS
 # =============================================================================
 # Form fields from hoa_addendum_fields.html
-# Note: Computed fields (combining multiple form values) are handled separately
+# Uses conditional fields for options that depend on doc_responsibility selection
 # =============================================================================
 
 fields:
-  # Property address (computed from multiple fields in old system)
+  # Property address
   - field_key: street_address
     docuseal_field: "Street address"
     role_key: seller
     source: form.property_address
 
-  # HOA information
+  # HOA information (combines name and phone)
   - field_key: association_info
     docuseal_field: "Association name & phone"
     role_key: seller
     source: form.hoa_name
 
-  # Section A - Document delivery options
+  # =============================================================================
+  # Section A - Document delivery options (radio buttons)
+  # doc_responsibility determines which option gets an "X"
+  # =============================================================================
+
+  # Option checkboxes - only one gets "X" based on selection
+  - field_key: option_1_checkbox
+    docuseal_field: "Option 1"
+    role_key: seller
+    source: form.doc_responsibility
+    transform: checkbox
+    condition_field: form.doc_responsibility
+    condition_equals: seller
+
+  - field_key: option_2_checkbox
+    docuseal_field: "Option 2"
+    role_key: seller
+    source: form.doc_responsibility
+    transform: checkbox
+    condition_field: form.doc_responsibility
+    condition_equals: buyer
+
+  - field_key: option_3_checkbox
+    docuseal_field: "Option 3"
+    role_key: seller
+    source: form.doc_responsibility
+    transform: checkbox
+    condition_field: form.doc_responsibility
+    condition_equals: already_received
+
+  - field_key: option_4_checkbox
+    docuseal_field: "Option 4"
+    role_key: seller
+    source: form.doc_responsibility
+    transform: checkbox
+    condition_field: form.doc_responsibility
+    condition_equals: not_required
+
+  # Days fields - conditional based on which option is selected
   - field_key: option_1_days
     docuseal_field: "1. Days after effective date"
     role_key: seller
     source: form.seller_delivery_days
+    condition_field: form.doc_responsibility
+    condition_equals: seller
 
   - field_key: option_2_days
     docuseal_field: "2. Days after effective date"
     role_key: seller
     source: form.buyer_delivery_days
+    condition_field: form.doc_responsibility
+    condition_equals: buyer
 
+  # =============================================================================
+  # Option 3 sub-options (require updated resale certificate)
+  # =============================================================================
+
+  - field_key: buyer_does_require
+    docuseal_field: "Buyer does"
+    role_key: seller
+    source: form.require_updated_resale
+    transform: checkbox
+    condition_field: form.require_updated_resale
+    condition_equals: "yes"
+
+  - field_key: buyer_does_not_require
+    docuseal_field: "Buyer does not"
+    role_key: seller
+    source: form.require_updated_resale
+    transform: checkbox
+    condition_field: form.require_updated_resale
+    condition_equals: "no"
+
+  # =============================================================================
   # Section C - Fees
+  # =============================================================================
+
   - field_key: buyer_fee_cap
     docuseal_field: "C. Buyer paid transfer fee"
     role_key: seller
     source: form.buyer_fee_cap
     transform: currency
 
+  # =============================================================================
+  # Section D - Additional document fees
+  # =============================================================================
+
+  - field_key: buyer_pays_additional
+    docuseal_field: "D. Buyer pays"
+    role_key: seller
+    source: form.additional_doc_fee_paid_by
+    transform: checkbox
+    condition_field: form.additional_doc_fee_paid_by
+    condition_equals: buyer
+
+  - field_key: seller_pays_additional
+    docuseal_field: "D. Seller pays"
+    role_key: seller
+    source: form.additional_doc_fee_paid_by
+    transform: checkbox
+    condition_field: form.additional_doc_fee_paid_by
+    condition_equals: seller
+
+  # =============================================================================
   # Signature fields - handled by DocuSeal
+  # =============================================================================
+
   - field_key: seller_signature
     docuseal_field: "Seller signature 1"
     role_key: seller
@@ -89,4 +178,3 @@ fields:
     docuseal_field: "Signature Field 2"
     role_key: seller_2
     source: null
-

--- a/documents/schema/v1.0.json
+++ b/documents/schema/v1.0.json
@@ -135,6 +135,14 @@
           "transform": {
             "type": "string",
             "description": "Optional transform function name"
+          },
+          "condition_field": {
+            "type": "string",
+            "description": "Field to check for conditional inclusion (e.g., 'form.doc_responsibility')"
+          },
+          "condition_equals": {
+            "type": "string",
+            "description": "Value that condition_field must equal for this field to be included"
           }
         },
         "additionalProperties": false

--- a/services/documents/field_resolver.py
+++ b/services/documents/field_resolver.py
@@ -86,8 +86,22 @@ class FieldResolver:
             context: Dict with data sources
             
         Returns:
-            ResolvedField with value populated
+            ResolvedField with value populated, or None value if condition not met
         """
+        # Check condition if specified
+        if field_def.condition_field and field_def.condition_equals is not None:
+            condition_value = cls.resolve_path(field_def.condition_field, context)
+            if str(condition_value) != str(field_def.condition_equals):
+                # Condition not met - return field with None value (won't be sent)
+                logger.debug(f"Condition not met for {field_def.field_key}: {condition_value} != {field_def.condition_equals}")
+                return ResolvedField(
+                    field_key=field_def.field_key,
+                    docuseal_field=field_def.docuseal_field,
+                    role_key=field_def.role_key,
+                    value=None,
+                    is_manual=False
+                )
+        
         # Manual entry fields have no source
         if field_def.source is None:
             return ResolvedField(

--- a/services/documents/transforms.py
+++ b/services/documents/transforms.py
@@ -229,26 +229,45 @@ def transform_checkbox(value: Any) -> str:
     """
     Convert checkbox/boolean values to 'X' for DocuSeal checkbox fields.
     
+    For conditional checkbox fields (where condition_field/condition_equals are used),
+    this is called only when the condition is met, so any truthy value returns "X".
+    
+    Note: We don't treat "no" as falsy because it could be a valid selection value
+    (e.g., user selected "No" option in a radio group).
+    
     Examples:
         True -> "X"
         "1" -> "X"
         "on" -> "X"
+        "seller" -> "X"
+        "no" -> "X" (valid selection value, not boolean false)
+        "yes" -> "X"
         False -> ""
         None -> ""
+        "" -> ""
+        "0" -> ""
+        "false" -> ""
     """
     if value is None:
         return ""
     
-    # Convert to string and check for truthy values
+    # Check for boolean False
+    if value is False:
+        return ""
+    
+    # Convert to string
     str_val = str(value).lower().strip()
-    if str_val in ('true', '1', 'on', 'yes', 'x', 'checked'):
-        return "X"
     
-    # Also check for boolean True
-    if value is True:
-        return "X"
+    # Empty string is falsy
+    if not str_val:
+        return ""
     
-    return ""
+    # Explicit boolean-like false values (but NOT "no" which could be a selection)
+    if str_val in ('false', '0', 'off'):
+        return ""
+    
+    # Any other non-empty value is truthy -> return X
+    return "X"
 
 
 def transform_none(value: Any) -> str:

--- a/services/documents/types.py
+++ b/services/documents/types.py
@@ -63,12 +63,16 @@ class FieldDefinition:
         role_key: Which role this field belongs to
         source: Data source path (e.g., "user.email", "form.list_price", null for manual)
         transform: Optional transform function name (e.g., "currency", "date")
+        condition_field: Optional field to check for conditional inclusion
+        condition_equals: Value that condition_field must equal for field to be included
     """
     field_key: str
     docuseal_field: str
     role_key: str
     source: Optional[str] = None  # None means manual entry in DocuSeal
     transform: Optional[str] = None
+    condition_field: Optional[str] = None  # e.g., "form.doc_responsibility"
+    condition_equals: Optional[str] = None  # e.g., "seller"
 
 
 @dataclass(frozen=True)
@@ -155,7 +159,9 @@ class DocumentDefinition:
                 docuseal_field=field_data['docuseal_field'],
                 role_key=field_data['role_key'],
                 source=field_data.get('source'),  # Can be None
-                transform=field_data.get('transform')
+                transform=field_data.get('transform'),
+                condition_field=field_data.get('condition_field'),
+                condition_equals=field_data.get('condition_equals')
             ))
         
         return cls(


### PR DESCRIPTION
- Add condition_field and condition_equals to FieldDefinition
- Update FieldResolver to check conditions before including fields
- Update hoa-addendum.yml with conditional option checkboxes and days fields
- Fix checkbox transform to not treat 'no' as falsy (it's a valid selection)
- Update schema to allow condition_field and condition_equals properties

This enables fields to be conditionally included based on other field values, supporting radio button options like HOA document delivery responsibility.