### PR TITLE
feat: add comprehensive audit trail for transactions and e-sign workflow

### DIFF
--- a/migrations/versions/add_audit_events_table.py
+++ b/migrations/versions/add_audit_events_table.py
@@ -46,7 +46,7 @@ def upgrade():
             sa.Column('actor_id', sa.Integer(), nullable=True),
             sa.Column('event_type', sa.String(length=50), nullable=False),
             sa.Column('description', sa.String(length=500), nullable=True),
-            sa.Column('metadata', sa.JSON(), nullable=True),
+            sa.Column('event_data', sa.JSON(), nullable=True),
             sa.Column('source', sa.String(length=50), nullable=True, server_default='app'),
             sa.Column('ip_address', sa.String(length=45), nullable=True),
             sa.Column('user_agent', sa.String(length=500), nullable=True),

--- a/migrations/versions/add_audit_events_table.py
+++ b/migrations/versions/add_audit_events_table.py
@@ -1,0 +1,88 @@
+"""add audit_events table and sent_by_id to transaction_documents
+
+Revision ID: b2c3d4e5f6g7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-01-13
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6g7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    # Add sent_by_id to transaction_documents if it doesn't exist
+    if 'transaction_documents' in tables:
+        columns = [c['name'] for c in inspector.get_columns('transaction_documents')]
+        if 'sent_by_id' not in columns:
+            op.add_column('transaction_documents',
+                sa.Column('sent_by_id', sa.Integer(), nullable=True)
+            )
+            op.create_foreign_key(
+                'fk_transaction_documents_sent_by_id',
+                'transaction_documents', 'user',
+                ['sent_by_id'], ['id'],
+                ondelete='SET NULL'
+            )
+
+    # Create audit_events table if it doesn't exist
+    if 'audit_events' not in tables:
+        op.create_table(
+            'audit_events',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('transaction_id', sa.Integer(), nullable=True),
+            sa.Column('document_id', sa.Integer(), nullable=True),
+            sa.Column('signature_id', sa.Integer(), nullable=True),
+            sa.Column('actor_id', sa.Integer(), nullable=True),
+            sa.Column('event_type', sa.String(length=50), nullable=False),
+            sa.Column('description', sa.String(length=500), nullable=True),
+            sa.Column('metadata', sa.JSON(), nullable=True),
+            sa.Column('source', sa.String(length=50), nullable=True, server_default='app'),
+            sa.Column('ip_address', sa.String(length=45), nullable=True),
+            sa.Column('user_agent', sa.String(length=500), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.ForeignKeyConstraint(['transaction_id'], ['transactions.id'], name='fk_audit_events_transaction_id', ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['document_id'], ['transaction_documents.id'], name='fk_audit_events_document_id', ondelete='SET NULL'),
+            sa.ForeignKeyConstraint(['signature_id'], ['document_signatures.id'], name='fk_audit_events_signature_id', ondelete='SET NULL'),
+            sa.ForeignKeyConstraint(['actor_id'], ['user.id'], name='fk_audit_events_actor_id', ondelete='SET NULL'),
+            sa.PrimaryKeyConstraint('id', name='pk_audit_events')
+        )
+
+        # Create indexes for common queries
+        op.create_index('ix_audit_events_transaction_id', 'audit_events', ['transaction_id'], unique=False)
+        op.create_index('ix_audit_events_document_id', 'audit_events', ['document_id'], unique=False)
+        op.create_index('ix_audit_events_actor_id', 'audit_events', ['actor_id'], unique=False)
+        op.create_index('ix_audit_events_created_at', 'audit_events', ['created_at'], unique=False)
+        op.create_index('ix_audit_events_event_type', 'audit_events', ['event_type'], unique=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    # Drop audit_events table
+    if 'audit_events' in tables:
+        op.drop_index('ix_audit_events_event_type', table_name='audit_events')
+        op.drop_index('ix_audit_events_created_at', table_name='audit_events')
+        op.drop_index('ix_audit_events_actor_id', table_name='audit_events')
+        op.drop_index('ix_audit_events_document_id', table_name='audit_events')
+        op.drop_index('ix_audit_events_transaction_id', table_name='audit_events')
+        op.drop_table('audit_events')
+
+    # Remove sent_by_id from transaction_documents
+    if 'transaction_documents' in tables:
+        columns = [c['name'] for c in inspector.get_columns('transaction_documents')]
+        if 'sent_by_id' in columns:
+            op.drop_constraint('fk_transaction_documents_sent_by_id', 'transaction_documents', type_='foreignkey')
+            op.drop_column('transaction_documents', 'sent_by_id')

--- a/models.py
+++ b/models.py
@@ -641,13 +641,13 @@ class AuditEvent(db.Model):
     # Human-readable description
     description = db.Column(db.String(500))
 
-    # Detailed metadata (JSON) - stores context-specific data
+    # Detailed event data (JSON) - stores context-specific data
     # Examples:
     # - For status changes: {"old_status": "pending", "new_status": "sent"}
     # - For field changes: {"changed_fields": ["seller_name", "price"]}
     # - For webhooks: {"raw_payload": {...}, "ip_address": "..."}
     # - For signatures: {"signer_email": "...", "signer_role": "Seller"}
-    metadata = db.Column(db.JSON, default={})
+    event_data = db.Column(db.JSON, default={})
 
     # Source of the event
     source = db.Column(db.String(50), default='app')  # app, webhook, system, api
@@ -700,7 +700,7 @@ class AuditEvent(db.Model):
 
     @classmethod
     def log(cls, event_type, transaction_id=None, document_id=None, signature_id=None,
-            actor_id=None, description=None, metadata=None, source='app',
+            actor_id=None, description=None, event_data=None, source='app',
             ip_address=None, user_agent=None):
         """
         Convenience method to create and save an audit event.
@@ -713,7 +713,7 @@ class AuditEvent(db.Model):
             signature_id=signature_id,
             actor_id=actor_id,
             description=description,
-            metadata=metadata or {},
+            event_data=event_data or {},
             source=source,
             ip_address=ip_address,
             user_agent=user_agent

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -1983,6 +1983,13 @@ def send_for_signature(id, doc_id):
             )
             db.session.add(signature)
         
+        # Track who sent the document
+        doc.sent_by_id = current_user.id
+        
+        # Log audit event for document sent (must be before commit)
+        signer_info = [{'email': s.get('email'), 'name': s.get('name', ''), 'role': s.get('role')} for s in submission.get('submitters', [])]
+        audit_service.log_document_sent(doc, signer_info, submission['id'])
+        
         db.session.commit()
         
         return jsonify({

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -10,9 +10,10 @@ from flask_login import login_required, current_user
 from functools import wraps
 from models import (
     db, Transaction, TransactionType, TransactionParticipant,
-    TransactionDocument, DocumentSignature, Contact, User
+    TransactionDocument, DocumentSignature, Contact, User, AuditEvent
 )
 from feature_flags import can_access_transactions
+from services import audit_service
 
 transactions_bp = Blueprint('transactions', __name__, url_prefix='/transactions')
 
@@ -224,11 +225,18 @@ def create_transaction():
             )
             db.session.add(agent_participant)
         
+        # Log transaction creation
+        audit_service.log_transaction_created(transaction)
+
+        # Log participant additions
+        for participant in transaction.participants.all():
+            audit_service.log_participant_added(transaction, participant)
+
         db.session.commit()
-        
+
         flash('Transaction created successfully!', 'success')
         return redirect(url_for('transactions.view_transaction', id=transaction.id))
-        
+
     except Exception as e:
         db.session.rollback()
         flash(f'Error creating transaction: {str(e)}', 'error')
@@ -297,14 +305,18 @@ def delete_transaction(id):
     try:
         # Get transaction address for flash message
         address = transaction.street_address
-        
+        transaction_id = transaction.id
+
+        # Log deletion before actually deleting
+        audit_service.log_transaction_deleted(transaction_id, address)
+
         # Delete the transaction - cascade will handle:
         # - TransactionParticipants (cascade='all, delete-orphan')
         # - TransactionDocuments (cascade='all, delete-orphan')
         #   - DocumentSignatures (cascade='all, delete-orphan' via TransactionDocument)
         db.session.delete(transaction)
         db.session.commit()
-        
+
         flash(f'Transaction for "{address}" has been deleted.', 'success')
         return redirect(url_for('transactions.list_transactions'))
         
@@ -320,36 +332,78 @@ def delete_transaction(id):
 def update_transaction(id):
     """Update a transaction."""
     from datetime import datetime as dt
-    
+
     transaction = Transaction.query.get_or_404(id)
-    
+
     if transaction.created_by_id != current_user.id:
         abort(403)
-    
+
     try:
-        # Update fields
-        transaction.street_address = request.form.get('street_address', transaction.street_address)
-        transaction.city = request.form.get('city') or None
-        transaction.state = request.form.get('state', transaction.state)
-        transaction.zip_code = request.form.get('zip_code') or None
-        transaction.county = request.form.get('county') or None
-        transaction.ownership_status = request.form.get('ownership_status') or None
-        transaction.status = request.form.get('status', transaction.status)
-        
+        # Track changes for audit
+        old_status = transaction.status
+        changed_fields = []
+
+        # Check each field for changes
+        new_address = request.form.get('street_address', transaction.street_address)
+        if new_address != transaction.street_address:
+            changed_fields.append('street_address')
+        transaction.street_address = new_address
+
+        new_city = request.form.get('city') or None
+        if new_city != transaction.city:
+            changed_fields.append('city')
+        transaction.city = new_city
+
+        new_state = request.form.get('state', transaction.state)
+        if new_state != transaction.state:
+            changed_fields.append('state')
+        transaction.state = new_state
+
+        new_zip = request.form.get('zip_code') or None
+        if new_zip != transaction.zip_code:
+            changed_fields.append('zip_code')
+        transaction.zip_code = new_zip
+
+        new_county = request.form.get('county') or None
+        if new_county != transaction.county:
+            changed_fields.append('county')
+        transaction.county = new_county
+
+        new_ownership = request.form.get('ownership_status') or None
+        if new_ownership != transaction.ownership_status:
+            changed_fields.append('ownership_status')
+        transaction.ownership_status = new_ownership
+
+        new_status = request.form.get('status', transaction.status)
+        if new_status != transaction.status:
+            changed_fields.append('status')
+        transaction.status = new_status
+
         # Parse expected close date if provided
         expected_close = request.form.get('expected_close_date')
-        if expected_close:
-            transaction.expected_close_date = dt.strptime(expected_close, '%Y-%m-%d').date()
-        else:
-            transaction.expected_close_date = None
-        
+        new_expected = dt.strptime(expected_close, '%Y-%m-%d').date() if expected_close else None
+        if new_expected != transaction.expected_close_date:
+            changed_fields.append('expected_close_date')
+        transaction.expected_close_date = new_expected
+
         # Parse actual close date if provided
         actual_close = request.form.get('actual_close_date')
-        if actual_close:
-            transaction.actual_close_date = dt.strptime(actual_close, '%Y-%m-%d').date()
-        else:
-            transaction.actual_close_date = None
-        
+        new_actual = dt.strptime(actual_close, '%Y-%m-%d').date() if actual_close else None
+        if new_actual != transaction.actual_close_date:
+            changed_fields.append('actual_close_date')
+        transaction.actual_close_date = new_actual
+
+        # Log audit events
+        if changed_fields:
+            # Log status change separately if status changed
+            if 'status' in changed_fields and old_status != new_status:
+                audit_service.log_transaction_status_changed(transaction, old_status, new_status)
+                changed_fields.remove('status')
+
+            # Log other field changes
+            if changed_fields:
+                audit_service.log_transaction_updated(transaction, changed_fields)
+
         db.session.commit()
         flash('Transaction updated successfully!', 'success')
         
@@ -396,8 +450,13 @@ def add_participant(id):
             is_primary=False
         )
         db.session.add(participant)
