### PR TITLE
feat: add Lead-Based Paint Disclosure as preview-only document

### DIFF
--- a/documents/lead-paint.yml
+++ b/documents/lead-paint.yml
@@ -1,0 +1,70 @@
+# =============================================================================
+# LEAD-BASED PAINT DISCLOSURE
+# =============================================================================
+# Addendum for Seller's Disclosure of Information on Lead-Based Paint
+# As Required by Federal Law
+#
+# This is a PDF-preview document - no custom form UI.
+# Property address is auto-populated. Seller fills out the disclosure
+# questions (checkboxes) and signs via DocuSeal. Agent also signs.
+#
+# Template ID: 2530549
+# =============================================================================
+
+schema_version: "1.0"
+slug: lead-paint
+name: "Lead-Based Paint Disclosure"
+docuseal_template_id: 2530549
+type: pdf-preview
+
+display:
+  color: "#3B82F6"
+  icon: "fas fa-paint-roller"
+  sort_order: 6
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Agent, Seller 2
+# 
+# - Seller: Fills out disclosure questions and signs
+# - Agent: Signs to acknowledge seller's obligations
+# - Seller 2: Optional second seller (signs if present)
+# =============================================================================
+
+roles:
+  # Seller role: Fills out disclosure and signs
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  # Agent role: Signs to acknowledge (no form fields to fill)
+  - role_key: agent
+    docuseal_role: Agent
+    email_source: user.email
+    name_source: user.full_name
+
+  # Seller 2 role: Optional second seller
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Only the property address is pre-filled.
+# Seller fills out the disclosure questions in DocuSeal during signing.
+# =============================================================================
+
+fields:
+  # Property Address - pre-filled and readonly
+  - field_key: property_address
+    docuseal_field: "Property address"
+    role_key: seller
+    source: transaction.full_address
+
+  # All other fields (checkboxes, explanations, signatures, dates) are
+  # handled by the seller/agent during the DocuSeal signing process

