### PR TITLE
fix: hide related transactions on contact page behind feature flag

### DIFF
--- a/templates/contacts/view.html
+++ b/templates/contacts/view.html
@@ -624,6 +624,7 @@
 
             <!-- Side Container - Related Tasks & Transactions -->
             <div class="lg:w-96 space-y-6 animate-fade-in-up-delay-3">
+                {% if show_transactions %}
                 <!-- Related Transactions Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
@@ -716,6 +717,7 @@
                         {% endfor %}
                     </div>
                 </div>
+                {% endif %}
 
                 <!-- Related Tasks Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">


### PR DESCRIPTION
- Import can_access_transactions in contacts route
- Only query related transactions if user has access
- Wrap Related Transactions card in show_transactions conditional
- Ensures consistency with other transaction features