### PR TITLE
feat: add combined field support and improve auto-mapper in Document …

### DIFF
--- a/documents/schema/v1.0.json
+++ b/documents/schema/v1.0.json
@@ -130,11 +130,21 @@
           },
           "source": {
             "type": ["string", "null"],
-            "description": "Data source path (null = manual entry)"
+            "description": "Single data source path (null = manual entry). Use 'source' for single fields, 'sources' for combined fields."
+          },
+          "sources": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 2,
+            "description": "Multiple source paths for combined fields (e.g., address components). Use with 'template'."
+          },
+          "template": {
+            "type": "string",
+            "description": "Format template for combined fields. Supports positional ({0}, {1}) or named ({field_name}) placeholders."
           },
           "transform": {
             "type": "string",
-            "description": "Optional transform function name"
+            "description": "Optional transform function name (applied after combining for combined fields)"
           },
           "condition_field": {
             "type": "string",
@@ -145,7 +155,19 @@
             "description": "Value that condition_field must equal for this field to be included"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "properties": {
+              "source": { "type": ["string", "null"] }
+            },
+            "not": { "required": ["sources"] }
+          },
+          {
+            "required": ["sources", "template"],
+            "not": { "required": ["source"] }
+          }
+        ]
       }
     }
   },

--- a/services/documents/auto_mapper.py
+++ b/services/documents/auto_mapper.py
@@ -1,52 +1,244 @@
 """
-Auto-Mapper Service
+Auto-Mapper Service v2
 
-Automatically maps HTML form fields to DocuSeal template fields using
-fuzzy string matching and type inference.
+Intelligent field mapping between HTML forms and DocuSeal templates.
+Uses domain-specific knowledge of real estate documents, semantic matching,
+and pattern recognition for high-quality automatic mappings.
 """
 
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from difflib import SequenceMatcher
 
 
 class AutoMapper:
     """
-    Automatic field mapping between HTML forms and DocuSeal templates.
-    
+    Intelligent field mapper for real estate document forms.
+
     Uses multiple strategies:
-    - Exact name matching (highest priority)
-    - Fuzzy string matching (Levenshtein-style)
-    - Word overlap scoring
-    - Type compatibility
+    - Semantic synonym matching (domain-specific)
+    - Pattern-based matching (numbered fields, options)
+    - Word-level analysis with weighted scoring
+    - Type and transform inference
+    - Role-aware matching
     """
-    
+
     # Minimum confidence score to suggest a mapping
-    MIN_CONFIDENCE = 40
-    
-    # Type compatibility mappings
+    MIN_CONFIDENCE = 35
+
+    # ==========================================================================
+    # DOMAIN-SPECIFIC SYNONYMS
+    # ==========================================================================
+    # Maps normalized terms to their synonyms/variations
+    # When any of these terms appear, they can match each other
+
+    SYNONYMS = {
+        # Address fields
+        'address': {'address', 'addr', 'street', 'street_address', 'property_address', 'location'},
+        'street': {'street', 'street_address', 'address', 'property_address'},
+        'city': {'city', 'town', 'municipality'},
+        'state': {'state', 'st', 'province'},
+        'zip': {'zip', 'zipcode', 'zip_code', 'postal', 'postal_code'},
+
+        # Name fields
+        'name': {'name', 'full_name', 'fullname', 'seller', 'buyer', 'client'},
+        'seller': {'seller', 'seller_name', 'seller_1', 'primary_seller', 'owner'},
+        'buyer': {'buyer', 'buyer_name', 'buyer_1', 'primary_buyer', 'purchaser'},
+
+        # Contact fields
+        'phone': {'phone', 'telephone', 'tel', 'mobile', 'cell', 'contact'},
+        'email': {'email', 'e_mail', 'mail', 'contact'},
+
+        # Date fields
+        'date': {'date', 'dt', 'effective_date', 'closing_date', 'expiration'},
+        'closing': {'closing', 'closing_date', 'close', 'settlement'},
+
+        # Money/Fee fields
+        'fee': {'fee', 'fees', 'cost', 'costs', 'price', 'amount', 'charge'},
+        'price': {'price', 'amount', 'cost', 'fee', 'value', 'sales_price'},
+        'amount': {'amount', 'amt', 'fee', 'cost', 'price', 'total'},
+        'total': {'total', 'sum', 'subtotal', 'amount', 'net'},
+
+        # Tax fields
+        'tax': {'tax', 'taxes', 'property_tax', 'annual_tax'},
+        'prorated': {'prorated', 'prorate', 'proration', 'pro_rated'},
+
+        # HOA/Association fields
+        'hoa': {'hoa', 'association', 'homeowners', 'owners_association'},
+        'maintenance': {'maintenance', 'maint', 'hoa_fee', 'association_fee'},
+
+        # Document/Option fields
+        'option': {'option', 'opt', 'choice', 'selection'},
+        'days': {'days', 'day', 'period', 'term'},
+
+        # Signature fields
+        'signature': {'signature', 'sign', 'sig', 'initials'},
+        'initials': {'initials', 'initial', 'init'},
+
+        # Financing fields
+        'financing': {'financing', 'finance', 'loan', 'mortgage'},
+        'conventional': {'conventional', 'conv'},
+        'fha': {'fha', 'federal_housing'},
+        'va': {'va', 'veterans'},
+        'usda': {'usda', 'rural'},
+        'cash': {'cash', 'all_cash'},
+
+        # Repair fields
+        'repairs': {'repairs', 'repair', 'fix', 'maintenance'},
+        'lender': {'lender', 'bank', 'mortgage_company'},
+
+        # Title/Escrow fields
+        'title': {'title', 'title_company', 'title_policy'},
+        'escrow': {'escrow', 'escrow_fee', 'closing'},
+        'survey': {'survey', 'surveyor', 'plat'},
+
+        # Misc
+        'prepared': {'prepared', 'prepared_by', 'agent', 'broker'},
+        'additional': {'additional', 'extra', 'other', 'custom'},
+    }
+
+    # ==========================================================================
+    # EXACT MATCH PATTERNS
+    # ==========================================================================
+    # Direct field name -> DocuSeal field mappings for common patterns
+
+    EXACT_MAPPINGS = {
+        # Address
+        'property_address': ['Street address', 'Address', 'Property Address', 'Property address'],
+        'street_address': ['Street address', 'Address', 'Street Address'],
+
+        # Names
+        'seller_name': ['Seller', 'Seller 1', 'Seller Name', 'Seller name'],
+        'buyer_name': ['Buyer', 'Buyer 1', 'Buyer Name'],
+        'prepared_by': ['Prepared By', 'Prepared by', 'Agent', 'Agent Name'],
+
+        # Dates
+        'closing_date': ['Anticipated Closing Date', 'Closing Date', 'Close Date'],
+        'effective_date': ['Effective Date', 'Contract Date'],
+
+        # Financial
+        'sales_price': ['Sales Price', 'Purchase Price', 'Sale Price'],
+        'list_price': ['List Price', 'Listing Price'],
+        'net_proceeds': ['Estimated Net Proceeds', 'Net Proceeds', 'Net'],
+        'total_costs': ['Total Estimated Costs', 'Total Costs', 'Total'],
+        'loan_payoff': ['Loan Payoff', 'Mortgage Payoff', 'Payoff'],
+
+        # Fees
+        'brokers_fee': ['Brokers Fee Calculated', 'Broker Fee', 'Commission'],
+        'brokers_fee_percent': ['Brokers Percentage', 'Commission %', 'Broker %'],
+        'escrow_fee': ['Escrow Fee', 'Escrow'],
+        'title_policy': ['Title Policy Owner', 'Title Policy', 'Title Insurance'],
+        'survey_fee': ['Survey Fee', 'Survey'],
+        'recording_fees': ['Recording Fees', 'Recording Fee', 'Recording'],
+        'wiring_fees': ['Wiring Fees', 'Wire Fee', 'Wire Transfer'],
+        'courier_fees': ['Courier Fee', 'Courier Fees', 'Courier'],
+        'attorneys_fees': ["Attorney's Fees", 'Attorney Fee', 'Legal Fees'],
+        'tax_cert_fee': ['Tax Certificate Fee', 'Tax Cert Fee'],
+
+        # Taxes
+        'annual_property_taxes': ['Estimated Annual Property Taxes', 'Annual Taxes', 'Property Taxes'],
+        'prorated_taxes': ['Taxes Amt', 'Prorated Taxes', 'Tax Proration'],
+
+        # HOA
+        'hoa_name': ['Association name & phone', 'HOA Name', 'Association Name'],
+        'annual_maintenance_fees': ['Estimated Annual Maintenance Fees', 'Annual Maintenance', 'HOA Fees'],
+        'condo_transfer_fee': ['Condo Transfer Fee', 'Transfer Fee'],
+
+        # Repairs
+        'repairs_buyer': ['Repairs Required by Buyer', 'Buyer Repairs'],
+        'repairs_lender': ['Repairs Required by Lender', 'Lender Repairs'],
+        'residential_service': ['Res Service Contract', 'Home Warranty', 'Service Contract'],
+
+        # Prorations
+        'prorated_days': ['Prorated For', 'Proration Days', 'Days'],
+        'prorated_interest': ['Interest Assumptions', 'Prorated Interest'],
+        'prorated_maintenance': ['Maintenance Fees', 'Prorated Maintenance'],
+
+        # Refunds
+        'unused_insurance': ['Unused Insurance', 'Insurance Refund'],
+        'escrow_balance': ['Escrow Balance', 'Escrow Refund'],
+        'total_refunds': ['Total Estimated Refunds', 'Total Refunds'],
+
+        # Assessments
+        'assessments': ['Assessments', 'Special Assessments'],
+        'rents': ['Rents fee', 'Rents', 'Rental Income'],
+        'seller_allowances': ['Nonallowables', 'Seller Allowances', 'Allowances'],
+    }
+
+    # ==========================================================================
+    # PATTERN MATCHERS
+    # ==========================================================================
+    # Regex patterns for numbered/sequential fields
+
+    NUMBERED_PATTERNS = [
+        # "custom_label_1" -> "Additional Cost txt 1"
+        (r'custom_label_(\d+)', r'Additional Cost txt {n}'),
+        (r'custom_amount_(\d+)', r'Additional Cost \$ {n}'),
+
+        # "option_1" -> "Option 1"
+        (r'option_(\d+)', r'Option {n}'),
+
+        # "seller_delivery_days" -> "1. Days after effective date"
+        (r'seller_delivery_days', r'1\. Days after effective date'),
+        (r'buyer_delivery_days', r'2\. Days after effective date'),
+
+        # Financing options
+        (r'financing_conventional', r'Conventional Option'),
+        (r'financing_va', r'VA Option'),
+        (r'financing_fha', r'FHA Option'),
+        (r'financing_usda', r'USDA Option'),
+        (r'financing_reverse', r'Reverse Mortgage Option'),
+        (r'financing_assumption', r'Assumption Option'),
+        (r'financing_owner', r'Owner Option'),
+        (r'financing_cash', r'Cash Option'),
+    ]
+
+    # ==========================================================================
+    # TRANSFORM INFERENCE
+    # ==========================================================================
+    # Field name patterns that suggest specific transforms
+
+    TRANSFORM_PATTERNS = {
+        'currency': [
+            r'fee', r'fees', r'cost', r'costs', r'price', r'amount', r'amt',
+            r'tax', r'taxes', r'payoff', r'proceeds', r'balance', r'refund',
+            r'repair', r'allowance', r'assessment', r'rent', r'insurance',
+            r'escrow', r'title', r'survey', r'courier', r'wiring', r'recording',
+            r'total', r'net', r'gross', r'deduction', r'credit'
+        ],
+        'date_short': [
+            r'date', r'closing', r'effective', r'expiration', r'term'
+        ],
+        'checkbox': [
+            r'option', r'financing', r'require', r'pays', r'does', r'checkbox',
+            r'selected', r'checked', r'approved'
+        ],
+        'phone': [
+            r'phone', r'tel', r'mobile', r'cell', r'fax'
+        ],
+        'percent': [
+            r'percent', r'percentage', r'rate', r'pct', r'\%'
+        ],
+    }
+
+    # ==========================================================================
+    # TYPE COMPATIBILITY
+    # ==========================================================================
+
     TYPE_COMPATIBILITY = {
-        'text': ['text', 'string'],
-        'number': ['number', 'text'],
-        'date': ['date', 'text'],
+        'text': ['text', 'string', 'textarea'],
+        'number': ['number', 'text', 'string'],
+        'date': ['date', 'text', 'string'],
         'checkbox': ['checkbox', 'text'],
         'radio': ['radio', 'checkbox', 'text'],
-        'select': ['select', 'text'],
-        'textarea': ['text', 'textarea'],
+        'select': ['select', 'text', 'string'],
+        'textarea': ['text', 'textarea', 'string'],
     }
-    
-    # Common field name variations to normalize
-    NAME_VARIATIONS = {
-        'address': ['addr', 'street', 'property_address', 'street_address'],
-        'phone': ['tel', 'telephone', 'mobile', 'cell'],
-        'email': ['mail', 'e-mail'],
-        'name': ['full_name', 'fullname'],
-        'date': ['dt', 'effective_date', 'closing_date'],
-        'fee': ['fees', 'cost', 'price', 'amount'],
-        'seller': ['seller_1', 'primary_seller'],
-        'buyer': ['buyer_1', 'primary_buyer'],
-    }
-    
+
+    # ==========================================================================
+    # MAIN API
+    # ==========================================================================
+
     @classmethod
     def auto_map(
         cls,
@@ -55,235 +247,346 @@ class AutoMapper:
     ) -> List[Dict[str, Any]]:
         """
         Automatically map HTML fields to DocuSeal fields.
-        
+
+        Uses intelligent matching with domain-specific knowledge.
+
         Args:
             html_fields: List of HTML field definitions
-                         [{'name': 'property_address', 'type': 'text', ...}, ...]
             docuseal_fields: List of DocuSeal field definitions
-                             [{'name': 'Property Address', 'type': 'text', 'role': 'Seller'}, ...]
-        
+
         Returns:
             List of mapping suggestions with confidence scores
-            [{'html_field': 'property_address', 
-              'docuseal_field': 'Property Address',
-              'docuseal_role': 'Seller',
-              'confidence': 95,
-              'suggested_transform': None}, ...]
         """
         mappings = []
