### PR TITLE
feat: add contact file upload functionality with Supabase Storage

### DIFF
--- a/migrations/versions/add_contact_files_table.py
+++ b/migrations/versions/add_contact_files_table.py
@@ -1,0 +1,44 @@
+"""Add contact_files table
+
+Revision ID: add_contact_files
+Revises: b2c3d4e5f6g7
+Create Date: 2026-01-13
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_contact_files'
+down_revision = 'b2c3d4e5f6g7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create contact_files table if it doesn't exist
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS contact_files (
+            id SERIAL PRIMARY KEY,
+            contact_id INTEGER NOT NULL REFERENCES contact(id) ON DELETE CASCADE,
+            user_id INTEGER REFERENCES "user"(id) ON DELETE SET NULL,
+            filename VARCHAR(255) NOT NULL,
+            original_filename VARCHAR(255) NOT NULL,
+            file_type VARCHAR(100),
+            file_size INTEGER,
+            storage_path VARCHAR(500) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+    """)
+    
+    # Create index on contact_id for faster lookups
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_contact_files_contact_id 
+        ON contact_files(contact_id);
+    """)
+
+
+def downgrade():
+    op.execute("DROP TABLE IF EXISTS contact_files;")

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,9 @@ requests==2.32.5
 # Database driver
 psycopg2-binary==2.9.11
 
+# Supabase Storage
+supabase==2.11.0
+
 # Security / serialization / templating dependencies
 itsdangerous==2.2.0
 PyYAML==6.0.3

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -10,7 +10,7 @@ from flask_login import login_required, current_user
 from functools import wraps
 from models import (
     db, Transaction, TransactionType, TransactionParticipant,
-    TransactionDocument, DocumentSignature, Contact, User, AuditEvent
+    TransactionDocument, DocumentSignature, Contact, User, AuditEvent, ContactFile
 )
 from feature_flags import can_access_transactions
 from services import audit_service
@@ -285,11 +285,20 @@ def view_transaction(id):
     # Get documents
     documents = transaction.documents.order_by(TransactionDocument.created_at).all()
     
+    # Get files from all contacts associated with this transaction
+    contact_ids = [p.contact_id for p in participants if p.contact_id]
+    contact_files = []
+    if contact_ids:
+        contact_files = ContactFile.query.filter(
+            ContactFile.contact_id.in_(contact_ids)
+        ).order_by(ContactFile.created_at.desc()).all()
+    
     return render_template(
         'transactions/detail.html',
         transaction=transaction,
         participants=participants,
-        documents=documents
+        documents=documents,
+        contact_files=contact_files
     )
 
 

--- a/services/supabase_storage.py
+++ b/services/supabase_storage.py
@@ -1,0 +1,187 @@
+"""
+Supabase Storage Service for Contact Files
+
+Handles file uploads, downloads, and deletions using Supabase Storage.
+Files are stored privately and accessed via signed URLs.
+"""
+
+import os
+import uuid
+from datetime import datetime
+from supabase import create_client, Client
+from flask import current_app
+
+# Supabase client singleton
+_supabase_client: Client = None
+
+# Bucket name for contact files
+BUCKET_NAME = 'contact-files'
+
+
+def get_supabase_client() -> Client:
+    """
+    Get or create the Supabase client.
+    Uses SUPABASE_URL and SUPABASE_KEY from environment.
+    """
+    global _supabase_client
+    
+    if _supabase_client is None:
+        supabase_url = os.getenv('SUPABASE_URL')
+        supabase_key = os.getenv('SUPABASE_KEY')
+        
+        if not supabase_url or not supabase_key:
+            raise ValueError(
+                "SUPABASE_URL and SUPABASE_KEY environment variables are required. "
+                "Get these from your Supabase project settings."
+            )
+        
+        _supabase_client = create_client(supabase_url, supabase_key)
+    
+    return _supabase_client
+
+
+def generate_storage_path(contact_id: int, original_filename: str) -> tuple[str, str]:
+    """
+    Generate a unique storage path for a file.
+    
+    Returns:
+        tuple: (storage_path, unique_filename)
+    """
+    # Get file extension
+    ext = ''
+    if '.' in original_filename:
+        ext = '.' + original_filename.rsplit('.', 1)[1].lower()
+    
+    # Generate unique filename with UUID
+    unique_filename = f"{uuid.uuid4().hex}{ext}"
+    
+    # Organize by contact_id for easy management
+    storage_path = f"contacts/{contact_id}/{unique_filename}"
+    
+    return storage_path, unique_filename
+
+
+def upload_file(contact_id: int, file_data: bytes, original_filename: str, content_type: str = None) -> dict:
+    """
+    Upload a file to Supabase Storage.
+    
+    Args:
+        contact_id: The contact this file belongs to
+        file_data: The file content as bytes
+        original_filename: The original filename from the upload
+        content_type: MIME type of the file (optional)
+    
+    Returns:
+        dict with 'path', 'filename', 'size' keys on success
+        
+    Raises:
+        Exception on upload failure
+    """
+    client = get_supabase_client()
+    
+    storage_path, unique_filename = generate_storage_path(contact_id, original_filename)
+    
+    # Set file options
+    file_options = {}
+    if content_type:
+        file_options['content-type'] = content_type
+    
+    # Upload to Supabase Storage
+    response = client.storage.from_(BUCKET_NAME).upload(
+        path=storage_path,
+        file=file_data,
+        file_options=file_options
+    )
+    
+    return {
+        'path': storage_path,
+        'filename': unique_filename,
+        'size': len(file_data)
+    }
+
+
+def get_signed_url(storage_path: str, expires_in: int = 3600) -> str:
+    """
+    Generate a signed URL for private file access.
+    
+    Args:
+        storage_path: The path to the file in storage
+        expires_in: URL expiry time in seconds (default: 1 hour)
+    
+    Returns:
+        Signed URL string
+    """
+    client = get_supabase_client()
+    
+    response = client.storage.from_(BUCKET_NAME).create_signed_url(
+        path=storage_path,
+        expires_in=expires_in
+    )
+    
+    return response['signedURL']
+
+
+def delete_file(storage_path: str) -> bool:
+    """
+    Delete a file from Supabase Storage.
+    
+    Args:
+        storage_path: The path to the file in storage
+    
+    Returns:
+        True on success, False on failure
+    """
+    client = get_supabase_client()
+    
+    try:
+        client.storage.from_(BUCKET_NAME).remove([storage_path])
+        return True
+    except Exception as e:
+        current_app.logger.error(f"Failed to delete file {storage_path}: {e}")
+        return False
+
+
+def get_file_icon(file_extension: str) -> str:
+    """
+    Get Font Awesome icon class for a file type.
+    
+    Args:
+        file_extension: File extension (without dot)
+    
+    Returns:
+        Font Awesome icon class
+    """
+    icons = {
+        'pdf': 'fa-file-pdf',
+        'doc': 'fa-file-word',
+        'docx': 'fa-file-word',
+        'xls': 'fa-file-excel',
+        'xlsx': 'fa-file-excel',
+        'csv': 'fa-file-csv',
+        'jpg': 'fa-file-image',
+        'jpeg': 'fa-file-image',
+        'png': 'fa-file-image',
+        'gif': 'fa-file-image',
+    }
+    return icons.get(file_extension.lower(), 'fa-file')
+
+
+def format_file_size(size_bytes: int) -> str:
+    """
+    Format file size in human-readable format.
+    
+    Args:
+        size_bytes: Size in bytes
+    
+    Returns:
+        Formatted string (e.g., "1.5 MB")
+    """
+    if not size_bytes:
+        return 'Unknown'
+    
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    
+    return f"{size_bytes:.1f} TB"

--- a/templates/contacts/view.html
+++ b/templates/contacts/view.html
@@ -719,6 +719,109 @@
                 </div>
                 {% endif %}
 
+                <!-- Related Files Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center">
+                                    <i class="fas fa-folder-open text-white text-sm"></i>
+                                </div>
+                                <h2 class="text-lg font-semibold text-slate-800">Related Files</h2>
+                            </div>
+                            <button onclick="document.getElementById('fileUploadInput').click()" 
+                                    class="inline-flex items-center px-3 py-1.5 bg-gradient-to-r from-emerald-500 to-teal-500 text-white rounded-lg text-xs font-medium shadow-sm hover:from-emerald-600 hover:to-teal-600 transition-all duration-200">
+                                <i class="fas fa-upload mr-1.5"></i>
+                                Upload File
+                            </button>
+                            <input type="file" id="fileUploadInput" class="hidden" 
+                                   accept=".jpg,.jpeg,.png,.gif,.pdf,.doc,.docx,.csv,.xlsx,.xls"
+                                   onchange="uploadContactFile(this)">
+                        </div>
+                    </div>
+
+                    <!-- Drop Zone (hidden by default, shown on drag) -->
+                    <div id="fileDropZone" class="hidden p-8 border-2 border-dashed border-emerald-300 bg-emerald-50 m-4 rounded-xl text-center transition-all duration-200">
+                        <i class="fas fa-cloud-upload-alt text-4xl text-emerald-400 mb-3"></i>
+                        <p class="text-emerald-600 font-medium">Drop files here to upload</p>
+                        <p class="text-emerald-500 text-sm mt-1">Max 10 MB per file</p>
+                    </div>
+
+                    <!-- File List -->
+                    <div id="contactFilesList" class="divide-y divide-slate-100 max-h-80 overflow-y-auto">
+                        {% for file in contact_files %}
+                        <div class="p-4 hover:bg-slate-50 transition-colors duration-150 group file-item" data-file-id="{{ file.id }}">
+                            <div class="flex items-center space-x-3">
+                                <!-- File Icon -->
+                                <div class="flex-shrink-0">
+                                    {% if file.is_image %}
+                                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 flex items-center justify-center shadow-sm">
+                                        <i class="fas fa-file-image text-white"></i>
+                                    </div>
+                                    {% elif file.file_extension == 'pdf' %}
+                                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-red-400 to-red-500 flex items-center justify-center shadow-sm">
+                                        <i class="fas fa-file-pdf text-white"></i>
+                                    </div>
+                                    {% elif file.file_extension in ['doc', 'docx'] %}
+                                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-blue-400 to-blue-500 flex items-center justify-center shadow-sm">
+                                        <i class="fas fa-file-word text-white"></i>
+                                    </div>
+                                    {% elif file.file_extension in ['xls', 'xlsx', 'csv'] %}
+                                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-green-400 to-green-500 flex items-center justify-center shadow-sm">
+                                        <i class="fas fa-file-excel text-white"></i>
+                                    </div>
+                                    {% else %}
+                                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-slate-400 to-slate-500 flex items-center justify-center shadow-sm">
+                                        <i class="fas fa-file text-white"></i>
+                                    </div>
+                                    {% endif %}
+                                </div>
+
+                                <!-- File Info -->
+                                <div class="flex-1 min-w-0">
+                                    <p class="text-sm font-medium text-slate-800 truncate">{{ file.original_filename }}</p>
+                                    <div class="flex items-center gap-2 mt-1 text-xs text-slate-500">
+                                        <span>{{ file.human_file_size }}</span>
+                                        <span>•</span>
+                                        <span>{{ file.created_at.strftime('%b %d, %Y') }}</span>
+                                    </div>
+                                </div>
+
+                                <!-- Actions -->
+                                <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                                    <button onclick="downloadContactFile({{ file.id }})" 
+                                            class="p-2 text-slate-400 hover:text-emerald-600 hover:bg-emerald-50 rounded-lg transition-colors"
+                                            title="Download">
+                                        <i class="fas fa-download"></i>
+                                    </button>
+                                    <button onclick="deleteContactFile({{ file.id }}, '{{ file.original_filename }}')" 
+                                            class="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                                            title="Delete">
+                                        <i class="fas fa-trash-alt"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        {% else %}
+                        <div id="noFilesMessage" class="p-8 text-center">
+                            <div class="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
+                                <i class="fas fa-folder-open text-slate-400 text-xl"></i>
+                            </div>
+                            <p class="text-slate-500 text-sm">No files uploaded</p>
+                            <p class="text-slate-400 text-xs mt-1">Click upload or drag files here</p>
+                        </div>
+                        {% endfor %}
+                    </div>
+
+                    <!-- Upload Progress (hidden by default) -->
+                    <div id="uploadProgress" class="hidden p-4 border-t border-slate-100">
+                        <div class="flex items-center gap-3">
+                            <div class="animate-spin rounded-full h-5 w-5 border-2 border-emerald-500 border-t-transparent"></div>
+                            <span class="text-sm text-slate-600">Uploading...</span>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Related Tasks Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
@@ -1401,6 +1504,228 @@ document.addEventListener('DOMContentLoaded', function() {
             openTaskModal(taskId);
         });
     });
+});
+
+// =============================================================================
+// CONTACT FILE MANAGEMENT
+// =============================================================================
+
+const contactId = {{ contact.id }};
+
+// File upload via button click
+function uploadContactFile(input) {
+    if (!input.files || input.files.length === 0) return;
+    
+    const file = input.files[0];
+    const formData = new FormData();
+    formData.append('file', file);
+    
+    // Show progress
+    document.getElementById('uploadProgress').classList.remove('hidden');
+    
+    fetch(`/contact/${contactId}/files`, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        document.getElementById('uploadProgress').classList.add('hidden');
+        input.value = ''; // Reset input
+        
+        if (data.success) {
+            // Add file to list
+            addFileToList(data.file);
+            showToast('File uploaded successfully', 'success');
+        } else {
+            showToast(data.error || 'Upload failed', 'error');
+        }
+    })
+    .catch(error => {
+        document.getElementById('uploadProgress').classList.add('hidden');
+        input.value = '';
+        showToast('Upload failed. Please try again.', 'error');
+        console.error('Upload error:', error);
+    });
+}
+
+// Add new file to the list
+function addFileToList(file) {
+    const filesList = document.getElementById('contactFilesList');
+    const noFilesMsg = document.getElementById('noFilesMessage');
+    
+    // Remove "no files" message if present
+    if (noFilesMsg) {
+        noFilesMsg.remove();
+    }
+    
+    // Get icon based on file type
+    let iconHtml = '';
+    const ext = file.original_filename.split('.').pop().toLowerCase();
+    
+    if (['jpg', 'jpeg', 'png', 'gif'].includes(ext)) {
+        iconHtml = `<div class="w-10 h-10 rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 flex items-center justify-center shadow-sm">
+            <i class="fas fa-file-image text-white"></i>
+        </div>`;
+    } else if (ext === 'pdf') {
+        iconHtml = `<div class="w-10 h-10 rounded-lg bg-gradient-to-br from-red-400 to-red-500 flex items-center justify-center shadow-sm">
+            <i class="fas fa-file-pdf text-white"></i>
+        </div>`;
+    } else if (['doc', 'docx'].includes(ext)) {
+        iconHtml = `<div class="w-10 h-10 rounded-lg bg-gradient-to-br from-blue-400 to-blue-500 flex items-center justify-center shadow-sm">
+            <i class="fas fa-file-word text-white"></i>
+        </div>`;
+    } else if (['xls', 'xlsx', 'csv'].includes(ext)) {
+        iconHtml = `<div class="w-10 h-10 rounded-lg bg-gradient-to-br from-green-400 to-green-500 flex items-center justify-center shadow-sm">
+            <i class="fas fa-file-excel text-white"></i>
+        </div>`;
+    } else {
+        iconHtml = `<div class="w-10 h-10 rounded-lg bg-gradient-to-br from-slate-400 to-slate-500 flex items-center justify-center shadow-sm">
+            <i class="fas fa-file text-white"></i>
+        </div>`;
+    }
+    
+    const fileHtml = `
+        <div class="p-4 hover:bg-slate-50 transition-colors duration-150 group file-item" data-file-id="${file.id}">
+            <div class="flex items-center space-x-3">
+                <div class="flex-shrink-0">${iconHtml}</div>
+                <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium text-slate-800 truncate">${file.original_filename}</p>
+                    <div class="flex items-center gap-2 mt-1 text-xs text-slate-500">
+                        <span>${file.file_size}</span>
+                        <span>•</span>
+                        <span>${file.created_at}</span>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+                    <button onclick="downloadContactFile(${file.id})" 
+                            class="p-2 text-slate-400 hover:text-emerald-600 hover:bg-emerald-50 rounded-lg transition-colors"
+                            title="Download">
+                        <i class="fas fa-download"></i>
+                    </button>
+                    <button onclick="deleteContactFile(${file.id}, '${file.original_filename.replace(/'/g, "\\'")}')" 
+                            class="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                            title="Delete">
+                        <i class="fas fa-trash-alt"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    filesList.insertAdjacentHTML('afterbegin', fileHtml);
+}
+
+// Download file
+function downloadContactFile(fileId) {
+    fetch(`/contact/${contactId}/files/${fileId}/download`)
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            // Open signed URL in new tab
+            window.open(data.url, '_blank');
+        } else {
+            showToast(data.error || 'Download failed', 'error');
+        }
+    })
+    .catch(error => {
+        showToast('Download failed. Please try again.', 'error');
+        console.error('Download error:', error);
+    });
+}
+
+// Delete file
+function deleteContactFile(fileId, filename) {
+    if (!confirm(`Are you sure you want to delete "${filename}"?`)) {
+        return;
+    }
+    
+    fetch(`/contact/${contactId}/files/${fileId}`, {
+        method: 'DELETE'
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            // Remove from DOM
+            const fileItem = document.querySelector(`.file-item[data-file-id="${fileId}"]`);
+            if (fileItem) {
+                fileItem.remove();
+            }
+            
+            // Show "no files" message if list is empty
+            const filesList = document.getElementById('contactFilesList');
+            if (filesList.querySelectorAll('.file-item').length === 0) {
+                filesList.innerHTML = `
+                    <div id="noFilesMessage" class="p-8 text-center">
+                        <div class="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
+                            <i class="fas fa-folder-open text-slate-400 text-xl"></i>
+                        </div>
+                        <p class="text-slate-500 text-sm">No files uploaded</p>
+                        <p class="text-slate-400 text-xs mt-1">Click upload or drag files here</p>
+                    </div>
+                `;
+            }
+            
+            showToast('File deleted', 'success');
+        } else {
+            showToast(data.error || 'Delete failed', 'error');
+        }
+    })
+    .catch(error => {
+        showToast('Delete failed. Please try again.', 'error');
+        console.error('Delete error:', error);
+    });
+}
+
+// Simple toast notification
+function showToast(message, type = 'info') {
+    const toast = document.createElement('div');
+    toast.className = `fixed bottom-4 right-4 px-4 py-3 rounded-lg shadow-lg text-white z-50 transition-all duration-300 transform translate-y-2 opacity-0 ${
+        type === 'success' ? 'bg-emerald-500' : 
+        type === 'error' ? 'bg-red-500' : 'bg-slate-700'
+    }`;
+    toast.innerHTML = `<i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'} mr-2"></i>${message}`;
+    document.body.appendChild(toast);
+    
+    // Animate in
+    requestAnimationFrame(() => {
+        toast.classList.remove('translate-y-2', 'opacity-0');
+    });
+    
+    // Remove after 3 seconds
+    setTimeout(() => {
+        toast.classList.add('translate-y-2', 'opacity-0');
+        setTimeout(() => toast.remove(), 300);
+    }, 3000);
+}
+
+// Drag and drop support
+const fileDropZone = document.getElementById('fileDropZone');
+const filesCard = fileDropZone.closest('.premium-card');
+
+filesCard.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    fileDropZone.classList.remove('hidden');
+});
+
+filesCard.addEventListener('dragleave', (e) => {
+    if (!filesCard.contains(e.relatedTarget)) {
+        fileDropZone.classList.add('hidden');
+    }
+});
+
+filesCard.addEventListener('drop', (e) => {
+    e.preventDefault();
+    fileDropZone.classList.add('hidden');
+    
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+        // Create a mock input event
+        const input = document.getElementById('fileUploadInput');
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(files[0]);
+        input.files = dataTransfer.files;
+        uploadContactFile(input);
+    }
 });
 </script>
 {% endblock %}

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -796,6 +796,69 @@
                     </div>
                 </div>
 
+                <!-- Contact Files Card -->
+                {% if contact_files %}
+                <div class="premium-card p-6 animate-fade-in-up-delay-2">
+                    <div class="flex items-center justify-between mb-5">
+                        <div class="flex items-center gap-3">
+                            <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center">
+                                <i class="fas fa-folder-open text-white"></i>
+                            </div>
+                            <div>
+                                <h2 class="text-lg font-bold text-slate-800">Contact Files</h2>
+                                <p class="text-xs text-slate-500">Files from associated contacts</p>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="space-y-2 max-h-64 overflow-y-auto">
+                        {% for file in contact_files %}
+                        <div class="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 transition-colors group">
+                            <!-- File Icon -->
+                            {% if file.is_image %}
+                            <div class="w-9 h-9 rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 flex items-center justify-center shadow-sm flex-shrink-0">
+                                <i class="fas fa-file-image text-white text-sm"></i>
+                            </div>
+                            {% elif file.file_extension == 'pdf' %}
+                            <div class="w-9 h-9 rounded-lg bg-gradient-to-br from-red-400 to-red-500 flex items-center justify-center shadow-sm flex-shrink-0">
+                                <i class="fas fa-file-pdf text-white text-sm"></i>
+                            </div>
+                            {% elif file.file_extension in ['doc', 'docx'] %}
+                            <div class="w-9 h-9 rounded-lg bg-gradient-to-br from-blue-400 to-blue-500 flex items-center justify-center shadow-sm flex-shrink-0">
+                                <i class="fas fa-file-word text-white text-sm"></i>
+                            </div>
+                            {% elif file.file_extension in ['xls', 'xlsx', 'csv'] %}
+                            <div class="w-9 h-9 rounded-lg bg-gradient-to-br from-green-400 to-green-500 flex items-center justify-center shadow-sm flex-shrink-0">
+                                <i class="fas fa-file-excel text-white text-sm"></i>
+                            </div>
+                            {% else %}
+                            <div class="w-9 h-9 rounded-lg bg-gradient-to-br from-slate-400 to-slate-500 flex items-center justify-center shadow-sm flex-shrink-0">
+                                <i class="fas fa-file text-white text-sm"></i>
+                            </div>
+                            {% endif %}
+                            
+                            <!-- File Info -->
+                            <div class="flex-1 min-w-0">
+                                <p class="text-sm font-medium text-slate-800 truncate">{{ file.original_filename }}</p>
+                                <div class="flex items-center gap-2 text-xs text-slate-500">
+                                    <span>{{ file.contact.first_name }} {{ file.contact.last_name }}</span>
+                                    <span>•</span>
+                                    <span>{{ file.human_file_size }}</span>
+                                </div>
+                            </div>
+                            
+                            <!-- Download Button -->
+                            <button onclick="downloadContactFileFromTx({{ file.contact_id }}, {{ file.id }})" 
+                                    class="p-2 text-slate-400 hover:text-emerald-600 hover:bg-emerald-50 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
+                                    title="Download">
+                                <i class="fas fa-download"></i>
+                            </button>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+
                 <!-- Recent Activity Card -->
                 <div class="premium-card p-6 animate-fade-in-up-delay-2">
                     <div class="flex items-center justify-between mb-5">
@@ -1572,6 +1635,26 @@ function fillAllForms() {
 
 function generateAllPDFs() {
     showToast('PDF generation coming soon with DocuSeal integration.', 'info');
+}
+
+// =============================================================================
+// CONTACT FILE DOWNLOAD
+// =============================================================================
+
+function downloadContactFileFromTx(contactId, fileId) {
+    fetch(`/contact/${contactId}/files/${fileId}/download`)
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            window.open(data.url, '_blank');
+        } else {
+            showToast(data.error || 'Download failed', 'error');
+        }
+    })
+    .catch(error => {
+        showToast('Download failed. Please try again.', 'error');
+        console.error('Download error:', error);
+    });
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
- Add ContactFile model for storing file metadata
- Create supabase_storage.py service for upload/download/delete operations
- Add file management API endpoints to contacts.py (upload, download, delete, list)
- Add Related Files card to contact view with drag-and-drop support
- Add Contact Files section to transaction detail page (read-only)
- Add supabase package to requirements.txt
- Include database migration for contact_files table

Files are stored privately in Supabase Storage with signed URLs for access. Supports images, PDFs, Word docs, Excel/CSV files up to 10MB.