### PR TITLE
fix: add static broker fields to IABS to ensure values are preserved

### DIFF
--- a/documents/iabs.yml
+++ b/documents/iabs.yml
@@ -60,54 +60,15 @@ roles:
 # =============================================================================
 # FIELDS
 # =============================================================================
-# Broker fields use static Origen Realty company info.
 # Agent fields are auto-populated from the user's profile.
+# Broker fields are pre-filled in the DocuSeal template (Origen Realty info).
 # Seller fields are left null (manual entry during signing).
+#
+# NOTE: To add broker fields here, get the exact field names from DocuSeal
+# template UI and use "source: static:value" syntax.
 # =============================================================================
 
 fields:
-  # Broker/Brokerage information (static Origen Realty company info)
-  - field_key: broker_name
-    docuseal_field: "Broker name"
-    role_key: broker
-    source: static:Origen Realty
-
-  - field_key: broker_license
-    docuseal_field: "Broker license"
-    role_key: broker
-    source: static:9003104
-
-  - field_key: broker_email
-    docuseal_field: "Broker email"
-    role_key: broker
-    source: static:cassie@origenrealty.com
-
-  - field_key: broker_phone
-    docuseal_field: "Broker Phone"
-    role_key: broker
-    source: static:(832) 419-0296
-
-  # Designated Broker information
-  - field_key: designated_broker_name
-    docuseal_field: "Designated Broker Name"
-    role_key: broker
-    source: static:Cassie Nichols
-
-  - field_key: designated_broker_license
-    docuseal_field: "Designated Broker license"
-    role_key: broker
-    source: static:633754
-
-  - field_key: designated_broker_email
-    docuseal_field: "Designated Broker email"
-    role_key: broker
-    source: static:cassie@origenrealty.com
-
-  - field_key: designated_broker_phone
-    docuseal_field: "Designated Broker Phone"
-    role_key: broker
-    source: static:(832) 419-0296
-
   # Agent information (from user profile)
   - field_key: agent_name
     docuseal_field: "Sales Agent Name"

--- a/documents/iabs.yml
+++ b/documents/iabs.yml
@@ -60,11 +60,54 @@ roles:
 # =============================================================================
 # FIELDS
 # =============================================================================
-# All fields belong to the "agent" role and are auto-populated from the
-# user's profile. Seller fields are left null (manual entry during signing).
+# Broker fields use static Origen Realty company info.
+# Agent fields are auto-populated from the user's profile.
+# Seller fields are left null (manual entry during signing).
 # =============================================================================
 
 fields:
+  # Broker/Brokerage information (static Origen Realty company info)
+  - field_key: broker_name
+    docuseal_field: "Broker name"
+    role_key: broker
+    source: static:Origen Realty
+
+  - field_key: broker_license
+    docuseal_field: "Broker license"
+    role_key: broker
+    source: static:9003104
+
+  - field_key: broker_email
+    docuseal_field: "Broker email"
+    role_key: broker
+    source: static:cassie@origenrealty.com
+
+  - field_key: broker_phone
+    docuseal_field: "Broker Phone"
+    role_key: broker
+    source: static:(832) 419-0296
+
+  # Designated Broker information
+  - field_key: designated_broker_name
+    docuseal_field: "Designated Broker Name"
+    role_key: broker
+    source: static:Cassie Nichols
+
+  - field_key: designated_broker_license
+    docuseal_field: "Designated Broker license"
+    role_key: broker
+    source: static:633754
+
+  - field_key: designated_broker_email
+    docuseal_field: "Designated Broker email"
+    role_key: broker
+    source: static:cassie@origenrealty.com
+
+  - field_key: designated_broker_phone
+    docuseal_field: "Designated Broker Phone"
+    role_key: broker
+    source: static:(832) 419-0296
+
   # Agent information (from user profile)
   - field_key: agent_name
     docuseal_field: "Sales Agent Name"

--- a/documents/iabs.yml
+++ b/documents/iabs.yml
@@ -60,15 +60,54 @@ roles:
 # =============================================================================
 # FIELDS
 # =============================================================================
+# Broker fields use static Origen Realty company info.
 # Agent fields are auto-populated from the user's profile.
-# Broker fields are pre-filled in the DocuSeal template (Origen Realty info).
 # Seller fields are left null (manual entry during signing).
-#
-# NOTE: To add broker fields here, get the exact field names from DocuSeal
-# template UI and use "source: static:value" syntax.
 # =============================================================================
 
 fields:
+  # Broker/Brokerage information (static Origen Realty company info)
+  - field_key: broker_name
+    docuseal_field: "Broker Name"
+    role_key: broker
+    source: static:Origen Realty
+
+  - field_key: broker_license
+    docuseal_field: "Broker License Number"
+    role_key: broker
+    source: static:9003104
+
+  - field_key: broker_email
+    docuseal_field: "Broker Email"
+    role_key: broker
+    source: static:cassie@origenrealty.com
+
+  - field_key: broker_phone
+    docuseal_field: "Broker Phone"
+    role_key: broker
+    source: static:(832) 419-0296
+
+  # Designated Broker information
+  - field_key: designated_broker_name
+    docuseal_field: "Designated Broker Name"
+    role_key: broker
+    source: static:Cassie Nichols
+
+  - field_key: designated_broker_license
+    docuseal_field: "Designated Broker license number"
+    role_key: broker
+    source: static:633754
+
+  - field_key: designated_broker_email
+    docuseal_field: "Designated Broker email"
+    role_key: broker
+    source: static:cassie@origenrealty.com
+
+  - field_key: designated_broker_phone
+    docuseal_field: "Designated Broker phone"
+    role_key: broker
+    source: static:(832) 419-0296
+
   # Agent information (from user profile)
   - field_key: agent_name
     docuseal_field: "Sales Agent Name"

--- a/services/documents/field_resolver.py
+++ b/services/documents/field_resolver.py
@@ -112,6 +112,17 @@ class FieldResolver:
                 is_manual=True
             )
         
+        # Static values use "static:" prefix (e.g., "static:Origen Realty")
+        if field_def.source.startswith('static:'):
+            static_value = field_def.source[7:]  # Remove "static:" prefix
+            return ResolvedField(
+                field_key=field_def.field_key,
+                docuseal_field=field_def.docuseal_field,
+                role_key=field_def.role_key,
+                value=static_value,
+                is_manual=False
+            )
+        
         # Resolve the source path
         raw_value = cls.resolve_path(field_def.source, context)
         


### PR DESCRIPTION
- Add Origen Realty broker/brokerage fields to iabs.yml with static values
- Add support for 'static:' prefix in FieldResolver for literal values
- This ensures broker info is always present when merging templates

The merge_templates API doesn't reliably preserve pre-filled values from original templates, so we now control these values through our YAML config.