-        used_docuseal_fields = set()
-        
-        # Sort HTML fields by specificity (longer names first)
-        sorted_html = sorted(html_fields, key=lambda f: len(f.get('name', '')), reverse=True)
-        
-        for html_field in sorted_html:
-            best_match = cls._find_best_match(html_field, docuseal_fields, used_docuseal_fields)
-            
-            if best_match:
-                mappings.append(best_match)
-                used_docuseal_fields.add(best_match['docuseal_field'])
-        
+        used_docuseal_fields: Set[str] = set()
+
+        # Build lookup structures for faster matching
+        ds_by_normalized = cls._build_docuseal_lookup(docuseal_fields)
+
+        # First pass: Try exact mappings (highest confidence)
+        for html_field in html_fields:
+            html_name = html_field.get('name', '')
+            html_normalized = cls._normalize_name(html_name)
+
+            # Check exact mappings first
+            exact_match = cls._find_exact_mapping(html_normalized, docuseal_fields, used_docuseal_fields)
+            if exact_match:
+                exact_match['html_field'] = html_name
+                exact_match['html_type'] = html_field.get('html_type', 'text')
+                exact_match['suggested_transform'] = cls._infer_transform(html_name, exact_match.get('docuseal_type', 'text'))
+                mappings.append(exact_match)
+                used_docuseal_fields.add(exact_match['docuseal_field'])
+
+        # Second pass: Pattern matching
+        for html_field in html_fields:
+            html_name = html_field.get('name', '')
+            if any(m['html_field'] == html_name for m in mappings):
+                continue
+
+            pattern_match = cls._find_pattern_match(html_name, docuseal_fields, used_docuseal_fields)
+            if pattern_match:
+                pattern_match['html_field'] = html_name
+                pattern_match['html_type'] = html_field.get('html_type', 'text')
+                pattern_match['suggested_transform'] = cls._infer_transform(html_name, pattern_match.get('docuseal_type', 'text'))
+                mappings.append(pattern_match)
+                used_docuseal_fields.add(pattern_match['docuseal_field'])
+
+        # Third pass: Semantic/fuzzy matching for remaining fields
+        for html_field in html_fields:
+            html_name = html_field.get('name', '')
+            if any(m['html_field'] == html_name for m in mappings):
+                continue
+
+            fuzzy_match = cls._find_semantic_match(html_field, docuseal_fields, used_docuseal_fields)
+            if fuzzy_match:
+                mappings.append(fuzzy_match)
+                used_docuseal_fields.add(fuzzy_match['docuseal_field'])
+
         # Sort by original HTML field order
         html_order = {f.get('name'): i for i, f in enumerate(html_fields)}
         mappings.sort(key=lambda m: html_order.get(m['html_field'], 999))
-        
+
         return mappings
-    
+
+    # ==========================================================================
+    # MATCHING STRATEGIES
+    # ==========================================================================
+
     @classmethod
