### PR TITLE
fix: New Relic initialization for Railway build compatibility

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: newrelic-admin run-program gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120
+web: gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120

--- a/app.py
+++ b/app.py
@@ -1,6 +1,12 @@
 from dotenv import load_dotenv
 load_dotenv()  # Load .env file before any other imports
 
+# Initialize New Relic APM (must be before other imports to instrument them)
+import os
+if os.environ.get('NEW_RELIC_LICENSE_KEY'):
+    import newrelic.agent
+    newrelic.agent.initialize('newrelic.ini')
+
 import warnings
 import html
 import pytz

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -3,8 +3,8 @@
 # ---------------------------------------------------------------------------
 
 [newrelic]
-# Your license key - also set via NEW_RELIC_LICENSE_KEY env var
-license_key = 5930d2d333bce874e6ae8fc70dc9f436FFFFNRAL
+# License key is set via NEW_RELIC_LICENSE_KEY environment variable
+# Do not hardcode here - set in Railway/hosting platform env vars
 
 # Application name as it will appear in New Relic dashboard
 app_name = TechnolOG


### PR DESCRIPTION
- Removed newrelic-admin wrapper from Procfile (caused build-time secret error)
- Initialize New Relic agent programmatically in app.py at runtime
- Only initializes when NEW_RELIC_LICENSE_KEY env var is present
- Removed hardcoded license key from newrelic.ini (use env var instead)

This fixes: 'secret NEW_RELIC_LICENSE_KEY: not found' during Railway build