### PR TITLE
feat: rebrand TechnolOG to Origen TechnolOG across all UI

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ class Config:
     MAIL_USE_TLS = os.getenv('MAIL_USE_TLS', 'True').lower() == 'true'
     MAIL_USERNAME = os.getenv('MAIL_USERNAME')
     MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
-    MAIL_DEFAULT_SENDER = (os.getenv('MAIL_SENDER_NAME', 'TechnolOG'), os.getenv('MAIL_SENDER_EMAIL', 'noreply@example.com'))
+    MAIL_DEFAULT_SENDER = (os.getenv('MAIL_SENDER_NAME', 'Origen TechnolOG'), os.getenv('MAIL_SENDER_EMAIL', 'noreply@example.com'))
     MAIL_MAX_EMAILS = None
     MAIL_ASCII_ATTACHMENTS = False
 

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -7,7 +7,7 @@
 # Do not hardcode here - set in Railway/hosting platform env vars
 
 # Application name as it will appear in New Relic dashboard
-app_name = TechnolOG
+app_name = Origen TechnolOG
 
 # Enable high security mode (false for most apps)
 high_security = false
@@ -58,15 +58,15 @@ application_logging.local_decorating.enabled = false
 [newrelic:development]
 # Disable monitoring in development to avoid noise
 monitor_mode = false
-app_name = TechnolOG (Development)
+app_name = Origen TechnolOG (Development)
 
 [newrelic:test]
 monitor_mode = false
 
 [newrelic:staging]
-app_name = TechnolOG (Staging)
+app_name = Origen TechnolOG (Staging)
 monitor_mode = true
 
 [newrelic:production]
 monitor_mode = true
-app_name = TechnolOG
+app_name = Origen TechnolOG

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -23,8 +23,8 @@ def format_datetime_cst(utc_dt):
 
 def send_reset_email(user):
     token = user.get_reset_token()
