### PR TITLE
feat: add print functionality for filled documents

### DIFF
--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -1989,6 +1989,9 @@ def preview_all_documents(id):
                 if preview_result and preview_result.get('slug'):
                     doc_preview['embed_slug'] = preview_result['slug']
                     doc_preview['embed_src'] = f"https://docuseal.com/s/{preview_result['slug']}"
+                    # Store submission ID for PDF printing
+                    doc_preview['submission_id'] = preview_result.get('id')
+                    doc.docuseal_submission_id = preview_result.get('id')
                 
                 # Update document status
                 doc.status = 'generated'
@@ -2881,6 +2884,299 @@ def view_stored_signed_document(id, doc_id):
         })
         
     except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@transactions_bp.route('/<int:id>/documents/print-all-pdf')
+@login_required
+@transactions_required
+def get_all_documents_print_pdf(id):
+    """
+    Get a SINGLE combined PDF URL for ALL filled documents in a transaction.
+    
+    This merges all templates into one, creates a preview submission,
+    and returns the combined PDF URL for printing.
+    """
+    from services.documents import (
+        DocumentLoader, FieldResolver, RoleBuilder, DocuSealClient
+    )
+    from services.documents.types import Submitter
+    
+    transaction = Transaction.query.get_or_404(id)
+    
+    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+    
+    # Check if in mock mode
+    if DocuSealClient.is_mock_mode():
+        return jsonify({
+            'success': False,
+            'error': 'PDF printing not available in test mode. Deploy to production to test.'
+        }), 400
+    
+    # Get all document slugs from new system
+    all_definitions = DocumentLoader.get_sorted()
+    all_valid_slugs = [d.slug for d in all_definitions]
+    
+    documents = transaction.documents.filter(
+        TransactionDocument.template_slug.in_(all_valid_slugs),
+        TransactionDocument.status.in_(['filled', 'draft', 'generated'])
+    ).order_by(TransactionDocument.created_at).all()
+    
+    if not documents:
+        return jsonify({
+            'success': False,
+            'error': 'No filled documents found to print.'
+        }), 404
+    
+    try:
+        # Step 1: Collect all template IDs and resolve fields for each document
+        template_ids = []
+        unique_docuseal_roles = set()
+        fields_by_docuseal_role = {}
+        
+        for doc in documents:
+            definition = DocumentLoader.get(doc.template_slug)
+            if not definition or not definition.docuseal_template_id:
+                continue
+            
+            template_ids.append(definition.docuseal_template_id)
+            
+            # Collect unique roles
+            for role_def in definition.roles:
+                unique_docuseal_roles.add(role_def.docuseal_role)
+            
+            # Build context for field resolution
+            context = {
+                'user': current_user,
+                'transaction': transaction,
+                'form': doc.field_data or {}
+            }
+            
+            # Resolve fields
+            resolved_fields = FieldResolver.resolve(definition, context)
+            
+            # Group fields by docuseal_role
+            for field in resolved_fields:
+                if field.is_manual or field.value is None:
+                    continue
+                
+                role_def = definition.get_role(field.role_key)
+                if role_def:
+                    docuseal_role = role_def.docuseal_role
+                    if docuseal_role not in fields_by_docuseal_role:
+                        fields_by_docuseal_role[docuseal_role] = []
+                    
+                    docuseal_field = {'name': field.docuseal_field, 'default_value': str(field.value)}
+                    fields_by_docuseal_role[docuseal_role].append(docuseal_field)
+        
+        if not template_ids:
+            return jsonify({
+                'success': False,
+                'error': 'No valid templates found for the documents.'
+            }), 404
+        
+        # Step 2: Merge templates into one combined template
+        merged_template = DocuSealClient.merge_templates(
+            template_ids=template_ids,
+            name=f"Print Package - {transaction.street_address} - TX{transaction.id}",
+            roles=None,  # Let DocuSeal preserve original roles
+            external_id=f"tx-{transaction.id}-print-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+        )
+        
+        merged_template_id = merged_template.get('id')
+        
+        # Step 3: Build submitters for preview (use placeholder emails for all roles)
+        participants = transaction.participants.all()
+        seller = next((p for p in participants if p.role == 'seller' and p.is_primary), None)
+        co_seller = next((p for p in participants if p.role == 'co_seller'), None)
+        listing_agent = next((p for p in participants if p.role == 'listing_agent'), None)
+        
+        agent_email = listing_agent.display_email if listing_agent else current_user.email
+        agent_name = listing_agent.display_name if listing_agent else f"{current_user.first_name} {current_user.last_name}"
+        
+        submitters = []
+        for docuseal_role in unique_docuseal_roles:
+            if docuseal_role == 'Seller':
+                email = seller.display_email if seller else f"seller-preview@preview.local"
+                name = seller.display_name if seller else "Seller"
+            elif docuseal_role == 'Seller 2':
+                if not co_seller or not co_seller.display_email:
+                    continue
+                email = co_seller.display_email
+                name = co_seller.display_name
+            elif docuseal_role in ['Agent', 'Broker']:
+                email = agent_email
+                name = agent_name
+            else:
+                continue
+            
+            submitters.append(Submitter(
+                role=docuseal_role,
+                email=email,
+                name=name,
+                fields=fields_by_docuseal_role.get(docuseal_role, [])
+            ))
+        
+        if not submitters:
+            return jsonify({
+                'success': False,
+                'error': 'No valid submitters could be created.'
+            }), 400
+        
+        # Step 4: Create preview submission (no email sent)
+        result = DocuSealClient.create_submission(
+            merged_template_id,
+            submitters,
+            send_email=False
+        )
+        
+        submission_id = result.get('id')
+        
+        if not submission_id:
+            return jsonify({
+                'success': False,
+                'error': 'Failed to create combined document submission.'
+            }), 500
+        
+        # Step 5: Get the combined PDF (merge=True merges all docs into single PDF)
+        pdf_documents = DocuSealClient.get_submission_documents(submission_id, merge=True)
+        
+        if not pdf_documents:
+            return jsonify({
+                'success': False,
+                'error': 'No PDF generated from combined documents.'
+            }), 404
+        
+        # Handle dict vs list response
+        if isinstance(pdf_documents, list):
+            pdf_doc = pdf_documents[0]
+        elif isinstance(pdf_documents, dict):
+            if 'documents' in pdf_documents:
+                doc_list = pdf_documents['documents']
+                pdf_doc = doc_list[0] if doc_list else None
+            else:
+                pdf_doc = next(iter(pdf_documents.values()), None)
+        else:
+            pdf_doc = None
+        
+        if not pdf_doc or not pdf_doc.get('url'):
+            return jsonify({
+                'success': False,
+                'error': 'Could not extract PDF URL from response.'
+            }), 404
+        
+        return jsonify({
+            'success': True,
+            'url': pdf_doc.get('url'),
+            'filename': f'{transaction.street_address.replace(" ", "_")}_All_Documents.pdf',
+            'document_count': len(documents),
+            'page_count': 'combined'
+        })
+        
+    except Exception as e:
+        print(f"Error creating combined print PDF: {e}")
+        import traceback
+        traceback.print_exc()
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@transactions_bp.route('/<int:id>/documents/<int:doc_id>/print-pdf')
+@login_required
+@transactions_required
+def get_document_print_pdf(id, doc_id):
+    """
+    Get the PDF URL for a filled document for printing.
+    
+    This fetches the PDF from DocuSeal using the submission ID.
+    The PDF includes all the filled field values.
+    
+    Works for documents in 'filled', 'generated', or 'sent' status.
+    """
+    from services.documents.docuseal_client import DocuSealClient
+    
+    transaction = Transaction.query.get_or_404(id)
+    
+    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+    
+    doc = TransactionDocument.query.get_or_404(doc_id)
+    
+    if doc.transaction_id != transaction.id:
+        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    
+    # Check if document has been filled
+    if doc.status == 'pending':
+        return jsonify({
+            'success': False,
+            'error': 'Document has not been filled yet. Please fill the form first.'
+        }), 400
+    
+    # Need submission ID to fetch PDF
+    if not doc.docuseal_submission_id:
+        return jsonify({
+            'success': False,
+            'error': 'No DocuSeal submission found. Please preview the document first.'
+        }), 400
+    
+    try:
+        # Check if in mock mode
+        if DocuSealClient.is_mock_mode():
+            return jsonify({
+                'success': False,
+                'error': 'PDF printing not available in test mode. Deploy to production to test.'
+            }), 400
+        
+        # Get documents from DocuSeal submission
+        submission_id = doc.docuseal_submission_id
+        documents = DocuSealClient.get_submission_documents(int(submission_id))
+        
+        if not documents:
+            return jsonify({
+                'success': False,
+                'error': 'No PDF documents found in submission.'
+            }), 404
+        
+        # DocuSeal may return a list or a dict - handle both formats
+        if isinstance(documents, list):
+            pdf_doc = documents[0]
+        elif isinstance(documents, dict):
+            # If it's a dict, get the first value or look for specific keys
+            if 'documents' in documents:
+                # Nested format: {'documents': [...]}
+                doc_list = documents['documents']
+                pdf_doc = doc_list[0] if doc_list else None
+            else:
+                # Direct dict format - get first value
+                pdf_doc = next(iter(documents.values()), None)
+        else:
+            pdf_doc = None
+        
+        if not pdf_doc:
+            return jsonify({
+                'success': False,
+                'error': 'Could not extract PDF document from response.'
+            }), 404
+        
+        # Handle different response formats for url/name
+        pdf_url = pdf_doc.get('url') if isinstance(pdf_doc, dict) else None
+        pdf_name = pdf_doc.get('name', f'{doc.template_name}.pdf') if isinstance(pdf_doc, dict) else f'{doc.template_name}.pdf'
+        
+        if not pdf_url:
+            return jsonify({
+                'success': False,
+                'error': f'No URL found in PDF document. Response: {pdf_doc}'
+            }), 404
+        
+        return jsonify({
+            'success': True,
+            'url': pdf_url,
+            'filename': pdf_name,
+            'document_count': len(documents) if isinstance(documents, list) else 1
+        })
+        
+    except Exception as e:
+        print(f"Error getting print PDF for doc {doc_id}: {e}")
         return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -777,6 +777,11 @@
                                             <i class="fas fa-edit w-5 text-slate-400"></i>
                                             <span class="ml-2">Edit Form</span>
                                         </a>
+                                        <a href="{{ url_for('transactions.document_preview', id=transaction.id, doc_id=doc.id) }}" 
+                                           class="flex items-center px-4 py-2.5 text-sm text-purple-600 hover:bg-purple-50 transition-colors">
+                                            <i class="fas fa-eye w-5"></i>
+                                            <span class="ml-2">View & Print</span>
+                                        </a>
                                         {% endif %}
                                         
                                         <!-- Mock DocuSeal Test Section -->

--- a/templates/transactions/document_preview.html
+++ b/templates/transactions/document_preview.html
@@ -23,16 +23,26 @@
                 </div>
                 
                 <!-- Action buttons -->
-                <div class="flex items-center gap-3">
-                    <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
-                       class="px-4 py-2 text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors flex items-center gap-2">
-                        <i class="fas fa-edit"></i>
-                        Edit Form
+                <div class="flex items-center gap-2 sm:gap-3">
+                    <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+                       class="px-3 py-2 text-sm font-medium text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg transition-colors flex items-center gap-2 no-print">
+                        <i class="fas fa-times"></i>
+                        <span class="hidden sm:inline">Close</span>
                     </a>
+                    <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
+                       class="px-3 py-2 text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors flex items-center gap-2 no-print">
+                        <i class="fas fa-edit"></i>
+                        <span class="hidden sm:inline">Edit Form</span>
+                    </a>
+                    <button onclick="printDocument()" 
+                            class="px-3 py-2 text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors flex items-center gap-2 no-print">
+                        <i class="fas fa-print"></i>
+                        <span class="hidden sm:inline">Print</span>
+                    </button>
                     <button onclick="confirmAndSend()" 
-                            class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all flex items-center gap-2">
+                            class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all flex items-center gap-2 no-print">
                         <i class="fas fa-paper-plane"></i>
-                        Send for Signature
+                        <span class="hidden sm:inline">Send for Signature</span>
                     </button>
                 </div>
             </div>
@@ -40,13 +50,13 @@
     </div>
     
     <!-- Preview info banner -->
-    <div class="bg-blue-50 border-b border-blue-100">
+    <div class="bg-blue-50 border-b border-blue-100 no-print">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
             <div class="flex items-center gap-3 text-blue-800">
                 <i class="fas fa-eye text-blue-500"></i>
                 <p class="text-sm">
                     <strong>Preview Mode:</strong> 
-                    Review the document below. When ready, click "Send for Signature" to email it to signers.
+                    Review the document below. Print for physical signature, or click "Send for Signature" for e-signing.
                     {% if mock_mode %}
                     <span class="ml-2 px-2 py-0.5 text-xs bg-amber-100 text-amber-700 rounded-full">Test Mode</span>
                     {% endif %}
@@ -131,12 +141,20 @@
     </div>
     
     <!-- Floating action bar for mobile -->
-    <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 p-4 sm:hidden z-50">
-        <div class="flex gap-3">
-            <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
-               class="flex-1 px-4 py-3 text-center text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors">
-                <i class="fas fa-edit mr-2"></i>Edit
+    <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 p-4 sm:hidden z-50 no-print">
+        <div class="flex gap-2">
+            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+               class="px-3 py-3 text-center text-sm font-medium text-slate-500 hover:bg-slate-100 rounded-lg transition-colors">
+                <i class="fas fa-times"></i>
             </a>
+            <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=document.id) }}" 
+               class="px-3 py-3 text-center text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors">
+                <i class="fas fa-edit"></i>
+            </a>
+            <button onclick="printDocument()" 
+                    class="px-3 py-3 text-center text-sm font-medium text-slate-600 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors">
+                <i class="fas fa-print"></i>
+            </button>
             <button onclick="confirmAndSend()" 
                     class="flex-1 px-4 py-3 text-center text-sm font-medium text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 rounded-lg shadow-sm transition-all">
                 <i class="fas fa-paper-plane mr-2"></i>Send
