### PR TITLE
chore: migrate company updates images to supabase storage

### DIFF
--- a/routes/contacts.py
+++ b/routes/contacts.py
@@ -635,7 +635,7 @@ def upload_contact_file(contact_id):
     
     try:
         # Upload to Supabase Storage
-        result = supabase_storage.upload_file(
+        result = supabase_storage.upload_contact_file(
             contact_id=contact_id,
             file_data=file_data,
             original_filename=file.filename,
@@ -695,6 +695,7 @@ def download_contact_file(contact_id, file_id):
     try:
         # Generate signed URL (valid for 1 hour)
         signed_url = supabase_storage.get_signed_url(
+            supabase_storage.CONTACT_FILES_BUCKET,
             contact_file.storage_path, 
             expires_in=3600
         )
@@ -731,7 +732,7 @@ def delete_contact_file(contact_id, file_id):
     
     try:
         # Delete from Supabase Storage
-        supabase_storage.delete_file(contact_file.storage_path)
+        supabase_storage.delete_file(supabase_storage.CONTACT_FILES_BUCKET, contact_file.storage_path)
         
         # Delete database record
         db.session.delete(contact_file)

--- a/templates/company_updates/form.html
+++ b/templates/company_updates/form.html
@@ -103,11 +103,11 @@
                     Cover Image <span class="text-slate-400 font-normal">(optional)</span>
                 </label>
 
-                {% if update and update.cover_image_url %}
+                {% if update and update.cover_image_signed_url %}
                 <!-- Existing image preview -->
                 <div id="existing-image-container" class="mb-4">
                     <div class="relative inline-block">
-                        <img src="{{ update.cover_image_url }}" alt="Current cover image"
+                        <img src="{{ update.cover_image_signed_url }}" alt="Current cover image"
                             class="w-48 h-32 object-cover rounded-xl border-2 border-slate-200">
                         <div class="absolute -top-2 -right-2">
                             <label
@@ -127,7 +127,7 @@
                 {% endif %}
 
                 <!-- File Upload Input -->
-                <div id="upload-container" class="{% if update and update.cover_image_url %}hidden{% endif %}">
+                <div id="upload-container" class="{% if update and update.cover_image_signed_url %}hidden{% endif %}">
                     <label for="cover_image"
                         class="flex flex-col items-center justify-center w-full h-40 border-2 border-dashed border-slate-300 rounded-xl cursor-pointer bg-slate-50 hover:bg-slate-100 hover:border-blue-400 transition-all duration-200">
                         <div id="upload-placeholder" class="flex flex-col items-center justify-center pt-5 pb-6">

--- a/templates/company_updates/list.html
+++ b/templates/company_updates/list.html
@@ -136,9 +136,9 @@
 
                     <!-- Main content area - clickable -->
                     <a href="{{ url_for('company_updates.view_update', update_id=update.id) }}" class="block group">
-                        {% if update.cover_image_url %}
+                        {% if update.cover_image_signed_url %}
                         <div class="w-full h-48 rounded-xl overflow-hidden bg-slate-100 mb-4">
-                            <img src="{{ update.cover_image_url }}" alt="{{ update.title }}"
+                            <img src="{{ update.cover_image_signed_url }}" alt="{{ update.title }}"
                                 class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300">
                         </div>
                         {% endif %}

--- a/templates/company_updates/view.html
+++ b/templates/company_updates/view.html
@@ -142,9 +142,9 @@
         <!-- Article -->
         <article class="animate-fade-in-up-delay-1 bg-white rounded-2xl shadow-xl border border-slate-200/60 overflow-hidden">
             <!-- Cover Image -->
-            {% if update.cover_image_url %}
+            {% if update.cover_image_signed_url %}
             <div class="w-full h-64 md:h-80 bg-slate-100">
-                <img src="{{ update.cover_image_url }}" alt="{{ update.title }}" 
+                <img src="{{ update.cover_image_signed_url }}" alt="{{ update.title }}" 
                      class="w-full h-full object-cover">
             </div>
             {% endif %}


### PR DESCRIPTION
## Summary
- add bucket-aware supabase storage helpers for company update images and contact files
- migrate company update create/edit flows to upload/delete via supabase with legacy cleanup fallback
- expose signed cover image urls on the model and update templates to render supabase images