-    msg = Message('Reset Your TechnolOG Password',
-                  sender=('TechnolOG', current_app.config['MAIL_USERNAME']),
+    msg = Message('Reset Your Origen TechnolOG Password',
+                  sender=('Origen TechnolOG', current_app.config['MAIL_USERNAME']),
                   recipients=[user.email])
     
     # HTML version of the email
@@ -180,13 +180,13 @@ def send_reset_email(user):
     <body>
         <div class="container">
             <div class="email-header">
-                <h1 class="header-logo">TechnolOG</h1>
+                <h1 class="header-logo">Origen TechnolOG</h1>
             </div>
             
             <div class="card">
                 <h2 class="title">Reset Your Password</h2>
                 <p class="text">Hello {user.first_name},</p>
-                <p class="text">We received a request to reset your password for your TechnolOG account. Click the button below to reset it:</p>
+                <p class="text">We received a request to reset your password for your Origen TechnolOG account. Click the button below to reset it:</p>
                 
                 <div class="button-container">
                     <a href="{url_for('auth.reset_password', token=token, _external=True)}" class="button">Reset Password</a>
@@ -204,7 +204,7 @@ def send_reset_email(user):
                     <a href="#" class="social-link">Contact</a>
                     <a href="#" class="social-link">Support</a>
                 </div>
-                <p class="footer">&copy; {datetime.now().year} TechnolOG. All rights reserved.</p>
+                <p class="footer">&copy; {datetime.now().year} Origen TechnolOG. All rights reserved.</p>
                 <p class="footer" style="margin-top: 8px;">This is an automated message, please do not reply to this email.</p>
             </div>
         </div>
@@ -215,7 +215,7 @@ def send_reset_email(user):
     # Plain text version as fallback
     msg.body = f'''Hello {user.first_name},
 
-We received a request to reset your password for your TechnolOG account.
+We received a request to reset your password for your Origen TechnolOG account.
 
 To reset your password, visit the following link:
 {url_for('auth.reset_password', token=token, _external=True)}
@@ -224,7 +224,7 @@ If you did not make this request, you can safely ignore this email.
 The link will expire in 30 minutes.
 
 Best regards,
-TechnolOG Team
+Origen TechnolOG Team
 '''
     current_app.extensions['mail'].send(msg)
 

--- a/routes/contact_us.py
+++ b/routes/contact_us.py
@@ -92,7 +92,7 @@ def contact_us():
             <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 30px 0;">
             
             <p style="font-size: 12px; color: #94a3b8; text-align: center; margin: 0;">
-                TechnolOG CRM - Contact Form Submission
+                Origen TechnolOG CRM - Contact Form Submission
             </p>
         </div>
         """
@@ -112,7 +112,7 @@ Message:
 ---
 Reply to: {user_email}
 
-TechnolOG CRM
+Origen TechnolOG CRM
         """
         
         mail.send(msg)

--- a/services/org_notifications.py
+++ b/services/org_notifications.py
@@ -33,7 +33,7 @@ def send_org_approved_email(org, owner_email):
         msg.html = f"""
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
             <div style="text-align: center; margin-bottom: 30px;">
-                <h1 style="color: #f97316; margin: 0;">Welcome to TechnolOG!</h1>
+                <h1 style="color: #f97316; margin: 0;">Welcome to Origen TechnolOG!</h1>
             </div>
             
             <p style="font-size: 16px; color: #374151;">
@@ -76,13 +76,13 @@ def send_org_approved_email(org, owner_email):
             <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
             
             <p style="font-size: 12px; color: #9ca3af; text-align: center;">
-                TechnolOG CRM - Powering Real Estate Success
+                Origen TechnolOG CRM - Powering Real Estate Success
             </p>
         </div>
         """
         
         msg.body = f"""
-Welcome to TechnolOG!
+Welcome to Origen TechnolOG!
 
 Great news! Your organization "{org.name}" has been approved and is now active.
 
@@ -96,7 +96,7 @@ Your Free Tier includes:
 
 Questions? Reply to this email and we'll help you get started.
 
-TechnolOG CRM
+Origen TechnolOG CRM
         """
         
         mail.send(msg)
@@ -123,7 +123,7 @@ def send_org_rejected_email(org, owner_email, reason=None):
         reason_text = reason if reason else "Your application did not meet our requirements at this time."
         
         msg = Message(
-            subject=f"Update on your TechnolOG application",
+            subject=f"Update on your Origen TechnolOG application",
             recipients=[owner_email],
         )
         
@@ -132,7 +132,7 @@ def send_org_rejected_email(org, owner_email, reason=None):
             <h2 style="color: #374151;">Application Update</h2>
             
             <p style="font-size: 16px; color: #374151;">
-                Thank you for your interest in TechnolOG. Unfortunately, we were unable to approve 
+                Thank you for your interest in Origen TechnolOG. Unfortunately, we were unable to approve 
                 your organization <strong>{org.name}</strong> at this time.
             </p>
             
@@ -150,7 +150,7 @@ def send_org_rejected_email(org, owner_email, reason=None):
             <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
             
             <p style="font-size: 12px; color: #9ca3af; text-align: center;">
-                TechnolOG CRM
+                Origen TechnolOG CRM
             </p>
         </div>
         """
@@ -158,7 +158,7 @@ def send_org_rejected_email(org, owner_email, reason=None):
         msg.body = f"""
 Application Update
 
-Thank you for your interest in TechnolOG. Unfortunately, we were unable to approve 
+Thank you for your interest in Origen TechnolOG. Unfortunately, we were unable to approve 
 your organization "{org.name}" at this time.
 
 Reason: {reason_text}
@@ -166,7 +166,7 @@ Reason: {reason_text}
 If you believe this was an error or would like to provide additional information, 
 please reply to this email.
 
-TechnolOG CRM
+Origen TechnolOG CRM
         """
         
         mail.send(msg)
@@ -191,7 +191,7 @@ def send_invite_email(org, inviter, invitee_email, invite_token):
         invite_url = url_for('auth.accept_invite', token=invite_token, _external=True)
         
         msg = Message(
-            subject=f"You've been invited to join {org.name} on TechnolOG",
+            subject=f"You've been invited to join {org.name} on Origen TechnolOG",
             recipients=[invitee_email],
         )
         
@@ -203,7 +203,7 @@ def send_invite_email(org, inviter, invitee_email, invite_token):
             
             <p style="font-size: 16px; color: #374151;">
                 <strong>{inviter.first_name} {inviter.last_name}</strong> has invited you to join 
-                <strong>{org.name}</strong> on TechnolOG CRM.
+                <strong>{org.name}</strong> on Origen TechnolOG CRM.
             </p>
             
             <div style="text-align: center; margin: 30px 0;">
@@ -227,7 +227,7 @@ def send_invite_email(org, inviter, invitee_email, invite_token):
             <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
             
             <p style="font-size: 12px; color: #9ca3af; text-align: center;">
-                TechnolOG CRM - Powering Real Estate Success
+                Origen TechnolOG CRM - Powering Real Estate Success
             </p>
         </div>
         """
@@ -235,14 +235,14 @@ def send_invite_email(org, inviter, invitee_email, invite_token):
         msg.body = f"""
 You're Invited!
 
-{inviter.first_name} {inviter.last_name} has invited you to join {org.name} on TechnolOG CRM.
+{inviter.first_name} {inviter.last_name} has invited you to join {org.name} on Origen TechnolOG CRM.
 
 Accept your invitation here: {invite_url}
 
 This invitation expires in 72 hours. If you didn't expect this invitation, 
 you can safely ignore this email.
 
-TechnolOG CRM
+Origen TechnolOG CRM
         """
         
         mail.send(msg)

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -183,7 +183,7 @@
         <div class="text-center mb-8 animate-fade-in-up">
             <div class="flex justify-center mb-6">
                 <div class="w-20 h-20 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-2xl flex items-center justify-center shadow-xl">
-                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-16 w-auto object-contain" />
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-16 w-auto object-contain" />
                 </div>
             </div>
         </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -246,7 +246,7 @@
             <div class="animate-fade-in-left">
                 <div class="flex items-center space-x-4 mb-16">
                     <div class="w-14 h-14 bg-gradient-to-br from-[#3d4d63] to-[#2d3e50] rounded-xl flex items-center justify-center shadow-xl border border-white/10">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-12 w-auto object-contain" />
+                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-12 w-auto object-contain" />
                     </div>
                 </div>
                 
@@ -315,7 +315,7 @@
             <div class="lg:hidden text-center mb-8">
                 <div class="flex justify-center mb-4">
                     <div class="w-16 h-16 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-xl flex items-center justify-center shadow-lg">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-14 w-auto object-contain" />
+                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-14 w-auto object-contain" />
                     </div>
                 </div>
             </div>

--- a/templates/auth/registration_status.html
+++ b/templates/auth/registration_status.html
@@ -194,7 +194,7 @@
         <div class="text-center mb-8 animate-fade-in-up">
             <div class="flex justify-center mb-6">
                 <div class="w-16 h-16 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-xl flex items-center justify-center shadow-xl">
-                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-14 w-auto object-contain" />
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-14 w-auto object-contain" />
                 </div>
             </div>
         </div>

--- a/templates/auth/reset_password.html
+++ b/templates/auth/reset_password.html
@@ -159,7 +159,7 @@
         <div class="text-center mb-8 animate-fade-in-up">
             <div class="flex justify-center mb-6">
                 <div class="w-16 h-16 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-xl flex items-center justify-center shadow-xl">
-                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-14 w-auto object-contain" />
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-14 w-auto object-contain" />
                 </div>
             </div>
         </div>

--- a/templates/auth/reset_request.html
+++ b/templates/auth/reset_request.html
@@ -159,7 +159,7 @@
         <div class="text-center mb-8 animate-fade-in-up">
             <div class="flex justify-center mb-6">
                 <div class="w-16 h-16 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-xl flex items-center justify-center shadow-xl">
-                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-14 w-auto object-contain" />
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-14 w-auto object-contain" />
                 </div>
             </div>
         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}TechnolOG{% endblock %}</title>