@@ -198,6 +216,60 @@
 }
 .animate-fade-in-up {
     animation: fade-in-up 0.3s ease-out forwards;
+}
+
+/* Print styles - hide UI elements when printing */
+@media print {
+    /* Hide navigation, action buttons, modals, and info banners */
+    .sticky, .fixed, #sendModal, .no-print { 
+        display: none !important; 
+    }
+    
+    /* Hide the blue info banner */
+    .bg-blue-50.border-b { 
+        display: none !important; 
+    }
+    
+    /* Maximize document area for printing */
+    .max-w-5xl { 
+        max-width: 100% !important; 
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+    
+    /* Remove shadow and border for cleaner print */
+    .shadow-lg, .rounded-2xl {
+        box-shadow: none !important;
+        border-radius: 0 !important;
+    }
+    
+    /* Hide document preview header bar */
+    .bg-slate-50.border-b.border-slate-200.px-6.py-4 {
+        display: none !important;
+    }
+    
+    /* Ensure background colors print */
+    * {
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+    }
+    
+    /* Remove min-height constraint */
+    #docuseal-container {
+        min-height: auto !important;
+    }
+    
+    /* Remove page margins for maximum content */
+    body {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+    
+    /* Hide the gradient background */
+    .min-h-screen.bg-gradient-to-br {
+        background: white !important;
+        min-height: auto !important;
+    }
 }
 </style>
 
