### PR TITLE
feat: add form.declined webhook handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -692,6 +692,7 @@ class AuditEvent(db.Model):
     DOCUMENT_VOIDED = 'document_voided'
     DOCUMENT_VIEWED = 'document_viewed'
     DOCUMENT_SIGNED = 'document_signed'
+    DOCUMENT_DECLINED = 'document_declined'
     ENVELOPE_SENT = 'envelope_sent'
 
     # System events

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -2453,6 +2453,28 @@ def docuseal_webhook():
 
             db.session.commit()
 
+        elif event_type == 'form.declined':
+            # Signer declined to sign
+            decline_reason = submitter_data.get('decline_reason', '')
+            signer_name = submitter_data.get('name', '')
+            
+            doc.status = 'declined'
+            
+            # Update the specific signature record that declined
+            if signature:
+                signature.status = 'declined'
+            
+            # Log document declined event
+            audit_service.log_document_declined(doc, signature, {
+                'signer_email': signer_email,
+                'signer_name': signer_name,
+                'signer_role': signer_role,
+                'decline_reason': decline_reason,
+                'submission_id': submission_id
+            })
+
+            db.session.commit()
+
         return jsonify({
             'received': True,
             'event': event_type,


### PR DESCRIPTION
- Handle form.declined event from DocuSeal webhooks
- Set document status to 'declined' when signer declines
- Update signature record status to 'declined'
- Add DOCUMENT_DECLINED event type constant
- Add log_document_declined audit function with decline reason
- Add display formatting for declined events (red icon, 'Declined' label)