### PR TITLE
fix: use pre-computed is_plural for SendGrid compatibility

### DIFF
--- a/email_templates/6_task_reminder.html
+++ b/email_templates/6_task_reminder.html
@@ -24,7 +24,7 @@
     
     <!-- Preheader -->
     <div style="display: none; max-height: 0; overflow: hidden;">
-        You have {{total_task_count}} task reminder{{#if (gt total_task_count 1)}}s{{/if}} for today.
+        You have {{total_task_count}} task reminder{{#if is_plural}}s{{/if}} for today.
     </div>
     
     <!-- Email Wrapper -->
@@ -63,7 +63,7 @@
                             
                             <!-- Title -->
                             <h2 class="title" style="margin: 0 0 32px 0; font-family: 'DM Sans', sans-serif; font-size: 26px; font-weight: 700; color: #102a43; line-height: 1.3;">
-                                You have {{total_task_count}} task{{#if (gt total_task_count 1)}}s{{/if}} that need attention
+                                You have {{total_task_count}} task{{#if is_plural}}s{{/if}} that need attention
                             </h2>
                             
                             <!-- ========== OVERDUE TASKS ========== -->
@@ -214,6 +214,7 @@ Test Data JSON:
 {
   "first_name": "Sarah",
   "total_task_count": 5,
+  "is_plural": true,
   "has_overdue": true,
   "has_today": true,
   "has_tomorrow": true,

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -269,6 +269,7 @@ class EmailService:
             template_data={
                 'first_name': user.first_name or 'there',
                 'total_task_count': total_count,
+                'is_plural': total_count > 1,  # Pre-computed for SendGrid template
                 'overdue_tasks': overdue_tasks,
                 'today_tasks': today_tasks,
                 'tomorrow_tasks': tomorrow_tasks,


### PR DESCRIPTION
SendGrid's Handlebars doesn't support the gt helper function. Pass is_plural boolean from backend instead.