@@ -303,6 +375,43 @@ function showToast(message, type) {
         toast.style.transition = 'all 0.3s ease-out';
         setTimeout(() => toast.remove(), 300);
     }, 3000);
+}
+
+function printDocument() {
+    // Show loading state
+    showToast('Preparing document for print...', 'info');
+    
+    // Fetch the actual PDF from DocuSeal
+    fetch(`/transactions/${transactionId}/documents/${documentId}/print-pdf`)
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.success && data.url) {
+                // Open PDF in new tab for printing
+                // This ensures ALL pages print correctly with filled data
+                const printWindow = window.open(data.url, '_blank');
+                if (printWindow) {
+                    showToast('PDF opened in new tab. Use browser print (Ctrl/Cmd+P)', 'success');
+                } else {
+                    // Popup blocked - provide direct link
+                    showToast('Pop-up blocked. Click the link below to open PDF.', 'error');
+                    // Create a temporary link
+                    const link = document.createElement('a');
+                    link.href = data.url;
+                    link.target = '_blank';
+                    link.textContent = 'Click here to open PDF';
+                    link.className = 'fixed bottom-32 right-6 px-4 py-2 bg-blue-600 text-white rounded-lg shadow-xl z-50';
+                    link.onclick = () => setTimeout(() => link.remove(), 1000);
+                    document.body.appendChild(link);
+                    setTimeout(() => link.remove(), 10000);
+                }
+            } else {
+                showToast(data.error || 'Failed to get printable PDF', 'error');
+            }
+        })
+        .catch(err => {
+            console.error('Print error:', err);
+            showToast('Failed to prepare document for printing', 'error');
+        });
 }
 </script>
 {% endblock %}

