### PR TITLE
feat: auto-save signed documents to Supabase storage

### DIFF
--- a/migrations/versions/add_signed_file_to_transaction_documents.py
+++ b/migrations/versions/add_signed_file_to_transaction_documents.py
@@ -1,0 +1,35 @@
+"""Add signed file columns to transaction_documents
+
+Revision ID: add_signed_file_cols
+Revises: add_rentcast_fields
+Create Date: 2026-01-16
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_signed_file_cols'
+down_revision = 'add_rentcast_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add columns for storing signed document files in Supabase
+    op.execute("""
+        ALTER TABLE transaction_documents
+        ADD COLUMN IF NOT EXISTS signed_file_path VARCHAR(500),
+        ADD COLUMN IF NOT EXISTS signed_file_size INTEGER,
+        ADD COLUMN IF NOT EXISTS signed_file_downloaded_at TIMESTAMP;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE transaction_documents
+        DROP COLUMN IF EXISTS signed_file_path,
+        DROP COLUMN IF EXISTS signed_file_size,
+        DROP COLUMN IF EXISTS signed_file_downloaded_at;
+    """)

--- a/models.py
+++ b/models.py
@@ -589,6 +589,11 @@ class TransactionDocument(db.Model):
     sent_at = db.Column(db.DateTime)  # When sent for signature
     signed_at = db.Column(db.DateTime)  # When all signatures complete
     
+    # Signed document storage (Supabase)
+    signed_file_path = db.Column(db.String(500))  # Path in Supabase storage
+    signed_file_size = db.Column(db.Integer)  # Size in bytes
+    signed_file_downloaded_at = db.Column(db.DateTime)  # When downloaded from DocuSeal
+    
     # Relationships
     signatures = db.relationship('DocumentSignature', backref='document',
                                 cascade='all, delete-orphan', lazy='dynamic')

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -732,6 +732,19 @@
                                 </div>
                             </div>
                             <div class="flex items-center gap-3">
+                                {% if doc.status == 'signed' and doc.signed_file_path %}
+                                <!-- Signed with local copy stored -->
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">
+                                        {{ doc.status|title }}
+                                    </span>
+                                    <span class="px-2 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-600 flex items-center gap-1" 
+                                          title="Local copy stored in Supabase{% if doc.signed_file_size %} ({{ (doc.signed_file_size / 1024)|round(1) }} KB){% endif %}">
+                                        <i class="fas fa-cloud-download-alt text-xs"></i>
+                                        Stored
+                                    </span>
+                                </div>
+                                {% else %}
                                 <span class="px-3 py-1 rounded-full text-xs font-semibold
                                     {% if doc.status == 'signed' %}bg-green-100 text-green-700
                                     {% elif doc.status == 'sent' %}bg-blue-100 text-blue-700
@@ -740,6 +753,7 @@
                                     {% else %}bg-slate-100 text-slate-600{% endif %}">
                                     {{ doc.status|title }}
                                 </span>
+                                {% endif %}
                                 
                                 <!-- Actions Dropdown Menu -->
                                 <div class="relative doc-actions-dropdown">
@@ -815,16 +829,35 @@
                                         {% endif %}
                                         
                                         {% if doc.status == 'signed' %}
+                                        <div class="border-t border-slate-100 my-2"></div>
+                                        <div class="px-4 py-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+                                            Signed Document
+                                        </div>
+                                        {% if doc.signed_file_path %}
+                                        <!-- Local copy available -->
+                                        <button onclick="viewStoredDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-emerald-600 hover:bg-emerald-50 transition-colors">
+                                            <i class="fas fa-eye w-5"></i>
+                                            <span class="ml-2">View (Local Copy)</span>
+                                        </button>
                                         <button onclick="downloadDocument({{ doc.id }})" 
                                                 class="w-full flex items-center px-4 py-2.5 text-sm text-green-600 hover:bg-green-50 transition-colors">
                                             <i class="fas fa-download w-5"></i>
-                                            <span class="ml-2">Download Signed</span>
+                                            <span class="ml-2">Download</span>
+                                        </button>
+                                        {% else %}
+                                        <!-- No local copy - fetch from DocuSeal -->
+                                        <button onclick="downloadDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-green-600 hover:bg-green-50 transition-colors">
+                                            <i class="fas fa-download w-5"></i>
+                                            <span class="ml-2">Download from DocuSeal</span>
                                         </button>
                                         <button onclick="viewSignedDocument({{ doc.id }})" 
                                                 class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
                                             <i class="fas fa-eye w-5 text-slate-400"></i>
-                                            <span class="ml-2">View Signed</span>
+                                            <span class="ml-2">View in DocuSeal</span>
                                         </button>
+                                        {% endif %}
                                         {% endif %}
                                         
                                         <!-- Remove -->
@@ -2511,6 +2544,23 @@ function viewSignedDocument(docId) {
         } else {
             showToast('Error: ' + (data.error || 'No signed documents available'), 'error');
         }
+    });
+}
+
+function viewStoredDocument(docId) {
+    // View locally stored signed document from Supabase
+    fetch(`/transactions/${transactionId}/documents/${docId}/view-signed`)
+    .then(res => res.json())
+    .then(data => {
+        if (data.success && data.url) {
+            window.open(data.url, '_blank');
+        } else {
+            showToast(data.error || 'Failed to get document URL', 'error');
+        }
+    })
+    .catch(error => {
+        showToast('Failed to view document. Please try again.', 'error');
+        console.error('View stored document error:', error);
     });
 }
 


### PR DESCRIPTION
When DocuSeal sends a form.completed webhook, automatically download the signed PDF and store it in Supabase for permanent local access.

- Add signed_file_path, signed_file_size, signed_file_downloaded_at to TransactionDocument
- Add transaction document storage helpers in supabase_storage.py
- Update webhook handler to download and store signed PDFs
- Modify download endpoint to prefer local copy over DocuSeal API
- Add new view-signed endpoint for viewing stored documents
- Update UI to show "Stored" indicator for locally saved documents