+        db.session.flush()  # Get participant ID
+
+        # Log audit event
+        audit_service.log_participant_added(transaction, participant)
+
         db.session.commit()
-        
+
         return jsonify({
             'success': True,
             'participant': {
@@ -407,7 +466,7 @@ def add_participant(id):
                 'email': participant.display_email
             }
         })
-        
+
     except Exception as e:
         db.session.rollback()
         return jsonify({'success': False, 'error': str(e)}), 500
@@ -419,16 +478,19 @@ def add_participant(id):
 def remove_participant(id, participant_id):
     """Remove a participant from a transaction."""
     transaction = Transaction.query.get_or_404(id)
-    
+
     if transaction.created_by_id != current_user.id:
         abort(403)
-    
+
     participant = TransactionParticipant.query.get_or_404(participant_id)
-    
+
     if participant.transaction_id != transaction.id:
         abort(404)
-    
+
     try:
+        # Log audit event before deletion
+        audit_service.log_participant_removed(transaction, participant)
+
         db.session.delete(participant)
         db.session.commit()
         return jsonify({'success': True})
@@ -608,14 +670,18 @@ def save_intake(id):
     try:
         # Save the intake data
         transaction.intake_data = intake_data
+
+        # Log audit event
+        audit_service.log_intake_saved(transaction, intake_data)
+
         db.session.commit()
-        
+
         if request.is_json:
             return jsonify({'success': True, 'intake_data': intake_data})
         else:
             flash('Questionnaire saved successfully!', 'success')
             return redirect(url_for('transactions.view_transaction', id=id))
-            
+
     except Exception as e:
         db.session.rollback()
         if request.is_json:
@@ -691,9 +757,19 @@ def generate_document_package(id):
                 tx_doc.field_data = field_data
             
             db.session.add(tx_doc)
-        
+
+        db.session.flush()  # Get document IDs
+
+        # Log audit event for package generation
+        created_docs = transaction.documents.all()
+        audit_service.log_document_package_generated(transaction, created_docs)
+
+        # Also log each individual document addition
+        for doc in created_docs:
+            audit_service.log_document_added(doc, doc.included_reason)
+
         db.session.commit()
-        
+
         flash(f'Document package generated with {len(required_docs)} documents!', 'success')
         return redirect(url_for('transactions.view_transaction', id=id))
         
@@ -742,8 +818,13 @@ def add_document(id):
             status='pending'
         )
         db.session.add(doc)
+        db.session.flush()  # Get doc ID
+
+        # Log audit event
+        audit_service.log_document_added(doc, reason)
+
         db.session.commit()
-        
+
         return jsonify({
             'success': True,
             'document': {
@@ -752,7 +833,7 @@ def add_document(id):
                 'status': doc.status
             }
         })
-        
+
     except Exception as e:
         db.session.rollback()
         return jsonify({'success': False, 'error': str(e)}), 500
@@ -764,16 +845,19 @@ def add_document(id):
 def remove_document(id, doc_id):
     """Remove a document from a transaction."""
     transaction = Transaction.query.get_or_404(id)
-    
+
     if transaction.created_by_id != current_user.id:
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
-    
+
     doc = TransactionDocument.query.get_or_404(doc_id)
-    
+
     if doc.transaction_id != transaction.id:
         return jsonify({'success': False, 'error': 'Document not found'}), 404
-    
+
     try:
+        # Log audit event before deletion
+        audit_service.log_document_removed(transaction.id, doc.id, doc.template_name)
+
         db.session.delete(doc)
         db.session.commit()
         return jsonify({'success': True})
@@ -974,17 +1058,26 @@ def save_document_form(id, doc_id):
                 if key.startswith('field_'):
                     field_data[key[6:]] = request.form.get(key)
         
+        # Track changed fields for audit
+        old_fields = set(doc.field_data.keys()) if doc.field_data else set()
+        new_fields = set(field_data.keys())
+        changed_fields = list(new_fields - old_fields) if old_fields != new_fields else list(new_fields)
+
         # Save field data
         doc.field_data = field_data
         doc.status = 'filled'
+
+        # Log audit event
+        audit_service.log_document_filled(doc, changed_fields)
+
         db.session.commit()
-        
+
         if request.is_json:
             return jsonify({'success': True, 'status': doc.status})
         else:
             # Check if this is "Save & Continue" (redirect to preview) or just "Save Draft"
             action = request.form.get('submit_action', 'save')
-            
+
             if action == 'continue':
                 # Redirect to document preview
                 return redirect(url_for('transactions.document_preview', id=id, doc_id=doc_id))
@@ -1547,12 +1640,13 @@ def send_all_for_signature(id):
             doc.status = 'sent'
             doc.docuseal_submission_id = str(submission_id)
             doc.sent_at = datetime.utcnow()
-            
+            doc.sent_by_id = current_user.id  # Track who sent
+
             # Create signature records for each signer
             for submitter_data in result.get('submitters', []):
                 role = submitter_data.get('role')
                 participant = participant_by_role.get(role)
-                
+
                 signature = DocumentSignature(
                     document_id=doc.id,
                     participant_id=participant.id if participant else None,
@@ -1564,7 +1658,11 @@ def send_all_for_signature(id):
                     sent_at=datetime.utcnow()
                 )
                 db.session.add(signature)
-        
+
+        # Log audit event for envelope sent
+        signer_info = [{'email': s.email, 'role': s.role} for s in submitters]
+        audit_service.log_envelope_sent(transaction, documents, submitters, submission_id)
+
         db.session.commit()
         
         doc_count = len(documents)
@@ -1984,22 +2082,26 @@ def void_document(id, doc_id):
         }), 400
     
     try:
+        # Log audit event before voiding
+        audit_service.log_document_voided(doc)
+
         # Clear DocuSeal submission info
         doc.docuseal_submission_id = None
         doc.sent_at = None
+        doc.sent_by_id = None
         doc.status = 'filled'  # Reset to filled so they can preview again
-        
+
         # Delete any signature records
         DocumentSignature.query.filter_by(document_id=doc.id).delete()
-        
+
         db.session.commit()
-        
+
         return jsonify({
             'success': True,
             'message': 'Document voided. You can now edit and resend.',
             'new_status': 'filled'
         })
-        
+
     except Exception as e:
         db.session.rollback()
         return jsonify({'success': False, 'error': str(e)}), 500
@@ -2014,29 +2116,29 @@ def resend_signature_request(id, doc_id):
     This uses the existing DocuSeal submission without creating a new one.
     """
     from services.docuseal_service import resend_signature_emails, DOCUSEAL_MOCK_MODE
-    
+
     transaction = Transaction.query.get_or_404(id)
-    
+
     if transaction.created_by_id != current_user.id:
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
-    
+
     doc = TransactionDocument.query.get_or_404(doc_id)
-    
+
     if doc.transaction_id != transaction.id:
         return jsonify({'success': False, 'error': 'Document not found'}), 404
-    
+
     if doc.status != 'sent':
         return jsonify({
             'success': False,
             'error': f'Cannot resend document in "{doc.status}" status. Document must be in "sent" status.'
         }), 400
-    
+
     if not doc.docuseal_submission_id:
         return jsonify({
             'success': False,
             'error': 'Document has not been sent for signature'
         }), 400
-    
+
     try:
         # Resend emails to pending submitters
         result = resend_signature_emails(
@@ -2046,7 +2148,10 @@ def resend_signature_request(id, doc_id):
                 'body': f'This is a reminder to sign the {doc.template_name} for {transaction.street_address}. Click here to sign: {{{{submitter.link}}}}'
             }
         )
-        
+
+        # Log audit event
+        audit_service.log_document_resent(doc, result.get('resent_count', 0))
+
         return jsonify({
             'success': True,
             'resent_count': result.get('resent_count', 0),
@@ -2253,63 +2358,198 @@ def docuseal_status():
 def docuseal_webhook():
     """
     Receive webhooks from DocuSeal for signature events.
-    
+
     Configure this URL in DocuSeal: https://yourdomain.com/transactions/webhook/docuseal