--- a/templates/transactions/preview_all_documents.html
+++ b/templates/transactions/preview_all_documents.html
@@ -154,6 +154,15 @@
             opacity: 0.5;
         }
     }
+    
+    @keyframes fade-in-up {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+    
+    .animate-fade-in-up {
+        animation: fade-in-up 0.3s ease-out forwards;
+    }
 </style>
 {% endblock %}
 
@@ -201,8 +210,7 @@
                 <i class="fas fa-eye text-blue-500"></i>
                 <p class="text-sm">
                     <strong>Preview Mode:</strong>
-                    Review each document below. When ready, scroll down and click "Send All for Signature" to email to
-                    signers.
+                    Review each document below. Print for physical signatures, or click "Send All for Signature" for e-signing.
                 </p>
             </div>
         </div>
@@ -418,10 +426,15 @@
         <!-- Action Buttons -->
         <div class="flex flex-col sm:flex-row gap-4">
             <a href="{{ url_for('transactions.fill_all_documents', id=transaction.id) }}"
-                class="flex-1 px-6 py-4 text-center text-slate-600 bg-white border border-slate-200 hover:bg-slate-50 rounded-xl font-medium transition-colors flex items-center justify-center gap-2">
+                class="px-6 py-4 text-center text-slate-600 bg-white border border-slate-200 hover:bg-slate-50 rounded-xl font-medium transition-colors flex items-center justify-center gap-2">
                 <i class="fas fa-edit"></i>
                 Edit Forms
             </a>
+            <button type="button" onclick="printAllDocuments()"
+                class="px-6 py-4 text-center text-slate-700 bg-white border border-slate-200 hover:bg-slate-50 rounded-xl font-medium transition-colors flex items-center justify-center gap-2">
+                <i class="fas fa-print"></i>
+                Print All
+            </button>
             <form action="{{ url_for('transactions.send_all_for_signature', id=transaction.id) }}" method="POST"
                 class="flex-1">
                 <button type="submit" {% if not signers %}disabled{% endif %}
@@ -517,5 +530,103 @@
     document.addEventListener('DOMContentLoaded', function () {
         updateNavButtons();
     });
+    
+    // Document IDs for printing
+    const transactionId = {{ transaction.id }};
+    const documentIds = [{% for doc in documents %}{{ doc.id }}{% if not loop.last %}, {% endif %}{% endfor %}];
+    
+    function showToast(message, type) {
+        const toast = document.createElement('div');
+        toast.className = `fixed bottom-6 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
+            type === 'success' ? 'bg-green-600 text-white' : 
+            type === 'error' ? 'bg-red-600 text-white' : 
+            'bg-slate-800 text-white'
+        }`;
+        toast.innerHTML = `
+            <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
+            <span>${message}</span>
+        `;
+        document.body.appendChild(toast);
+        
+        setTimeout(() => {
+            toast.style.opacity = '0';
+            toast.style.transform = 'translateY(20px)';
+            toast.style.transition = 'all 0.3s ease-out';
+            setTimeout(() => toast.remove(), 300);
+        }, 5000);
+    }
+    
+    async function printAllDocuments() {
+        showToast('Preparing combined document for printing...', 'info');
+        
+        try {
+            // Fetch the COMBINED PDF URL (all docs merged into one)
+            const response = await fetch(`/transactions/${transactionId}/documents/print-all-pdf`);
+            const data = await response.json();
+            
+            if (data.success && data.url) {
+                // Open the combined PDF in a new tab
+                const printWindow = window.open(data.url, '_blank');
+                if (printWindow) {
+                    showToast(`Combined PDF opened (${data.document_count} documents). Use browser print (Ctrl/Cmd+P).`, 'success');
+                } else {
+                    // Popup blocked - show link
+                    showPrintLink(data.url, data.filename);
+                }
+            } else {
+                showToast(data.error || 'Failed to prepare combined PDF for printing.', 'error');
+            }
+        } catch (err) {
+            console.error('Error fetching combined PDF:', err);
+            showToast('Failed to prepare documents for printing. Please try again.', 'error');
+        }
+    }
+    
+    function showPrintLink(url, filename) {
+        // Remove any existing modal
+        const existingModal = document.getElementById('printModal');
+        if (existingModal) existingModal.remove();
+        
+        // Create modal with single link
+        const modal = document.createElement('div');
+        modal.id = 'printModal';
+        modal.className = 'fixed inset-0 z-50 flex items-center justify-center';
+        modal.innerHTML = `
+            <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" onclick="closePrintModal()"></div>
+            <div class="relative bg-white rounded-2xl shadow-2xl max-w-md w-full mx-4 p-6 animate-fade-in-up">
+                <button onclick="closePrintModal()" class="absolute top-4 right-4 text-slate-400 hover:text-slate-600">
+                    <i class="fas fa-times text-xl"></i>
+                </button>
+                
+                <div class="text-center mb-6">
+                    <div class="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center mx-auto mb-4">
+                        <i class="fas fa-exclamation-triangle text-2xl text-amber-600"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-slate-800">Pop-up Blocked</h3>
+                    <p class="text-slate-600 mt-2">
+                        Your browser blocked the PDF. Click below to open it manually.
+                    </p>
+                </div>
+                
+                <a href="${url}" target="_blank" onclick="closePrintModal()"
+                   class="flex items-center justify-center gap-3 w-full p-4 bg-blue-600 hover:bg-blue-700 text-white rounded-xl transition-colors font-medium">
+                    <i class="fas fa-file-pdf"></i>
+                    Open Combined PDF
+                    <i class="fas fa-external-link-alt text-sm"></i>
+                </a>
+                
+                <p class="text-xs text-slate-500 text-center mt-4">
+                    Use your browser's print function (Ctrl/Cmd+P) after opening.
+                </p>
+            </div>
+        `;
+        
+        document.body.appendChild(modal);
+    }
+    
+    function closePrintModal() {
+        const modal = document.getElementById('printModal');
+        if (modal) modal.remove();
+    }
 </script>
 {% endblock %}

--- a/templates/transactions/simple_preview.html
+++ b/templates/transactions/simple_preview.html
@@ -115,6 +115,60 @@
         0%, 100% { opacity: 1; }
         50% { opacity: 0.5; }
     }