+    <title>{% block title %}Origen TechnolOG{% endblock %}</title>
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
     <!-- Include Tailwind CSS from CDN -->
@@ -130,7 +130,7 @@
     <!-- Top Header - Hidden on Mobile -->
     <header class="text-white h-14 items-center justify-between hidden md:flex">
         <div class="pl-4">
-            <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG"
+            <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG"
                 class="block h-24 w-auto object-contain mt-2.5" />
         </div>
         <div class="flex items-center space-x-4 pr-4 relative">
@@ -157,7 +157,7 @@
                 <i class="fas fa-bars text-xl"></i>
             </button>
             {% endif %}
-            <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG"
+            <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG"
                 class="block h-10 w-auto object-contain" />
         </div>
         <div class="flex items-center space-x-3">

--- a/templates/company_updates/list.html
+++ b/templates/company_updates/list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Company Updates - TechnolOG{% endblock %}
+{% block title %}Company Updates - Origen TechnolOG{% endblock %}
 
 {% block head_scripts %}
 <style>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TechnolOG - The Real Estate CRM Built for Serious Agents</title>
-    <meta name="description" content="Manage contacts, close more deals, and scale your real estate business with TechnolOG CRM. AI-powered tools, transaction management, and team collaboration.">
+    <title>Origen TechnolOG - The Real Estate CRM Built for Serious Agents</title>
+    <meta name="description" content="Manage contacts, close more deals, and scale your real estate business with Origen TechnolOG CRM. AI-powered tools, transaction management, and team collaboration.">
     
     <!-- Favicon -->
     <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
@@ -184,9 +184,9 @@
                 <!-- Logo -->
                 <a href="/" class="flex items-center gap-3">
                     <div class="w-10 h-10 md:w-12 md:h-12 bg-gradient-to-br from-brand-800 to-brand-900 rounded-xl flex items-center justify-center shadow-lg">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-8 md:h-10 w-auto object-contain" />
+                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" />
                     </div>
-                    <span class="text-xl md:text-2xl font-bold text-brand-900 hidden sm:block">TechnolOG</span>
+                    <span class="text-xl md:text-2xl font-bold text-brand-900 hidden sm:block">Origen TechnolOG</span>
                 </a>
                 
                 <!-- Desktop Nav Links -->
