### PR TITLE
feat: add sewer facility doc and always include net proceeds

### DIFF
--- a/documents/sewer-facility.yml
+++ b/documents/sewer-facility.yml
@@ -1,0 +1,59 @@
+# =============================================================================
+# ON-SITE SEWER FACILITY DISCLOSURE
+# =============================================================================
+# Information About On-Site Sewer Facility (Seller Signed)
+# Required for properties with septic systems or on-site sewage facilities
+#
+# This is a PDF-preview document - no custom form UI.
+# Property address is auto-populated. Seller reviews and signs via DocuSeal.
+#
+# Template ID: 2555051
+# =============================================================================
+
+schema_version: "1.0"
+slug: sewer-facility
+name: "Information About On-Site Sewer Facility"
+docuseal_template_id: 2555051
+type: pdf-preview
+
+display:
+  color: "#14B8A6"
+  icon: "fas fa-toilet"
+  sort_order: 7
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Seller, Seller 2
+# 
+# - Seller: Reviews disclosure and signs
+# - Seller 2: Optional second seller (signs if present)
+# =============================================================================
+
+roles:
+  # Seller role: Reviews and signs
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  # Seller 2 role: Optional second seller
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Only the property address is pre-filled.
+# Seller reviews the disclosure information and signs in DocuSeal.
+# =============================================================================
+
+fields:
+  # Property Address - pre-filled and readonly
+  - field_key: property_address
+    docuseal_field: "Address"
+    role_key: seller
+    source: transaction.full_address

--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -38,6 +38,13 @@
           "required": true
         },
         {
+          "id": "has_septic",
+          "type": "boolean",
+          "label": "Does this property have a septic system or on-site sewer facility?",
+          "help_text": "Properties with septic tanks or on-site sewage systems require disclosure.",
+          "required": true
+        },
+        {
           "id": "referral_fee",
           "type": "boolean",
           "label": "Will another party get a referral fee from you for this transaction?",
@@ -85,6 +92,12 @@
       "reason": "Required for all seller transactions"
     },
     {
+      "slug": "seller-net-proceeds",
+      "name": "Seller's Estimated Net Proceeds",
+      "always": true,
+      "reason": "Required for all seller transactions"
+    },
+    {
       "slug": "lead-paint",
       "name": "Addendum for Seller's Disclosure of Information on Lead-Based Paint",
       "condition": {"field": "built_before_1978", "equals": true},
@@ -107,6 +120,12 @@
       "name": "Information About Special Flood Hazard Areas",
       "condition": {"field": "flood_hazard", "equals": true},
       "reason": "Property in flood hazard area"
+    },
+    {
+      "slug": "sewer-facility",
+      "name": "Information About On-Site Sewer Facility",
+      "condition": {"field": "has_septic", "equals": true},
+      "reason": "Property has septic system or on-site sewer facility"
     },
     {
       "slug": "referral-agreement",


### PR DESCRIPTION
- Add Seller's Estimated Net Proceeds as always-included document
- Add septic/sewer question to transaction questionnaire
- Add conditional On-Site Sewer Facility document (PDF preview)
- Template ID 2555051 for DocuSeal integration