+    
+    /* Print styles - hide UI elements when printing */
+    @media print {
+        /* Hide navigation, action buttons, and overlays */
+        .sticky, .fixed, .loading-overlay, .no-print { 
+            display: none !important; 
+        }
+        
+        /* Hide the blue info banner */
+        .bg-blue-50.border-b { 
+            display: none !important; 
+        }
+        
+        /* Maximize document area for printing */
+        .max-w-5xl { 
+            max-width: 100% !important; 
+            padding: 0 !important;
+            margin: 0 !important;
+        }
+        
+        /* Remove shadow and border for cleaner print */
+        .shadow-lg, .shadow-2xl, .rounded-2xl {
+            box-shadow: none !important;
+            border-radius: 0 !important;
+        }
+        
+        /* Ensure background colors print */
+        * {
+            -webkit-print-color-adjust: exact !important;
+            print-color-adjust: exact !important;
+        }
+        
+        /* Remove min-height constraint */
+        .preview-embed-container {
+            min-height: auto !important;
+        }
+        
+        /* Remove page margins for maximum content */
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+        }
+        
+        /* Hide the gradient background */
+        .min-h-screen.bg-gradient-to-br {
+            background: white !important;
+            min-height: auto !important;
+        }
+        
+        /* Hide spacer for floating action bar */
+        .h-24 {
+            display: none !important;
+        }
+    }
 </style>
 
 <div class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50/30">
