### PR TITLE
feat: Add production gunicorn deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ itsdangerous>=2.1.2
 PyYAML>=6.0
 jsonschema>=4.0.0
 pytest>=7.0.0
+gunicorn>=21.0.0


### PR DESCRIPTION
- Add Procfile with gunicorn binding to port 5011 (matches Railway networking config)
- Add gunicorn>=21.0.0 to requirements.txt
- 2 workers, 120s timeout for DocuSeal API calls

Tested locally. Flask dev server still works for local development.