@@ -309,7 +309,7 @@
                             </div>
                             <div class="flex-1 mx-4">
                                 <div class="bg-white rounded-lg px-4 py-1.5 text-xs text-brand-400 border border-brand-100">
-                                    app.technolog.com/dashboard
+                                    origentechnolog.com/dashboard
                                 </div>
                             </div>
                         </div>
@@ -422,7 +422,7 @@
                     Great businesses don't just happen
                 </h2>
                 <p class="text-lg text-brand-600 max-w-2xl mx-auto">
-                    You build them with flexible systems that scale as you grow. Here's how TechnolOG helps.
+                    You build them with flexible systems that scale as you grow. Here's how Origen TechnolOG helps.
                 </p>
             </div>
             
@@ -871,7 +871,7 @@
                 Ready to grow your business?
             </h2>
             <p class="text-xl text-white/90 mb-10 max-w-2xl mx-auto">
-                Join agents across Texas who are closing more deals with TechnolOG. Start free today.
+                Join agents across Texas who are closing more deals with Origen TechnolOG. Start free today.
             </p>
             
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
@@ -895,9 +895,9 @@
                 <!-- Logo -->
                 <div class="flex items-center gap-3">
                     <div class="w-10 h-10 bg-brand-800 rounded-xl flex items-center justify-center">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="TechnolOG" class="h-8 w-auto object-contain" />
+                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 w-auto object-contain" />
                     </div>
-                    <span class="text-xl font-bold text-white">TechnolOG</span>
+                    <span class="text-xl font-bold text-white">Origen TechnolOG</span>
                 </div>
                 
                 <!-- Links -->
@@ -909,7 +909,7 @@
                 
                 <!-- Copyright -->
                 <div class="text-brand-500 text-sm">
-                    &copy; {{ current_year }} TechnolOG. All rights reserved.
+                    &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
                 </div>
             </div>
             

--- a/templates/modals/contact_us_modal.html
+++ b/templates/modals/contact_us_modal.html
@@ -100,7 +100,7 @@
 const CONTACT_PLACEHOLDERS = {
     landing: {
         subject: "Questions about pricing, features, or getting started?",
-        message: "Tell us what you'd like to know about TechnolOG CRM. Ask about features, pricing plans, signing up, or schedule a demo..."
+        message: "Tell us what you'd like to know about Origen TechnolOG CRM. Ask about features, pricing plans, signing up, or schedule a demo..."
     },
     app: {
         subject: "Brief summary of your inquiry",

--- a/templates/transactions/create.html
+++ b/templates/transactions/create.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Transaction - TechnolOG{% endblock %}
+{% block title %}New Transaction - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}{{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/document_field_editor.html
+++ b/templates/transactions/document_field_editor.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Field Editor - {{ document.template_name }} - TechnolOG{% endblock %}
+{% block title %}Field Editor - {{ document.template_name }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/document_form.html
+++ b/templates/transactions/document_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/edit.html
+++ b/templates/transactions/edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Edit Transaction - TechnolOG{% endblock %}
+{% block title %}Edit Transaction - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Fill All Documents - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Fill All Documents - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/flood_hazard_form.html
+++ b/templates/transactions/flood_hazard_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Flood Hazard Info - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Flood Hazard Info - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/history.html
+++ b/templates/transactions/history.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Activity History - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Activity History - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/hoa_addendum_form.html
+++ b/templates/transactions/hoa_addendum_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}HOA Addendum - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}HOA Addendum - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/iabs_preview.html
+++ b/templates/transactions/iabs_preview.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Property Questionnaire - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Property Questionnaire - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/list.html
+++ b/templates/transactions/list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Transactions - TechnolOG{% endblock %}
+{% block title %}Transactions - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/listing_agreement_form.html
+++ b/templates/transactions/listing_agreement_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Listing Agreement - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Listing Agreement - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/seller_net_proceeds_form.html
+++ b/templates/transactions/seller_net_proceeds_form.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Seller's Estimated Net Proceeds - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}Seller's Estimated Net Proceeds - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>

--- a/templates/transactions/simple_preview.html
+++ b/templates/transactions/simple_preview.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - TechnolOG{% endblock %}
+{% block title %}{{ document.template_name }} - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
 <style>


### PR DESCRIPTION
Update all branding text from "TechnolOG" to "Origen TechnolOG" to match the origentechnolog.com domain. Changes include:

- Landing page: title, meta description, nav, features, CTA, footer
- Base template: default title, logo alt text
- Auth pages: login, register, reset password, registration status
- Transaction templates: all page titles (16 files)
- Email templates: password reset, org notifications, contact form
- Config: mail sender name, NewRelic app name