@@ -148,13 +202,13 @@
     </div>
 
     <!-- Info banner -->
-    <div class="bg-blue-50 border-b border-blue-100">
+    <div class="bg-blue-50 border-b border-blue-100 no-print">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
             <div class="flex items-center gap-3 text-blue-800">
                 <i class="fas fa-info-circle text-blue-500"></i>
                 <p class="text-sm">
                     <strong>Preview Mode:</strong>
-                    Property address has been pre-filled. The seller will complete and sign this document when sent for e-signature.
+                    Property address has been pre-filled. Print for physical signature, or continue to send for e-signature.
                     {% if preview_info.mock_mode %}
                     <span class="ml-2 px-2 py-0.5 text-xs bg-amber-100 text-amber-700 rounded-full">Test Mode</span>
                     {% endif %}
@@ -279,17 +333,17 @@
 </div>
 
 <!-- Floating Action Bar -->
-<div class="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white px-4 py-3 rounded-2xl shadow-2xl border border-slate-200 z-50 flex items-center gap-3">
+<div class="fixed bottom-6 left-1/2 transform -translate-x-1/2 bg-white px-4 py-3 rounded-2xl shadow-2xl border border-slate-200 z-50 flex items-center gap-3 no-print">
     <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
         class="px-5 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-lg transition-colors">