--- a/services/document_registry.py
+++ b/services/document_registry.py
@@ -142,15 +142,7 @@ DOCUMENT_REGISTRY: Dict[str, DocumentConfig] = {
     #     partial_template='transactions/partials/sellers_disclosure_fields.html',
     #     color='emerald',
     #     icon='fa-clipboard-list',
-    #     sort_order=3,
-    # ),
-    # 'lead-paint': DocumentConfig(
-    #     slug='lead-paint',
-    #     name='Lead-Based Paint Disclosure',
-    #     partial_template='transactions/partials/lead_paint_fields.html',
-    #     color='blue',
-    #     icon='fa-paint-roller',
-    #     sort_order=4,
+    #     sort_order=6,
     # ),
     # 'wire-fraud-warning': DocumentConfig(
     #     slug='wire-fraud-warning',
@@ -158,7 +150,7 @@ DOCUMENT_REGISTRY: Dict[str, DocumentConfig] = {
     #     partial_template='transactions/partials/wire_fraud_fields.html',
     #     color='rose',
     #     icon='fa-exclamation-triangle',
-    #     sort_order=5,
+    #     sort_order=7,
     # ),
 }
 
@@ -311,6 +303,15 @@ PREVIEW_DOCUMENT_REGISTRY: Dict[str, PreviewDocumentConfig] = {
         icon='fa-handshake',
         sort_order=100,  # High number ensures it appears after form UI docs
         description='TXR-2501 Information About Brokerage Services'
+    ),
+    'lead-paint': PreviewDocumentConfig(
+        slug='lead-paint',
+        name='Lead-Based Paint Disclosure',
+        docuseal_template_id=2530549,
+        color='blue',
+        icon='fa-paint-roller',
+        sort_order=101,
+        description='Addendum for Seller\'s Disclosure of Information on Lead-Based Paint'
     ),
     # Future preview-only documents can be added here:
     # 'wire-fraud-warning': PreviewDocumentConfig(...),

--- a/services/docuseal_service.py
+++ b/services/docuseal_service.py
@@ -54,9 +54,9 @@ TEMPLATE_MAP = {
     'listing-agreement': 2468023,  # Listing Agreement template
     'hoa-addendum': 2469165,  # HOA Addendum template (https://docuseal.com/d/b3S4Ryi2HCjoh4)
     'iabs': 2508644,  # TXR-2501 Information About Brokerage Services (preview-only)
+    'lead-paint': 2530549,  # Lead-Based Paint Addendum
     'sellers-disclosure': None,
     'wire-fraud-warning': None,
-    'lead-paint': None,
     'flood-hazard': None,
     'water-district': None,
     't47-affidavit': None,
@@ -93,6 +93,12 @@ DOCUMENT_FORMS = {
         'form_template': 'transactions/seller_net_proceeds_form.html',
         'template_id': None,  # Set when DocuSeal template is created
         'description': 'TXR-1935 Seller\'s Estimated Net Proceeds'
+    },
+    'lead-paint': {
+        'name': 'Lead-Based Paint Disclosure',
+        'form_template': None,  # Preview-only document, seller fills in DocuSeal
+        'template_id': 2530549,
+        'description': 'Addendum for Seller\'s Disclosure of Information on Lead-Based Paint (auto-populated address only)'
     },
     'iabs': {
         'name': 'Information About Brokerage Services',

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -710,7 +710,7 @@
             </div>
 
             <p class="text-sm text-slate-500 text-center mb-6">
-                These documents are auto-populated from your profile. Review the preview below.
+                These documents are pre-filled with relevant data. Review the preview below.
             </p>
 
             {% for preview in preview_data %}
@@ -726,7 +726,11 @@
                     </div>
                     <div>
                         <h3 class="section-title">{{ doc.template_name }}</h3>
+                        {% if doc.template_slug == 'iabs' %}
                         <p class="section-subtitle">Auto-populated from your agent profile</p>
+                        {% else %}
+                        <p class="section-subtitle">Pre-filled with property address - seller completes during signing</p>
+                        {% endif %}
                     </div>
                     <span
                         class="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">
@@ -741,11 +745,12 @@
                     {% if preview.mock_mode %}
                     <!-- Mock mode placeholder -->
                     <div
-                        class="flex flex-col items-center justify-center h-full min-h-[400px] bg-gradient-to-br from-slate-50 to-indigo-50 p-8">
-                        <div class="w-20 h-20 rounded-full bg-indigo-100 flex items-center justify-center mb-4">
-                            <i class="fas fa-file-pdf text-4xl text-indigo-500"></i>
+                        class="flex flex-col items-center justify-center h-full min-h-[400px] bg-gradient-to-br from-slate-50 to-{{ config.color }}-50 p-8">
+                        <div class="w-20 h-20 rounded-full bg-{{ config.color }}-100 flex items-center justify-center mb-4">
+                            <i class="fas fa-file-pdf text-4xl text-{{ config.color }}-500"></i>
                         </div>
                         <h4 class="text-lg font-semibold text-slate-800 mb-2">{{ doc.template_name }}</h4>
+                        {% if doc.template_slug == 'iabs' %}
                         <p class="text-slate-500 text-center max-w-md mb-6">
                             Document preview is available in production mode. This document has been
                             pre-filled with your agent and supervisor information.
@@ -772,6 +777,28 @@
                                 {% endif %}
                             </ul>
                         </div>
+                        {% else %}
+                        <p class="text-slate-500 text-center max-w-md mb-6">
+                            Document preview is available in production mode. The property address has been
+                            pre-filled. The seller will complete this form during the signing process.
+                        </p>
+                        <div class="bg-white rounded-xl border border-slate-200 p-6 max-w-sm text-left">
+                            <h5 class="font-medium text-slate-700 mb-3 flex items-center gap-2">
+                                <i class="fas fa-check-circle text-green-500"></i>
+                                Pre-filled Fields
+                            </h5>
+                            <ul class="space-y-2 text-sm text-slate-600">
+                                <li class="flex items-center gap-2">
+                                    <i class="fas fa-map-marker-alt text-blue-400 w-4"></i>
+                                    Address: {{ doc.field_data.get('property_address', transaction.full_address) if doc.field_data else transaction.full_address }}
+                                </li>
+                            </ul>
+                            <p class="text-xs text-slate-500 mt-3">
+                                <i class="fas fa-pen-fancy mr-1"></i>
+                                Seller completes disclosure questions during signing
+                            </p>
+                        </div>
+                        {% endif %}
                     </div>
                     {% elif preview.embed_src %}
                     <!-- Real DocuSeal embed preview -->

--- a/templates/transactions/simple_preview.html
+++ b/templates/transactions/simple_preview.html
@@ -1,0 +1,324 @@
+{% extends "base.html" %}
+
+{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - TechnolOG{% endblock %}
+
+{% block content %}
+<style>
+    @keyframes fadeInUp {
+        from {
+            opacity: 0;
+            transform: translateY(20px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    .preview-embed-container {
+        min-height: 700px;
+        border-radius: 12px;
+        overflow: hidden;
+        border: 1px solid #e2e8f0;
+        background: #f9fafb;
+    }
+
+    .preview-embed-container docuseal-form {
+        display: block;
+        width: 100%;
+        min-height: 700px;
+    }
+
+    /* Hide DocuSeal submit button in preview mode */
+    docuseal-form::part(submit-button) {
+        display: none !important;
+    }
+
+    /* Loading Overlay */
+    .loading-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: rgba(15, 23, 42, 0.7);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+    }
+
+    .loading-overlay.show {
+        display: flex;
+        animation: overlayFadeIn 0.3s ease-out forwards;
+    }
+
+    @keyframes overlayFadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .loading-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 2.5rem 3rem;
+        background: white;
+        border-radius: 1.5rem;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        animation: contentSlideUp 0.4s ease-out forwards;
+    }
+
+    @keyframes contentSlideUp {
+        from {
+            opacity: 0;
+            transform: translateY(20px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    .spinner-ring {
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        border: 4px solid #f1f5f9;
+        border-top-color: #3b82f6;
+        border-right-color: #60a5fa;
+        animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+
+    .loading-text {
+        margin-top: 1.5rem;
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: #1e293b;
+    }
+
+    .loading-subtext {
+        margin-top: 0.5rem;
+        font-size: 0.875rem;
+        color: #64748b;
+        animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+</style>
+
+<div class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50/30">
+    <!-- Header -->
+    <div class="bg-white border-b border-slate-200 sticky top-0 z-40">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <!-- Back button and title -->
+                <div class="flex items-center gap-4">
+                    <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
+                        class="flex items-center gap-2 text-slate-600 hover:text-blue-600 transition-colors">
+                        <i class="fas fa-arrow-left"></i>
+                        <span class="hidden sm:inline">Back to Transaction</span>
+                    </a>
+                    <div class="h-6 w-px bg-slate-200"></div>
+                    <div>
+                        <h1 class="text-lg font-semibold text-slate-800">{{ document.template_name }}</h1>
+                        <p class="text-xs text-slate-500">{{ transaction.street_address }}</p>
+                    </div>
+                </div>
+
+                <!-- Status badge -->
+                <div class="flex items-center gap-3">
+                    <span class="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold bg-green-100 text-green-700">
+                        <i class="fas fa-check-circle mr-1.5"></i>
+                        Ready for Signing
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Info banner -->
+    <div class="bg-blue-50 border-b border-blue-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <div class="flex items-center gap-3 text-blue-800">
+                <i class="fas fa-info-circle text-blue-500"></i>
+                <p class="text-sm">
+                    <strong>Preview Mode:</strong>
+                    Property address has been pre-filled. The seller will complete and sign this document when sent for e-signature.
+                    {% if preview_info.mock_mode %}
+                    <span class="ml-2 px-2 py-0.5 text-xs bg-amber-100 text-amber-700 rounded-full">Test Mode</span>
+                    {% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <!-- Document Info Card -->
+        <div class="bg-white rounded-2xl shadow-lg border border-slate-200 overflow-hidden mb-6 animate-fade-in-up">
+            <!-- Document header -->
+            <div class="bg-gradient-to-r from-blue-500 to-blue-600 px-6 py-4">
+                <div class="flex items-center gap-4">
+                    <div class="w-12 h-12 rounded-xl bg-white/20 flex items-center justify-center">
+                        <i class="fas {{ config.icon if config else 'fa-file-alt' }} text-2xl text-white"></i>
+                    </div>
+                    <div>
+                        <h2 class="font-semibold text-white text-lg">{{ document.template_name }}</h2>
+                        <p class="text-blue-100 text-sm">Pre-filled with property address</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Pre-filled data summary -->
+            <div class="px-6 py-4 bg-slate-50 border-b border-slate-200">
+                <h3 class="text-sm font-medium text-slate-700 mb-3">Pre-Filled Information:</h3>
+                <div class="bg-white rounded-lg border border-slate-200 p-4">
+                    <h4 class="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Property Address</h4>
+                    <div class="flex items-center gap-2 text-sm">
+                        <i class="fas fa-map-marker-alt text-blue-400 w-4"></i>
+                        <span class="text-slate-700">{{ document.field_data.get('property_address', transaction.full_address) if document.field_data else transaction.full_address }}</span>
+                    </div>
+                </div>
+                
+                <div class="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                    <div class="flex items-start gap-2 text-blue-800">
+                        <i class="fas fa-pen-fancy mt-0.5"></i>
+                        <div class="text-sm">
+                            <strong>Seller Completes This Form:</strong>
+                            When sent for e-signature, the seller will fill out the disclosure questions and sign. 
+                            The agent will also sign to acknowledge.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- DocuSeal Preview Embed -->
+        <div class="bg-white rounded-2xl shadow-lg border border-slate-200 overflow-hidden animate-fade-in-up"
+            style="animation-delay: 0.1s;">
+            <!-- Preview header -->
+            <div class="bg-slate-50 border-b border-slate-200 px-6 py-4">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-xl bg-blue-100 flex items-center justify-center">
+                            <i class="fas fa-file-pdf text-blue-600"></i>
+                        </div>
+                        <div>
+                            <h2 class="font-semibold text-slate-800">Document Preview</h2>
+                            <p class="text-xs text-slate-500">Scroll to review all pages</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2 text-sm text-slate-500">
+                        <i class="fas fa-info-circle"></i>
+                        <span>Read-only preview</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- DocuSeal embed -->
+            <div class="p-4">
+                {% if preview_info.embed_src %}
+                <div class="preview-embed-container">
+                    <docuseal-form 
+                        data-src="{{ preview_info.embed_src }}"
+                        data-preview="true"
+                        data-go-to-last="false"
+                        data-expand="true">
+                    </docuseal-form>
+                </div>
+                {% elif preview_info.mock_mode %}
+                <div class="preview-embed-container flex items-center justify-center bg-slate-100">
+                    <div class="text-center p-8">
+                        <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-amber-100 flex items-center justify-center">
+                            <i class="fas fa-flask text-amber-600 text-2xl"></i>
+                        </div>
+                        <h3 class="font-semibold text-slate-700 mb-2">Test Mode Active</h3>
+                        <p class="text-slate-500 text-sm max-w-md">
+                            DocuSeal preview is not available in test mode. 
+                            In production, the document preview will appear here.
+                        </p>
+                    </div>
+                </div>
+                {% elif preview_info.error %}
+                <div class="preview-embed-container flex items-center justify-center bg-red-50">
+                    <div class="text-center p-8">
+                        <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 flex items-center justify-center">
+                            <i class="fas fa-exclamation-triangle text-red-600 text-2xl"></i>
+                        </div>
+                        <h3 class="font-semibold text-red-700 mb-2">Preview Error</h3>
+                        <p class="text-red-600 text-sm max-w-md">{{ preview_info.error }}</p>
+                    </div>
+                </div>
+                {% else %}
+                <div class="preview-embed-container flex items-center justify-center">
+                    <div class="text-center p-8">
+                        <div class="w-16 h-16 mx-auto mb-4 rounded-full bg-slate-200 flex items-center justify-center">
+                            <i class="fas fa-file-alt text-slate-400 text-2xl"></i>
+                        </div>
+                        <h3 class="font-semibold text-slate-700 mb-2">Loading Preview...</h3>
+                        <p class="text-slate-500 text-sm">Please wait while we generate the document preview.</p>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Spacer for floating action bar -->
+        <div class="h-24"></div>
+    </div>
+</div>
+
+<!-- Floating Action Bar -->
+<div class="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white px-4 py-3 rounded-2xl shadow-2xl border border-slate-200 z-50 flex items-center gap-3">
+    <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
+        class="px-5 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-lg transition-colors">
+        Cancel
+    </a>
+    <div class="w-px h-8 bg-slate-200"></div>
+    <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
+        class="px-5 py-2.5 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg flex items-center gap-2 transition-colors">
+        <i class="fas fa-save text-slate-500"></i>
+        Save Draft
+    </a>
+    <a href="{{ url_for('transactions.document_preview', id=transaction.id, doc_id=document.id) }}"
+        onclick="showLoadingOverlay('Generating Preview...', 'This may take a few moments')"
+        class="px-5 py-2.5 text-sm font-medium text-white bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 rounded-lg flex items-center gap-2 shadow-sm transition-all">
+        <i class="fas fa-paper-plane"></i>
+        Continue to Send
+    </a>
+</div>
+
+<!-- Loading Overlay -->
+<div id="loadingOverlay" class="loading-overlay">
+    <div class="loading-content">
+        <div class="spinner-ring"></div>
+        <div class="loading-text" id="loadingText">Processing...</div>
+        <div class="loading-subtext" id="loadingSubtext">Please wait</div>
+    </div>
+</div>
+
+<!-- DocuSeal JS -->
+<script src="https://cdn.docuseal.com/js/form.js"></script>
+
+<script>
+    function showLoadingOverlay(message, submessage) {
+        if (message) {
+            document.getElementById('loadingText').textContent = message;
+        }
+        if (submessage) {
+            document.getElementById('loadingSubtext').textContent = submessage;
+        }
+        document.getElementById('loadingOverlay').classList.add('show');
+    }
+</script>
+{% endblock %}


### PR DESCRIPTION
- Add lead-paint.yml with pdf-preview type (seller fills during signing)
- Add simple_preview.html template for generic preview documents
- Register lead-paint in PREVIEW_DOCUMENT_REGISTRY and DOCUMENT_FORMS
- Update routes/transactions.py to handle simple preview documents
- Update fill_all_documents.html to show document-appropriate pre-filled info
- Property address auto-populated; seller completes disclosure questions via DocuSeal