-    
+
     Events:
     - form.viewed: Signer opened the document
     - form.started: Signer began filling
     - form.completed: All signers finished
     """
     from services.docuseal_service import process_webhook
-    
+
     try:
         payload = request.get_json()
-        
+
         if not payload:
             return jsonify({'error': 'No payload'}), 400
-        
+
         # Process the webhook
         result = process_webhook(payload)
         event_type = result.get('event_type')
         submission_id = result.get('submission_id')
-        
+
+        # Extract signer info from payload
+        submitter_data = payload.get('data', {})
+        signer_email = submitter_data.get('email')
+        signer_role = submitter_data.get('role')
+
         # Find the document by submission ID
         doc = TransactionDocument.query.filter_by(
             docuseal_submission_id=str(submission_id)
         ).first()
-        
+
         if not doc:
-            # Log but don't error - might be from a different source
+            # Log webhook received even if no matching doc (for debugging)
+            audit_service.log_webhook_received(None, None, event_type, payload)
             return jsonify({'received': True, 'matched': False})
-        
+
+        # Log webhook received for audit trail
+        audit_service.log_webhook_received(doc.transaction_id, doc.id, event_type, payload)
+
+        # Find matching signature record if possible
+        signature = None
+        if signer_email:
+            signature = DocumentSignature.query.filter_by(
+                document_id=doc.id,
+                signer_email=signer_email
+            ).first()
+
         # Update based on event type
         if event_type == 'form.viewed':
-            # Update signature record
-            pass  # Optionally track viewed_at
-            
+            # Update signature record with viewed timestamp
+            if signature:
+                signature.viewed_at = datetime.utcnow()
+                signature.status = 'viewed'
+
+            # Log document viewed event
+            audit_service.log_document_viewed(doc, signature, {
+                'signer_email': signer_email,
+                'signer_role': signer_role,
+                'submission_id': submission_id
+            })
+
+            db.session.commit()
+
         elif event_type == 'form.started':
-            # Signer started filling
+            # Signer started filling - just log
             pass
-            
+
         elif event_type == 'form.completed':
-            # All signers finished!
+            # Check if this is a single signer completion or all signers
+            # For now assume all signers finished
             doc.status = 'signed'
-            doc.signed_at = db.func.now()
-            
+            doc.signed_at = datetime.utcnow()
+
             # Update all signature records
             signatures = DocumentSignature.query.filter_by(document_id=doc.id).all()
             for sig in signatures:
-                sig.signed_at = db.func.now()
-            
+                sig.signed_at = datetime.utcnow()
+                sig.status = 'signed'
+
+            # Log document signed event
+            audit_service.log_document_signed(doc, signature, {
+                'signer_email': signer_email,
+                'signer_role': signer_role,
+                'submission_id': submission_id
+            })
+
             db.session.commit()
-        
+
         return jsonify({
             'received': True,
             'event': event_type,
             'document_id': doc.id if doc else None
         })
-        
+
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
+
+# =============================================================================
+# AUDIT HISTORY API
+# =============================================================================
+
+@transactions_bp.route('/<int:id>/history')
+@login_required
+@transactions_required
+def transaction_history(id):
+    """
+    Get the audit history for a transaction.
+    Returns a paginated list of all events related to this transaction.
+    """
+    transaction = Transaction.query.get_or_404(id)
+
+    if transaction.created_by_id != current_user.id:
+        abort(403)
+
+    # Get pagination params
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 50, type=int)
+    per_page = min(per_page, 100)  # Max 100 per page
+
+    # Get events
+    events = audit_service.get_transaction_history(
+        transaction_id=id,
+        limit=per_page,
+        offset=(page - 1) * per_page
+    )
+
+    # Format for display
+    formatted_events = [audit_service.format_event_for_display(e) for e in events]
+
+    # Get total count for pagination
+    total = AuditEvent.query.filter_by(transaction_id=id).count()
+
+    return jsonify({
+        'success': True,
+        'events': formatted_events,
+        'pagination': {
+            'page': page,
+            'per_page': per_page,
+            'total': total,
+            'pages': (total + per_page - 1) // per_page
+        }
+    })
+
+
+@transactions_bp.route('/<int:id>/history/view')
+@login_required
+@transactions_required
+def view_transaction_history(id):
+    """
+    Render the transaction history page.
+    """
+    transaction = Transaction.query.get_or_404(id)
+
+    if transaction.created_by_id != current_user.id:
+        abort(403)
+
+    return render_template(
+        'transactions/history.html',
+        transaction=transaction
+    )
+
+
+@transactions_bp.route('/<int:id>/documents/<int:doc_id>/history')
+@login_required
+@transactions_required
+def document_history(id, doc_id):
+    """
+    Get the audit history for a specific document.
+    """
+    transaction = Transaction.query.get_or_404(id)
+
+    if transaction.created_by_id != current_user.id:
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+
+    doc = TransactionDocument.query.get_or_404(doc_id)
+
+    if doc.transaction_id != transaction.id:
+        return jsonify({'success': False, 'error': 'Document not found'}), 404
+
+    # Get events for this document
+    events = audit_service.get_document_history(document_id=doc_id)
+
+    # Format for display
+    formatted_events = [audit_service.format_event_for_display(e) for e in events]
+
+    return jsonify({
+        'success': True,
+        'document': {
+            'id': doc.id,
+            'name': doc.template_name,
+            'status': doc.status
+        },
+        'events': formatted_events
+    })

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -1,0 +1,527 @@
+"""
+Audit Service - Centralized audit trail logging for transactions and documents.
+
+Provides helper functions to log audit events consistently throughout the application.
+All significant actions in the document generation and e-signature flow are tracked.
+"""
+
+from flask import request
+from flask_login import current_user
+from models import db, AuditEvent
+
+
+def get_request_context():
+    """
+    Extract IP address and user agent from the current request.
+    Returns (ip_address, user_agent) tuple.
+    """
+    ip_address = None
+    user_agent = None
+
+    try:
+        if request:
+            # Get IP, handling proxies
+            ip_address = request.headers.get('X-Forwarded-For', request.remote_addr)
+            if ip_address and ',' in ip_address:
+                ip_address = ip_address.split(',')[0].strip()
+
+            user_agent = request.headers.get('User-Agent', '')[:500]  # Truncate if too long
+    except RuntimeError:
+        # Outside of request context
+        pass
+
+    return ip_address, user_agent
+
+
+def get_current_actor_id():
+    """Get the current user's ID if authenticated."""
+    try:
+        if current_user and current_user.is_authenticated:
+            return current_user.id
+    except RuntimeError:
+        pass
+    return None
+
+
+def log_event(event_type, transaction_id=None, document_id=None, signature_id=None,
+              description=None, metadata=None, source='app', actor_id=None):
+    """
+    Log an audit event with automatic context extraction.
+
+    Args:
+        event_type: One of the AuditEvent type constants
+        transaction_id: ID of the related transaction
+        document_id: ID of the related document (optional)
+        signature_id: ID of the related signature (optional)
+        description: Human-readable description of the event
+        metadata: Dict of additional context data
+        source: Source of the event ('app', 'webhook', 'system', 'api')
+        actor_id: Override for the actor (defaults to current user)
+
+    Returns:
+        The created AuditEvent instance
+    """
+    ip_address, user_agent = get_request_context()
+
+    if actor_id is None:
+        actor_id = get_current_actor_id()
+
+    event = AuditEvent.log(
+        event_type=event_type,
+        transaction_id=transaction_id,
+        document_id=document_id,
+        signature_id=signature_id,
+        actor_id=actor_id,
+        description=description,
+        metadata=metadata or {},
+        source=source,
+        ip_address=ip_address,
+        user_agent=user_agent
+    )
+
+    return event
+
+
+# =============================================================================
+# TRANSACTION EVENTS
+# =============================================================================
+
+def log_transaction_created(transaction, actor_id=None):
+    """Log when a transaction is created."""
+    return log_event(
+        event_type=AuditEvent.TRANSACTION_CREATED,
+        transaction_id=transaction.id,
+        description=f"Transaction created for {transaction.street_address}",
+        metadata={
+            'transaction_type': transaction.transaction_type.name if transaction.transaction_type else None,
+            'address': transaction.full_address,
+            'status': transaction.status
+        },
+        actor_id=actor_id
+    )
+
+
+def log_transaction_updated(transaction, changed_fields, actor_id=None):
+    """Log when a transaction is updated."""
+    return log_event(
+        event_type=AuditEvent.TRANSACTION_UPDATED,
+        transaction_id=transaction.id,
+        description=f"Transaction updated",
+        metadata={
+            'changed_fields': changed_fields
+        },
+        actor_id=actor_id
+    )
+
+
+def log_transaction_status_changed(transaction, old_status, new_status, actor_id=None):
+    """Log when a transaction status changes."""
+    return log_event(
+        event_type=AuditEvent.TRANSACTION_STATUS_CHANGED,
+        transaction_id=transaction.id,
+        description=f"Status changed from '{old_status}' to '{new_status}'",
+        metadata={
+            'old_status': old_status,
+            'new_status': new_status
+        },
+        actor_id=actor_id
+    )
+
+
+def log_transaction_deleted(transaction_id, address, actor_id=None):
+    """Log when a transaction is deleted."""
+    return log_event(
+        event_type=AuditEvent.TRANSACTION_DELETED,
+        transaction_id=transaction_id,
+        description=f"Transaction deleted: {address}",
+        metadata={
+            'address': address
+        },
+        actor_id=actor_id
+    )
+
+
+# =============================================================================
+# PARTICIPANT EVENTS
+# =============================================================================
+
+def log_participant_added(transaction, participant, actor_id=None):
+    """Log when a participant is added to a transaction."""
+    return log_event(
+        event_type=AuditEvent.PARTICIPANT_ADDED,
+        transaction_id=transaction.id,
+        description=f"Added {participant.role}: {participant.display_name}",
+        metadata={
+            'participant_id': participant.id,
+            'role': participant.role,
+            'name': participant.display_name,
+            'email': participant.display_email,
+            'contact_id': participant.contact_id,
+            'user_id': participant.user_id
+        },
+        actor_id=actor_id
+    )
+
+
+def log_participant_removed(transaction, participant, actor_id=None):
+    """Log when a participant is removed from a transaction."""
+    return log_event(
+        event_type=AuditEvent.PARTICIPANT_REMOVED,
+        transaction_id=transaction.id,
+        description=f"Removed {participant.role}: {participant.display_name}",
+        metadata={
+            'participant_id': participant.id,
+            'role': participant.role,
+            'name': participant.display_name,
+            'email': participant.display_email
+        },
+        actor_id=actor_id
+    )
+
+
+# =============================================================================
+# DOCUMENT LIFECYCLE EVENTS
+# =============================================================================
+
+def log_document_added(document, reason=None, actor_id=None):
+    """Log when a document is added to a transaction."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_ADDED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Document added: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'template_name': document.template_name,
+            'included_reason': reason or document.included_reason
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_removed(transaction_id, document_id, template_name, actor_id=None):
+    """Log when a document is removed from a transaction."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_REMOVED,
+        transaction_id=transaction_id,
+        document_id=document_id,
+        description=f"Document removed: {template_name}",
+        metadata={
+            'template_name': template_name
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_filled(document, changed_fields=None, actor_id=None):
+    """Log when a document form is filled/updated."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_FILLED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Document form saved: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'changed_fields': changed_fields,
+            'field_count': len(document.field_data) if document.field_data else 0
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_generated(document, actor_id=None):
+    """Log when a document preview is generated."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_GENERATED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Document preview generated: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'docuseal_submission_id': document.docuseal_submission_id
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_package_generated(transaction, documents, actor_id=None):
+    """Log when a document package is generated from intake."""
+    doc_names = [d.template_name for d in documents]
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_PACKAGE_GENERATED,
+        transaction_id=transaction.id,
+        description=f"Document package generated with {len(documents)} documents",
+        metadata={
+            'document_count': len(documents),
+            'documents': doc_names
+        },
+        actor_id=actor_id
+    )
+
+
+def log_intake_saved(transaction, intake_data, actor_id=None):
+    """Log when intake questionnaire is saved."""
+    return log_event(
+        event_type=AuditEvent.INTAKE_SAVED,
+        transaction_id=transaction.id,
+        description="Intake questionnaire saved",
+        metadata={
+            'question_count': len(intake_data) if intake_data else 0,
+            'questions_answered': list(intake_data.keys()) if intake_data else []
+        },
+        actor_id=actor_id
+    )
+
+
+# =============================================================================
+# E-SIGNATURE EVENTS
+# =============================================================================
+
+def log_document_sent(document, signers, submission_id, actor_id=None):
+    """Log when a document is sent for signature."""
+    signer_info = [{'email': s.get('email'), 'role': s.get('role')} for s in signers]
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_SENT,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Document sent for signature: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'docuseal_submission_id': submission_id,
+            'signers': signer_info,
+            'signer_count': len(signers)
+        },
+        actor_id=actor_id
+    )
+
+
+def log_envelope_sent(transaction, documents, signers, submission_id, actor_id=None):
+    """Log when multiple documents are sent as one envelope."""
+    doc_names = [d.template_name for d in documents]
+    signer_info = [{'email': s.email if hasattr(s, 'email') else s.get('email'),
+                    'role': s.role if hasattr(s, 'role') else s.get('role')} for s in signers]
+    return log_event(
+        event_type=AuditEvent.ENVELOPE_SENT,
+        transaction_id=transaction.id,
+        description=f"Document package sent for signature ({len(documents)} documents)",
+        metadata={
+            'docuseal_submission_id': submission_id,
+            'documents': doc_names,
+            'document_count': len(documents),
+            'signers': signer_info,
+            'signer_count': len(signers)
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_resent(document, resent_count, actor_id=None):
+    """Log when signature request emails are resent."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_RESENT,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Signature request resent for: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'docuseal_submission_id': document.docuseal_submission_id,
+            'resent_count': resent_count
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_voided(document, actor_id=None):
+    """Log when a document is voided/reset."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_VOIDED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        description=f"Document voided: {document.template_name}",
+        metadata={
+            'template_slug': document.template_slug,
+            'previous_submission_id': document.docuseal_submission_id
+        },
+        actor_id=actor_id
+    )
+
+
+def log_document_viewed(document, signature, webhook_data=None):
+    """Log when a signer views a document (from webhook)."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_VIEWED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        signature_id=signature.id if signature else None,
+        description=f"Document viewed by {signature.signer_name if signature else 'signer'}",
+        metadata={
+            'signer_email': signature.signer_email if signature else None,
+            'signer_role': signature.signer_role if signature else None,
+            'webhook_data': webhook_data
+        },
+        source='webhook',
+        actor_id=None  # Webhook events have no actor
+    )
+
+
+def log_document_signed(document, signature=None, webhook_data=None):
+    """Log when a document is signed (from webhook or completion)."""
+    return log_event(
+        event_type=AuditEvent.DOCUMENT_SIGNED,
+        transaction_id=document.transaction_id,
+        document_id=document.id,
+        signature_id=signature.id if signature else None,
+        description=f"Document signed: {document.template_name}" +
+                    (f" by {signature.signer_name}" if signature else ""),
+        metadata={
+            'template_slug': document.template_slug,
+            'signer_email': signature.signer_email if signature else None,
+            'signer_role': signature.signer_role if signature else None,
+            'docuseal_submission_id': document.docuseal_submission_id,
+            'webhook_data': webhook_data
+        },
+        source='webhook' if webhook_data else 'app',
+        actor_id=None  # Signature events have no app actor
+    )
+
+
+# =============================================================================
+# WEBHOOK EVENTS
+# =============================================================================
+
+def log_webhook_received(transaction_id, document_id, event_type, raw_payload):
+    """Log raw webhook receipt for audit trail."""
+    # Sanitize payload - remove any sensitive data
+    sanitized_payload = {
+        'event_type': raw_payload.get('event_type'),
+        'submission_id': raw_payload.get('submission_id'),
+        'submitter_id': raw_payload.get('data', {}).get('id') if raw_payload.get('data') else None,
+        'status': raw_payload.get('data', {}).get('status') if raw_payload.get('data') else None,
+    }
+
+    return log_event(
+        event_type=AuditEvent.WEBHOOK_RECEIVED,
+        transaction_id=transaction_id,
+        document_id=document_id,
+        description=f"Webhook received: {event_type}",
+        metadata={
+            'webhook_event_type': event_type,
+            'payload_summary': sanitized_payload
+        },
+        source='webhook',
+        actor_id=None
+    )
+
+
+# =============================================================================
+# QUERY HELPERS
+# =============================================================================
+
+def get_transaction_history(transaction_id, limit=100, offset=0):
+    """
+    Get audit history for a transaction, ordered by most recent first.
+
+    Args:
+        transaction_id: The transaction ID to query
+        limit: Maximum number of events to return
+        offset: Number of events to skip
+
+    Returns:
+        List of AuditEvent objects
+    """
+    return AuditEvent.query.filter_by(
+        transaction_id=transaction_id
+    ).order_by(
+        AuditEvent.created_at.desc()
+    ).offset(offset).limit(limit).all()
+
+
+def get_document_history(document_id, limit=50, offset=0):
+    """
+    Get audit history for a specific document.
+
+    Args:
+        document_id: The document ID to query
+        limit: Maximum number of events to return
+        offset: Number of events to skip
+
+    Returns:
+        List of AuditEvent objects
+    """
+    return AuditEvent.query.filter_by(
+        document_id=document_id
+    ).order_by(
+        AuditEvent.created_at.desc()
+    ).offset(offset).limit(limit).all()
+
+
+def get_user_activity(user_id, limit=50, offset=0):
+    """
+    Get audit history for actions by a specific user.
+
+    Args:
+        user_id: The user ID to query
+        limit: Maximum number of events to return
+        offset: Number of events to skip
+
+    Returns:
+        List of AuditEvent objects
+    """
+    return AuditEvent.query.filter_by(
+        actor_id=user_id
+    ).order_by(
+        AuditEvent.created_at.desc()
+    ).offset(offset).limit(limit).all()
+
+
+def format_event_for_display(event):
+    """
+    Format an audit event for display in the UI.
+
+    Returns a dict with display-friendly data.
+    """
+    # Map event types to icons and colors
+    event_display = {
+        AuditEvent.TRANSACTION_CREATED: {'icon': 'fas fa-plus-circle', 'color': 'success', 'label': 'Transaction Created'},
+        AuditEvent.TRANSACTION_UPDATED: {'icon': 'fas fa-edit', 'color': 'info', 'label': 'Transaction Updated'},
+        AuditEvent.TRANSACTION_STATUS_CHANGED: {'icon': 'fas fa-exchange-alt', 'color': 'warning', 'label': 'Status Changed'},
+        AuditEvent.TRANSACTION_DELETED: {'icon': 'fas fa-trash', 'color': 'danger', 'label': 'Transaction Deleted'},
+        AuditEvent.PARTICIPANT_ADDED: {'icon': 'fas fa-user-plus', 'color': 'success', 'label': 'Participant Added'},
+        AuditEvent.PARTICIPANT_REMOVED: {'icon': 'fas fa-user-minus', 'color': 'danger', 'label': 'Participant Removed'},
+        AuditEvent.DOCUMENT_ADDED: {'icon': 'fas fa-file-medical', 'color': 'success', 'label': 'Document Added'},
+        AuditEvent.DOCUMENT_REMOVED: {'icon': 'fas fa-file-excel', 'color': 'danger', 'label': 'Document Removed'},
+        AuditEvent.DOCUMENT_FILLED: {'icon': 'fas fa-file-alt', 'color': 'info', 'label': 'Document Filled'},
+        AuditEvent.DOCUMENT_GENERATED: {'icon': 'fas fa-file-pdf', 'color': 'primary', 'label': 'Preview Generated'},
+        AuditEvent.DOCUMENT_PACKAGE_GENERATED: {'icon': 'fas fa-folder-plus', 'color': 'success', 'label': 'Package Generated'},
+        AuditEvent.DOCUMENT_SENT: {'icon': 'fas fa-paper-plane', 'color': 'primary', 'label': 'Sent for Signature'},
+        AuditEvent.ENVELOPE_SENT: {'icon': 'fas fa-envelope', 'color': 'primary', 'label': 'Envelope Sent'},
+        AuditEvent.DOCUMENT_RESENT: {'icon': 'fas fa-redo', 'color': 'warning', 'label': 'Resent'},
+        AuditEvent.DOCUMENT_VOIDED: {'icon': 'fas fa-ban', 'color': 'danger', 'label': 'Document Voided'},
+        AuditEvent.DOCUMENT_VIEWED: {'icon': 'fas fa-eye', 'color': 'info', 'label': 'Viewed'},
+        AuditEvent.DOCUMENT_SIGNED: {'icon': 'fas fa-signature', 'color': 'success', 'label': 'Signed'},
+        AuditEvent.WEBHOOK_RECEIVED: {'icon': 'fas fa-webhook', 'color': 'secondary', 'label': 'Webhook'},
+        AuditEvent.INTAKE_SAVED: {'icon': 'fas fa-clipboard-check', 'color': 'info', 'label': 'Intake Saved'},
+    }
+
+    display = event_display.get(event.event_type, {
+        'icon': 'fas fa-circle',
+        'color': 'secondary',
+        'label': event.event_type.replace('_', ' ').title()
+    })
+
+    return {
+        'id': event.id,
+        'event_type': event.event_type,
+        'description': event.description,
+        'metadata': event.metadata,
+        'source': event.source,
+        'created_at': event.created_at.isoformat() if event.created_at else None,
+        'actor_id': event.actor_id,
+        'actor_name': f"{event.actor.first_name} {event.actor.last_name}" if event.actor else None,
+        'document_id': event.document_id,
+        'signature_id': event.signature_id,
+        'icon': display['icon'],
+        'color': display['color'],
+        'label': display['label'],
+        'ip_address': event.ip_address
+    }

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -296,12 +296,21 @@
                 </div>
             </div>
             
-            <!-- Delete Button -->
-            <button onclick="confirmDelete()" 
-                    class="premium-btn px-4 py-2 text-sm border-2 border-red-200 text-red-600 bg-red-50 hover:bg-red-100 flex items-center gap-2">
-                <i class="fas fa-trash-alt"></i>
-                <span class="hidden sm:inline">Delete</span>
-            </button>
+            <!-- Action Buttons -->
+            <div class="flex items-center gap-2">
+                <!-- History Button -->
+                <a href="{{ url_for('transactions.view_transaction_history', id=transaction.id) }}"
+                   class="premium-btn px-4 py-2 text-sm border-2 border-slate-200 text-slate-600 bg-slate-50 hover:bg-slate-100 flex items-center gap-2">
+                    <i class="fas fa-history"></i>
+                    <span class="hidden sm:inline">History</span>
+                </a>
+                <!-- Delete Button -->
+                <button onclick="confirmDelete()"
+                        class="premium-btn px-4 py-2 text-sm border-2 border-red-200 text-red-600 bg-red-50 hover:bg-red-100 flex items-center gap-2">
+                    <i class="fas fa-trash-alt"></i>
+                    <span class="hidden sm:inline">Delete</span>
+                </button>
+            </div>
         </div>
 
         <!-- Prominent Type & Status Badges -->

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -785,52 +785,112 @@
                     </div>
                 </div>
 
-                <!-- Transaction Timeline Card -->
+                <!-- Recent Activity Card -->
                 <div class="premium-card p-6 animate-fade-in-up-delay-2">
-                    <div class="flex items-center gap-3 mb-5">
-                        <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-slate-500 to-slate-600 flex items-center justify-center">
-                            <i class="fas fa-history text-white"></i>
+                    <div class="flex items-center justify-between mb-5">
+                        <div class="flex items-center gap-3">
+                            <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-slate-500 to-slate-600 flex items-center justify-center">
+                                <i class="fas fa-clock-rotate-left text-white"></i>
+                            </div>
+                            <h2 class="text-lg font-bold text-slate-800">Recent Activity</h2>
                         </div>
-                        <h2 class="text-lg font-bold text-slate-800">Timeline</h2>
+                        <a href="{{ url_for('transactions.view_transaction_history', id=transaction.id) }}" 
+                           class="text-xs font-medium text-orange-600 hover:text-orange-700 flex items-center gap-1 transition-colors">
+                            View All
+                            <i class="fas fa-arrow-right text-[10px]"></i>
+                        </a>
                     </div>
                     
-                    <div class="space-y-4">
-                        <div class="flex gap-3">
-                            <div class="w-2 h-2 rounded-full bg-green-500 mt-2 flex-shrink-0"></div>
-                            <div>
-                                <div class="text-sm font-medium text-slate-800">Transaction Created</div>
-                                <div class="text-xs text-slate-500">{{ transaction.created_at.strftime('%b %d, %Y at %I:%M %p') }}</div>
-                            </div>
+                    <div id="activity-feed" class="space-y-3">
+                        <div class="flex justify-center py-4">
+                            <div class="w-5 h-5 border-2 border-gray-200 border-t-orange-500 rounded-full animate-spin"></div>
                         </div>
-                        {% if transaction.intake_data %}
-                        <div class="flex gap-3">
-                            <div class="w-2 h-2 rounded-full bg-purple-500 mt-2 flex-shrink-0"></div>
-                            <div>
-                                <div class="text-sm font-medium text-slate-800">Questionnaire Completed</div>
-                                <div class="text-xs text-slate-500">Property details gathered</div>
-                            </div>
-                        </div>
-                        {% endif %}
-                        {% if documents|length > 0 %}
-                        <div class="flex gap-3">
-                            <div class="w-2 h-2 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-                            <div>
-                                <div class="text-sm font-medium text-slate-800">{{ documents|length }} Document{% if documents|length != 1 %}s{% endif %} Added</div>
-                                <div class="text-xs text-slate-500">Document package created</div>
-                            </div>
-                        </div>
-                        {% endif %}
-                        {% if transaction.status == 'closed' and transaction.actual_close_date %}
-                        <div class="flex gap-3">
-                            <div class="w-2 h-2 rounded-full bg-emerald-500 mt-2 flex-shrink-0"></div>
-                            <div>
-                                <div class="text-sm font-medium text-slate-800">Transaction Closed</div>
-                                <div class="text-xs text-slate-500">{{ transaction.actual_close_date.strftime('%b %d, %Y') }}</div>
-                            </div>
-                        </div>
-                        {% endif %}
+                    </div>
+                    
+                    <div id="activity-footer" class="hidden pt-4 mt-4 border-t border-gray-100">
+                        <a href="{{ url_for('transactions.view_transaction_history', id=transaction.id) }}" 
+                           class="flex items-center justify-center gap-2 w-full py-2.5 px-4 bg-gray-50 hover:bg-gray-100 text-gray-600 hover:text-gray-800 rounded-lg text-sm font-medium transition-colors">
+                            <i class="fas fa-history"></i>
+                            View Full Activity History
+                        </a>
                     </div>
                 </div>
+                
+                <script>
+                (function() {
+                    const feed = document.getElementById('activity-feed');
+                    const footer = document.getElementById('activity-footer');
+                    
+                    fetch('{{ url_for("transactions.transaction_history", id=transaction.id) }}?per_page=5')
+                        .then(r => r.json())
+                        .then(data => {
+                            if (!data.success || !data.events.length) {
+                                feed.innerHTML = `
+                                    <div class="text-center py-4 text-gray-400">
+                                        <i class="fas fa-inbox text-2xl mb-2"></i>
+                                        <p class="text-sm">No activity yet</p>
+                                    </div>
+                                `;
+                                return;
+                            }
+                            
+                            const colorMap = {
+                                success: 'bg-green-500',
+                                info: 'bg-blue-500',
+                                warning: 'bg-amber-500',
+                                danger: 'bg-red-500',
+                                primary: 'bg-orange-500',
+                                secondary: 'bg-gray-400'
+                            };
+                            
+                            let html = data.events.map(e => {
+                                const dotColor = colorMap[e.color] || 'bg-gray-400';
+                                const time = formatRelativeTime(e.created_at);
+                                return `
+                                    <div class="flex gap-3 group">
+                                        <div class="w-2 h-2 rounded-full ${dotColor} mt-1.5 flex-shrink-0 ring-4 ring-white"></div>
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex items-start justify-between gap-2">
+                                                <span class="text-sm font-medium text-gray-800 truncate">${e.label}</span>
+                                                <span class="text-[11px] text-gray-400 whitespace-nowrap">${time}</span>
+                                            </div>
+                                            <p class="text-xs text-gray-500 truncate">${e.description || ''}</p>
+                                            ${e.actor_name ? `<p class="text-[11px] text-gray-400 mt-0.5"><i class="fas fa-user mr-1"></i>${e.actor_name}</p>` : ''}
+                                        </div>
+                                    </div>
+                                `;
+                            }).join('');
+                            
+                            feed.innerHTML = html;
+                            
+                            if (data.pagination.total > 5) {
+                                footer.classList.remove('hidden');
+                            }
+                        })
+                        .catch(err => {
+                            feed.innerHTML = `
+                                <div class="text-center py-4 text-gray-400">
+                                    <i class="fas fa-exclamation-circle text-2xl mb-2"></i>
+                                    <p class="text-sm">Unable to load activity</p>
+                                </div>
+                            `;
+                        });
+                    
+                    function formatRelativeTime(iso) {
+                        if (!iso) return '';
+                        const date = new Date(iso);
+                        const now = new Date();
+                        const diff = Math.floor((now - date) / 1000);
+                        
+                        if (diff < 60) return 'Just now';
+                        if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+                        if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+                        if (diff < 604800) return Math.floor(diff / 86400) + 'd ago';
+                        
+                        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                    }
+                })();
+                </script>
             </div>
         </div>
     </div>

--- a/templates/transactions/history.html
+++ b/templates/transactions/history.html
@@ -4,156 +4,78 @@
 
 {% block content %}
 <style>
-    /* Premium animations */
-    @keyframes fadeInUp {
-        from { opacity: 0; transform: translateY(20px); }
-        to { opacity: 1; transform: translateY(0); }
+    .history-table {
+        width: 100%;
+        border-collapse: collapse;
     }
 
-    .animate-fade-in-up {
-        animation: fadeInUp 0.6s ease-out forwards;
-    }
-
-    /* Premium card styling */
-    .premium-card {
-        background: white;
-        border-radius: 1rem;
-        border: 1px solid #e2e8f0;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-        transition: all 0.2s ease-out;
-    }
-
-    .premium-card:hover {
-        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-    }
-
-    /* Timeline styling */
-    .timeline {
-        position: relative;
-    }
-
-    .timeline::before {
-        content: '';
-        position: absolute;
-        left: 1.5rem;
-        top: 0;
-        bottom: 0;
-        width: 2px;
-        background: linear-gradient(to bottom, #f97316, #ea580c);
-        opacity: 0.2;
-    }
-
-    .timeline-item {
-        position: relative;
-        padding-left: 4rem;
-        padding-bottom: 1.5rem;
-    }
-
-    .timeline-item:last-child {
-        padding-bottom: 0;
-    }
-
-    .timeline-icon {
-        position: absolute;
-        left: 0;
-        width: 3rem;
-        height: 3rem;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.875rem;
-        border: 3px solid white;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-
-    .timeline-icon.success { background: #dcfce7; color: #166534; }
-    .timeline-icon.info { background: #dbeafe; color: #1e40af; }
-    .timeline-icon.warning { background: #fef3c7; color: #92400e; }
-    .timeline-icon.danger { background: #fee2e2; color: #991b1b; }
-    .timeline-icon.primary { background: #fed7aa; color: #c2410c; }
-    .timeline-icon.secondary { background: #f1f5f9; color: #475569; }
-
-    .timeline-content {
-        background: #f8fafc;
-        border-radius: 0.75rem;
-        padding: 1rem 1.25rem;
-        border: 1px solid #e2e8f0;
-        transition: all 0.2s ease-out;
-    }
-
-    .timeline-content:hover {
-        background: white;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-    }
-
-    .timeline-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        margin-bottom: 0.5rem;
-    }
-
-    .timeline-label {
-        font-weight: 600;
-        color: #1e293b;
-        font-size: 0.9375rem;
-    }
-
-    .timeline-time {
+    .history-table th {
+        text-align: left;
+        padding: 0.75rem 1rem;
         font-size: 0.75rem;
-        color: #94a3b8;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+        background: #f8fafc;
+        border-bottom: 2px solid #e2e8f0;
         white-space: nowrap;
     }
 
-    .timeline-description {
-        color: #64748b;
+    .history-table td {
+        padding: 0.875rem 1rem;
         font-size: 0.875rem;
-        line-height: 1.5;
+        color: #334155;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: top;
     }
 
-    .timeline-actor {
+    .history-table tbody tr:hover {
+        background: #fefce8;
+    }
+
+    .history-table tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    .event-badge {
         display: inline-flex;
         align-items: center;
         gap: 0.375rem;
-        font-size: 0.75rem;
-        color: #94a3b8;
-        margin-top: 0.5rem;
-    }
-
-    .timeline-actor i {
-        font-size: 0.625rem;
-    }
-
-    .timeline-metadata {
-        margin-top: 0.75rem;
-        padding-top: 0.75rem;
-        border-top: 1px solid #e2e8f0;
-    }
-
-    .metadata-item {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.375rem;
-        font-size: 0.75rem;
-        color: #64748b;
-        background: #f1f5f9;
         padding: 0.25rem 0.625rem;
         border-radius: 9999px;
-        margin-right: 0.375rem;
-        margin-bottom: 0.375rem;
+        font-size: 0.75rem;
+        font-weight: 500;
+        white-space: nowrap;
     }
 
-    /* Filter buttons */
+    .event-badge.success { background: #dcfce7; color: #166534; }
+    .event-badge.info { background: #dbeafe; color: #1e40af; }
+    .event-badge.warning { background: #fef3c7; color: #92400e; }
+    .event-badge.danger { background: #fee2e2; color: #991b1b; }
+    .event-badge.primary { background: #fed7aa; color: #c2410c; }
+    .event-badge.secondary { background: #f1f5f9; color: #475569; }
+
+    .detail-tag {
+        display: inline-block;
+        padding: 0.125rem 0.5rem;
+        background: #f1f5f9;
+        color: #64748b;
+        border-radius: 0.25rem;
+        font-size: 0.75rem;
+        margin-right: 0.25rem;
+        margin-bottom: 0.25rem;
+    }
+
     .filter-btn {
         padding: 0.5rem 1rem;
-        border-radius: 9999px;
+        border-radius: 0.5rem;
         font-size: 0.75rem;
         font-weight: 500;
         border: 1px solid #e2e8f0;
         background: white;
         color: #64748b;
-        transition: all 0.2s ease-out;
+        transition: all 0.15s ease;
         cursor: pointer;
     }
 
@@ -163,12 +85,17 @@
     }
 
     .filter-btn.active {
-        background: linear-gradient(135deg, #f97316, #ea580c);
+        background: #f97316;
         color: white;
-        border-color: transparent;
+        border-color: #f97316;
     }
 
-    /* Loading spinner */
+    .empty-state {
+        text-align: center;
+        padding: 3rem;
+        color: #94a3b8;
+    }
+
     .loading-spinner {
         display: inline-block;
         width: 1.5rem;
@@ -184,23 +111,40 @@
         100% { transform: rotate(360deg); }
     }
 
-    /* Empty state */
-    .empty-state {
-        text-align: center;
-        padding: 3rem;
-        color: #94a3b8;
-    }
+    @media (max-width: 768px) {
+        .history-table thead {
+            display: none;
+        }
 
-    .empty-state i {
-        font-size: 3rem;
-        margin-bottom: 1rem;
-        opacity: 0.5;
+        .history-table tbody tr {
+            display: block;
+            margin-bottom: 1rem;
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 0.5rem;
+            padding: 0.75rem;
+        }
+
+        .history-table td {
+            display: block;
+            padding: 0.375rem 0;
+            border: none;
+        }
+
+        .history-table td::before {
+            content: attr(data-label);
+            font-weight: 600;
+            font-size: 0.75rem;
+            color: #64748b;
+            display: block;
+            margin-bottom: 0.25rem;
+        }
     }
 </style>
 
-<div class="max-w-6xl mx-auto px-4 py-8">
+<div class="max-w-7xl mx-auto px-4 py-8">
     <!-- Header -->
-    <div class="animate-fade-in-up mb-6">
+    <div class="mb-6">
         <div class="flex items-center gap-3 mb-2">
             <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
                class="text-gray-400 hover:text-gray-600 transition-colors">
@@ -212,7 +156,7 @@
     </div>
 
     <!-- Filters -->
-    <div class="premium-card p-4 mb-6 animate-fade-in-up" style="animation-delay: 0.1s;">
+    <div class="bg-white rounded-lg border border-gray-200 p-4 mb-6">
         <div class="flex flex-wrap items-center gap-2">
             <span class="text-sm text-gray-500 mr-2">Filter:</span>
             <button class="filter-btn active" data-filter="all">All Events</button>
@@ -223,16 +167,32 @@
         </div>
     </div>
 
-    <!-- Timeline -->
-    <div class="premium-card p-6 animate-fade-in-up" style="animation-delay: 0.2s;">
-        <div id="timeline-container">
-            <div class="flex justify-center py-8">
-                <div class="loading-spinner"></div>
-            </div>
+    <!-- History Table -->
+    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="history-table">
+                <thead>
+                    <tr>
+                        <th>Date & Time</th>
+                        <th>Event</th>
+                        <th>Description</th>
+                        <th>Document</th>
+                        <th>User</th>
+                        <th>Details</th>
+                    </tr>
+                </thead>
+                <tbody id="history-body">
+                    <tr>
+                        <td colspan="6" class="text-center py-8">
+                            <div class="loading-spinner"></div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
 
         <!-- Pagination -->
-        <div id="pagination-container" class="hidden mt-6 pt-4 border-t border-gray-100">
+        <div id="pagination-container" class="hidden border-t border-gray-100 px-4 py-3">
             <div class="flex justify-between items-center">
                 <span class="text-sm text-gray-500">
                     Showing <span id="showing-count">0</span> of <span id="total-count">0</span> events
@@ -264,10 +224,9 @@ document.addEventListener('DOMContentLoaded', function() {
         'webhook': ['webhook_received']
     };
 
-    // Fetch and render events
     async function loadEvents(page = 1) {
-        const container = document.getElementById('timeline-container');
-        container.innerHTML = '<div class="flex justify-center py-8"><div class="loading-spinner"></div></div>';
+        const tbody = document.getElementById('history-body');
+        tbody.innerHTML = '<tr><td colspan="6" class="text-center py-8"><div class="loading-spinner"></div></td></tr>';
 
         try {
             const response = await fetch(`{{ url_for('transactions.transaction_history', id=transaction.id) }}?page=${page}&per_page=50`);
@@ -284,120 +243,137 @@ document.addEventListener('DOMContentLoaded', function() {
                 events = events.filter(e => filterMap[currentFilter].includes(e.event_type));
             }
 
-            renderTimeline(events);
+            renderTable(events);
             updatePagination(data.pagination, events.length);
 
         } catch (error) {
-            container.innerHTML = `
-                <div class="empty-state">
-                    <i class="fas fa-exclamation-circle"></i>
-                    <p>Error loading activity history</p>
-                    <p class="text-sm mt-2">${error.message}</p>
-                </div>
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="6" class="empty-state">
+                        <i class="fas fa-exclamation-circle text-3xl mb-2"></i>
+                        <p>Error loading activity history</p>
+                        <p class="text-sm mt-2">${error.message}</p>
+                    </td>
+                </tr>
             `;
         }
     }
 
-    function renderTimeline(events) {
-        const container = document.getElementById('timeline-container');
+    function renderTable(events) {
+        const tbody = document.getElementById('history-body');
 
         if (events.length === 0) {
-            container.innerHTML = `
-                <div class="empty-state">
-                    <i class="fas fa-history"></i>
-                    <p>No activity recorded yet</p>
-                    <p class="text-sm mt-2">Events will appear here as you work with this transaction</p>
-                </div>
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="6" class="empty-state">
+                        <i class="fas fa-history text-3xl mb-2 block"></i>
+                        <p>No activity recorded yet</p>
+                        <p class="text-sm mt-2">Events will appear here as you work with this transaction</p>
+                    </td>
+                </tr>
             `;
             return;
         }
 
-        let html = '<div class="timeline">';
+        let html = '';
 
         events.forEach(event => {
-            const time = formatTime(event.created_at);
-            const metadata = renderMetadata(event);
+            const dateTime = formatDateTime(event.created_at);
+            const details = formatDetails(event.event_data);
+            const docName = event.event_data?.template_name || event.event_data?.documents?.join(', ') || '-';
 
             html += `
-                <div class="timeline-item" data-event-type="${event.event_type}">
-                    <div class="timeline-icon ${event.color}">
-                        <i class="${event.icon}"></i>
-                    </div>
-                    <div class="timeline-content">
-                        <div class="timeline-header">
-                            <span class="timeline-label">${event.label}</span>
-                            <span class="timeline-time">${time}</span>
-                        </div>
-                        <p class="timeline-description">${event.description || ''}</p>
-                        ${event.actor_name ? `
-                            <div class="timeline-actor">
-                                <i class="fas fa-user"></i>
-                                ${event.actor_name}
-                            </div>
-                        ` : ''}
-                        ${metadata}
-                    </div>
-                </div>
+                <tr data-event-type="${event.event_type}">
+                    <td data-label="Date & Time">
+                        <div class="font-medium text-gray-800">${dateTime.date}</div>
+                        <div class="text-xs text-gray-500">${dateTime.time}</div>
+                    </td>
+                    <td data-label="Event">
+                        <span class="event-badge ${event.color}">
+                            <i class="${event.icon}"></i>
+                            ${event.label}
+                        </span>
+                    </td>
+                    <td data-label="Description">
+                        ${event.description || '-'}
+                    </td>
+                    <td data-label="Document">
+                        ${docName}
+                    </td>
+                    <td data-label="User">
+                        ${event.actor_name || '<span class="text-gray-400">System</span>'}
+                    </td>
+                    <td data-label="Details">
+                        ${details || '-'}
+                    </td>
+                </tr>
             `;
         });
 
-        html += '</div>';
-        container.innerHTML = html;
+        tbody.innerHTML = html;
     }
 
-    function renderMetadata(event) {
-        const meta = event.metadata;
+    function formatDateTime(isoString) {
+        if (!isoString) return { date: '-', time: '' };
+        const date = new Date(isoString);
+
+        return {
+            date: date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric'
+            }),
+            time: date.toLocaleTimeString('en-US', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            })
+        };
+    }
+
+    function formatDetails(meta) {
         if (!meta || Object.keys(meta).length === 0) return '';
 
-        let items = [];
+        let tags = [];
 
-        // Document-related
-        if (meta.template_name) items.push(`<span class="metadata-item"><i class="fas fa-file"></i> ${meta.template_name}</span>`);
-        if (meta.document_count) items.push(`<span class="metadata-item"><i class="fas fa-copy"></i> ${meta.document_count} documents</span>`);
-
-        // Participant-related
-        if (meta.role) items.push(`<span class="metadata-item"><i class="fas fa-user-tag"></i> ${meta.role}</span>`);
-        if (meta.name && !event.description.includes(meta.name)) items.push(`<span class="metadata-item"><i class="fas fa-user"></i> ${meta.name}</span>`);
-
-        // Status changes
+        // Status change
         if (meta.old_status && meta.new_status) {
-            items.push(`<span class="metadata-item"><i class="fas fa-exchange-alt"></i> ${formatStatus(meta.old_status)} → ${formatStatus(meta.new_status)}</span>`);
+            tags.push(`<span class="detail-tag">${formatStatus(meta.old_status)} → ${formatStatus(meta.new_status)}</span>`);
         }
 
-        // Signers
-        if (meta.signer_count) items.push(`<span class="metadata-item"><i class="fas fa-signature"></i> ${meta.signer_count} signers</span>`);
-        if (meta.signer_email) items.push(`<span class="metadata-item"><i class="fas fa-envelope"></i> ${meta.signer_email}</span>`);
+        // Participant info (for participant added/removed)
+        if (meta.role && meta.name && !meta.signers) {
+            tags.push(`<span class="detail-tag">${meta.role}: ${meta.name}</span>`);
+        }
 
-        // Resend count
-        if (meta.resent_count !== undefined) items.push(`<span class="metadata-item"><i class="fas fa-redo"></i> ${meta.resent_count} emails resent</span>`);
+        // Signers info (for document/envelope sent)
+        if (meta.signers && meta.signers.length > 0) {
+            meta.signers.forEach(s => {
+                const name = s.name || s.email;
+                const role = s.role || 'Signer';
+                tags.push(`<span class="detail-tag"><i class="fas fa-user text-xs mr-1"></i>${name} (${role})</span>`);
+            });
+        } else if (meta.signer_email) {
+            // Fallback for single signer info
+            tags.push(`<span class="detail-tag">${meta.signer_email}</span>`);
+        }
 
-        // DocuSeal ID
-        if (meta.docuseal_submission_id) items.push(`<span class="metadata-item"><i class="fas fa-hashtag"></i> ${meta.docuseal_submission_id}</span>`);
+        // Document count (for envelope)
+        if (meta.document_count && meta.document_count > 1) {
+            tags.push(`<span class="detail-tag"><i class="fas fa-copy text-xs mr-1"></i>${meta.document_count} docs</span>`);
+        }
 
-        if (items.length === 0) return '';
+        // Submission ID
+        if (meta.docuseal_submission_id) {
+            tags.push(`<span class="detail-tag">ID: ${meta.docuseal_submission_id}</span>`);
+        }
 
-        return `<div class="timeline-metadata">${items.join('')}</div>`;
-    }
+        // IP address (for webhooks/compliance)
+        if (meta.ip_address) {
+            tags.push(`<span class="detail-tag">IP: ${meta.ip_address}</span>`);
+        }
 
-    function formatTime(isoString) {
-        if (!isoString) return '';
-        const date = new Date(isoString);
-        const now = new Date();
-        const diffMs = now - date;
-        const diffMins = Math.floor(diffMs / 60000);
-        const diffHours = Math.floor(diffMs / 3600000);
-        const diffDays = Math.floor(diffMs / 86400000);
-
-        if (diffMins < 1) return 'Just now';
-        if (diffMins < 60) return `${diffMins}m ago`;
-        if (diffHours < 24) return `${diffHours}h ago`;
-        if (diffDays < 7) return `${diffDays}d ago`;
-
-        return date.toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
-        });
+        return tags.join('');
     }
 
     function formatStatus(status) {

--- a/templates/transactions/history.html
+++ b/templates/transactions/history.html
@@ -1,0 +1,456 @@
+{% extends "base.html" %}
+
+{% block title %}Activity History - {{ transaction.street_address }} - TechnolOG{% endblock %}
+
+{% block content %}
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    /* Premium card styling */
+    .premium-card {
+        background: white;
+        border-radius: 1rem;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        transition: all 0.2s ease-out;
+    }
+
+    .premium-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+
+    /* Timeline styling */
+    .timeline {
+        position: relative;
+    }
+
+    .timeline::before {
+        content: '';
+        position: absolute;
+        left: 1.5rem;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        background: linear-gradient(to bottom, #f97316, #ea580c);
+        opacity: 0.2;
+    }
+
+    .timeline-item {
+        position: relative;
+        padding-left: 4rem;
+        padding-bottom: 1.5rem;
+    }
+
+    .timeline-item:last-child {
+        padding-bottom: 0;
+    }
+
+    .timeline-icon {
+        position: absolute;
+        left: 0;
+        width: 3rem;
+        height: 3rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.875rem;
+        border: 3px solid white;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .timeline-icon.success { background: #dcfce7; color: #166534; }
+    .timeline-icon.info { background: #dbeafe; color: #1e40af; }
+    .timeline-icon.warning { background: #fef3c7; color: #92400e; }
+    .timeline-icon.danger { background: #fee2e2; color: #991b1b; }
+    .timeline-icon.primary { background: #fed7aa; color: #c2410c; }
+    .timeline-icon.secondary { background: #f1f5f9; color: #475569; }
+
+    .timeline-content {
+        background: #f8fafc;
+        border-radius: 0.75rem;
+        padding: 1rem 1.25rem;
+        border: 1px solid #e2e8f0;
+        transition: all 0.2s ease-out;
+    }
+
+    .timeline-content:hover {
+        background: white;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    }
+
+    .timeline-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 0.5rem;
+    }
+
+    .timeline-label {
+        font-weight: 600;
+        color: #1e293b;
+        font-size: 0.9375rem;
+    }
+
+    .timeline-time {
+        font-size: 0.75rem;
+        color: #94a3b8;
+        white-space: nowrap;
+    }
+
+    .timeline-description {
+        color: #64748b;
+        font-size: 0.875rem;
+        line-height: 1.5;
+    }
+
+    .timeline-actor {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.75rem;
+        color: #94a3b8;
+        margin-top: 0.5rem;
+    }
+
+    .timeline-actor i {
+        font-size: 0.625rem;
+    }
+
+    .timeline-metadata {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    .metadata-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.75rem;
+        color: #64748b;
+        background: #f1f5f9;
+        padding: 0.25rem 0.625rem;
+        border-radius: 9999px;
+        margin-right: 0.375rem;
+        margin-bottom: 0.375rem;
+    }
+
+    /* Filter buttons */
+    .filter-btn {
+        padding: 0.5rem 1rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        border: 1px solid #e2e8f0;
+        background: white;
+        color: #64748b;
+        transition: all 0.2s ease-out;
+        cursor: pointer;
+    }
+
+    .filter-btn:hover {
+        background: #f8fafc;
+        border-color: #cbd5e1;
+    }
+
+    .filter-btn.active {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: white;
+        border-color: transparent;
+    }
+
+    /* Loading spinner */
+    .loading-spinner {
+        display: inline-block;
+        width: 1.5rem;
+        height: 1.5rem;
+        border: 2px solid #f3f3f3;
+        border-top: 2px solid #f97316;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+
+    /* Empty state */
+    .empty-state {
+        text-align: center;
+        padding: 3rem;
+        color: #94a3b8;
+    }
+
+    .empty-state i {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+        opacity: 0.5;
+    }
+</style>
+
+<div class="max-w-6xl mx-auto px-4 py-8">
+    <!-- Header -->
+    <div class="animate-fade-in-up mb-6">
+        <div class="flex items-center gap-3 mb-2">
+            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
+               class="text-gray-400 hover:text-gray-600 transition-colors">
+                <i class="fas fa-arrow-left"></i>
+            </a>
+            <h1 class="text-2xl font-bold text-gray-800">Activity History</h1>
+        </div>
+        <p class="text-gray-500 ml-7">{{ transaction.street_address }}</p>
+    </div>
+
+    <!-- Filters -->
+    <div class="premium-card p-4 mb-6 animate-fade-in-up" style="animation-delay: 0.1s;">
+        <div class="flex flex-wrap items-center gap-2">
+            <span class="text-sm text-gray-500 mr-2">Filter:</span>
+            <button class="filter-btn active" data-filter="all">All Events</button>
+            <button class="filter-btn" data-filter="transaction">Transaction</button>
+            <button class="filter-btn" data-filter="document">Documents</button>
+            <button class="filter-btn" data-filter="signature">Signatures</button>
+            <button class="filter-btn" data-filter="webhook">System</button>
+        </div>
+    </div>
+
+    <!-- Timeline -->
+    <div class="premium-card p-6 animate-fade-in-up" style="animation-delay: 0.2s;">
+        <div id="timeline-container">
+            <div class="flex justify-center py-8">
+                <div class="loading-spinner"></div>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        <div id="pagination-container" class="hidden mt-6 pt-4 border-t border-gray-100">
+            <div class="flex justify-between items-center">
+                <span class="text-sm text-gray-500">
+                    Showing <span id="showing-count">0</span> of <span id="total-count">0</span> events
+                </span>
+                <div class="flex gap-2">
+                    <button id="prev-page" class="px-4 py-2 text-sm bg-gray-100 text-gray-600 rounded-lg hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed">
+                        <i class="fas fa-chevron-left mr-1"></i> Previous
+                    </button>
+                    <button id="next-page" class="px-4 py-2 text-sm bg-gray-100 text-gray-600 rounded-lg hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed">
+                        Next <i class="fas fa-chevron-right ml-1"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    let currentPage = 1;
+    let currentFilter = 'all';
+    let totalPages = 1;
+
+    const filterMap = {
+        'all': null,
+        'transaction': ['transaction_created', 'transaction_updated', 'transaction_status_changed', 'transaction_deleted', 'participant_added', 'participant_removed'],
+        'document': ['document_added', 'document_removed', 'document_filled', 'document_generated', 'document_package_generated', 'intake_saved'],
+        'signature': ['document_sent', 'envelope_sent', 'document_resent', 'document_voided', 'document_viewed', 'document_signed'],
+        'webhook': ['webhook_received']
+    };
+
+    // Fetch and render events
+    async function loadEvents(page = 1) {
+        const container = document.getElementById('timeline-container');
+        container.innerHTML = '<div class="flex justify-center py-8"><div class="loading-spinner"></div></div>';
+
+        try {
+            const response = await fetch(`{{ url_for('transactions.transaction_history', id=transaction.id) }}?page=${page}&per_page=50`);
+            const data = await response.json();
+
+            if (!data.success) {
+                throw new Error(data.error || 'Failed to load events');
+            }
+
+            let events = data.events;
+
+            // Apply filter
+            if (currentFilter !== 'all' && filterMap[currentFilter]) {
+                events = events.filter(e => filterMap[currentFilter].includes(e.event_type));
+            }
+
+            renderTimeline(events);
+            updatePagination(data.pagination, events.length);
+
+        } catch (error) {
+            container.innerHTML = `
+                <div class="empty-state">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <p>Error loading activity history</p>
+                    <p class="text-sm mt-2">${error.message}</p>
+                </div>
+            `;
+        }
+    }
+
+    function renderTimeline(events) {
+        const container = document.getElementById('timeline-container');
+
+        if (events.length === 0) {
+            container.innerHTML = `
+                <div class="empty-state">
+                    <i class="fas fa-history"></i>
+                    <p>No activity recorded yet</p>
+                    <p class="text-sm mt-2">Events will appear here as you work with this transaction</p>
+                </div>
+            `;
+            return;
+        }
+
+        let html = '<div class="timeline">';
+
+        events.forEach(event => {
+            const time = formatTime(event.created_at);
+            const metadata = renderMetadata(event);
+
+            html += `
+                <div class="timeline-item" data-event-type="${event.event_type}">
+                    <div class="timeline-icon ${event.color}">
+                        <i class="${event.icon}"></i>
+                    </div>
+                    <div class="timeline-content">
+                        <div class="timeline-header">
+                            <span class="timeline-label">${event.label}</span>
+                            <span class="timeline-time">${time}</span>
+                        </div>
+                        <p class="timeline-description">${event.description || ''}</p>
+                        ${event.actor_name ? `
+                            <div class="timeline-actor">
+                                <i class="fas fa-user"></i>
+                                ${event.actor_name}
+                            </div>
+                        ` : ''}
+                        ${metadata}
+                    </div>
+                </div>
+            `;
+        });
+
+        html += '</div>';
+        container.innerHTML = html;
+    }
+
+    function renderMetadata(event) {
+        const meta = event.metadata;
+        if (!meta || Object.keys(meta).length === 0) return '';
+
+        let items = [];
+
+        // Document-related
+        if (meta.template_name) items.push(`<span class="metadata-item"><i class="fas fa-file"></i> ${meta.template_name}</span>`);
+        if (meta.document_count) items.push(`<span class="metadata-item"><i class="fas fa-copy"></i> ${meta.document_count} documents</span>`);
+
+        // Participant-related
+        if (meta.role) items.push(`<span class="metadata-item"><i class="fas fa-user-tag"></i> ${meta.role}</span>`);
+        if (meta.name && !event.description.includes(meta.name)) items.push(`<span class="metadata-item"><i class="fas fa-user"></i> ${meta.name}</span>`);
+
+        // Status changes
+        if (meta.old_status && meta.new_status) {
+            items.push(`<span class="metadata-item"><i class="fas fa-exchange-alt"></i> ${formatStatus(meta.old_status)} → ${formatStatus(meta.new_status)}</span>`);
+        }
+
+        // Signers
+        if (meta.signer_count) items.push(`<span class="metadata-item"><i class="fas fa-signature"></i> ${meta.signer_count} signers</span>`);
+        if (meta.signer_email) items.push(`<span class="metadata-item"><i class="fas fa-envelope"></i> ${meta.signer_email}</span>`);
+
+        // Resend count
+        if (meta.resent_count !== undefined) items.push(`<span class="metadata-item"><i class="fas fa-redo"></i> ${meta.resent_count} emails resent</span>`);
+
+        // DocuSeal ID
+        if (meta.docuseal_submission_id) items.push(`<span class="metadata-item"><i class="fas fa-hashtag"></i> ${meta.docuseal_submission_id}</span>`);
+
+        if (items.length === 0) return '';
+
+        return `<div class="timeline-metadata">${items.join('')}</div>`;
+    }
+
+    function formatTime(isoString) {
+        if (!isoString) return '';
+        const date = new Date(isoString);
+        const now = new Date();
+        const diffMs = now - date;
+        const diffMins = Math.floor(diffMs / 60000);
+        const diffHours = Math.floor(diffMs / 3600000);
+        const diffDays = Math.floor(diffMs / 86400000);
+
+        if (diffMins < 1) return 'Just now';
+        if (diffMins < 60) return `${diffMins}m ago`;
+        if (diffHours < 24) return `${diffHours}h ago`;
+        if (diffDays < 7) return `${diffDays}d ago`;
+
+        return date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
+        });
+    }
+
+    function formatStatus(status) {
+        return status.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+    }
+
+    function updatePagination(pagination, filteredCount) {
+        const paginationContainer = document.getElementById('pagination-container');
+        const showingCount = document.getElementById('showing-count');
+        const totalCount = document.getElementById('total-count');
+        const prevBtn = document.getElementById('prev-page');
+        const nextBtn = document.getElementById('next-page');
+
+        totalPages = pagination.pages;
+        currentPage = pagination.page;
+
+        showingCount.textContent = filteredCount;
+        totalCount.textContent = pagination.total;
+
+        prevBtn.disabled = currentPage <= 1;
+        nextBtn.disabled = currentPage >= totalPages;
+
+        paginationContainer.classList.remove('hidden');
+    }
+
+    // Event listeners for filters
+    document.querySelectorAll('.filter-btn').forEach(btn => {
+        btn.addEventListener('click', function() {
+            document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+            currentFilter = this.dataset.filter;
+            currentPage = 1;
+            loadEvents(1);
+        });
+    });
+
+    // Pagination
+    document.getElementById('prev-page').addEventListener('click', function() {
+        if (currentPage > 1) {
+            currentPage--;
+            loadEvents(currentPage);
+        }
+    });
+
+    document.getElementById('next-page').addEventListener('click', function() {
+        if (currentPage < totalPages) {
+            currentPage++;
+            loadEvents(currentPage);
+        }
+    });
+
+    // Initial load
+    loadEvents(1);
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
- Add AuditEvent model to track all transaction/document lifecycle events
- Add sent_by_id field to TransactionDocument to track who sent documents
- Create audit_service.py with helpers for logging events consistently
- Update transaction routes to log: create, update, delete, status changes
- Update participant routes to log: add, remove participants
- Update document routes to log: add, remove, fill, generate, send, resend, void
- Update webhook handler to store webhook payloads and log viewed/signed events
- Add API endpoints for fetching transaction and document history
- Create transaction history UI with timeline view and filters
- Add History button to transaction detail page
- Add database migration for audit_events table

Events tracked:
- Transaction: created, updated, deleted, status_changed
- Participants: added, removed
- Documents: added, removed, filled, generated, package_generated
- E-Sign: sent, envelope_sent, resent, voided, viewed, signed
- System: webhook_received, intake_saved