### PR TITLE
feat: add user-adjustable task window preference

### DIFF
--- a/migrations/versions/add_task_window_preference.py
+++ b/migrations/versions/add_task_window_preference.py
@@ -1,0 +1,31 @@
+"""add task window preference to user
+
+Revision ID: b2c3d4e5f7g8
+Revises: add_task_reminder_fields
+Create Date: 2026-01-19
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f7g8'
+down_revision = 'add_task_reminder_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add task_window_days column with default 30
+    op.execute("""
+        ALTER TABLE "user"
+        ADD COLUMN IF NOT EXISTS task_window_days INTEGER NOT NULL DEFAULT 30;
+    """)
+
+
+def downgrade():
+    # Remove the column
+    op.execute("""
+        ALTER TABLE "user"
+        DROP COLUMN IF EXISTS task_window_days;
+    """)

--- a/models.py
+++ b/models.py
@@ -230,6 +230,9 @@ class User(UserMixin, db.Model):
     licensed_supervisor_email = db.Column(db.String(120))
     licensed_supervisor_phone = db.Column(db.String(20))
     
+    # User preferences
+    task_window_days = db.Column(db.Integer, nullable=False, default=30)  # Days for upcoming tasks view (7, 30, 60, or 90)
+    
     # Organization relationship
     organization = db.relationship('Organization', backref=db.backref('users', lazy='dynamic'),
                                    foreign_keys=[organization_id])

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -677,22 +677,49 @@
             <!-- Upcoming Tasks Section -->
             <div class="premium-card bg-white rounded-2xl shadow-lg border border-slate-200/60 overflow-hidden">
                 <!-- Header -->
-                <div class="px-4 md:px-6 py-4 md:py-5 section-header border-b border-slate-100 flex items-center justify-between gap-3">
-                    <div class="flex items-center space-x-3 min-w-0">
-                        <div class="w-10 h-10 bg-gradient-to-br from-orange-500 to-amber-500 rounded-xl flex items-center justify-center shadow-md flex-shrink-0">
-                            <i class="fas fa-tasks text-white"></i>
+                <div class="px-4 md:px-6 py-4 md:py-5 section-header border-b border-slate-100">
+                    <div class="flex items-center justify-between gap-3 mb-3">
+                        <div class="flex items-center space-x-3 min-w-0">
+                            <div class="w-10 h-10 bg-gradient-to-br from-orange-500 to-amber-500 rounded-xl flex items-center justify-center shadow-md flex-shrink-0">
+                                <i class="fas fa-tasks text-white"></i>
+                            </div>
+                            <div class="min-w-0">
+                                <h3 class="text-base md:text-lg font-bold text-slate-800">Upcoming Client Tasks</h3>
+                            </div>
                         </div>
-                        <div class="min-w-0">
-                            <h3 class="text-base md:text-lg font-bold text-slate-800">Upcoming Client Tasks</h3>
-                            <p class="text-xs md:text-sm text-slate-500 hidden sm:block">Client tasks due in the next 7 days</p>
+                        <a href="{{ url_for('tasks.tasks') }}" 
+                           class="group inline-flex items-center px-3 md:px-4 py-2 bg-slate-50 hover:bg-orange-50 text-sm font-medium text-slate-600 hover:text-orange-600 rounded-xl transition-all duration-200 border border-slate-200 hover:border-orange-200 flex-shrink-0">
+                            <span class="hidden sm:inline">View all</span>
+                            <span class="sm:hidden">All</span>
+                            <i class="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
+                        </a>
+                    </div>
+                    <!-- Task Window Selector -->
+                    <div class="flex items-center gap-2 flex-wrap">
+                        <span class="text-xs text-slate-500 font-medium">Showing next:</span>
+                        <div class="inline-flex items-center bg-slate-50 rounded-lg p-1 gap-1">
+                            <button onclick="updateTaskWindow(7)" 
+                                    class="task-window-btn px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 {% if task_window_days == 7 %}bg-white text-orange-600 shadow-sm{% else %}text-slate-600 hover:text-slate-900{% endif %}"
+                                    data-days="7">
+                                7 days
+                            </button>
+                            <button onclick="updateTaskWindow(30)" 
+                                    class="task-window-btn px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 {% if task_window_days == 30 %}bg-white text-orange-600 shadow-sm{% else %}text-slate-600 hover:text-slate-900{% endif %}"
+                                    data-days="30">
+                                30 days
+                            </button>
+                            <button onclick="updateTaskWindow(60)" 
+                                    class="task-window-btn px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 {% if task_window_days == 60 %}bg-white text-orange-600 shadow-sm{% else %}text-slate-600 hover:text-slate-900{% endif %}"
+                                    data-days="60">
+                                60 days
+                            </button>
+                            <button onclick="updateTaskWindow(90)" 
+                                    class="task-window-btn px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 {% if task_window_days == 90 %}bg-white text-orange-600 shadow-sm{% else %}text-slate-600 hover:text-slate-900{% endif %}"
+                                    data-days="90">
+                                90 days
+                            </button>
                         </div>
                     </div>
-                    <a href="{{ url_for('tasks.tasks') }}" 
-                       class="group inline-flex items-center px-3 md:px-4 py-2 bg-slate-50 hover:bg-orange-50 text-sm font-medium text-slate-600 hover:text-orange-600 rounded-xl transition-all duration-200 border border-slate-200 hover:border-orange-200 flex-shrink-0">
-                        <span class="hidden sm:inline">View all</span>
-                        <span class="sm:hidden">All</span>
-                        <i class="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
-                    </a>
                 </div>
 
                 <!-- Task List -->
@@ -1225,6 +1252,33 @@ document.addEventListener('click', function(event) {
         allMenus.forEach(menu => menu.classList.add('hidden'));
     }
 });
+
+// Task window preference update function
+function updateTaskWindow(days) {
+    fetch('/api/update-task-window', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ days: parseInt(days) })
+    })
+    .then(response => {
+        if (!response.ok) throw new Error('Network response was not ok');
+        return response.json();
+    })
+    .then(data => {
+        if (data.success) {
+            // Reload the page to show tasks with new window
+            window.location.reload();
+        } else {
+            alert('Error updating task window: ' + (data.error || 'Unknown error'));
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert('Error updating task window preference');
+    });
+}
 
 // Pipeline Value Counter Animation
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Add ability for users to customize the time window for upcoming tasks on the dashboard. Users can now choose between 7, 30, 60, or 90 days, with 30 days as the default (previously hardcoded to 7 days).

Changes:
- Add task_window_days field to User model with default of 30 days
- Create migration to add task_window_days column to user table
- Update dashboard route to use user's preference instead of hardcoded 7 days
- Add API endpoint (/api/update-task-window) to persist user preference
- Implement modern segmented button UI for task window selection
- Add JavaScript to handle preference updates and reload dashboard
- Preference persists across user sessions

The UI features a polished, iOS-inspired segmented control that fits seamlessly with the premium dashboard design.