### PR TITLE
feat: add task reminder email system with batched digest

### DIFF
--- a/email_templates/6_task_reminder.html
+++ b/email_templates/6_task_reminder.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Task Reminders</title>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body, table, td, p, a, li { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+        table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+        img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+        body { margin: 0 !important; padding: 0 !important; width: 100% !important; font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f0f4f8; }
+        
+        @media only screen and (max-width: 600px) {
+            .container { width: 100% !important; }
+            .content-padding { padding: 32px 24px !important; }
+            .header-padding { padding: 28px 24px !important; }
+            .title { font-size: 26px !important; }
+            .task-item { padding: 14px 16px !important; }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f4f8;">
+    
+    <!-- Preheader -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        You have {{total_task_count}} task{{#if (gt total_task_count 1)}}s{{/if}} that need your attention today.
+    </div>
+    
+    <!-- Email Wrapper -->
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color: #f0f4f8;">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+                
+                <!-- Main Container -->
+                <table role="presentation" cellpadding="0" cellspacing="0" width="600" class="container" style="max-width: 600px; background-color: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 32px rgba(16, 42, 67, 0.08);">
+                    
+                    <!-- ========== HEADER ========== -->
+                    <tr>
+                        <td class="header-padding" style="background: linear-gradient(135deg, #1e2d3d 0%, #102a43 100%); padding: 36px 40px; text-align: center;">
+                            <h1 style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 26px; font-weight: 700; letter-spacing: 0.3px;">
+                                <span style="color: #ffffff;">Origen Technol</span><span style="color: #f97316;">OG</span>
+                            </h1>
+                            <p style="margin: 8px 0 0 0; font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 500; color: #829ab1; letter-spacing: 0.5px; text-transform: uppercase;">
+                                The Real Estate CRM
+                            </p>
+                        </td>
+                    </tr>
+                    
+                    <!-- Orange Accent Line -->
+                    <tr>
+                        <td style="height: 4px; background: linear-gradient(90deg, #f97316 0%, #fb923c 50%, #f97316 100%);"></td>
+                    </tr>
+                    
+                    <!-- ========== BODY CONTENT ========== -->
+                    <tr>
+                        <td class="content-padding" style="padding: 48px 48px 40px 48px;">
+                            
+                            <!-- Title -->
+                            <h2 class="title" style="margin: 0 0 12px 0; font-family: 'DM Sans', sans-serif; font-size: 28px; font-weight: 700; color: #102a43; text-align: center; line-height: 1.3;">
+                                Task Reminders
+                            </h2>
+                            
+                            <!-- Subtitle with count -->
+                            <p style="margin: 0 0 32px 0; font-family: 'DM Sans', sans-serif; font-size: 16px; color: #627d98; text-align: center; line-height: 1.5;">
+                                Hi {{first_name}}, you have <strong style="color: #102a43;">{{total_task_count}}</strong> task{{#if (gt total_task_count 1)}}s{{/if}} that need your attention.
+                            </p>
+                            
+                            <!-- ========== OVERDUE TASKS ========== -->
+                            {{#if has_overdue}}
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 24px;">
+                                <tr>
+                                    <td style="padding: 12px 16px; background-color: #fef2f2; border-radius: 8px 8px 0 0; border-left: 4px solid #dc2626;">
+                                        <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 700; color: #dc2626; text-transform: uppercase; letter-spacing: 0.5px;">
+                                            ⚠️ Overdue
+                                        </p>
+                                    </td>
+                                </tr>
+                                {{#each overdue_tasks}}
+                                <tr>
+                                    <td class="task-item" style="padding: 16px 20px; background-color: #fff5f5; border-left: 4px solid #dc2626; border-bottom: 1px solid #fecaca;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td>
+                                                    <a href="{{task_url}}" style="font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #102a43; text-decoration: none; display: block; margin-bottom: 4px;">
+                                                        {{subject}}
+                                                    </a>
+                                                    <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 13px; color: #627d98;">
+                                                        {{contact_name}} • Due: <span style="color: #dc2626; font-weight: 500;">{{due_date}}</span>
+                                                        {{#if priority}}<span style="margin-left: 8px; padding: 2px 8px; background-color: {{#if (eq priority 'high')}}#fef2f2{{else if (eq priority 'medium')}}#fffbeb{{else}}#f0fdf4{{/if}}; color: {{#if (eq priority 'high')}}#dc2626{{else if (eq priority 'medium')}}#d97706{{else}}#16a34a{{/if}}; border-radius: 4px; font-size: 11px; font-weight: 600; text-transform: uppercase;">{{priority}}</span>{{/if}}
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                                {{/each}}
+                            </table>
+                            {{/if}}
+                            
+                            <!-- ========== DUE TOMORROW TASKS ========== -->
+                            {{#if has_tomorrow}}
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 24px;">
+                                <tr>
+                                    <td style="padding: 12px 16px; background-color: #fffbeb; border-radius: 8px 8px 0 0; border-left: 4px solid #f59e0b;">
+                                        <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 700; color: #d97706; text-transform: uppercase; letter-spacing: 0.5px;">
+                                            📅 Due Tomorrow
+                                        </p>
+                                    </td>
+                                </tr>
+                                {{#each tomorrow_tasks}}
+                                <tr>
+                                    <td class="task-item" style="padding: 16px 20px; background-color: #fffef5; border-left: 4px solid #f59e0b; border-bottom: 1px solid #fde68a;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td>
+                                                    <a href="{{task_url}}" style="font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #102a43; text-decoration: none; display: block; margin-bottom: 4px;">
+                                                        {{subject}}
+                                                    </a>
+                                                    <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 13px; color: #627d98;">
+                                                        {{contact_name}} • Due: <span style="color: #d97706; font-weight: 500;">{{due_date}}</span>
+                                                        {{#if priority}}<span style="margin-left: 8px; padding: 2px 8px; background-color: {{#if (eq priority 'high')}}#fef2f2{{else if (eq priority 'medium')}}#fffbeb{{else}}#f0fdf4{{/if}}; color: {{#if (eq priority 'high')}}#dc2626{{else if (eq priority 'medium')}}#d97706{{else}}#16a34a{{/if}}; border-radius: 4px; font-size: 11px; font-weight: 600; text-transform: uppercase;">{{priority}}</span>{{/if}}
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                                {{/each}}
+                            </table>
+                            {{/if}}
+                            
+                            <!-- ========== DUE IN 2 DAYS TASKS ========== -->
+                            {{#if has_upcoming}}
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 24px;">
+                                <tr>
+                                    <td style="padding: 12px 16px; background-color: #eff6ff; border-radius: 8px 8px 0 0; border-left: 4px solid #3b82f6;">
+                                        <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 700; color: #2563eb; text-transform: uppercase; letter-spacing: 0.5px;">
+                                            🗓️ Due in 2 Days
+                                        </p>
+                                    </td>
+                                </tr>
+                                {{#each upcoming_tasks}}
+                                <tr>
+                                    <td class="task-item" style="padding: 16px 20px; background-color: #f8faff; border-left: 4px solid #3b82f6; border-bottom: 1px solid #bfdbfe;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td>
+                                                    <a href="{{task_url}}" style="font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; color: #102a43; text-decoration: none; display: block; margin-bottom: 4px;">
+                                                        {{subject}}
+                                                    </a>
+                                                    <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 13px; color: #627d98;">
+                                                        {{contact_name}} • Due: <span style="color: #2563eb; font-weight: 500;">{{due_date}}</span>
+                                                        {{#if priority}}<span style="margin-left: 8px; padding: 2px 8px; background-color: {{#if (eq priority 'high')}}#fef2f2{{else if (eq priority 'medium')}}#fffbeb{{else}}#f0fdf4{{/if}}; color: {{#if (eq priority 'high')}}#dc2626{{else if (eq priority 'medium')}}#d97706{{else}}#16a34a{{/if}}; border-radius: 4px; font-size: 11px; font-weight: 600; text-transform: uppercase;">{{priority}}</span>{{/if}}
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                                {{/each}}
+                            </table>
+                            {{/if}}
+                            
+                            <!-- CTA Button -->
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding: 16px 0 0 0;">
+                                        <a href="{{view_all_url}}" style="display: inline-block; font-family: 'DM Sans', sans-serif; background: linear-gradient(135deg, #f97316 0%, #ea580c 100%); color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; padding: 15px 44px; border-radius: 10px; box-shadow: 0 6px 20px rgba(249, 115, 22, 0.35);">
+                                            View All Tasks
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                            
+                        </td>
+                    </tr>
+                    
+                    <!-- ========== FOOTER ========== -->
+                    <tr>
+                        <td style="background-color: #f8fafc; border-top: 1px solid #e8eff5; padding: 28px 40px; text-align: center;">
+                            <p style="margin: 0 0 6px 0; font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 700;">
+                                <span style="color: #334e68;">Origen Technol</span><span style="color: #f97316;">OG</span>
+                            </p>
+                            <p style="margin: 0 0 16px 0; font-family: 'DM Sans', sans-serif; font-size: 12px; color: #829ab1;">
+                                The Real Estate CRM Built for Serious Agents
+                            </p>
+                            <p style="margin: 0 0 16px 0; font-family: 'DM Sans', sans-serif; font-size: 12px; color: #d1d5db; letter-spacing: 8px;">
+                                • • •
+                            </p>
+                            <p style="margin: 0; font-family: 'DM Sans', sans-serif; font-size: 11px; color: #9fb3c8;">
+                                © {{current_year}} Origen TechnolOG. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                    
+                </table>
+                
+            </td>
+        </tr>
+    </table>
+    
+</body>
+</html>
+
+<!--
+SENDGRID TEMPLATE INFO
+======================
+Template Name: Task Reminder Digest
+Subject Line: You have {{total_task_count}} task reminder{{#if (gt total_task_count 1)}}s{{/if}}
+
+Test Data JSON:
+{
+  "first_name": "Sarah",
+  "total_task_count": 4,
+  "has_overdue": true,
+  "has_tomorrow": true,
+  "has_upcoming": true,
+  "overdue_tasks": [
+    {
+      "subject": "Call John Smith about listing",
+      "contact_name": "John Smith",
+      "due_date": "Jan 17, 2026",
+      "priority": "high",
+      "task_url": "https://app.origentechnolog.com/tasks/123"
+    },
+    {
+      "subject": "Follow up with buyer lead",
+      "contact_name": "Jane Doe",
+      "due_date": "Jan 18, 2026",
+      "priority": "medium",
+      "task_url": "https://app.origentechnolog.com/tasks/124"
+    }
+  ],
+  "tomorrow_tasks": [
+    {
+      "subject": "Schedule showing at 123 Main St",
+      "contact_name": "Bob Wilson",
+      "due_date": "Jan 20, 2026",
+      "priority": "high",
+      "task_url": "https://app.origentechnolog.com/tasks/125"
+    }
+  ],
+  "upcoming_tasks": [
+    {
+      "subject": "Send market analysis to seller",
+      "contact_name": "Alice Johnson",
+      "due_date": "Jan 21, 2026",
+      "priority": "low",
+      "task_url": "https://app.origentechnolog.com/tasks/126"
+    }
+  ],
+  "view_all_url": "https://app.origentechnolog.com/tasks",
+  "current_year": "2026"
+}
+-->

--- a/jobs/task_reminder.py
+++ b/jobs/task_reminder.py
@@ -1,0 +1,210 @@
+# jobs/task_reminder.py
+"""
+Task Reminder Email Job
+
+Sends batched task reminder emails for all organizations.
+Runs daily via Railway Cron Job at 8:00 AM CT.
+
+Each user receives ONE consolidated email with all their tasks organized by urgency:
+- Overdue tasks (should have been done already)
+- Due tomorrow (24-48 hours from now)
+- Due in 2 days (48-72 hours from now)
+
+Usage:
+    python jobs/task_reminder.py
+"""
+
+import os
+import sys
+import logging
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+import pytz
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Central timezone for time calculations
+CT = pytz.timezone('America/Chicago')
+
+
+def send_task_reminders():
+    """
+    Send batched task reminder emails for all organizations.
+    
+    For each organization:
+    1. Query all pending tasks needing reminders
+    2. Group tasks by user
+    3. Send ONE digest email per user with all their tasks
+    4. Mark tasks as reminded (only if email succeeds)
+    """
+    from models import db, Organization, Task, User
+    from services.email_service import get_email_service
+    from jobs.base import set_job_org_context
+    
+    now_utc = datetime.utcnow()
+    now_ct = datetime.now(CT)
+    
+    logger.info(f"Starting task reminder job at {now_ct.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+    
+    # Calculate time windows (in UTC for database queries)
+    # Note: We use UTC for queries since that's how dates are stored
+    
+    # Overdue: due before now
+    overdue_cutoff = now_utc
+    
+    # Tomorrow: due between 24-48 hours from now
+    tomorrow_start = now_utc + timedelta(hours=24)
+    tomorrow_end = now_utc + timedelta(hours=48)
+    
+    # Upcoming (2 days): due between 48-72 hours from now
+    upcoming_start = now_utc + timedelta(hours=48)
+    upcoming_end = now_utc + timedelta(hours=72)
+    
+    # Get all active orgs
+    orgs = Organization.query.filter_by(status='active').all()
+    logger.info(f"Processing {len(orgs)} active organizations")
+    
+    total_emails_sent = 0
+    total_tasks_processed = 0
+    
+    for org in orgs:
+        try:
+            # Set RLS context for this org
+            set_job_org_context(org.id)
+            
+            # Collect all tasks needing reminders, grouped by user
+            user_tasks = defaultdict(lambda: {'overdue': [], 'tomorrow': [], 'upcoming': []})
+            
+            # Query overdue tasks
+            overdue_tasks = Task.query.filter(
+                Task.organization_id == org.id,
+                Task.status == 'pending',
+                Task.due_date < overdue_cutoff,
+                Task.overdue_reminder_sent == False
+            ).all()
+            
+            for task in overdue_tasks:
+                user_tasks[task.assigned_to_id]['overdue'].append(task)
+            
+            # Query tomorrow tasks (24-48 hours)
+            tomorrow_tasks = Task.query.filter(
+                Task.organization_id == org.id,
+                Task.status == 'pending',
+                Task.due_date >= tomorrow_start,
+                Task.due_date < tomorrow_end,
+                Task.one_day_reminder_sent == False
+            ).all()
+            
+            for task in tomorrow_tasks:
+                user_tasks[task.assigned_to_id]['tomorrow'].append(task)
+            
+            # Query upcoming tasks (48-72 hours)
+            upcoming_tasks = Task.query.filter(
+                Task.organization_id == org.id,
+                Task.status == 'pending',
+                Task.due_date >= upcoming_start,
+                Task.due_date < upcoming_end,
+                Task.two_day_reminder_sent == False
+            ).all()
+            
+            for task in upcoming_tasks:
+                user_tasks[task.assigned_to_id]['upcoming'].append(task)
+            
+            # Send ONE email per user with all their tasks
+            email_service = get_email_service()
+            
+            for user_id, tasks_by_type in user_tasks.items():
+                # Skip if no tasks for this user
+                total_tasks = (
+                    len(tasks_by_type['overdue']) + 
+                    len(tasks_by_type['tomorrow']) + 
+                    len(tasks_by_type['upcoming'])
+                )
+                if total_tasks == 0:
+                    continue
+                
+                user = User.query.get(user_id)
+                if not user:
+                    logger.warning(f"User {user_id} not found, skipping")
+                    continue
+                
+                if not user.email:
+                    logger.warning(f"User {user_id} has no email, skipping")
+                    continue
+                
+                try:
+                    # Send the batched reminder email
+                    success = email_service.send_task_reminder_digest(user, tasks_by_type)
+                    
+                    if success:
+                        logger.info(
+                            f"Sent reminder to {user.email}: "
+                            f"{len(tasks_by_type['overdue'])} overdue, "
+                            f"{len(tasks_by_type['tomorrow'])} tomorrow, "
+                            f"{len(tasks_by_type['upcoming'])} upcoming"
+                        )
+                        
+                        # Mark all tasks as reminded (only after successful send)
+                        for task in tasks_by_type['overdue']:
+                            task.overdue_reminder_sent = True
+                            task.last_reminder_sent_at = now_utc
+                            total_tasks_processed += 1
+                        
+                        for task in tasks_by_type['tomorrow']:
+                            task.one_day_reminder_sent = True
+                            task.last_reminder_sent_at = now_utc
+                            total_tasks_processed += 1
+                        
+                        for task in tasks_by_type['upcoming']:
+                            task.two_day_reminder_sent = True
+                            task.last_reminder_sent_at = now_utc
+                            total_tasks_processed += 1
+                        
+                        total_emails_sent += 1
+                    else:
+                        logger.error(f"Failed to send reminder to {user.email}")
+                        
+                except Exception as e:
+                    logger.exception(f"Error sending reminder to user {user_id}: {e}")
+                    # Continue with other users even if one fails
+                    continue
+            
+        except Exception as e:
+            logger.exception(f"Error processing org {org.id}: {e}")
+            # Continue with other orgs even if one fails
+            continue
+    
+    # Commit all changes
+    try:
+        db.session.commit()
+        logger.info(
+            f"Task reminder job completed: "
+            f"{total_emails_sent} emails sent, "
+            f"{total_tasks_processed} tasks processed"
+        )
+    except Exception as e:
+        logger.exception(f"Error committing changes: {e}")
+        db.session.rollback()
+        raise
+
+
+def run_task_reminders():
+    """Entry point for scheduler/cron - creates app context and runs job."""
+    from app import create_app
+    
+    app = create_app()
+    with app.app_context():
+        send_task_reminders()
+
+
+if __name__ == '__main__':
+    run_task_reminders()

--- a/migrations/versions/add_task_reminder_fields.py
+++ b/migrations/versions/add_task_reminder_fields.py
@@ -1,0 +1,66 @@
+"""Add task reminder tracking fields
+
+Revision ID: add_task_reminder_fields
+Revises: add_signing_method
+Create Date: 2026-01-19
+
+Adds boolean flags to track which reminder types have been sent for each task:
+- two_day_reminder_sent: Reminder sent 48-72 hours before due date
+- one_day_reminder_sent: Reminder sent 24-48 hours before due date  
+- overdue_reminder_sent: Reminder sent after task became overdue
+- last_reminder_sent_at: Timestamp of most recent reminder (for debugging)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_task_reminder_fields'
+down_revision = 'add_rls_agent_resources'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add reminder tracking columns to task table
+    op.execute("""
+        ALTER TABLE task
+        ADD COLUMN IF NOT EXISTS two_day_reminder_sent BOOLEAN NOT NULL DEFAULT FALSE;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        ADD COLUMN IF NOT EXISTS one_day_reminder_sent BOOLEAN NOT NULL DEFAULT FALSE;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        ADD COLUMN IF NOT EXISTS overdue_reminder_sent BOOLEAN NOT NULL DEFAULT FALSE;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        ADD COLUMN IF NOT EXISTS last_reminder_sent_at TIMESTAMP;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE task
+        DROP COLUMN IF EXISTS last_reminder_sent_at;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        DROP COLUMN IF EXISTS overdue_reminder_sent;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        DROP COLUMN IF EXISTS one_day_reminder_sent;
+    """)
+    
+    op.execute("""
+        ALTER TABLE task
+        DROP COLUMN IF EXISTS two_day_reminder_sent;
+    """)

--- a/models.py
+++ b/models.py
@@ -395,7 +395,13 @@ class Task(db.Model):
     # Optional fields specific to real estate
     property_address = db.Column(db.String(200))  # If task is related to specific property
     scheduled_time = db.Column(db.DateTime)  # For meetings/showings
-    reminder_sent = db.Column(db.Boolean, default=False)
+    reminder_sent = db.Column(db.Boolean, default=False)  # DEPRECATED: Use specific flags below
+    
+    # Email reminder tracking (one flag per reminder type)
+    two_day_reminder_sent = db.Column(db.Boolean, default=False)  # Sent 48-72 hours before due
+    one_day_reminder_sent = db.Column(db.Boolean, default=False)  # Sent 24-48 hours before due
+    overdue_reminder_sent = db.Column(db.Boolean, default=False)  # Sent after task became overdue
+    last_reminder_sent_at = db.Column(db.DateTime)  # Timestamp of most recent reminder
     
     # Relationships
     contact = db.relationship('Contact', backref=db.backref('tasks', lazy=True))


### PR DESCRIPTION
Implements automated task reminder emails that send one consolidated digest per user daily, organized by urgency (overdue, due tomorrow, due in 2 days). Designed to run via Railway Cron Job at 8 AM CT.

Changes:
- Add 4 new columns to Task model for tracking reminder status
- Create batched email template with urgency-based sections
- Add send_task_reminder_digest() method to EmailService
- Create background job for Railway cron execution
- Add database migration for new task reminder fields