### PR TITLE
fix: dashboard todo list layout jolt and checkbox persistence

### DIFF
--- a/static/js/todo-manager.js
+++ b/static/js/todo-manager.js
@@ -311,24 +311,30 @@ class TodoManager {
             if (isChecked && !isInCompleted) {
                 // Moving to completed
                 if (this.completedList) {
+                    // If we have a completed list, move the item there
                     todoItem.remove();
                     this.completedList.appendChild(todoItem);
                     todoItem.style.opacity = '1';
                     todoItem.style.transform = 'translateX(0)';
+                    this.syncFromDOM();
+                    this.saveTodos();
+                } else {
+                    // No completed list (dashboard) - move from active to completed array
+                    const todoText = todoItem.querySelector('.todo-text').textContent;
+                    const activeIndex = this.todos.indexOf(todoText);
+                    if (activeIndex !== -1) {
+                        this.todos.splice(activeIndex, 1);
+                        this.completedTodos.push(todoText);
+                    }
+                    todoItem.remove();
+                    this.saveTodos();
                 }
-                this.syncFromDOM();
-                this.saveTodos();
             } else if (!isChecked && isInCompleted) {
                 // Moving back to active
                 todoItem.remove();
                 this.activeList.appendChild(todoItem);
                 todoItem.style.opacity = '1';
                 todoItem.style.transform = 'translateX(0)';
-                this.syncFromDOM();
-                this.saveTodos();
-            } else {
-                // Simple complete (no completed list - like dashboard)
-                todoItem.remove();
                 this.syncFromDOM();
                 this.saveTodos();
             }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -513,9 +513,11 @@
                                 <span class="relative z-10">Add To Do</span>
                             </button>
                         </div>
-                        <ul id="dashboardActiveTodoList" class="space-y-3">
-                            <!-- Active todos will be inserted here via JavaScript -->
-                        </ul>
+                        <div class="h-[228px] overflow-y-auto">
+                            <ul id="dashboardActiveTodoList" class="space-y-3">
+                                <!-- Active todos will be inserted here via JavaScript -->
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -671,7 +673,7 @@
 
 <!-- Todo Item Template -->
 <template id="todoItemTemplate">
-    <li class="todo-item group bg-white border border-slate-200 rounded-xl shadow-sm hover:shadow-md transition-all duration-300 ease-in-out transform hover:-translate-y-0.5">
+    <li class="todo-item min-h-[76px] group bg-white border border-slate-200 rounded-xl shadow-sm hover:shadow-md transition-all duration-300 ease-in-out transform hover:-translate-y-0.5">
         <div class="px-5 py-4 flex items-center justify-between">
             <div class="flex items-center flex-1 min-w-0">
                 <div class="flex-shrink-0 flex items-center space-x-3">
@@ -846,7 +848,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 <!-- Todo Item Template -->
 <template id="todoItemTemplate">
-    <li class="todo-item group bg-white border border-slate-200 rounded-xl shadow-sm hover:shadow-md transition-all duration-300 ease-in-out transform hover:-translate-y-0.5">
+    <li class="todo-item min-h-[76px] group bg-white border border-slate-200 rounded-xl shadow-sm hover:shadow-md transition-all duration-300 ease-in-out transform hover:-translate-y-0.5">
         <div class="px-5 py-4 flex items-center justify-between">
             <div class="flex items-center flex-1 min-w-0">
                 <div class="flex-shrink-0 flex items-center space-x-3">


### PR DESCRIPTION
- Fixed layout shift by adding fixed-height container (h-[228px]) to dashboard todo list area
- Set consistent todo item height (min-h-[76px]) for exact 3-row display
- Fixed checkbox behavior on dashboard to properly move todos to completed array
- Container calculation: (76px * 3 rows) + (12px * 2 gaps) = 228px
- Todos now persist as completed after refresh when checked from dashboard