-    def _find_best_match(
+    def _find_exact_mapping(
+        cls,
+        html_normalized: str,
+        docuseal_fields: List[Dict[str, Any]],
+        used_fields: Set[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Find exact mapping from predefined mappings."""
+        if html_normalized in cls.EXACT_MAPPINGS:
+            for ds_name_candidate in cls.EXACT_MAPPINGS[html_normalized]:
+                for ds_field in docuseal_fields:
+                    ds_name = ds_field.get('name', '')
+                    if ds_name in used_fields:
+                        continue
+                    if ds_name.lower() == ds_name_candidate.lower():
+                        return {
+                            'docuseal_field': ds_name,
+                            'docuseal_role': ds_field.get('role', 'Seller'),
+                            'docuseal_type': ds_field.get('type', 'text'),
+                            'confidence': 98,
+                            'match_type': 'exact'
+                        }
+        return None
+
+    @classmethod
+    def _find_pattern_match(
+        cls,
+        html_name: str,
+        docuseal_fields: List[Dict[str, Any]],
+        used_fields: Set[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Find match using regex patterns."""
+        html_normalized = cls._normalize_name(html_name)
+
+        for pattern, replacement in cls.NUMBERED_PATTERNS:
+            match = re.match(pattern, html_normalized)
+            if match:
+                # Build expected DocuSeal field name
+                if match.groups():
+                    expected = replacement.replace('{n}', match.group(1))
+                else:
+                    expected = replacement
+
+                # Search for this in DocuSeal fields
+                for ds_field in docuseal_fields:
+                    ds_name = ds_field.get('name', '')
+                    if ds_name in used_fields:
+                        continue
+
+                    # Check if matches expected pattern
+                    if re.search(re.escape(expected), ds_name, re.IGNORECASE):
+                        return {
+                            'docuseal_field': ds_name,
+                            'docuseal_role': ds_field.get('role', 'Seller'),
+                            'docuseal_type': ds_field.get('type', 'text'),
+                            'confidence': 95,
+                            'match_type': 'pattern'
+                        }
+        return None
+
+    @classmethod
+    def _find_semantic_match(
         cls,
         html_field: Dict[str, Any],
         docuseal_fields: List[Dict[str, Any]],
-        used_fields: set
+        used_fields: Set[str]
     ) -> Optional[Dict[str, Any]]:
-        """Find the best matching DocuSeal field for an HTML field."""
+        """Find best semantic/fuzzy match for an HTML field."""
         html_name = html_field.get('name', '')
         html_type = html_field.get('html_type', 'text')
-        
+        html_normalized = cls._normalize_name(html_name)
+        html_words = set(html_normalized.split('_'))
+
         best_score = 0
         best_match = None
-        
+
         for ds_field in docuseal_fields:
             ds_name = ds_field.get('name', '')
-            ds_type = ds_field.get('type', 'text')
-            ds_role = ds_field.get('role', 'Seller')
-            
-            # Skip already used fields
             if ds_name in used_fields:
                 continue
-            
-            # Calculate match score
-            score = cls._calculate_match_score(html_name, html_type, ds_name, ds_type)
-            
+
+            ds_type = ds_field.get('type', 'text')
+            ds_role = ds_field.get('role', 'Seller')
+            ds_normalized = cls._normalize_name(ds_name)
+            ds_words = set(ds_normalized.split('_'))
+
+            score = 0
+
+            # 1. Exact normalized match (very high)
+            if html_normalized == ds_normalized:
+                score = 95
+
+            else:
+                # 2. Synonym matching (high value)
+                synonym_score = cls._calculate_synonym_score(html_words, ds_words)
+                score += synonym_score * 0.5  # Up to 50 points
+
+                # 3. Word overlap (medium value)
+                if html_words and ds_words:
+                    overlap = len(html_words & ds_words)
+                    total = len(html_words | ds_words)
+                    word_score = (overlap / total) * 30
+                    score += word_score
+
+                # 4. Fuzzy string similarity (lower value)
+                similarity = SequenceMatcher(None, html_normalized, ds_normalized).ratio()
+                score += similarity * 15
+
+                # 5. Type compatibility bonus
+                if cls._types_compatible(html_type, ds_type):
+                    score += 5
+
             if score > best_score and score >= cls.MIN_CONFIDENCE:
                 best_score = score
                 best_match = {
                     'html_field': html_name,
+                    'html_type': html_type,
                     'docuseal_field': ds_name,
                     'docuseal_role': ds_role,
-                    'confidence': score,
-                    'suggested_transform': cls._suggest_transform(html_type, ds_type),
-                    'html_type': html_type,
-                    'docuseal_type': ds_type
+                    'docuseal_type': ds_type,
+                    'confidence': min(int(score), 94),  # Cap below exact match
+                    'suggested_transform': cls._infer_transform(html_name, ds_type),
+                    'match_type': 'semantic'
                 }
-        
+
         return best_match
-    
+
     @classmethod
-    def _calculate_match_score(
-        cls,
-        html_name: str,
-        html_type: str,
-        ds_name: str,
-        ds_type: str
-    ) -> int:
+    def _calculate_synonym_score(cls, html_words: Set[str], ds_words: Set[str]) -> int:
         """
-        Calculate a match score between HTML and DocuSeal fields.
-        
-        Score components:
-        - Exact match: 100 points
-        - Fuzzy similarity: up to 60 points
-        - Word overlap: up to 30 points  
-        - Type compatibility: 10 points
-        
-        Returns:
-            Score from 0-100
+        Calculate synonym-based match score.
+
+        Checks if words from HTML field are synonyms of words in DocuSeal field.
         """
         score = 0
-        
-        # Normalize names for comparison
-        html_normalized = cls._normalize_name(html_name)
-        ds_normalized = cls._normalize_name(ds_name)
-        
-        # Exact match (highest priority)
-        if html_normalized == ds_normalized:
-            return 100
-        
-        # Fuzzy string similarity (SequenceMatcher)
-        similarity = SequenceMatcher(None, html_normalized, ds_normalized).ratio()
-        score += int(similarity * 60)
-        
-        # Word overlap scoring
-        html_words = set(html_normalized.split('_'))
-        ds_words = set(ds_normalized.split('_'))
-        
-        if html_words and ds_words:
-            overlap = len(html_words & ds_words)
-            max_words = max(len(html_words), len(ds_words))
-            word_score = (overlap / max_words) * 30
-            score += int(word_score)
-        
-        # Type compatibility bonus
-        if cls._types_compatible(html_type, ds_type):
-            score += 10
-        
-        return min(score, 99)  # Cap at 99 (100 is reserved for exact match)
-    
+        matched_html = set()
+        matched_ds = set()
+
+        for hw in html_words:
+            for dw in ds_words:
+                # Direct match
+                if hw == dw:
+                    score += 25
+                    matched_html.add(hw)
+                    matched_ds.add(dw)
+                    continue
+
+                # Synonym match
+                hw_synonyms = cls._get_synonyms(hw)
+                dw_synonyms = cls._get_synonyms(dw)
+
+                if hw in dw_synonyms or dw in hw_synonyms or (hw_synonyms & dw_synonyms):
+                    score += 20
+                    matched_html.add(hw)
+                    matched_ds.add(dw)
+
+        # Bonus for matching most words
+        if html_words and matched_html:
+            coverage = len(matched_html) / len(html_words)
+            score += int(coverage * 20)
+
+        return min(score, 100)
+
+    @classmethod
+    def _get_synonyms(cls, word: str) -> Set[str]:
+        """Get all synonyms for a word."""
+        synonyms = {word}
+        for key, syn_set in cls.SYNONYMS.items():
+            if word in syn_set or word == key:
+                synonyms |= syn_set
+                synonyms.add(key)
+        return synonyms
+
+    # ==========================================================================
+    # TRANSFORM INFERENCE
+    # ==========================================================================
+
+    @classmethod
+    def _infer_transform(cls, field_name: str, ds_type: str) -> Optional[str]:
+        """Infer the best transform based on field name and type."""
+        name_lower = field_name.lower()
+
+        # Check each transform pattern
+        for transform, patterns in cls.TRANSFORM_PATTERNS.items():
+            for pattern in patterns:
+                if re.search(pattern, name_lower):
+                    return transform
+
+        # Type-based fallback
+        if ds_type == 'date':
+            return 'date_short'
+        if ds_type == 'checkbox':
+            return 'checkbox'
+
+        return None
+
+    # ==========================================================================
+    # UTILITIES
+    # ==========================================================================
+
     @classmethod
     def _normalize_name(cls, name: str) -> str:
-        """
-        Normalize a field name for comparison.
-        
-        - Convert to lowercase
-        - Replace spaces with underscores
-        - Remove common prefixes/suffixes
-        - Handle common variations
-        """
+        """Normalize a field name for comparison."""
         if not name:
             return ''
-        
-        # Lowercase and replace spaces/special chars
+
+        # Lowercase and replace non-alphanumeric with underscores
         normalized = name.lower()
         normalized = re.sub(r'[^a-z0-9]', '_', normalized)
         normalized = re.sub(r'_+', '_', normalized)
         normalized = normalized.strip('_')
-        
+
         # Remove common prefixes
-        prefixes = ['field_', 'form_', 'input_']
-        for prefix in prefixes:
+        for prefix in ['field_', 'form_', 'input_', 'txt_']:
             if normalized.startswith(prefix):
                 normalized = normalized[len(prefix):]
-        
+
         # Remove common suffixes
-        suffixes = ['_field', '_input', '_1', '_2']
-        for suffix in suffixes:
+        for suffix in ['_field', '_input', '_txt']:
             if normalized.endswith(suffix):
                 normalized = normalized[:-len(suffix)]
-        
+
         return normalized
-    
+
+    @classmethod
+    def _build_docuseal_lookup(
+        cls,
+        docuseal_fields: List[Dict[str, Any]]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Build a lookup dict of normalized DocuSeal field names."""
+        lookup = {}
+        for field in docuseal_fields:
+            name = field.get('name', '')
+            normalized = cls._normalize_name(name)
+            lookup[normalized] = field
+        return lookup
+
     @classmethod
     def _types_compatible(cls, html_type: str, ds_type: str) -> bool:
         """Check if HTML and DocuSeal field types are compatible."""
         html_type = html_type.lower()
         ds_type = ds_type.lower()
-        
-        # Same type is always compatible
+
         if html_type == ds_type:
             return True
-        
-        # Check compatibility map
+
         compatible = cls.TYPE_COMPATIBILITY.get(html_type, ['text'])
         return ds_type in compatible
-    
-    @classmethod
-    def _suggest_transform(cls, html_type: str, ds_type: str) -> Optional[str]:
-        """Suggest a transform based on field types."""
-        html_type = html_type.lower()
-        ds_type = ds_type.lower()
-        
-        # Currency fields
-        if 'money' in html_type or 'currency' in html_type or 'fee' in ds_type or 'price' in ds_type:
-            return 'currency'
-        
-        # Date fields
-        if html_type == 'date' or ds_type == 'date':
-            return 'date_short'
-        
-        # Checkbox fields
-        if html_type == 'checkbox' or ds_type == 'checkbox':
-            return 'checkbox'
-        
-        return None
-    
+
+    # ==========================================================================
+    # LEGACY API METHODS (for backward compatibility)
+    # ==========================================================================
+
     @classmethod
     def suggest_role_key(cls, docuseal_role: str) -> str:
-        """
-        Suggest a role_key based on DocuSeal role name.
-        
-        Examples:
-            "Seller" -> "seller"
-            "Seller 2" -> "seller_2"
-            "Listing Agent" -> "listing_agent"
-        """
+        """Suggest a role_key based on DocuSeal role name."""
         if not docuseal_role:
             return 'seller'
-        
-        # Normalize to snake_case
+
         role_key = docuseal_role.lower()
         role_key = re.sub(r'[^a-z0-9]', '_', role_key)
         role_key = re.sub(r'_+', '_', role_key)
         role_key = role_key.strip('_')
-        
+
         return role_key
-    
+
     @classmethod
     def suggest_source_path(cls, role_key: str, field_name: str) -> str:
-        """
-        Suggest a source path based on role and field name.
-        
-        Returns paths like:
-        - "form.property_address"
-        - "transaction.full_address"
-        - "user.email"
-        """
+        """Suggest a source path based on role and field name."""
         field_normalized = cls._normalize_name(field_name)
-        
+
         # Check for computed properties
         if 'full_address' in field_normalized or 'property_address' in field_normalized:
             if 'city' in field_normalized or 'state' in field_normalized:
                 return 'transaction.full_address'
-        
+
         # Default to form data
         return f'form.{field_normalized}'
-

--- a/static/css/document_mapper.css
+++ b/static/css/document_mapper.css
@@ -869,15 +869,594 @@
     background: var(--mapper-text-muted);
 }
 
+/* =============================================================================
+   COMBINED FIELD SUPPORT - NEW STYLES
+   ============================================================================= */
+
+/* Field Checkbox for Multi-Select */
+.field-checkbox {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--mapper-primary);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.html-field.selected {
+    border-color: var(--mapper-primary) !important;
+    background: rgba(59, 130, 246, 0.15) !important;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+/* Combine Button */
+.btn-combine {
+    background: linear-gradient(135deg, var(--mapper-primary) 0%, #2563eb 100%);
+    color: white;
+    border: none !important;
+}
+
+.btn-combine:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
+}
+
+/* Combined Mapping Card */
+.mapping-combined {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, rgba(139, 92, 246, 0.05) 100%);
+    border-color: rgba(59, 130, 246, 0.3);
+}
+
+.mapping-combined:hover {
+    border-color: var(--mapper-primary);
+}
+
+.mapping-html-combined {
+    flex: 1.5;
+    padding: 0.75rem;
+    background: rgba(249, 115, 22, 0.08);
+}
+
+.combined-sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-bottom: 0.5rem;
+}
+
+.combined-source-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    background: rgba(249, 115, 22, 0.2);
+    border: 1px solid rgba(249, 115, 22, 0.3);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    color: var(--mapper-html);
+}
+
+.combined-template-display {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    background: var(--mapper-surface);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-family: 'Roboto Mono', monospace;
+    color: var(--mapper-text-muted);
+}
+
+.combined-template-display i {
+    color: var(--mapper-primary);
+}
+
+/* Drop Zone Hint */
+.drop-zone-hint {
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+    opacity: 0.7;
+}
+
+/* =============================================================================
+   PICKER MODAL
+   ============================================================================= */
+.picker-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+    padding: 2rem;
+    animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.picker-modal-content {
+    background: var(--mapper-surface);
+    border-radius: var(--panel-radius);
+    border: 1px solid var(--mapper-border);
+    width: 100%;
+    max-width: 550px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: slideUp 0.2s ease;
+}
+
+@keyframes slideUp {
+    from { transform: translateY(20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+.picker-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    background: var(--mapper-surface-hover);
+    border-bottom: 1px solid var(--mapper-border);
+}
+
+.picker-modal-header h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.picker-modal-body {
+    padding: 1rem;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.picker-source {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--mapper-bg);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+
+.picker-label {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--mapper-text-muted);
+}
+
+.picker-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.picker-field-html {
+    background: rgba(249, 115, 22, 0.15);
+    border: 1px solid rgba(249, 115, 22, 0.3);
+    color: var(--mapper-html);
+}
+
+.picker-field-docuseal {
+    background: rgba(139, 92, 246, 0.15);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    color: var(--mapper-docuseal);
+}
+
+.picker-search {
+    margin-bottom: 0.75rem;
+}
+
+.picker-search input {
+    width: 100%;
+    padding: 0.625rem 0.875rem;
+    border-radius: 6px;
+    border: 1px solid var(--mapper-border);
+    background: var(--mapper-bg);
+    color: var(--mapper-text);
+    font-size: 0.9rem;
+}
+
+.picker-search input:focus {
+    outline: none;
+    border-color: var(--mapper-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.picker-fields {
+    flex: 1;
+    overflow-y: auto;
+    max-height: 350px;
+}
+
+.picker-role-group {
+    margin-bottom: 1rem;
+}
+
+.picker-role-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--mapper-docuseal);
+    background: rgba(139, 92, 246, 0.1);
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+}
+
+.picker-field-option {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.625rem 0.875rem;
+    background: var(--mapper-bg);
+    border-radius: 6px;
+    margin-bottom: 0.375rem;
+    cursor: pointer;
+    transition: var(--transition);
+    border: 1px solid transparent;
+}
+
+.picker-field-option:hover {
+    border-color: var(--mapper-primary);
+    background: var(--mapper-surface-hover);
+}
+
+.picker-field-option.good-match {
+    border-color: rgba(16, 185, 129, 0.4);
+    background: rgba(16, 185, 129, 0.1);
+}
+
+.picker-field-option.partial-match {
+    border-color: rgba(245, 158, 11, 0.3);
+}
+
+.picker-field-name {
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.picker-field-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.match-score {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+    font-weight: 600;
+}
+
+.field-role {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    background: rgba(139, 92, 246, 0.2);
+    color: #a78bfa;
+}
+
+/* =============================================================================
+   COMBINE MODAL
+   ============================================================================= */
+.combine-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+    padding: 2rem;
+}
+
+.combine-modal-content {
+    background: var(--mapper-surface);
+    border-radius: var(--panel-radius);
+    border: 1px solid var(--mapper-border);
+    width: 100%;
+    max-width: 600px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.combine-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(139, 92, 246, 0.15) 100%);
+    border-bottom: 1px solid var(--mapper-border);
+}
+
+.combine-modal-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--mapper-primary);
+}
+
+.combine-modal-body {
+    padding: 1.25rem;
+    overflow-y: auto;
+}
+
+.combine-section {
+    margin-bottom: 1.25rem;
+}
+
+.combine-section:last-child {
+    margin-bottom: 0;
+}
+
+.combine-label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--mapper-text);
+    margin-bottom: 0.5rem;
+}
+
+.combine-fields-list {
+    background: var(--mapper-bg);
+    border-radius: 8px;
+    border: 1px solid var(--mapper-border);
+    overflow: hidden;
+}
+
+.combine-field-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--mapper-bg);
+    border-bottom: 1px solid var(--mapper-border);
+    cursor: grab;
+    transition: var(--transition);
+}
+
+.combine-field-item:last-child {
+    border-bottom: none;
+}
+
+.combine-field-item:hover {
+    background: var(--mapper-surface-hover);
+}
+
+.combine-field-item.dragging {
+    opacity: 0.5;
+    background: var(--mapper-surface);
+}
+
+.combine-field-handle {
+    color: var(--mapper-text-muted);
+    cursor: grab;
+}
+
+.combine-field-index {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--mapper-primary);
+    color: white;
+    border-radius: 50%;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.combine-field-name {
+    flex: 1;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--mapper-html);
+}
+
+.combine-field-remove {
+    background: none;
+    border: none;
+    color: var(--mapper-text-muted);
+    cursor: pointer;
+    padding: 0.25rem;
+    transition: var(--transition);
+}
+
+.combine-field-remove:hover {
+    color: var(--mapper-danger);
+}
+
+/* Preset and Separator Buttons */
+.preset-buttons,
+.separator-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.preset-btn,
+.separator-btn {
+    padding: 0.5rem 0.875rem;
+    border-radius: 6px;
+    border: 1px solid var(--mapper-border);
+    background: var(--mapper-bg);
+    color: var(--mapper-text);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.preset-btn:hover,
+.separator-btn:hover {
+    border-color: var(--mapper-primary);
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--mapper-primary);
+}
+
+.separator-btn {
+    font-family: 'Roboto Mono', monospace;
+}
+
+/* Combine Input */
+.combine-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    border: 1px solid var(--mapper-border);
+    background: var(--mapper-bg);
+    color: var(--mapper-text);
+    font-size: 0.9rem;
+    font-family: 'Roboto Mono', monospace;
+}
+
+.combine-input:focus {
+    outline: none;
+    border-color: var(--mapper-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.template-help {
+    font-size: 0.75rem;
+    color: var(--mapper-text-muted);
+    margin-top: 0.5rem;
+}
+
+.template-help code {
+    background: var(--mapper-surface-hover);
+    padding: 0.15rem 0.375rem;
+    border-radius: 3px;
+    font-family: 'Roboto Mono', monospace;
+    color: var(--mapper-primary);
+}
+
+/* Combine Preview */
+.combine-preview {
+    padding: 1rem;
+    background: var(--mapper-bg);
+    border-radius: 8px;
+    border: 1px solid var(--mapper-border);
+}
+
+.combine-preview code {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.95rem;
+    color: var(--mapper-success);
+}
+
+/* Combine Select */
+.combine-select {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    border: 1px solid var(--mapper-border);
+    background: var(--mapper-bg);
+    color: var(--mapper-text);
+    font-size: 0.9rem;
+}
+
+.combine-select:focus {
+    outline: none;
+    border-color: var(--mapper-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+/* Combine Modal Footer */
+.combine-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    background: var(--mapper-surface-hover);
+    border-top: 1px solid var(--mapper-border);
+}
+
+.btn-cancel {
+    background: var(--mapper-surface);
+    color: var(--mapper-text);
+    border: 1px solid var(--mapper-border);
+}
+
+.btn-cancel:hover {
+    background: var(--mapper-surface-hover);
+}
+
+/* Edit Sources List in Edit Modal */
+.edit-sources-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    padding: 0.75rem;
+    background: var(--mapper-bg);
+    border-radius: 6px;
+    border: 1px solid var(--mapper-border);
+}
+
+.source-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.625rem;
+    background: rgba(249, 115, 22, 0.15);
+    border: 1px solid rgba(249, 115, 22, 0.3);
+    border-radius: 4px;
+    font-size: 0.8rem;
+    color: var(--mapper-html);
+}
+
 /* Responsive */
 @media (max-width: 1200px) {
     .mapper-main {
         grid-template-columns: 1fr;
         height: auto;
     }
-    
+
     .panel {
         max-height: 400px;
+    }
+}
+
+@media (max-width: 600px) {
+    .combine-modal-content,
+    .picker-modal-content {
+        max-width: 100%;
+        max-height: 100%;
+        border-radius: 0;
+    }
+
+    .preset-buttons,
+    .separator-buttons {
+        flex-direction: column;
+    }
+
+    .preset-btn,
+    .separator-btn {
+        width: 100%;
+        text-align: center;
     }
 }
 

--- a/static/js/document_mapper.js
+++ b/static/js/document_mapper.js
@@ -1,57 +1,102 @@
 /**
- * Document Mapper v2 - JavaScript
- * 
- * Handles field mapping, drag-drop, auto-mapping, and YAML generation.
+ * Document Mapper v2 - Complete Redesign
+ *
+ * Features:
+ * - Combined field support (multiple sources → one DocuSeal field)
+ * - Proper modal-based field selection
+ * - Multi-select for combining fields
+ * - Drag-drop with visual feedback
+ * - Template presets and custom separators
+ * - Live preview for combined fields
  */
 
 (function() {
     'use strict';
 
-    // State
+    // =============================================================================
+    // STATE
+    // =============================================================================
     const state = {
-        mappings: [],
-        roles: [],
-        yamlContent: '',
-        isValid: false
+        mappings: [],           // All mappings (single + combined)
+        roles: [],              // Role configurations
+        selectedHtmlFields: [], // Multi-selected HTML fields for combining
+        yamlContent: '',        // Generated YAML
+        isValid: false,         // Schema validation result
+        draggedField: null,     // Currently dragged field
+        combineMode: false      // Whether we're in "combine fields" mode
     };
 
-    // DOM Elements
+    // Separator presets
+    const SEPARATORS = {
+        'comma_space': { label: ', ', value: ', ', display: 'Comma + Space' },
+        'space': { label: ' ', value: ' ', display: 'Space' },
+        'dash': { label: ' - ', value: ' - ', display: 'Dash' },
+        'newline': { label: '\\n', value: '\n', display: 'New Line' }
+    };
+
+    // Template presets
+    const TEMPLATE_PRESETS = [
+        { name: 'Address', template: '{0}, {1}, {2} {3}', fields: 4, desc: 'Street, City, State Zip' },
+        { name: 'Full Name', template: '{0} {1}', fields: 2, desc: 'First Last' },
+        { name: 'Name & Phone', template: '{0} - {1}', fields: 2, desc: 'Name - Phone' },
+        { name: 'City, State', template: '{0}, {1}', fields: 2, desc: 'City, State' }
+    ];
+
+    // =============================================================================
+    // DOM ELEMENTS
+    // =============================================================================
     const elements = {
-        htmlFieldsList: document.getElementById('htmlFieldsList'),
-        docusealFieldsList: document.getElementById('docusealFieldsList'),
-        mappingsList: document.getElementById('mappingsList'),
-        dropZone: document.getElementById('dropZone'),
-        mappingCount: document.getElementById('mappingCount'),
-        btnAutoMap: document.getElementById('btnAutoMap'),
-        btnPreviewYaml: document.getElementById('btnPreviewYaml'),
-        btnSave: document.getElementById('btnSave'),
-        btnClearMappings: document.getElementById('btnClearMappings'),
-        btnFetchTemplate: document.getElementById('btnFetchTemplate'),
-        templateIdInput: document.getElementById('templateIdInput'),
-        searchHtml: document.getElementById('searchHtml'),
-        searchDocuseal: document.getElementById('searchDocuseal'),
-        yamlModal: document.getElementById('yamlModal'),
-        yamlPreview: document.getElementById('yamlPreview'),
-        validationStatus: document.getElementById('validationStatus'),
-        validationErrors: document.getElementById('validationErrors'),
-        btnCopyYaml: document.getElementById('btnCopyYaml'),
-        btnCloseModal: document.getElementById('btnCloseModal'),
-        btnSaveFromModal: document.getElementById('btnSaveFromModal'),
-        editModal: document.getElementById('editModal'),
-        rolesGrid: document.getElementById('rolesGrid')
+        htmlFieldsList: null,
+        docusealFieldsList: null,
+        mappingsList: null,
+        mappingCount: null,
+        btnAutoMap: null,
+        btnCombine: null,
+        btnPreviewYaml: null,
+        btnSave: null,
+        btnClearMappings: null,
+        searchHtml: null,
+        searchDocuseal: null,
+        yamlModal: null,
+        fieldPickerModal: null,
+        combineModal: null,
+        rolesGrid: null
     };
 
-    // Initialize
+    // =============================================================================
+    // INITIALIZATION
+    // =============================================================================
     function init() {
+        cacheElements();
         initializeRoles();
         setupDragDrop();
         setupEventListeners();
         setupSearch();
+        setupMultiSelect();
+        renderMappings();
+        updateUI();
     }
 
-    // Initialize roles from DocuSeal submitters
+    function cacheElements() {
+        elements.htmlFieldsList = document.getElementById('htmlFieldsList');
+        elements.docusealFieldsList = document.getElementById('docusealFieldsList');
+        elements.mappingsList = document.getElementById('mappingsList');
+        elements.mappingCount = document.getElementById('mappingCount');
+        elements.btnAutoMap = document.getElementById('btnAutoMap');
+        elements.btnCombine = document.getElementById('btnCombine');
+        elements.btnPreviewYaml = document.getElementById('btnPreviewYaml');
+        elements.btnSave = document.getElementById('btnSave');
+        elements.btnClearMappings = document.getElementById('btnClearMappings');
+        elements.searchHtml = document.getElementById('searchHtml');
+        elements.searchDocuseal = document.getElementById('searchDocuseal');
+        elements.yamlModal = document.getElementById('yamlModal');
+        elements.fieldPickerModal = document.getElementById('fieldPickerModal');
+        elements.combineModal = document.getElementById('combineModal');
+        elements.rolesGrid = document.getElementById('rolesGrid');
+    }
+
     function initializeRoles() {
-        if (!window.mapperData.docusealSubmitters) return;
+        if (!window.mapperData?.docusealSubmitters) return;
 
         state.roles = window.mapperData.docusealSubmitters.map(role => {
             const roleKey = role.toLowerCase().replace(/\s+/g, '_');
@@ -79,7 +124,87 @@
         });
     }
 
-    // Setup drag and drop
+    // =============================================================================
+    // MULTI-SELECT FOR COMBINING FIELDS
+    // =============================================================================
+    function setupMultiSelect() {
+        document.querySelectorAll('.html-field').forEach(field => {
+            // Add checkbox for multi-select
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'field-checkbox';
+            checkbox.dataset.name = field.dataset.name;
+            checkbox.addEventListener('change', handleFieldCheckbox);
+            field.insertBefore(checkbox, field.firstChild);
+
+            // Cmd/Ctrl+click for quick selection
+            field.addEventListener('click', (e) => {
+                if (e.metaKey || e.ctrlKey) {
+                    e.preventDefault();
+                    checkbox.checked = !checkbox.checked;
+                    handleFieldCheckbox({ target: checkbox });
+                }
+            });
+        });
+    }
+
+    function handleFieldCheckbox(e) {
+        const fieldName = e.target.dataset.name;
+        const isChecked = e.target.checked;
+        const fieldEl = e.target.closest('.html-field');
+
+        if (isChecked) {
+            if (!state.selectedHtmlFields.includes(fieldName)) {
+                state.selectedHtmlFields.push(fieldName);
+            }
+            fieldEl.classList.add('selected');
+        } else {
+            state.selectedHtmlFields = state.selectedHtmlFields.filter(f => f !== fieldName);
+            fieldEl.classList.remove('selected');
+        }
+
+        updateCombineButton();
+    }
+
+    function updateCombineButton() {
+        const count = state.selectedHtmlFields.length;
+
+        if (!elements.btnCombine) {
+            // Create combine button if it doesn't exist
+            const toolbar = document.querySelector('.panel-html .panel-toolbar');
+            if (toolbar && !document.getElementById('btnCombine')) {
+                const btn = document.createElement('button');
+                btn.id = 'btnCombine';
+                btn.className = 'btn-toolbar btn-combine';
+                btn.innerHTML = '<i class="fas fa-link"></i> Combine (<span class="combine-count">0</span>)';
+                btn.style.display = 'none';
+                btn.addEventListener('click', openCombineModal);
+                toolbar.appendChild(btn);
+                elements.btnCombine = btn;
+            }
+        }
+
+        if (elements.btnCombine) {
+            const countSpan = elements.btnCombine.querySelector('.combine-count');
+            if (countSpan) countSpan.textContent = count;
+            elements.btnCombine.style.display = count >= 2 ? 'inline-flex' : 'none';
+        }
+    }
+
+    function clearSelection() {
+        state.selectedHtmlFields = [];
+        document.querySelectorAll('.html-field.selected').forEach(el => {
+            el.classList.remove('selected');
+        });
+        document.querySelectorAll('.field-checkbox:checked').forEach(cb => {
+            cb.checked = false;
+        });
+        updateCombineButton();
+    }
+
+    // =============================================================================
+    // DRAG AND DROP
+    // =============================================================================
     function setupDragDrop() {
         // HTML fields are draggable
         document.querySelectorAll('.html-field').forEach(field => {
@@ -88,7 +213,7 @@
         });
 
         // Mappings panel is a drop zone
-        if (elements.dropZone) {
+        if (elements.mappingsList) {
             elements.mappingsList.addEventListener('dragover', handleDragOver);
             elements.mappingsList.addEventListener('dragleave', handleDragLeave);
             elements.mappingsList.addEventListener('drop', handleDrop);
@@ -100,219 +225,648 @@
         });
     }
 
-    // Drag handlers
     function handleDragStart(e) {
-        e.dataTransfer.setData('text/plain', e.target.dataset.name);
+        const fieldName = e.target.dataset.name;
+        state.draggedField = fieldName;
+        e.dataTransfer.setData('text/plain', fieldName);
+        e.dataTransfer.effectAllowed = 'copy';
         e.target.classList.add('dragging');
+
+        // Create custom drag image
+        const ghost = e.target.cloneNode(true);
+        ghost.classList.add('drag-ghost');
+        ghost.style.position = 'absolute';
+        ghost.style.top = '-1000px';
+        document.body.appendChild(ghost);
+        e.dataTransfer.setDragImage(ghost, 0, 0);
+        setTimeout(() => ghost.remove(), 0);
     }
 
     function handleDragEnd(e) {
         e.target.classList.remove('dragging');
+        state.draggedField = null;
+        document.querySelector('.drop-zone')?.classList.remove('drag-over');
     }
 
     function handleDragOver(e) {
         e.preventDefault();
-        if (elements.dropZone) {
-            elements.dropZone.classList.add('drag-over');
-        }
+        e.dataTransfer.dropEffect = 'copy';
+        const dropZone = document.getElementById('dropZone');
+        if (dropZone) dropZone.classList.add('drag-over');
     }
 
     function handleDragLeave(e) {
-        if (elements.dropZone) {
-            elements.dropZone.classList.remove('drag-over');
+        const dropZone = document.getElementById('dropZone');
+        if (dropZone && !elements.mappingsList.contains(e.relatedTarget)) {
+            dropZone.classList.remove('drag-over');
         }
     }
 
     function handleDrop(e) {
         e.preventDefault();
-        if (elements.dropZone) {
-            elements.dropZone.classList.remove('drag-over');
-        }
+        document.getElementById('dropZone')?.classList.remove('drag-over');
 
         const htmlFieldName = e.dataTransfer.getData('text/plain');
         if (!htmlFieldName) return;
 
-        // If we have DocuSeal fields, prompt for selection
-        if (window.mapperData.docusealFields && window.mapperData.docusealFields.length > 0) {
-            promptForDocuSealField(htmlFieldName);
-        } else {
-            // No DocuSeal fields - create a manual mapping
-            addManualMapping(htmlFieldName);
-        }
+        // Open field picker modal for selecting DocuSeal target
+        openFieldPickerModal(htmlFieldName);
     }
 
-    // Handle DocuSeal field click for quick mapping
     function handleDocuSealClick(fieldElement) {
         const dsName = fieldElement.dataset.name;
         const dsRole = fieldElement.dataset.role;
         const dsType = fieldElement.dataset.type;
 
         // Check if already mapped
-        if (state.mappings.some(m => m.docuseal_field === dsName)) {
+        if (isDocuSealFieldMapped(dsName)) {
             showToast('This DocuSeal field is already mapped', 'warning');
             return;
         }
 
-        // Find best matching HTML field
+        // If we have selected HTML fields, open combine modal
+        if (state.selectedHtmlFields.length >= 2) {
+            openCombineModalWithTarget(dsName, dsRole, dsType);
+            return;
+        }
+
+        // Otherwise, try to find best matching HTML field
         const bestMatch = findBestHtmlMatch(dsName);
-        
-        if (bestMatch) {
-            addMapping({
+
+        if (bestMatch && !isHtmlFieldMapped(bestMatch.name)) {
+            addSingleMapping({
                 html_field: bestMatch.name,
                 docuseal_field: dsName,
                 docuseal_role: dsRole,
                 html_type: bestMatch.html_type,
                 docuseal_type: dsType,
-                suggested_transform: suggestTransform(bestMatch.html_type, dsType),
+                source: `form.${bestMatch.name}`,
+                transform: suggestTransform(bestMatch.html_type, dsType),
                 confidence: 100
             });
         } else {
-            // Prompt for HTML field selection
-            promptForHtmlField(dsName, dsRole, dsType);
+            // Open field picker for HTML field selection
+            openHtmlPickerModal(dsName, dsRole, dsType);
         }
     }
 
-    // Prompt user to select a DocuSeal field
-    function promptForDocuSealField(htmlFieldName) {
-        // Find unmapped DocuSeal fields
-        const unmapped = window.mapperData.docusealFields.filter(
-            f => !state.mappings.some(m => m.docuseal_field === f.name)
-        );
+    // =============================================================================
+    // FIELD PICKER MODAL (replaces prompt())
+    // =============================================================================
+    function openFieldPickerModal(htmlFieldName) {
+        // Get unmapped DocuSeal fields
+        const unmappedFields = getUnmappedDocuSealFields();
 
-        if (unmapped.length === 0) {
+        if (unmappedFields.length === 0) {
             showToast('All DocuSeal fields are already mapped', 'warning');
             return;
         }
 
-        // Create a simple selection (in production, this could be a nice modal)
-        const selected = prompt(
-            `Select a DocuSeal field to map "${htmlFieldName}" to:\n\n` +
-            unmapped.map((f, i) => `${i + 1}. ${f.name} (${f.role})`).join('\n') +
-            '\n\nEnter the number:'
-        );
+        const htmlField = window.mapperData.htmlFields.find(f => f.name === htmlFieldName);
 
-        if (selected && !isNaN(selected)) {
-            const index = parseInt(selected) - 1;
-            if (index >= 0 && index < unmapped.length) {
-                const dsField = unmapped[index];
-                const htmlField = window.mapperData.htmlFields.find(f => f.name === htmlFieldName);
+        const modalHtml = `
+            <div class="picker-modal" id="fieldPickerModal">
+                <div class="picker-modal-content">
+                    <div class="picker-modal-header">
+                        <h3><i class="fas fa-crosshairs"></i> Select Target Field</h3>
+                        <button class="btn-close-modal" onclick="closePickerModal()"><i class="fas fa-times"></i></button>
+                    </div>
+                    <div class="picker-modal-body">
+                        <div class="picker-source">
+                            <span class="picker-label">Source:</span>
+                            <span class="picker-field picker-field-html">
+                                ${htmlFieldName}
+                                <span class="field-type">${htmlField?.html_type || 'text'}</span>
+                            </span>
+                        </div>
+                        <div class="picker-search">
+                            <input type="text" id="pickerSearch" placeholder="Search DocuSeal fields..." autofocus>
+                        </div>
+                        <div class="picker-fields" id="pickerFieldsList">
+                            ${renderPickerFields(unmappedFields, htmlFieldName)}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
 
-                addMapping({
+        // Remove existing modal
+        document.getElementById('fieldPickerModal')?.remove();
+
+        // Add modal to body
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        // Setup search
+        document.getElementById('pickerSearch').addEventListener('input', (e) => {
+            filterPickerFields(e.target.value, unmappedFields, htmlFieldName);
+        });
+
+        // Setup field clicks
+        document.querySelectorAll('.picker-field-option').forEach(opt => {
+            opt.addEventListener('click', () => {
+                const dsName = opt.dataset.name;
+                const dsRole = opt.dataset.role;
+                const dsType = opt.dataset.type;
+
+                addSingleMapping({
                     html_field: htmlFieldName,
-                    docuseal_field: dsField.name,
-                    docuseal_role: dsField.role,
+                    docuseal_field: dsName,
+                    docuseal_role: dsRole,
                     html_type: htmlField?.html_type || 'text',
-                    docuseal_type: dsField.type,
-                    suggested_transform: suggestTransform(htmlField?.html_type, dsField.type),
+                    docuseal_type: dsType,
+                    source: `form.${htmlFieldName}`,
+                    transform: suggestTransform(htmlField?.html_type, dsType),
                     confidence: 80
                 });
-            }
-        }
+
+                closePickerModal();
+            });
+        });
+
+        // Close on backdrop click
+        document.getElementById('fieldPickerModal').addEventListener('click', (e) => {
+            if (e.target.id === 'fieldPickerModal') closePickerModal();
+        });
     }
 
-    // Prompt for HTML field when clicking DocuSeal field
-    function promptForHtmlField(dsName, dsRole, dsType) {
-        const unmapped = window.mapperData.htmlFields.filter(
-            f => !state.mappings.some(m => m.html_field === f.name)
-        );
+    function openHtmlPickerModal(dsName, dsRole, dsType) {
+        const unmappedFields = getUnmappedHtmlFields();
 
-        if (unmapped.length === 0) {
+        if (unmappedFields.length === 0) {
             showToast('All HTML fields are already mapped', 'warning');
             return;
         }
 
-        const selected = prompt(
-            `Select an HTML field to map to "${dsName}":\n\n` +
-            unmapped.map((f, i) => `${i + 1}. ${f.name}`).join('\n') +
-            '\n\nEnter the number:'
-        );
+        const modalHtml = `
+            <div class="picker-modal" id="fieldPickerModal">
+                <div class="picker-modal-content">
+                    <div class="picker-modal-header">
+                        <h3><i class="fas fa-crosshairs"></i> Select Source Field</h3>
+                        <button class="btn-close-modal" onclick="closePickerModal()"><i class="fas fa-times"></i></button>
+                    </div>
+                    <div class="picker-modal-body">
+                        <div class="picker-source">
+                            <span class="picker-label">Target:</span>
+                            <span class="picker-field picker-field-docuseal">
+                                ${dsName}
+                                <span class="field-role">${dsRole}</span>
+                            </span>
+                        </div>
+                        <div class="picker-search">
+                            <input type="text" id="pickerSearch" placeholder="Search HTML fields..." autofocus>
+                        </div>
+                        <div class="picker-fields" id="pickerFieldsList">
+                            ${renderHtmlPickerFields(unmappedFields)}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
 
-        if (selected && !isNaN(selected)) {
-            const index = parseInt(selected) - 1;
-            if (index >= 0 && index < unmapped.length) {
-                const htmlField = unmapped[index];
+        document.getElementById('fieldPickerModal')?.remove();
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
 
-                addMapping({
-                    html_field: htmlField.name,
-                    docuseal_field: dsName,
-                    docuseal_role: dsRole,
-                    html_type: htmlField.html_type || 'text',
-                    docuseal_type: dsType,
-                    suggested_transform: suggestTransform(htmlField.html_type, dsType),
-                    confidence: 80
-                });
-            }
-        }
-    }
-
-    // Find best matching HTML field for a DocuSeal field
-    function findBestHtmlMatch(dsFieldName) {
-        const dsNormalized = normalizeFieldName(dsFieldName);
-        let bestMatch = null;
-        let bestScore = 0;
-
-        window.mapperData.htmlFields.forEach(htmlField => {
-            // Skip if already mapped
-            if (state.mappings.some(m => m.html_field === htmlField.name)) return;
-
-            const htmlNormalized = normalizeFieldName(htmlField.name);
-            
-            // Exact match
-            if (htmlNormalized === dsNormalized) {
-                bestMatch = htmlField;
-                bestScore = 100;
-                return;
-            }
-
-            // Calculate similarity
-            const similarity = calculateSimilarity(htmlNormalized, dsNormalized);
-            if (similarity > bestScore && similarity > 60) {
-                bestScore = similarity;
-                bestMatch = htmlField;
-            }
+        document.getElementById('pickerSearch').addEventListener('input', (e) => {
+            filterHtmlPickerFields(e.target.value, unmappedFields);
         });
 
-        return bestMatch;
+        document.querySelectorAll('.picker-field-option').forEach(opt => {
+            opt.addEventListener('click', () => {
+                const htmlFieldName = opt.dataset.name;
+                const htmlField = window.mapperData.htmlFields.find(f => f.name === htmlFieldName);
+
+                addSingleMapping({
+                    html_field: htmlFieldName,
+                    docuseal_field: dsName,
+                    docuseal_role: dsRole,
+                    html_type: htmlField?.html_type || 'text',
+                    docuseal_type: dsType,
+                    source: `form.${htmlFieldName}`,
+                    transform: suggestTransform(htmlField?.html_type, dsType),
+                    confidence: 80
+                });
+
+                closePickerModal();
+            });
+        });
+
+        document.getElementById('fieldPickerModal').addEventListener('click', (e) => {
+            if (e.target.id === 'fieldPickerModal') closePickerModal();
+        });
     }
 
-    // Normalize field name
-    function normalizeFieldName(name) {
-        return name.toLowerCase()
-            .replace(/[^a-z0-9]/g, '_')
-            .replace(/_+/g, '_')
-            .replace(/^_|_$/g, '');
+    function renderPickerFields(fields, sourceHtmlField) {
+        // Group by role
+        const byRole = {};
+        fields.forEach(f => {
+            if (!byRole[f.role]) byRole[f.role] = [];
+            byRole[f.role].push(f);
+        });
+
+        let html = '';
+        for (const [role, roleFields] of Object.entries(byRole)) {
+            html += `<div class="picker-role-group">
+                <div class="picker-role-header"><i class="fas fa-user"></i> ${role}</div>`;
+
+            roleFields.forEach(f => {
+                const similarity = calculateSimilarity(
+                    normalizeFieldName(sourceHtmlField),
+                    normalizeFieldName(f.name)
+                );
+                const matchClass = similarity > 60 ? 'good-match' : similarity > 30 ? 'partial-match' : '';
+
+                html += `
+                    <div class="picker-field-option ${matchClass}"
+                         data-name="${f.name}" data-role="${f.role}" data-type="${f.type}">
+                        <span class="picker-field-name">${f.name}</span>
+                        <span class="picker-field-meta">
+                            <span class="field-type">${f.type}</span>
+                            ${similarity > 30 ? `<span class="match-score">${Math.round(similarity)}%</span>` : ''}
+                        </span>
+                    </div>
+                `;
+            });
+
+            html += '</div>';
+        }
+        return html;
     }
 
-    // Calculate string similarity (simple version)
-    function calculateSimilarity(a, b) {
-        const aWords = new Set(a.split('_'));
-        const bWords = new Set(b.split('_'));
-        const intersection = new Set([...aWords].filter(x => bWords.has(x)));
-        const union = new Set([...aWords, ...bWords]);
-        return (intersection.size / union.size) * 100;
+    function renderHtmlPickerFields(fields) {
+        return fields.map(f => `
+            <div class="picker-field-option" data-name="${f.name}">
+                <span class="picker-field-name">${f.name}</span>
+                <span class="field-type">${f.html_type || 'text'}</span>
+            </div>
+        `).join('');
     }
 
-    // Suggest transform based on types
-    function suggestTransform(htmlType, dsType) {
-        if (htmlType === 'checkbox' || dsType === 'checkbox') return 'checkbox';
-        if (htmlType === 'date' || dsType === 'date') return 'date_short';
-        if (htmlType === 'money' || htmlType === 'number') return 'currency';
-        return null;
+    function filterPickerFields(query, fields, sourceHtmlField) {
+        const q = query.toLowerCase();
+        const filtered = fields.filter(f => f.name.toLowerCase().includes(q));
+        document.getElementById('pickerFieldsList').innerHTML = renderPickerFields(filtered, sourceHtmlField);
+
+        // Re-attach click handlers
+        document.querySelectorAll('.picker-field-option').forEach(opt => {
+            opt.addEventListener('click', () => {
+                const htmlField = window.mapperData.htmlFields.find(f => f.name === sourceHtmlField);
+                addSingleMapping({
+                    html_field: sourceHtmlField,
+                    docuseal_field: opt.dataset.name,
+                    docuseal_role: opt.dataset.role,
+                    html_type: htmlField?.html_type || 'text',
+                    docuseal_type: opt.dataset.type,
+                    source: `form.${sourceHtmlField}`,
+                    transform: suggestTransform(htmlField?.html_type, opt.dataset.type),
+                    confidence: 80
+                });
+                closePickerModal();
+            });
+        });
     }
 
-    // Add a mapping
-    function addMapping(mapping) {
+    function filterHtmlPickerFields(query, fields) {
+        const q = query.toLowerCase();
+        const filtered = fields.filter(f => f.name.toLowerCase().includes(q));
+        document.getElementById('pickerFieldsList').innerHTML = renderHtmlPickerFields(filtered);
+    }
+
+    window.closePickerModal = function() {
+        document.getElementById('fieldPickerModal')?.remove();
+    };
+
+    // =============================================================================
+    // COMBINED FIELD MODAL
+    // =============================================================================
+    function openCombineModal() {
+        if (state.selectedHtmlFields.length < 2) {
+            showToast('Select at least 2 fields to combine', 'warning');
+            return;
+        }
+
+        const unmappedDocuSeal = getUnmappedDocuSealFields();
+
+        const modalHtml = createCombineModalHtml(unmappedDocuSeal);
+
+        document.getElementById('combineModal')?.remove();
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        setupCombineModal();
+    }
+
+    function openCombineModalWithTarget(dsName, dsRole, dsType) {
+        const unmappedDocuSeal = getUnmappedDocuSealFields();
+
+        const modalHtml = createCombineModalHtml(unmappedDocuSeal, { name: dsName, role: dsRole, type: dsType });
+
+        document.getElementById('combineModal')?.remove();
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        setupCombineModal();
+    }
+
+    function createCombineModalHtml(docusealFields, preselectedTarget = null) {
+        const fieldsHtml = state.selectedHtmlFields.map((name, idx) => `
+            <div class="combine-field-item" data-name="${name}" data-index="${idx}">
+                <span class="combine-field-handle"><i class="fas fa-grip-vertical"></i></span>
+                <span class="combine-field-index">${idx + 1}</span>
+                <span class="combine-field-name">${name}</span>
+                <button class="combine-field-remove" onclick="removeCombineField('${name}')">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+        `).join('');
+
+        const targetOptionsHtml = docusealFields.map(f => `
+            <option value="${f.name}" data-role="${f.role}" data-type="${f.type}"
+                    ${preselectedTarget?.name === f.name ? 'selected' : ''}>
+                ${f.name} (${f.role})
+            </option>
+        `).join('');
+
+        const presetButtonsHtml = TEMPLATE_PRESETS.map(p => `
+            <button class="preset-btn" data-template="${p.template}" title="${p.desc}">
+                ${p.name}
+            </button>
+        `).join('');
+
+        const separatorButtonsHtml = Object.entries(SEPARATORS).map(([key, sep]) => `
+            <button class="separator-btn" data-separator="${key}" data-value="${sep.value}">
+                ${sep.display}
+            </button>
+        `).join('');
+
+        const defaultTemplate = generateDefaultTemplate(state.selectedHtmlFields.length);
+
+        return `
+            <div class="combine-modal" id="combineModal">
+                <div class="combine-modal-content">
+                    <div class="combine-modal-header">
+                        <h3><i class="fas fa-object-group"></i> Create Combined Field</h3>
+                        <button class="btn-close-modal" onclick="closeCombineModal()">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                    <div class="combine-modal-body">
+                        <div class="combine-section">
+                            <label class="combine-label">Source Fields (drag to reorder)</label>
+                            <div class="combine-fields-list" id="combineFieldsList">
+                                ${fieldsHtml}
+                            </div>
+                        </div>
+
+                        <div class="combine-section">
+                            <label class="combine-label">Template Presets</label>
+                            <div class="preset-buttons">
+                                ${presetButtonsHtml}
+                            </div>
+                        </div>
+
+                        <div class="combine-section">
+                            <label class="combine-label">Quick Separators</label>
+                            <div class="separator-buttons">
+                                ${separatorButtonsHtml}
+                            </div>
+                        </div>
+
+                        <div class="combine-section">
+                            <label class="combine-label">Custom Template</label>
+                            <input type="text" id="combineTemplate" class="combine-input"
+                                   value="${defaultTemplate}" placeholder="{0}, {1}, {2}">
+                            <div class="template-help">
+                                Use <code>{0}</code>, <code>{1}</code>, etc. for positional, or <code>{field_name}</code> for named placeholders
+                            </div>
+                        </div>
+
+                        <div class="combine-section">
+                            <label class="combine-label">Preview</label>
+                            <div class="combine-preview" id="combinePreview">
+                                ${generatePreview(state.selectedHtmlFields, defaultTemplate)}
+                            </div>
+                        </div>
+
+                        <div class="combine-section">
+                            <label class="combine-label">Target DocuSeal Field</label>
+                            <select id="combineTarget" class="combine-select">
+                                <option value="">Select target field...</option>
+                                ${targetOptionsHtml}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="combine-modal-footer">
+                        <button class="btn-action btn-cancel" onclick="closeCombineModal()">Cancel</button>
+                        <button class="btn-action btn-save" id="btnCreateCombined" onclick="createCombinedMapping()">
+                            <i class="fas fa-link"></i> Create Combined Field
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    function setupCombineModal() {
+        // Setup template input
+        const templateInput = document.getElementById('combineTemplate');
+        templateInput?.addEventListener('input', () => updateCombinePreview());
+
+        // Setup separator buttons
+        document.querySelectorAll('.separator-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const template = generateTemplateFromSeparator(btn.dataset.value, state.selectedHtmlFields.length);
+                templateInput.value = template;
+                updateCombinePreview();
+            });
+        });
+
+        // Setup preset buttons
+        document.querySelectorAll('.preset-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                templateInput.value = btn.dataset.template;
+                updateCombinePreview();
+            });
+        });
+
+        // Setup drag-drop reordering
+        setupCombineFieldSorting();
+
+        // Close on backdrop click
+        document.getElementById('combineModal')?.addEventListener('click', (e) => {
+            if (e.target.id === 'combineModal') closeCombineModal();
+        });
+    }
+
+    function setupCombineFieldSorting() {
+        const list = document.getElementById('combineFieldsList');
+        if (!list) return;
+
+        let draggedItem = null;
+
+        list.querySelectorAll('.combine-field-item').forEach(item => {
+            item.setAttribute('draggable', 'true');
+
+            item.addEventListener('dragstart', (e) => {
+                draggedItem = item;
+                item.classList.add('dragging');
+                e.dataTransfer.effectAllowed = 'move';
+            });
+
+            item.addEventListener('dragend', () => {
+                item.classList.remove('dragging');
+                draggedItem = null;
+                updateFieldOrder();
+            });
+
+            item.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                if (draggedItem && draggedItem !== item) {
+                    const rect = item.getBoundingClientRect();
+                    const midY = rect.top + rect.height / 2;
+                    if (e.clientY < midY) {
+                        item.parentNode.insertBefore(draggedItem, item);
+                    } else {
+                        item.parentNode.insertBefore(draggedItem, item.nextSibling);
+                    }
+                }
+            });
+        });
+    }
+
+    function updateFieldOrder() {
+        const newOrder = [];
+        document.querySelectorAll('.combine-field-item').forEach((item, idx) => {
+            const name = item.dataset.name;
+            newOrder.push(name);
+            item.querySelector('.combine-field-index').textContent = idx + 1;
+            item.dataset.index = idx;
+        });
+        state.selectedHtmlFields = newOrder;
+        updateCombinePreview();
+    }
+
+    window.removeCombineField = function(name) {
+        state.selectedHtmlFields = state.selectedHtmlFields.filter(f => f !== name);
+        document.querySelector(`.combine-field-item[data-name="${name}"]`)?.remove();
+        updateFieldOrder();
+
+        // Update checkboxes in HTML fields list
+        const checkbox = document.querySelector(`.field-checkbox[data-name="${name}"]`);
+        if (checkbox) {
+            checkbox.checked = false;
+            checkbox.closest('.html-field')?.classList.remove('selected');
+        }
+
+        if (state.selectedHtmlFields.length < 2) {
+            closeCombineModal();
+            showToast('Combined field requires at least 2 fields', 'warning');
+        }
+    };
+
+    function updateCombinePreview() {
+        const template = document.getElementById('combineTemplate')?.value || '';
+        const preview = generatePreview(state.selectedHtmlFields, template);
+        const previewEl = document.getElementById('combinePreview');
+        if (previewEl) previewEl.innerHTML = preview;
+    }
+
+    function generatePreview(fields, template) {
+        // Use sample values for preview
+        const sampleValues = fields.map((name, idx) => {
+            if (name.toLowerCase().includes('address') || name.toLowerCase().includes('street')) return '123 Main St';
+            if (name.toLowerCase().includes('city')) return 'Austin';
+            if (name.toLowerCase().includes('state')) return 'TX';
+            if (name.toLowerCase().includes('zip')) return '78701';
+            if (name.toLowerCase().includes('phone')) return '(555) 123-4567';
+            if (name.toLowerCase().includes('name')) return 'John Doe';
+            if (name.toLowerCase().includes('email')) return 'john@example.com';
+            return `[${name}]`;
+        });
+
+        let result = template;
+
+        // Replace positional
+        sampleValues.forEach((val, idx) => {
+            result = result.replace(new RegExp(`\\{${idx}\\}`, 'g'), val);
+        });
+
+        // Replace named
+        fields.forEach((name, idx) => {
+            result = result.replace(new RegExp(`\\{${name}\\}`, 'g'), sampleValues[idx]);
+        });
+
+        return `<code>${escapeHtml(result)}</code>`;
+    }
+
+    function generateDefaultTemplate(count) {
+        return Array.from({ length: count }, (_, i) => `{${i}}`).join(', ');
+    }
+
+    function generateTemplateFromSeparator(separator, count) {
+        return Array.from({ length: count }, (_, i) => `{${i}}`).join(separator);
+    }
+
+    window.createCombinedMapping = function() {
+        const template = document.getElementById('combineTemplate')?.value;
+        const targetSelect = document.getElementById('combineTarget');
+        const targetName = targetSelect?.value;
+
+        if (!template) {
+            showToast('Please enter a template', 'error');
+            return;
+        }
+
+        if (!targetName) {
+            showToast('Please select a target DocuSeal field', 'error');
+            return;
+        }
+
+        const selectedOption = targetSelect.options[targetSelect.selectedIndex];
+        const targetRole = selectedOption.dataset.role;
+        const targetType = selectedOption.dataset.type;
+
+        // Create sources array
+        const sources = state.selectedHtmlFields.map(name => `form.${name}`);
+
+        // Generate field key from first field
+        const fieldKey = state.selectedHtmlFields[0].replace(/-/g, '_') + '_combined';
+
+        addCombinedMapping({
+            field_key: fieldKey,
+            html_fields: [...state.selectedHtmlFields],
+            docuseal_field: targetName,
+            docuseal_role: targetRole,
+            docuseal_type: targetType,
+            sources: sources,
+            template: template,
+            transform: null,
+            confidence: 100
+        });
+
+        closeCombineModal();
+        clearSelection();
+        showToast('Combined field created!', 'success');
+    };
+
+    window.closeCombineModal = function() {
+        document.getElementById('combineModal')?.remove();
+    };
+
+    // =============================================================================
+    // MAPPING MANAGEMENT
+    // =============================================================================
+    function addSingleMapping(mapping) {
         // Check for duplicates
-        if (state.mappings.some(m => m.html_field === mapping.html_field)) {
+        if (isHtmlFieldMapped(mapping.html_field)) {
             showToast(`HTML field "${mapping.html_field}" is already mapped`, 'warning');
             return;
         }
 
-        // Set default source
-        mapping.source = mapping.source || `form.${mapping.html_field}`;
-        mapping.transform = mapping.transform || mapping.suggested_transform || null;
-        mapping.condition_field = mapping.condition_field || null;
-        mapping.condition_equals = mapping.condition_equals || null;
+        if (isDocuSealFieldMapped(mapping.docuseal_field)) {
+            showToast(`DocuSeal field "${mapping.docuseal_field}" is already mapped`, 'warning');
+            return;
+        }
+
+        mapping.type = 'single';
+        mapping.field_key = mapping.html_field.replace(/-/g, '_');
 
         state.mappings.push(mapping);
         renderMappings();
@@ -320,49 +874,80 @@
         updateUI();
     }
 
-    // Remove a mapping
-    function removeMapping(htmlFieldName) {
-        state.mappings = state.mappings.filter(m => m.html_field !== htmlFieldName);
+    function addCombinedMapping(mapping) {
+        // Check if DocuSeal field is already mapped
+        if (isDocuSealFieldMapped(mapping.docuseal_field)) {
+            showToast(`DocuSeal field "${mapping.docuseal_field}" is already mapped`, 'warning');
+            return;
+        }
+
+        mapping.type = 'combined';
+
+        state.mappings.push(mapping);
         renderMappings();
         updateFieldStatus();
         updateUI();
     }
 
-    // Add manual mapping (no DocuSeal field)
-    function addManualMapping(htmlFieldName) {
-        const dsFieldName = prompt(`Enter the DocuSeal field name for "${htmlFieldName}":`);
-        if (!dsFieldName) return;
+    function removeMapping(index) {
+        state.mappings.splice(index, 1);
+        renderMappings();
+        updateFieldStatus();
+        updateUI();
+    }
 
-        const dsRole = prompt('Enter the DocuSeal role (e.g., Seller, Buyer, Agent):', 'Seller');
-        if (!dsRole) return;
-
-        const htmlField = window.mapperData.htmlFields.find(f => f.name === htmlFieldName);
-
-        addMapping({
-            html_field: htmlFieldName,
-            docuseal_field: dsFieldName,
-            docuseal_role: dsRole,
-            html_type: htmlField?.html_type || 'text',
-            docuseal_type: 'text',
-            suggested_transform: null,
-            confidence: 50
+    function isHtmlFieldMapped(fieldName) {
+        return state.mappings.some(m => {
+            if (m.type === 'combined') {
+                return m.html_fields.includes(fieldName);
+            }
+            return m.html_field === fieldName;
         });
     }
 
-    // Render mappings list
+    function isDocuSealFieldMapped(fieldName) {
+        return state.mappings.some(m => m.docuseal_field === fieldName);
+    }
+
+    function getUnmappedDocuSealFields() {
+        if (!window.mapperData?.docusealFields) return [];
+        return window.mapperData.docusealFields.filter(f => !isDocuSealFieldMapped(f.name));
+    }
+
+    function getUnmappedHtmlFields() {
+        if (!window.mapperData?.htmlFields) return [];
+        return window.mapperData.htmlFields.filter(f => !isHtmlFieldMapped(f.name));
+    }
+
+    // =============================================================================
+    // RENDER MAPPINGS
+    // =============================================================================
     function renderMappings() {
         if (state.mappings.length === 0) {
             elements.mappingsList.innerHTML = `
                 <div class="drop-zone" id="dropZone">
                     <i class="fas fa-arrows-alt"></i>
-                    <p>Drag HTML fields here or use Auto-Map</p>
+                    <p>Drag HTML fields here or click DocuSeal fields</p>
+                    <p class="drop-zone-hint">Select multiple fields (Cmd/Ctrl+click) and use "Combine" for combined fields</p>
                 </div>
             `;
             return;
         }
 
-        elements.mappingsList.innerHTML = state.mappings.map((m, index) => `
-            <div class="mapping-item" data-index="${index}" data-html="${m.html_field}">
+        elements.mappingsList.innerHTML = state.mappings.map((m, index) => {
+            if (m.type === 'combined') {
+                return renderCombinedMapping(m, index);
+            }
+            return renderSingleMapping(m, index);
+        }).join('');
+
+        // Re-attach event listeners
+        attachMappingEventListeners();
+    }
+
+    function renderSingleMapping(m, index) {
+        return `
+            <div class="mapping-item mapping-single" data-index="${index}">
                 <div class="mapping-row">
                     <div class="mapping-html">${m.html_field}</div>
                     <i class="fas fa-arrow-right mapping-arrow"></i>
@@ -375,7 +960,7 @@
                 <div class="mapping-config">
                     <select class="mapping-transform" data-index="${index}">
                         <option value="">No transform</option>
-                        ${window.mapperData.availableTransforms.map(t => 
+                        ${window.mapperData.availableTransforms.map(t =>
                             `<option value="${t}" ${m.transform === t ? 'selected' : ''}>${t}</option>`
                         ).join('')}
                     </select>
@@ -389,151 +974,411 @@
                     </div>
                 </div>
             </div>
+        `;
+    }
+
+    function renderCombinedMapping(m, index) {
+        const sourcesHtml = m.html_fields.map((name, i) => `
+            <span class="combined-source-pill">${i + 1}. ${name}</span>
         `).join('');
 
-        // Add event listeners to new elements
-        elements.mappingsList.querySelectorAll('.mapping-transform').forEach(select => {
+        return `
+            <div class="mapping-item mapping-combined" data-index="${index}">
+                <div class="mapping-row">
+                    <div class="mapping-html mapping-html-combined">
+                        <div class="combined-sources">
+                            ${sourcesHtml}
+                        </div>
+                        <div class="combined-template-display">
+                            <i class="fas fa-code"></i> ${escapeHtml(m.template)}
+                        </div>
+                    </div>
+                    <i class="fas fa-arrow-right mapping-arrow"></i>
+                    <div class="mapping-docuseal">
+                        ${m.docuseal_field}
+                        <span class="mapping-role">${m.docuseal_role}</span>
+                    </div>
+                </div>
+                <div class="mapping-config">
+                    <select class="mapping-transform" data-index="${index}">
+                        <option value="">No transform</option>
+                        ${window.mapperData.availableTransforms.map(t =>
+                            `<option value="${t}" ${m.transform === t ? 'selected' : ''}>${t}</option>`
+                        ).join('')}
+                    </select>
+                    <div class="mapping-actions">
+                        <button class="mapping-btn btn-edit-combined" data-index="${index}" title="Edit Template">
+                            <i class="fas fa-edit"></i>
+                        </button>
+                        <button class="mapping-btn btn-remove" data-index="${index}" title="Remove">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    function attachMappingEventListeners() {
+        // Transform selects
+        document.querySelectorAll('.mapping-transform').forEach(select => {
             select.addEventListener('change', (e) => {
                 const index = parseInt(e.target.dataset.index);
                 state.mappings[index].transform = e.target.value || null;
             });
         });
 
-        elements.mappingsList.querySelectorAll('.btn-edit').forEach(btn => {
+        // Remove buttons
+        document.querySelectorAll('.btn-remove').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const index = parseInt(e.target.closest('button').dataset.index);
+                removeMapping(index);
+            });
+        });
+
+        // Edit buttons for single mappings
+        document.querySelectorAll('.btn-edit').forEach(btn => {
             btn.addEventListener('click', (e) => {
                 const index = parseInt(e.target.closest('button').dataset.index);
                 openEditModal(index);
             });
         });
 
-        elements.mappingsList.querySelectorAll('.btn-remove').forEach(btn => {
+        // Edit buttons for combined mappings
+        document.querySelectorAll('.btn-edit-combined').forEach(btn => {
             btn.addEventListener('click', (e) => {
                 const index = parseInt(e.target.closest('button').dataset.index);
-                removeMapping(state.mappings[index].html_field);
+                openEditCombinedModal(index);
             });
         });
     }
 
-    // Get confidence class
     function getConfidenceClass(confidence) {
         if (confidence >= 80) return 'confidence-high';
         if (confidence >= 50) return 'confidence-medium';
         return 'confidence-low';
     }
 
-    // Update field status (mapped/unmapped)
-    function updateFieldStatus() {
-        const mappedHtml = new Set(state.mappings.map(m => m.html_field));
-        const mappedDocuSeal = new Set(state.mappings.map(m => m.docuseal_field));
+    // =============================================================================
+    // EDIT MODALS
+    // =============================================================================
+    function openEditModal(index) {
+        const mapping = state.mappings[index];
+        if (!mapping) return;
 
-        document.querySelectorAll('.html-field').forEach(field => {
-            if (mappedHtml.has(field.dataset.name)) {
-                field.classList.add('mapped');
-            } else {
-                field.classList.remove('mapped');
-            }
+        const modalHtml = `
+            <div class="edit-modal" id="editModal">
+                <div class="edit-modal-content">
+                    <div class="edit-modal-header">
+                        <h3><i class="fas fa-edit"></i> Edit Mapping</h3>
+                        <button class="btn-close-modal" onclick="closeEditModal()"><i class="fas fa-times"></i></button>
+                    </div>
+                    <div class="edit-modal-body">
+                        <div class="form-group">
+                            <label>Field Key</label>
+                            <input type="text" id="editFieldKey" class="form-input" value="${mapping.field_key || mapping.html_field}" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label>DocuSeal Field</label>
+                            <input type="text" id="editDocusealField" class="form-input" value="${mapping.docuseal_field}" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label>Source Path</label>
+                            <select id="editSource" class="form-input">
+                                ${renderSourceOptions(mapping.source || `form.${mapping.html_field}`)}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Transform</label>
+                            <select id="editTransform" class="form-input">
+                                <option value="">None</option>
+                                ${window.mapperData.availableTransforms.map(t =>
+                                    `<option value="${t}" ${mapping.transform === t ? 'selected' : ''}>${t}</option>`
+                                ).join('')}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" id="editHasCondition" ${mapping.condition_field ? 'checked' : ''}>
+                                Conditional field
+                            </label>
+                        </div>
+                        <div id="conditionFields" style="display: ${mapping.condition_field ? 'block' : 'none'}">
+                            <div class="form-group">
+                                <label>Condition Field</label>
+                                <input type="text" id="editConditionField" class="form-input"
+                                       value="${mapping.condition_field || ''}" placeholder="e.g., form.doc_responsibility">
+                            </div>
+                            <div class="form-group">
+                                <label>Condition Equals</label>
+                                <input type="text" id="editConditionEquals" class="form-input"
+                                       value="${mapping.condition_equals || ''}" placeholder="e.g., seller">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="edit-modal-footer">
+                        <button class="btn-action btn-danger" onclick="deleteEditMapping(${index})">
+                            <i class="fas fa-trash"></i> Remove
+                        </button>
+                        <button class="btn-action btn-save" onclick="saveEditMapping(${index})">
+                            <i class="fas fa-check"></i> Apply
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        document.getElementById('editModal')?.remove();
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        document.getElementById('editHasCondition').addEventListener('change', (e) => {
+            document.getElementById('conditionFields').style.display = e.target.checked ? 'block' : 'none';
         });
 
-        document.querySelectorAll('.docuseal-field').forEach(field => {
-            if (mappedDocuSeal.has(field.dataset.name)) {
-                field.classList.add('mapped');
-            } else {
-                field.classList.remove('mapped');
-            }
+        document.getElementById('editModal').addEventListener('click', (e) => {
+            if (e.target.id === 'editModal') closeEditModal();
         });
     }
 
-    // Update UI elements
-    function updateUI() {
-        elements.mappingCount.textContent = state.mappings.length;
-        elements.btnSave.disabled = state.mappings.length === 0;
+    function openEditCombinedModal(index) {
+        const mapping = state.mappings[index];
+        if (!mapping || mapping.type !== 'combined') return;
+
+        const modalHtml = `
+            <div class="edit-modal" id="editModal">
+                <div class="edit-modal-content">
+                    <div class="edit-modal-header">
+                        <h3><i class="fas fa-edit"></i> Edit Combined Field</h3>
+                        <button class="btn-close-modal" onclick="closeEditModal()"><i class="fas fa-times"></i></button>
+                    </div>
+                    <div class="edit-modal-body">
+                        <div class="form-group">
+                            <label>Source Fields</label>
+                            <div class="edit-sources-list">
+                                ${mapping.html_fields.map((f, i) => `<span class="source-pill">${i + 1}. ${f}</span>`).join('')}
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label>DocuSeal Field</label>
+                            <input type="text" class="form-input" value="${mapping.docuseal_field}" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label>Template</label>
+                            <input type="text" id="editCombinedTemplate" class="form-input" value="${escapeHtml(mapping.template)}">
+                        </div>
+                        <div class="form-group">
+                            <label>Preview</label>
+                            <div class="combine-preview" id="editCombinePreview">
+                                ${generatePreview(mapping.html_fields, mapping.template)}
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label>Transform</label>
+                            <select id="editCombinedTransform" class="form-input">
+                                <option value="">None</option>
+                                ${window.mapperData.availableTransforms.map(t =>
+                                    `<option value="${t}" ${mapping.transform === t ? 'selected' : ''}>${t}</option>`
+                                ).join('')}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="edit-modal-footer">
+                        <button class="btn-action btn-danger" onclick="deleteEditMapping(${index})">
+                            <i class="fas fa-trash"></i> Remove
+                        </button>
+                        <button class="btn-action btn-save" onclick="saveCombinedEditMapping(${index})">
+                            <i class="fas fa-check"></i> Apply
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        document.getElementById('editModal')?.remove();
+        document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+        // Update preview on template change
+        document.getElementById('editCombinedTemplate').addEventListener('input', (e) => {
+            document.getElementById('editCombinePreview').innerHTML =
+                generatePreview(mapping.html_fields, e.target.value);
+        });
+
+        document.getElementById('editModal').addEventListener('click', (e) => {
+            if (e.target.id === 'editModal') closeEditModal();
+        });
     }
 
-    // Setup event listeners
-    function setupEventListeners() {
-        // Auto-map button
-        if (elements.btnAutoMap) {
-            elements.btnAutoMap.addEventListener('click', handleAutoMap);
-        }
+    function renderSourceOptions(currentSource) {
+        const options = [
+            { group: 'Form Data', options: [
+                { value: '', label: 'form.[field_name]' }
+            ]},
+            { group: 'Transaction', options: [
+                { value: 'transaction.full_address', label: 'transaction.full_address' },
+                { value: 'transaction.street_address', label: 'transaction.street_address' },
+                { value: 'transaction.city', label: 'transaction.city' },
+                { value: 'transaction.state', label: 'transaction.state' },
+                { value: 'transaction.zip_code', label: 'transaction.zip_code' }
+            ]},
+            { group: 'User/Agent', options: [
+                { value: 'user.email', label: 'user.email' },
+                { value: 'user.full_name', label: 'user.full_name' },
+                { value: 'user.phone', label: 'user.phone' }
+            ]}
+        ];
 
-        // Preview YAML button
-        if (elements.btnPreviewYaml) {
-            elements.btnPreviewYaml.addEventListener('click', handlePreviewYaml);
-        }
+        let html = `<option value="${currentSource}">${currentSource}</option>`;
 
-        // Save button
-        if (elements.btnSave) {
-            elements.btnSave.addEventListener('click', handleSave);
-        }
-
-        // Clear mappings
-        if (elements.btnClearMappings) {
-            elements.btnClearMappings.addEventListener('click', handleClearMappings);
-        }
-
-        // Fetch template
-        if (elements.btnFetchTemplate) {
-            elements.btnFetchTemplate.addEventListener('click', handleFetchTemplate);
-        }
-
-        // YAML modal buttons
-        if (elements.btnCopyYaml) {
-            elements.btnCopyYaml.addEventListener('click', handleCopyYaml);
-        }
-        if (elements.btnCloseModal) {
-            elements.btnCloseModal.addEventListener('click', () => elements.yamlModal.style.display = 'none');
-        }
-        if (elements.btnSaveFromModal) {
-            elements.btnSaveFromModal.addEventListener('click', handleSave);
-        }
-
-        // Role configuration changes
-        if (elements.rolesGrid) {
-            elements.rolesGrid.addEventListener('change', handleRoleChange);
-        }
-
-        // Edit modal
-        setupEditModal();
-
-        // Close modals on outside click
-        document.querySelectorAll('.yaml-modal, .edit-modal').forEach(modal => {
-            modal.addEventListener('click', (e) => {
-                if (e.target === modal) {
-                    modal.style.display = 'none';
+        options.forEach(group => {
+            html += `<optgroup label="${group.group}">`;
+            group.options.forEach(opt => {
+                if (opt.value !== currentSource) {
+                    html += `<option value="${opt.value}">${opt.label}</option>`;
                 }
             });
+            html += '</optgroup>';
+        });
+
+        return html;
+    }
+
+    window.saveEditMapping = function(index) {
+        const hasCondition = document.getElementById('editHasCondition').checked;
+
+        state.mappings[index] = {
+            ...state.mappings[index],
+            source: document.getElementById('editSource').value || `form.${state.mappings[index].html_field}`,
+            transform: document.getElementById('editTransform').value || null,
+            condition_field: hasCondition ? document.getElementById('editConditionField').value : null,
+            condition_equals: hasCondition ? document.getElementById('editConditionEquals').value : null
+        };
+
+        renderMappings();
+        closeEditModal();
+        showToast('Mapping updated', 'success');
+    };
+
+    window.saveCombinedEditMapping = function(index) {
+        state.mappings[index] = {
+            ...state.mappings[index],
+            template: document.getElementById('editCombinedTemplate').value,
+            transform: document.getElementById('editCombinedTransform').value || null
+        };
+
+        renderMappings();
+        closeEditModal();
+        showToast('Combined field updated', 'success');
+    };
+
+    window.deleteEditMapping = function(index) {
+        removeMapping(index);
+        closeEditModal();
+    };
+
+    window.closeEditModal = function() {
+        document.getElementById('editModal')?.remove();
+    };
+
+    // =============================================================================
+    // FIELD STATUS UPDATES
+    // =============================================================================
+    function updateFieldStatus() {
+        // Get all mapped HTML field names
+        const mappedHtml = new Set();
+        state.mappings.forEach(m => {
+            if (m.type === 'combined') {
+                m.html_fields.forEach(f => mappedHtml.add(f));
+            } else {
+                mappedHtml.add(m.html_field);
+            }
+        });
+
+        const mappedDocuSeal = new Set(state.mappings.map(m => m.docuseal_field));
+
+        // Update HTML fields
+        document.querySelectorAll('.html-field').forEach(field => {
+            const name = field.dataset.name;
+            if (mappedHtml.has(name)) {
+                field.classList.add('mapped');
+                field.querySelector('.status-mapped').style.display = 'inline-block';
+                field.querySelector('.status-unmapped').style.display = 'none';
+            } else {
+                field.classList.remove('mapped');
+                field.querySelector('.status-mapped').style.display = 'none';
+                field.querySelector('.status-unmapped').style.display = 'inline-block';
+            }
+        });
+
+        // Update DocuSeal fields
+        document.querySelectorAll('.docuseal-field').forEach(field => {
+            const name = field.dataset.name;
+            if (mappedDocuSeal.has(name)) {
+                field.classList.add('mapped');
+                field.querySelector('.status-mapped').style.display = 'inline-block';
+                field.querySelector('.status-unmapped').style.display = 'none';
+            } else {
+                field.classList.remove('mapped');
+                field.querySelector('.status-mapped').style.display = 'none';
+                field.querySelector('.status-unmapped').style.display = 'inline-block';
+            }
         });
     }
 
-    // Setup search
-    function setupSearch() {
-        if (elements.searchHtml) {
-            elements.searchHtml.addEventListener('input', (e) => {
-                filterFields('.html-field', e.target.value);
-            });
+    function updateUI() {
+        if (elements.mappingCount) {
+            elements.mappingCount.textContent = state.mappings.length;
         }
-
-        if (elements.searchDocuseal) {
-            elements.searchDocuseal.addEventListener('input', (e) => {
-                filterFields('.docuseal-field', e.target.value);
-            });
+        if (elements.btnSave) {
+            elements.btnSave.disabled = state.mappings.length === 0;
         }
     }
 
-    // Filter fields
+    // =============================================================================
+    // EVENT LISTENERS
+    // =============================================================================
+    function setupEventListeners() {
+        elements.btnAutoMap?.addEventListener('click', handleAutoMap);
+        elements.btnPreviewYaml?.addEventListener('click', handlePreviewYaml);
+        elements.btnSave?.addEventListener('click', handleSave);
+        elements.btnClearMappings?.addEventListener('click', handleClearMappings);
+        elements.rolesGrid?.addEventListener('change', handleRoleChange);
+
+        // YAML modal buttons
+        document.getElementById('btnCopyYaml')?.addEventListener('click', handleCopyYaml);
+        document.getElementById('btnCloseModal')?.addEventListener('click', () => {
+            elements.yamlModal.style.display = 'none';
+        });
+        document.getElementById('btnSaveFromModal')?.addEventListener('click', handleSave);
+
+        // Close modals on backdrop click
+        elements.yamlModal?.addEventListener('click', (e) => {
+            if (e.target === elements.yamlModal) {
+                elements.yamlModal.style.display = 'none';
+            }
+        });
+    }
+
+    function setupSearch() {
+        elements.searchHtml?.addEventListener('input', (e) => {
+            filterFields('.html-field', e.target.value);
+        });
+
+        elements.searchDocuseal?.addEventListener('input', (e) => {
+            filterFields('.docuseal-field', e.target.value);
+        });
+    }
+
     function filterFields(selector, query) {
         const normalizedQuery = query.toLowerCase();
         document.querySelectorAll(selector).forEach(field => {
             const name = field.dataset.name.toLowerCase();
-            if (name.includes(normalizedQuery)) {
-                field.style.display = '';
-            } else {
-                field.style.display = 'none';
-            }
+            field.style.display = name.includes(normalizedQuery) ? '' : 'none';
         });
     }
 
-    // Handle auto-map
+    // =============================================================================
+    // AUTO-MAP
+    // =============================================================================
     async function handleAutoMap() {
         elements.btnAutoMap.disabled = true;
         elements.btnAutoMap.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Mapping...';
@@ -541,9 +1386,7 @@
         try {
             const response = await fetch('/api/mapper/auto-map', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     html_fields: window.mapperData.htmlFields,
                     docuseal_fields: window.mapperData.docusealFields
@@ -553,15 +1396,16 @@
             const data = await response.json();
 
             if (data.success && data.mappings) {
-                // Add auto-mapped fields
                 let addedCount = 0;
                 data.mappings.forEach(mapping => {
-                    if (!state.mappings.some(m => m.html_field === mapping.html_field)) {
-                        addMapping(mapping);
+                    if (!isHtmlFieldMapped(mapping.html_field) && !isDocuSealFieldMapped(mapping.docuseal_field)) {
+                        addSingleMapping({
+                            ...mapping,
+                            source: `form.${mapping.html_field}`
+                        });
                         addedCount++;
                     }
                 });
-
                 showToast(`Auto-mapped ${addedCount} fields`, 'success');
             } else {
                 showToast('Auto-mapping failed: ' + (data.error || 'Unknown error'), 'error');
@@ -575,16 +1419,16 @@
         }
     }
 
-    // Handle preview YAML
+    // =============================================================================
+    // YAML GENERATION & SAVE
+    // =============================================================================
     async function handlePreviewYaml() {
         const config = buildConfig();
 
         try {
             const response = await fetch('/api/mapper/generate-yaml', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(config)
             });
 
@@ -594,19 +1438,20 @@
                 state.yamlContent = data.yaml;
                 state.isValid = data.valid;
 
-                // Display in modal
-                elements.yamlPreview.textContent = data.yaml;
-                hljs.highlightElement(elements.yamlPreview);
+                document.getElementById('yamlPreview').textContent = data.yaml;
+                hljs.highlightElement(document.getElementById('yamlPreview'));
 
-                // Update validation status
+                const validationStatus = document.getElementById('validationStatus');
+                const validationErrors = document.getElementById('validationErrors');
+
                 if (data.valid) {
-                    elements.validationStatus.className = 'validation-status valid';
-                    elements.validationStatus.innerHTML = '<i class="fas fa-check-circle"></i> Valid';
-                    elements.validationErrors.textContent = '';
+                    validationStatus.className = 'validation-status valid';
+                    validationStatus.innerHTML = '<i class="fas fa-check-circle"></i> Valid';
+                    validationErrors.textContent = '';
                 } else {
-                    elements.validationStatus.className = 'validation-status invalid';
-                    elements.validationStatus.innerHTML = '<i class="fas fa-exclamation-circle"></i> Invalid';
-                    elements.validationErrors.textContent = data.errors.join('\n');
+                    validationStatus.className = 'validation-status invalid';
+                    validationStatus.innerHTML = '<i class="fas fa-exclamation-circle"></i> Invalid';
+                    validationErrors.textContent = data.errors.join('\n');
                 }
 
                 elements.yamlModal.style.display = 'flex';
@@ -619,7 +1464,6 @@
         }
     }
 
-    // Build config from current state
     function buildConfig() {
         // Get role configurations from the UI
         const roles = [];
@@ -636,15 +1480,27 @@
         });
 
         // Build fields from mappings
-        const fields = state.mappings.map(m => ({
-            field_key: m.html_field.replace(/-/g, '_'),
-            docuseal_field: m.docuseal_field,
-            role_key: m.docuseal_role.toLowerCase().replace(/\s+/g, '_'),
-            source: m.source || `form.${m.html_field}`,
-            transform: m.transform || null,
-            condition_field: m.condition_field || null,
-            condition_equals: m.condition_equals || null
-        }));
+        const fields = state.mappings.map(m => {
+            const field = {
+                field_key: m.field_key || m.html_field?.replace(/-/g, '_'),
+                docuseal_field: m.docuseal_field,
+                role_key: m.docuseal_role.toLowerCase().replace(/\s+/g, '_'),
+                transform: m.transform || null,
+                condition_field: m.condition_field || null,
+                condition_equals: m.condition_equals || null
+            };
+
+            if (m.type === 'combined') {
+                // Combined field - use sources and template
+                field.sources = m.sources;
+                field.template = m.template;
+            } else {
+                // Single field - use source
+                field.source = m.source || `form.${m.html_field}`;
+            }
+
+            return field;
+        });
 
         return {
             slug: window.mapperData.slug,
@@ -665,10 +1521,8 @@
         };
     }
 
-    // Handle save
     async function handleSave() {
         if (!state.yamlContent) {
-            // Generate YAML first
             await handlePreviewYaml();
         }
 
@@ -680,9 +1534,7 @@
         try {
             const response = await fetch('/api/mapper/save', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     slug: window.mapperData.slug,
                     yaml_content: state.yamlContent
@@ -703,7 +1555,6 @@
         }
     }
 
-    // Handle clear mappings
     function handleClearMappings() {
         if (confirm('Are you sure you want to clear all mappings?')) {
             state.mappings = [];
@@ -714,39 +1565,6 @@
         }
     }
 
-    // Handle fetch template
-    async function handleFetchTemplate() {
-        const templateId = elements.templateIdInput?.value;
-        if (!templateId) {
-            showToast('Please enter a template ID', 'warning');
-            return;
-        }
-
-        try {
-            const response = await fetch('/admin/document-mapping/fetch-template', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ template_id: templateId })
-            });
-
-            const data = await response.json();
-
-            if (data.success) {
-                showToast(`Fetched template: ${data.template_name}`, 'success');
-                // Reload the page to show new fields
-                location.reload();
-            } else {
-                showToast('Failed to fetch template: ' + (data.error || 'Unknown error'), 'error');
-            }
-        } catch (error) {
-            console.error('Fetch template error:', error);
-            showToast('Failed to fetch template: ' + error.message, 'error');
-        }
-    }
-
-    // Handle copy YAML
     function handleCopyYaml() {
         navigator.clipboard.writeText(state.yamlContent).then(() => {
             showToast('YAML copied to clipboard!', 'success');
@@ -756,14 +1574,13 @@
         });
     }
 
-    // Handle role configuration change
     function handleRoleChange(e) {
         const card = e.target.closest('.role-card');
         if (!card) return;
 
         const roleName = card.dataset.role;
         const roleIndex = state.roles.findIndex(r => r.docuseal_role === roleName);
-        
+
         if (roleIndex >= 0) {
             state.roles[roleIndex] = {
                 ...state.roles[roleIndex],
@@ -775,121 +1592,83 @@
         }
     }
 
-    // Setup edit modal
-    function setupEditModal() {
-        const modal = elements.editModal;
-        if (!modal) return;
+    // =============================================================================
+    // UTILITY FUNCTIONS
+    // =============================================================================
+    function findBestHtmlMatch(dsFieldName) {
+        const dsNormalized = normalizeFieldName(dsFieldName);
+        let bestMatch = null;
+        let bestScore = 0;
 
-        const closeBtn = modal.querySelector('.btn-close-modal');
-        const saveBtn = document.getElementById('btnSaveMapping');
-        const removeBtn = document.getElementById('btnRemoveMapping');
-        const hasConditionCheckbox = document.getElementById('editHasCondition');
-        const conditionFields = document.getElementById('conditionFields');
+        window.mapperData.htmlFields.forEach(htmlField => {
+            if (isHtmlFieldMapped(htmlField.name)) return;
 
-        if (closeBtn) {
-            closeBtn.addEventListener('click', () => modal.style.display = 'none');
-        }
+            const htmlNormalized = normalizeFieldName(htmlField.name);
 
-        if (hasConditionCheckbox) {
-            hasConditionCheckbox.addEventListener('change', (e) => {
-                conditionFields.style.display = e.target.checked ? 'block' : 'none';
-            });
-        }
-
-        if (saveBtn) {
-            saveBtn.addEventListener('click', saveEditedMapping);
-        }
-
-        if (removeBtn) {
-            removeBtn.addEventListener('click', () => {
-                const index = parseInt(modal.dataset.index);
-                if (index >= 0 && index < state.mappings.length) {
-                    removeMapping(state.mappings[index].html_field);
-                    modal.style.display = 'none';
-                }
-            });
-        }
-    }
-
-    // Open edit modal
-    function openEditModal(index) {
-        const mapping = state.mappings[index];
-        if (!mapping) return;
-
-        const modal = elements.editModal;
-        modal.dataset.index = index;
-
-        document.getElementById('editFieldKey').value = mapping.html_field;
-        document.getElementById('editDocusealField').value = mapping.docuseal_field;
-        document.getElementById('editTransform').value = mapping.transform || '';
-
-        // Set source
-        const sourceSelect = document.getElementById('editSource');
-        let sourceFound = false;
-        for (let i = 0; i < sourceSelect.options.length; i++) {
-            if (sourceSelect.options[i].value === mapping.source) {
-                sourceSelect.selectedIndex = i;
-                sourceFound = true;
-                break;
+            if (htmlNormalized === dsNormalized) {
+                bestMatch = htmlField;
+                bestScore = 100;
+                return;
             }
-        }
-        if (!sourceFound) {
-            // Add custom option
-            const option = document.createElement('option');
-            option.value = mapping.source;
-            option.textContent = mapping.source;
-            option.selected = true;
-            sourceSelect.appendChild(option);
-        }
 
-        // Set condition
-        const hasCondition = !!mapping.condition_field;
-        document.getElementById('editHasCondition').checked = hasCondition;
-        document.getElementById('conditionFields').style.display = hasCondition ? 'block' : 'none';
-        document.getElementById('editConditionField').value = mapping.condition_field || '';
-        document.getElementById('editConditionEquals').value = mapping.condition_equals || '';
+            const similarity = calculateSimilarity(htmlNormalized, dsNormalized);
+            if (similarity > bestScore && similarity > 60) {
+                bestScore = similarity;
+                bestMatch = htmlField;
+            }
+        });
 
-        modal.style.display = 'flex';
+        return bestMatch;
     }
 
-    // Save edited mapping
-    function saveEditedMapping() {
-        const modal = elements.editModal;
-        const index = parseInt(modal.dataset.index);
-        
-        if (index >= 0 && index < state.mappings.length) {
-            const hasCondition = document.getElementById('editHasCondition').checked;
-            
-            state.mappings[index] = {
-                ...state.mappings[index],
-                source: document.getElementById('editSource').value || `form.${state.mappings[index].html_field}`,
-                transform: document.getElementById('editTransform').value || null,
-                condition_field: hasCondition ? document.getElementById('editConditionField').value : null,
-                condition_equals: hasCondition ? document.getElementById('editConditionEquals').value : null
-            };
-
-            renderMappings();
-            modal.style.display = 'none';
-            showToast('Mapping updated', 'success');
-        }
+    function normalizeFieldName(name) {
+        return name.toLowerCase()
+            .replace(/[^a-z0-9]/g, '_')
+            .replace(/_+/g, '_')
+            .replace(/^_|_$/g, '');
     }
 
-    // Toast notification
+    function calculateSimilarity(a, b) {
+        const aWords = new Set(a.split('_'));
+        const bWords = new Set(b.split('_'));
+        const intersection = new Set([...aWords].filter(x => bWords.has(x)));
+        const union = new Set([...aWords, ...bWords]);
+        return (intersection.size / union.size) * 100;
+    }
+
+    function suggestTransform(htmlType, dsType) {
+        if (htmlType === 'checkbox' || dsType === 'checkbox') return 'checkbox';
+        if (htmlType === 'date' || dsType === 'date') return 'date_short';
+        if (htmlType === 'money' || htmlType === 'number') return 'currency';
+        return null;
+    }
+
+    function escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
     function showToast(message, type = 'info') {
-        // Simple toast implementation
         const toast = document.createElement('div');
         toast.className = `toast toast-${type}`;
-        toast.innerHTML = `
-            <i class="fas fa-${type === 'success' ? 'check-circle' : type === 'error' ? 'exclamation-circle' : type === 'warning' ? 'exclamation-triangle' : 'info-circle'}"></i>
-            <span>${message}</span>
-        `;
+
+        const icon = type === 'success' ? 'check-circle' :
+                     type === 'error' ? 'exclamation-circle' :
+                     type === 'warning' ? 'exclamation-triangle' : 'info-circle';
+
+        const bg = type === 'success' ? '#10b981' :
+                   type === 'error' ? '#ef4444' :
+                   type === 'warning' ? '#f59e0b' : '#3b82f6';
+
+        toast.innerHTML = `<i class="fas fa-${icon}"></i><span>${message}</span>`;
         toast.style.cssText = `
             position: fixed;
             bottom: 20px;
             right: 20px;
             padding: 12px 20px;
             border-radius: 8px;
-            background: ${type === 'success' ? '#10b981' : type === 'error' ? '#ef4444' : type === 'warning' ? '#f59e0b' : '#3b82f6'};
+            background: ${bg};
             color: white;
             font-weight: 500;
             display: flex;
@@ -921,11 +1700,12 @@
     `;
     document.head.appendChild(style);
 
-    // Initialize when DOM is ready
+    // =============================================================================
+    // INITIALIZATION
+    // =============================================================================
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init);
     } else {
         init();
     }
 })();
-


### PR DESCRIPTION
…Mapper V2

Combined Fields:
- Add sources/template properties to JSON schema for multi-field mappings
- Update FieldDefinition with sources, template, and is_combined property
- Add resolve_combined_field() to FieldResolver with positional and named placeholders
- Support templates like "{0}, {1}, {2}" or "{street}, {city}, {state}"
- Update YAML generator to output combined field syntax

UI Redesign:
- Add multi-select for HTML fields (checkboxes + Cmd/Ctrl+click)
- Add Combined Field Builder modal with drag-to-reorder
- Add separator presets (comma, space, dash, newline)
- Add template presets (Address, Full Name, etc.)
- Add live preview of combined output
- Replace prompt() dialogs with proper Field Picker modal
- Add enhanced mapping cards for combined fields
- Add comprehensive CSS for new modals and components

Auto-Mapper Improvements:
- Add domain-specific synonyms for real estate terminology
- Add exact mappings for common field patterns
- Add pattern matching for numbered/sequential fields
- Implement 3-pass matching: Exact → Pattern → Semantic
- Add smart transform inference from field names
- Significantly improve match confidence and accuracy