-        Cancel
+        Close
     </a>
     <div class="w-px h-8 bg-slate-200"></div>
-    <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}"
+    <button onclick="printDocument()"
         class="px-5 py-2.5 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg flex items-center gap-2 transition-colors">
-        <i class="fas fa-save text-slate-500"></i>
-        Save Draft
-    </a>
+        <i class="fas fa-print text-slate-500"></i>
+        Print
+    </button>
     <a href="{{ url_for('transactions.document_preview', id=transaction.id, doc_id=document.id) }}"
         onclick="showLoadingOverlay('Generating Preview...', 'This may take a few moments')"
         class="px-5 py-2.5 text-sm font-medium text-white bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 rounded-lg flex items-center gap-2 shadow-sm transition-all">
@@ -311,6 +365,9 @@
 <script src="https://cdn.docuseal.com/js/form.js"></script>
 
 <script>
+    const transactionId = {{ transaction.id }};
+    const documentId = {{ document.id }};
+    
     function showLoadingOverlay(message, submessage) {
         if (message) {
             document.getElementById('loadingText').textContent = message;
@@ -319,6 +376,58 @@
             document.getElementById('loadingSubtext').textContent = submessage;
         }
         document.getElementById('loadingOverlay').classList.add('show');
+    }
+    
+    function showToast(message, type) {
+        const toast = document.createElement('div');
+        toast.className = `fixed bottom-24 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
+            type === 'success' ? 'bg-green-600 text-white' : 
+            type === 'error' ? 'bg-red-600 text-white' : 
+            'bg-slate-800 text-white'
+        }`;
+        toast.innerHTML = `
+            <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
+            <span>${message}</span>
+        `;
+        document.body.appendChild(toast);
+        
+        setTimeout(() => {
+            toast.style.opacity = '0';
+            toast.style.transform = 'translateY(20px)';
+            toast.style.transition = 'all 0.3s ease-out';
+            setTimeout(() => toast.remove(), 300);
+        }, 3000);
+    }
+    
+    function printDocument() {
+        showToast('Preparing document for print...', 'info');
+        
+        fetch(`/transactions/${transactionId}/documents/${documentId}/print-pdf`)
+            .then(resp => resp.json())
+            .then(data => {
+                if (data.success && data.url) {
+                    const printWindow = window.open(data.url, '_blank');
+                    if (printWindow) {
+                        showToast('PDF opened in new tab. Use browser print (Ctrl/Cmd+P)', 'success');
+                    } else {
+                        showToast('Pop-up blocked. Click the link below to open PDF.', 'error');
+                        const link = document.createElement('a');
+                        link.href = data.url;
+                        link.target = '_blank';
+                        link.textContent = 'Click here to open PDF';
+                        link.className = 'fixed bottom-32 right-6 px-4 py-2 bg-blue-600 text-white rounded-lg shadow-xl z-50';
+                        link.onclick = () => setTimeout(() => link.remove(), 1000);
+                        document.body.appendChild(link);
+                        setTimeout(() => link.remove(), 10000);
+                    }
+                } else {
+                    showToast(data.error || 'Failed to get printable PDF', 'error');
+                }
+            })
+            .catch(err => {
+                console.error('Print error:', err);
+                showToast('Failed to prepare document for printing', 'error');
+            });
     }
 </script>
 {% endblock %}


### PR DESCRIPTION
Enable agents to print filled documents for physical signatures:

- Add Print button to document_preview.html and simple_preview.html
- Add View & Print option in 3-dots menu for filled docs
- Add print-pdf endpoint to fetch PDF from DocuSeal submission
- Add print-all-pdf endpoint that merges all docs into single PDF
- Update DocuSealClient to return submission ID and support merge param
- Store submission ID when creating preview submissions
- Add print CSS to hide UI elements when printing
- Update info banners to mention print option

The print-all feature uses DocuSeal's merge templates API to combine all documents into one package, then fetches a single merged PDF using the merge=true parameter on the documents endpoint.