### PR TITLE
feat: add document placeholder support with static upload and preview

### DIFF
--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -110,10 +110,11 @@
       "reason": "Property subject to owner's association"
     },
     {
-      "slug": "water-district",
-      "name": "Information About On-Site Sewer Facility",
+      "slug": "special-tax-district-notice",
+      "name": "Notice to Purchaser of Real Property Located in a Special Tax District",
       "condition": {"field": "special_districts", "equals": true},
-      "reason": "Property in special district (MUD, PID, etc.)"
+      "reason": "Property in special taxing district (MUD, PID, etc.)",
+      "is_placeholder": true
     },
     {
       "slug": "flood-hazard",
@@ -131,7 +132,8 @@
       "slug": "referral-agreement",
       "name": "Referral Agreement",
       "condition": {"field": "referral_fee", "equals": true},
-      "reason": "Referral fee will be paid"
+      "reason": "Referral fee will be paid",
+      "is_placeholder": true
     },
     {
       "slug": "t47-affidavit",

--- a/migrations/versions/add_placeholder_support.py
+++ b/migrations/versions/add_placeholder_support.py
@@ -1,0 +1,41 @@
+"""Add is_placeholder column to transaction_documents
+
+Revision ID: add_placeholder_support
+Revises: add_adhoc_doc_cols
+Create Date: 2026-01-20
+
+Adds is_placeholder field to mark documents that are created as reminders
+for agents to upload content later (e.g., Special Tax District Notice,
+Referral Agreement when agent-provided).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_placeholder_support'
+down_revision = 'b2c3d4e5f7g8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add is_placeholder column with default False for existing docs
+    op.execute("""
+        ALTER TABLE transaction_documents
+        ADD COLUMN IF NOT EXISTS is_placeholder BOOLEAN DEFAULT FALSE;
+    """)
+    
+    # Backfill: ensure all existing docs have is_placeholder = false
+    op.execute("""
+        UPDATE transaction_documents
+        SET is_placeholder = FALSE
+        WHERE is_placeholder IS NULL;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE transaction_documents
+        DROP COLUMN IF EXISTS is_placeholder;
+    """)

--- a/models.py
+++ b/models.py
@@ -876,14 +876,19 @@ class TransactionDocument(db.Model):
     # Signing method: 'esign', 'physical', or null (not yet signed)
     signing_method = db.Column(db.String(20), nullable=True)
     
-    # Document source: 'template' (our generated), 'external' (uploaded from other party), 'hybrid' (wet+esign combo)
+    # Document source: 'template' (our generated), 'external' (uploaded from other party), 
+    # 'hybrid' (wet+esign combo), 'static' (uploaded PDF, no signing), 'placeholder' (awaiting content)
     document_source = db.Column(db.String(20), default='template')
     
-    # For external/hybrid docs: path to the uploaded source PDF in Supabase
+    # For external/hybrid/static docs: path to the uploaded source PDF in Supabase
     source_file_path = db.Column(db.String(500), nullable=True)
     
     # Manual field placements for ad-hoc signing: [{type, role, page, x, y, w, h, required}]
     field_placements = db.Column(db.JSON, nullable=True)
+    
+    # Placeholder documents: created by questionnaire as reminders for agent to upload content later
+    # (e.g., Special Tax District Notice, Referral Agreement when agent-provided)
+    is_placeholder = db.Column(db.Boolean, default=False)
     
     # Relationships
     signatures = db.relationship('DocumentSignature', backref='document',

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -72,7 +72,8 @@ def evaluate_document_rules(schema: dict, intake_data: dict) -> list:
                 'slug': rule['slug'],
                 'name': rule['name'],
                 'reason': reason,
-                'always': rule.get('always', False)
+                'always': rule.get('always', False),
+                'is_placeholder': rule.get('is_placeholder', False)
             })
     
     return required_docs

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -712,14 +712,19 @@
                     {% if documents %}
                     <div class="space-y-2">
                         {% for doc in documents %}
-                        <div class="doc-row flex items-center justify-between p-4 rounded-xl border border-slate-100">
+                        <div class="doc-row flex items-center justify-between p-4 rounded-xl border 
+                            {% if doc.is_placeholder and doc.status == 'pending' %}border-amber-300 bg-amber-50
+                            {% else %}border-slate-100{% endif %}">
                             <div class="flex items-center gap-4">
                                 <div class="w-12 h-12 rounded-xl flex items-center justify-center
-                                    {% if doc.status == 'signed' %}bg-green-100
+                                    {% if doc.is_placeholder and doc.status == 'pending' %}bg-amber-100
+                                    {% elif doc.status == 'signed' %}bg-green-100
                                     {% elif doc.status == 'sent' %}bg-blue-100
                                     {% elif doc.status == 'filled' %}bg-purple-100
                                     {% else %}bg-slate-100{% endif %}">
-                                    {% if doc.status == 'signed' and doc.signing_method == 'physical' %}
+                                    {% if doc.is_placeholder and doc.status == 'pending' %}
+                                    <i class="fas fa-exclamation-circle text-amber-600 text-lg"></i>
+                                    {% elif doc.status == 'signed' and doc.signing_method == 'physical' %}
                                     <i class="fas fa-pen-nib text-green-600 text-lg"></i>
                                     {% elif doc.status == 'signed' %}
                                     <i class="fas fa-file-signature text-green-600 text-lg"></i>
@@ -734,7 +739,13 @@
                                 <div>
                                     <div class="flex items-center gap-2">
                                         <span class="font-medium text-slate-800">{{ doc.template_name }}</span>
-                                        {% if doc.document_source == 'external' %}
+                                        {% if doc.is_placeholder and doc.status == 'pending' %}
+                                        <span class="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-100 text-amber-700">
+                                            <i class="fas fa-exclamation-triangle mr-1"></i>Needs Content
+                                        </span>
+                                        {% elif doc.document_source == 'static' %}
+                                        <span class="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-teal-100 text-teal-700">Static PDF</span>
+                                        {% elif doc.document_source == 'external' %}
                                         <span class="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-purple-100 text-purple-700">External</span>
                                         {% elif doc.document_source == 'hybrid' %}
                                         <span class="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-orange-100 text-orange-700">Hybrid</span>
@@ -809,8 +820,41 @@
                                         <div class="border-t border-slate-100 my-2"></div>
                                         {% endif %}
                                         
-                                        <!-- PENDING: Fill Form (Template docs only) -->
-                                        {% if doc.status == 'pending' and doc.document_source != 'external' %}
+                                        <!-- PLACEHOLDER DOCUMENTS: Upload options -->
+                                        {% if doc.is_placeholder and doc.status == 'pending' %}
+                                        <div class="px-4 py-1.5 text-xs font-semibold text-amber-600 uppercase tracking-wider">
+                                            Placeholder - Add Content
+                                        </div>
+                                        <button onclick='showUploadStaticModal({{ doc.id }}, {{ doc.template_name|tojson }})'
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-teal-600 hover:bg-teal-50 transition-colors">
+                                            <i class="fas fa-file-upload w-5"></i>
+                                            <span class="ml-2">Upload Document</span>
+                                        </button>
+                                        <button onclick='showUploadForSignatureModal({{ doc.id }}, {{ doc.template_name|tojson }})'
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-purple-600 hover:bg-purple-50 transition-colors">
+                                            <i class="fas fa-file-signature w-5"></i>
+                                            <span class="ml-2">Upload & Prep for Signature</span>
+                                        </button>
+                                        <div class="border-t border-slate-100 my-2"></div>
+                                        {% endif %}
+                                        
+                                        <!-- STATIC DOCUMENTS: View options -->
+                                        {% if doc.document_source == 'static' and doc.status == 'filled' %}
+                                        <button onclick="viewStaticDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-teal-600 hover:bg-teal-50 transition-colors">
+                                            <i class="fas fa-eye w-5"></i>
+                                            <span class="ml-2">View Document</span>
+                                        </button>
+                                        <button onclick='showUploadStaticModal({{ doc.id }}, {{ doc.template_name|tojson }})'
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
+                                            <i class="fas fa-sync-alt w-5 text-slate-400"></i>
+                                            <span class="ml-2">Replace Document</span>
+                                        </button>
+                                        <div class="border-t border-slate-100 my-2"></div>
+                                        {% endif %}
+                                        
+                                        <!-- PENDING: Fill Form (Template docs only, not placeholders) -->
+                                        {% if doc.status == 'pending' and doc.document_source != 'external' and not doc.is_placeholder %}
                                         <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=doc.id) }}" 
                                            class="flex items-center px-4 py-2.5 text-sm text-blue-600 hover:bg-blue-50 transition-colors">
                                             <i class="fas fa-edit w-5"></i>
@@ -818,8 +862,8 @@
                                         </a>
                                         {% endif %}
                                         
-                                        <!-- FILLED/GENERATED: Edit, Preview, Signing Options -->
-                                        {% if doc.status in ['filled', 'generated'] %}
+                                        <!-- FILLED/GENERATED: Edit, Preview, Signing Options (not for static or external docs) -->
+                                        {% if doc.status in ['filled', 'generated'] and doc.document_source not in ['static', 'external'] %}
                                         <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=doc.id) }}" 
                                            class="flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
                                             <i class="fas fa-edit w-5 text-slate-400"></i>
@@ -1839,6 +1883,164 @@
     </div>
 </div>
 
+<!-- Upload Static Document Modal (for placeholders, no signing) -->
+<div id="uploadStaticModal" class="fixed inset-0 z-50 hidden">
+    <div class="modal-overlay absolute inset-0" onclick="closeUploadStaticModal()"></div>
+    <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6 relative z-10">
+            <div class="flex items-center gap-3 mb-5">
+                <div class="w-10 h-10 bg-teal-100 rounded-xl flex items-center justify-center">
+                    <i class="fas fa-file-upload text-teal-600"></i>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-slate-800">Upload Document</h3>
+                    <p id="staticDocName" class="text-sm text-slate-500"></p>
+                </div>
+            </div>
+            
+            <div class="mb-4 p-3 bg-teal-50 border border-teal-200 rounded-lg">
+                <p class="text-sm text-teal-700">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    This document will be included in your package as-is, without requiring any signatures.
+                </p>
+            </div>
+            
+            <form id="uploadStaticForm" enctype="multipart/form-data">
+                <input type="hidden" id="staticDocId" name="doc_id" value="">
+                
+                <!-- Drag and Drop Zone -->
+                <div id="staticDropZone" 
+                     class="border-2 border-dashed border-slate-200 rounded-xl p-8 text-center cursor-pointer hover:border-teal-400 hover:bg-teal-50/30 transition-colors mb-4"
+                     onclick="document.getElementById('staticFileInput').click()">
+                    <div id="staticDropContent">
+                        <i class="fas fa-cloud-upload-alt text-4xl text-slate-300 mb-3"></i>
+                        <p class="text-sm font-medium text-slate-600">Drop your PDF here</p>
+                        <p class="text-xs text-slate-400 mt-1">or click to browse</p>
+                    </div>
+                    <div id="staticFileInfo" class="hidden">
+                        <i class="fas fa-file-pdf text-4xl text-red-500 mb-3"></i>
+                        <p id="staticFileName" class="text-sm font-medium text-slate-700"></p>
+                        <p id="staticFileSize" class="text-xs text-slate-400 mt-1"></p>
+                    </div>
+                </div>
+                <input type="file" id="staticFileInput" name="file" accept=".pdf" class="hidden" onchange="handleStaticFileSelect(this)">
+                
+                <!-- Upload Progress -->
+                <div id="staticProgress" class="hidden mb-4">
+                    <div class="flex items-center justify-between text-sm mb-2">
+                        <span class="text-slate-600">Uploading...</span>
+                        <span id="staticPercent" class="font-medium text-teal-600">0%</span>
+                    </div>
+                    <div class="h-2 bg-slate-100 rounded-full overflow-hidden">
+                        <div id="staticProgressBar" class="h-full bg-gradient-to-r from-teal-400 to-teal-500 rounded-full transition-all duration-300" style="width: 0%"></div>
+                    </div>
+                </div>
+                
+                <!-- Error Message -->
+                <div id="staticError" class="hidden mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <p id="staticErrorText" class="text-sm text-red-600"></p>
+                </div>
+                
+                <!-- Info Text -->
+                <p class="text-xs text-slate-400 mb-4">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    Only PDF files are accepted. Maximum file size: 25MB.
+                </p>
+                
+                <div class="flex gap-3">
+                    <button type="button" onclick="closeUploadStaticModal()" 
+                            class="flex-1 px-4 py-3 bg-slate-100 text-slate-700 rounded-xl font-medium hover:bg-slate-200 transition-colors">
+                        Cancel
+                    </button>
+                    <button type="submit" id="uploadStaticBtn" disabled
+                            class="flex-1 px-4 py-3 bg-gradient-to-r from-teal-500 to-teal-600 text-white rounded-xl font-medium hover:from-teal-600 hover:to-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                        <i class="fas fa-upload mr-2"></i>Upload
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Upload for Signature Modal (for placeholders, with e-signature) -->
+<div id="uploadForSignatureModal" class="fixed inset-0 z-50 hidden">
+    <div class="modal-overlay absolute inset-0" onclick="closeUploadForSignatureModal()"></div>
+    <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6 relative z-10">
+            <div class="flex items-center gap-3 mb-5">
+                <div class="w-10 h-10 bg-purple-100 rounded-xl flex items-center justify-center">
+                    <i class="fas fa-file-signature text-purple-600"></i>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-slate-800">Upload & Prep for Signature</h3>
+                    <p id="signatureDocName" class="text-sm text-slate-500"></p>
+                </div>
+            </div>
+            
+            <div class="mb-4 p-3 bg-purple-50 border border-purple-200 rounded-lg">
+                <p class="text-sm text-purple-700">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    After uploading, you'll place signature fields on the document for e-signature.
+                </p>
+            </div>
+            
+            <form id="uploadForSignatureForm" enctype="multipart/form-data">
+                <input type="hidden" id="signatureDocId" name="doc_id" value="">
+                
+                <!-- Drag and Drop Zone -->
+                <div id="signatureDropZone" 
+                     class="border-2 border-dashed border-slate-200 rounded-xl p-8 text-center cursor-pointer hover:border-purple-400 hover:bg-purple-50/30 transition-colors mb-4"
+                     onclick="document.getElementById('signatureFileInput').click()">
+                    <div id="signatureDropContent">
+                        <i class="fas fa-cloud-upload-alt text-4xl text-slate-300 mb-3"></i>
+                        <p class="text-sm font-medium text-slate-600">Drop your PDF here</p>
+                        <p class="text-xs text-slate-400 mt-1">or click to browse</p>
+                    </div>
+                    <div id="signatureFileInfo" class="hidden">
+                        <i class="fas fa-file-pdf text-4xl text-red-500 mb-3"></i>
+                        <p id="signatureFileName" class="text-sm font-medium text-slate-700"></p>
+                        <p id="signatureFileSize" class="text-xs text-slate-400 mt-1"></p>
+                    </div>
+                </div>
+                <input type="file" id="signatureFileInput" name="file" accept=".pdf" class="hidden" onchange="handleSignatureFileSelect(this)">
+                
+                <!-- Upload Progress -->
+                <div id="signatureProgress" class="hidden mb-4">
+                    <div class="flex items-center justify-between text-sm mb-2">
+                        <span class="text-slate-600">Uploading...</span>
+                        <span id="signaturePercent" class="font-medium text-purple-600">0%</span>
+                    </div>
+                    <div class="h-2 bg-slate-100 rounded-full overflow-hidden">
+                        <div id="signatureProgressBar" class="h-full bg-gradient-to-r from-purple-400 to-purple-500 rounded-full transition-all duration-300" style="width: 0%"></div>
+                    </div>
+                </div>
+                
+                <!-- Error Message -->
+                <div id="signatureError" class="hidden mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <p id="signatureErrorText" class="text-sm text-red-600"></p>
+                </div>
+                
+                <!-- Info Text -->
+                <p class="text-xs text-slate-400 mb-4">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    Only PDF files are accepted. Maximum file size: 25MB.
+                </p>
+                
+                <div class="flex gap-3">
+                    <button type="button" onclick="closeUploadForSignatureModal()" 
+                            class="flex-1 px-4 py-3 bg-slate-100 text-slate-700 rounded-xl font-medium hover:bg-slate-200 transition-colors">
+                        Cancel
+                    </button>
+                    <button type="submit" id="uploadForSignatureBtn" disabled
+                            class="flex-1 px-4 py-3 bg-gradient-to-r from-purple-500 to-purple-600 text-white rounded-xl font-medium hover:from-purple-600 hover:to-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                        <i class="fas fa-upload mr-2"></i>Upload & Continue
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <!-- Toast Notification -->
 <div id="toast" class="fixed top-6 left-1/2 transform -translate-x-1/2 z-50 hidden">
     <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-2xl shadow-2xl border border-slate-200">
@@ -2525,6 +2727,8 @@ document.addEventListener('keydown', function(e) {
         closeDocumentModal();
         closeUploadScanModal();
         closeExternalModal();
+        closeUploadStaticModal();
+        closeUploadForSignatureModal();
     }
 });
 
@@ -2685,6 +2889,330 @@ if (externalForm) {
         
         xhr.open('POST', `/transactions/${transactionId}/documents/upload-external`);
         xhr.send(formData);
+    });
+}
+
+// =============================================================================
+// UPLOAD STATIC DOCUMENT MODAL (FOR PLACEHOLDERS)
+// =============================================================================
+
+let currentStaticDocId = null;
+
+function showUploadStaticModal(docId, docName) {
+    currentStaticDocId = docId;
+    document.getElementById('staticDocId').value = docId;
+    document.getElementById('staticDocName').textContent = docName;
+    
+    // Reset form state
+    document.getElementById('staticFileInput').value = '';
+    document.getElementById('staticDropContent').classList.remove('hidden');
+    document.getElementById('staticFileInfo').classList.add('hidden');
+    document.getElementById('staticProgress').classList.add('hidden');
+    document.getElementById('staticError').classList.add('hidden');
+    document.getElementById('uploadStaticBtn').disabled = true;
+    
+    document.getElementById('uploadStaticModal').classList.remove('hidden');
+}
+
+function closeUploadStaticModal() {
+    document.getElementById('uploadStaticModal').classList.add('hidden');
+    currentStaticDocId = null;
+}
+
+function handleStaticFileSelect(input) {
+    const file = input.files[0];
+    if (!file) return;
+    
+    // Validate file type
+    if (!file.name.toLowerCase().endsWith('.pdf')) {
+        showStaticError('Please select a PDF file.');
+        return;
+    }
+    
+    // Validate file size (25MB max)
+    const maxSize = 25 * 1024 * 1024;
+    if (file.size > maxSize) {
+        showStaticError('File too large. Maximum size is 25MB.');
+        return;
+    }
+    
+    // Show selected file info
+    document.getElementById('staticDropContent').classList.add('hidden');
+    document.getElementById('staticFileInfo').classList.remove('hidden');
+    document.getElementById('staticFileName').textContent = file.name;
+    document.getElementById('staticFileSize').textContent = formatFileSize(file.size);
+    document.getElementById('staticError').classList.add('hidden');
+    document.getElementById('uploadStaticBtn').disabled = false;
+}
+
+function showStaticError(message) {
+    document.getElementById('staticError').classList.remove('hidden');
+    document.getElementById('staticErrorText').textContent = message;
+    document.getElementById('uploadStaticBtn').disabled = true;
+}
+
+// Handle drag and drop for static upload
+const staticDropZone = document.getElementById('staticDropZone');
+if (staticDropZone) {
+    staticDropZone.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        this.classList.add('border-teal-400', 'bg-teal-50/30');
+    });
+    
+    staticDropZone.addEventListener('dragleave', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-teal-400', 'bg-teal-50/30');
+    });
+    
+    staticDropZone.addEventListener('drop', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-teal-400', 'bg-teal-50/30');
+        
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            const fileInput = document.getElementById('staticFileInput');
+            fileInput.files = files;
+            handleStaticFileSelect(fileInput);
+        }
+    });
+}
+
+// Handle static document form submission
+const staticForm = document.getElementById('uploadStaticForm');
+if (staticForm) {
+    staticForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        
+        const fileInput = document.getElementById('staticFileInput');
+        const file = fileInput.files[0];
+        if (!file) {
+            showStaticError('Please select a file first.');
+            return;
+        }
+        
+        const formData = new FormData();
+        formData.append('file', file);
+        
+        // Show progress
+        document.getElementById('staticProgress').classList.remove('hidden');
+        document.getElementById('uploadStaticBtn').disabled = true;
+        
+        // Use XMLHttpRequest for progress tracking
+        const xhr = new XMLHttpRequest();
+        
+        xhr.upload.addEventListener('progress', function(e) {
+            if (e.lengthComputable) {
+                const percent = Math.round((e.loaded / e.total) * 100);
+                document.getElementById('staticPercent').textContent = percent + '%';
+                document.getElementById('staticProgressBar').style.width = percent + '%';
+            }
+        });
+        
+        xhr.addEventListener('load', function() {
+            if (xhr.status === 200) {
+                const data = JSON.parse(xhr.responseText);
+                if (data.success) {
+                    showToast('Document uploaded successfully!', 'success');
+                    closeUploadStaticModal();
+                    location.reload();
+                } else {
+                    showStaticError(data.error || 'Upload failed');
+                    document.getElementById('staticProgress').classList.add('hidden');
+                    document.getElementById('uploadStaticBtn').disabled = false;
+                }
+            } else {
+                try {
+                    const data = JSON.parse(xhr.responseText);
+                    showStaticError(data.error || 'Upload failed');
+                } catch (err) {
+                    showStaticError('Upload failed. Please try again.');
+                }
+                document.getElementById('staticProgress').classList.add('hidden');
+                document.getElementById('uploadStaticBtn').disabled = false;
+            }
+        });
+        
+        xhr.addEventListener('error', function() {
+            showStaticError('Network error. Please try again.');
+            document.getElementById('staticProgress').classList.add('hidden');
+            document.getElementById('uploadStaticBtn').disabled = false;
+        });
+        
+        xhr.open('POST', `/transactions/${transactionId}/documents/${currentStaticDocId}/upload-static`);
+        xhr.send(formData);
+    });
+}
+
+// =============================================================================
+// UPLOAD FOR SIGNATURE MODAL (PLACEHOLDER TO EXTERNAL)
+// =============================================================================
+
+let currentSignatureDocId = null;
+
+function showUploadForSignatureModal(docId, docName) {
+    currentSignatureDocId = docId;
+    document.getElementById('signatureDocId').value = docId;
+    document.getElementById('signatureDocName').textContent = docName;
+    
+    // Reset form state
+    document.getElementById('signatureFileInput').value = '';
+    document.getElementById('signatureDropContent').classList.remove('hidden');
+    document.getElementById('signatureFileInfo').classList.add('hidden');
+    document.getElementById('signatureProgress').classList.add('hidden');
+    document.getElementById('signatureError').classList.add('hidden');
+    document.getElementById('uploadForSignatureBtn').disabled = true;
+    
+    document.getElementById('uploadForSignatureModal').classList.remove('hidden');
+}
+
+function closeUploadForSignatureModal() {
+    document.getElementById('uploadForSignatureModal').classList.add('hidden');
+    currentSignatureDocId = null;
+}
+
+function handleSignatureFileSelect(input) {
+    const file = input.files[0];
+    if (!file) return;
+    
+    // Validate file type
+    if (!file.name.toLowerCase().endsWith('.pdf')) {
+        showSignatureError('Please select a PDF file.');
+        return;
+    }
+    
+    // Validate file size (25MB max)
+    const maxSize = 25 * 1024 * 1024;
+    if (file.size > maxSize) {
+        showSignatureError('File too large. Maximum size is 25MB.');
+        return;
+    }
+    
+    // Show selected file info
+    document.getElementById('signatureDropContent').classList.add('hidden');
+    document.getElementById('signatureFileInfo').classList.remove('hidden');
+    document.getElementById('signatureFileName').textContent = file.name;
+    document.getElementById('signatureFileSize').textContent = formatFileSize(file.size);
+    document.getElementById('signatureError').classList.add('hidden');
+    document.getElementById('uploadForSignatureBtn').disabled = false;
+}
+
+function showSignatureError(message) {
+    document.getElementById('signatureError').classList.remove('hidden');
+    document.getElementById('signatureErrorText').textContent = message;
+    document.getElementById('uploadForSignatureBtn').disabled = true;
+}
+
+// Handle drag and drop for signature upload
+const signatureDropZone = document.getElementById('signatureDropZone');
+if (signatureDropZone) {
+    signatureDropZone.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        this.classList.add('border-purple-400', 'bg-purple-50/30');
+    });
+    
+    signatureDropZone.addEventListener('dragleave', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-purple-400', 'bg-purple-50/30');
+    });
+    
+    signatureDropZone.addEventListener('drop', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-purple-400', 'bg-purple-50/30');
+        
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            const fileInput = document.getElementById('signatureFileInput');
+            fileInput.files = files;
+            handleSignatureFileSelect(fileInput);
+        }
+    });
+}
+
+// Handle signature document form submission
+const signatureForm = document.getElementById('uploadForSignatureForm');
+if (signatureForm) {
+    signatureForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        
+        const fileInput = document.getElementById('signatureFileInput');
+        const file = fileInput.files[0];
+        if (!file) {
+            showSignatureError('Please select a file first.');
+            return;
+        }
+        
+        const formData = new FormData();
+        formData.append('file', file);
+        
+        // Show progress
+        document.getElementById('signatureProgress').classList.remove('hidden');
+        document.getElementById('uploadForSignatureBtn').disabled = true;
+        
+        // Use XMLHttpRequest for progress tracking
+        const xhr = new XMLHttpRequest();
+        
+        xhr.upload.addEventListener('progress', function(e) {
+            if (e.lengthComputable) {
+                const percent = Math.round((e.loaded / e.total) * 100);
+                document.getElementById('signaturePercent').textContent = percent + '%';
+                document.getElementById('signatureProgressBar').style.width = percent + '%';
+            }
+        });
+        
+        xhr.addEventListener('load', function() {
+            if (xhr.status === 200) {
+                const data = JSON.parse(xhr.responseText);
+                if (data.success) {
+                    showToast('Document uploaded! Redirecting to field editor...', 'success');
+                    closeUploadForSignatureModal();
+                    // Redirect to field editor
+                    if (data.redirect_url) {
+                        window.location.href = data.redirect_url;
+                    } else {
+                        location.reload();
+                    }
+                } else {
+                    showSignatureError(data.error || 'Upload failed');
+                    document.getElementById('signatureProgress').classList.add('hidden');
+                    document.getElementById('uploadForSignatureBtn').disabled = false;
+                }
+            } else {
+                try {
+                    const data = JSON.parse(xhr.responseText);
+                    showSignatureError(data.error || 'Upload failed');
+                } catch (err) {
+                    showSignatureError('Upload failed. Please try again.');
+                }
+                document.getElementById('signatureProgress').classList.add('hidden');
+                document.getElementById('uploadForSignatureBtn').disabled = false;
+            }
+        });
+        
+        xhr.addEventListener('error', function() {
+            showSignatureError('Network error. Please try again.');
+            document.getElementById('signatureProgress').classList.add('hidden');
+            document.getElementById('uploadForSignatureBtn').disabled = false;
+        });
+        
+        xhr.open('POST', `/transactions/${transactionId}/documents/${currentSignatureDocId}/upload-for-signature`);
+        xhr.send(formData);
+    });
+}
+
+// View static document function
+function viewStaticDocument(docId) {
+    fetch(`/transactions/${transactionId}/documents/${docId}/view-static`)
+    .then(res => res.json())
+    .then(data => {
+        if (data.success && data.url) {
+            window.open(data.url, '_blank');
+        } else {
+            showToast(data.error || 'Failed to get document URL', 'error');
+        }
+    })
+    .catch(error => {
+        showToast('Failed to view document. Please try again.', 'error');
+        console.error('View static document error:', error);
     });
 }
 
@@ -2873,6 +3401,10 @@ document.getElementById('addDocumentForm').addEventListener('submit', function(e
     .then(res => res.json())
     .then(data => {
         if (data.success) {
+            if (data.placeholder_updated) {
+                // Show special message for placeholder conversion
+                showToast(data.message || 'Placeholder updated with generated document.', 'success');
+            }
             location.reload();
         } else {
             showToast('Error adding document: ' + data.error, 'error');

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -834,6 +834,63 @@
         </div>
         {% endif %}
 
+        <!-- Static Documents Section (Uploaded PDFs, no signing) -->
+        {% if has_static_docs and static_documents %}
+        <div class="static-documents-section mt-8">
+            <!-- Section Divider -->
+            <div class="document-divider">
+                <div class="document-divider-content">
+                    <span class="document-badge document-badge-cyan">
+                        <i class="fas fa-file-pdf"></i>
+                        Uploaded Documents
+                    </span>
+                </div>
+            </div>
+
+            <p class="text-sm text-slate-500 text-center mb-6">
+                These documents have been uploaded and will be included in the final package.
+            </p>
+
+            {% for doc in static_documents %}
+            <!-- Static Document Card -->
+            <div class="premium-card p-6 mb-6">
+                <!-- Document Header -->
+                <div class="section-header">
+                    <div class="section-number bg-teal-100 text-teal-700">
+                        <i class="fas fa-file-pdf"></i>
+                    </div>
+                    <div>
+                        <h3 class="section-title">{{ doc.template_name }}</h3>
+                        <p class="section-subtitle">Uploaded document - no signatures required</p>
+                    </div>
+                    <span class="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-teal-100 text-teal-700">
+                        <i class="fas fa-check-circle mr-1"></i>
+                        Will be included
+                    </span>
+                </div>
+
+                <!-- Document Preview -->
+                <div class="flex items-center justify-center p-8 bg-gradient-to-br from-slate-50 to-teal-50 rounded-lg border border-slate-200">
+                    <div class="text-center">
+                        <div class="w-16 h-16 rounded-full bg-teal-100 flex items-center justify-center mx-auto mb-4">
+                            <i class="fas fa-file-pdf text-3xl text-teal-600"></i>
+                        </div>
+                        <h4 class="text-lg font-semibold text-slate-800 mb-2">{{ doc.template_name }}</h4>
+                        <p class="text-sm text-slate-500 mb-4">
+                            This document will be included in the package when sent to the client.
+                        </p>
+                        {% if doc.included_reason %}
+                        <p class="text-xs text-slate-400">
+                            <i class="fas fa-info-circle mr-1"></i>{{ doc.included_reason }}
+                        </p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
         <!-- Spacer for floating action bar -->
         <div class="form-bottom-spacer"></div>
 

--- a/templates/transactions/preview_all_documents.html
+++ b/templates/transactions/preview_all_documents.html
@@ -5,13 +5,29 @@
 {% block head %}
 {{ super() }}
 <style>
-    /* DocuSeal embed container */
+    /* DocuSeal embed container and PDF iframe container */
     .docuseal-embed-container {
         min-height: 700px;
         border-radius: 8px;
         overflow: hidden;
         border: 1px solid #e5e7eb;
         background: #f9fafb;
+    }
+    
+    /* PDF iframe styling */
+    .pdf-embed-container {
+        min-height: 700px;
+        border-radius: 8px;
+        overflow: hidden;
+        border: 1px solid #e5e7eb;
+        background: #f9fafb;
+    }
+    
+    .pdf-embed-container iframe {
+        width: 100%;
+        height: 700px;
+        border: none;
+        border-radius: 8px;
     }
 
     .docuseal-embed-container docuseal-form {
@@ -223,7 +239,8 @@
         <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
             <div class="flex flex-wrap gap-3">
                 {% for doc in documents %}
-                {% set config = doc_configs.get(doc.template_slug) %}
+                {% set preview = preview_docs[loop.index0] %}
+                {% set config = preview.config %}
                 <button type="button" class="doc-tab flex items-center gap-2 px-4 py-2.5 rounded-lg border-2 border-slate-200 font-medium text-sm transition-all
                                {% if loop.first %}active{% endif %}" data-doc-index="{{ loop.index0 }}"
                     onclick="switchDocument({{ loop.index0 }})">
@@ -233,6 +250,11 @@
                             {% if config %}text-{{ config.color }}-600{% else %}text-slate-600{% endif %}"></i>
                     </div>
                     <span class="text-slate-700">{{ doc.template_name }}</span>
+                    {% if preview.is_static %}
+                    <span class="px-1.5 py-0.5 text-[10px] font-semibold rounded bg-teal-100 text-teal-700">Static</span>
+                    {% elif preview.is_external %}
+                    <span class="px-1.5 py-0.5 text-[10px] font-semibold rounded bg-purple-100 text-purple-700">External</span>
+                    {% endif %}
                 </button>
                 {% endfor %}
             </div>
@@ -242,7 +264,7 @@
         <!-- Document Preview Panels -->
         {% for doc in documents %}
         {% set preview = preview_docs[loop.index0] %}
-        {% set config = doc_configs.get(doc.template_slug) %}
+        {% set config = preview.config %}
 
         <div class="doc-preview-panel {% if loop.first %}active{% endif %}" data-doc-index="{{ loop.index0 }}">
             <div class="bg-white rounded-2xl shadow-lg border border-slate-200 overflow-hidden">
@@ -255,20 +277,60 @@
                         </div>
                         <div class="flex-1">
                             <h2 class="font-semibold text-white text-lg">{{ doc.template_name }}</h2>
+                            {% if preview.is_static %}
+                            <p class="text-white/80 text-sm">Uploaded document (no signatures required)</p>
+                            {% elif preview.is_external %}
+                            <p class="text-white/80 text-sm">External document with signature fields</p>
+                            {% else %}
                             <p class="text-white/80 text-sm">Scroll through to review all pages</p>
+                            {% endif %}
                         </div>
-                        {% if documents|length > 1 %}
-                        <span class="px-3 py-1.5 bg-white/20 text-white text-sm font-medium rounded-full">
-                            Document {{ loop.index }} of {{ documents|length }}
-                        </span>
-                        {% endif %}
+                        <div class="flex items-center gap-2">
+                            {% if preview.is_static %}
+                            <span class="px-3 py-1.5 bg-teal-400/30 text-white text-xs font-medium rounded-full">
+                                <i class="fas fa-file-pdf mr-1"></i>Static PDF
+                            </span>
+                            {% elif preview.is_external %}
+                            <span class="px-3 py-1.5 bg-purple-400/30 text-white text-xs font-medium rounded-full">
+                                <i class="fas fa-file-import mr-1"></i>External
+                            </span>
+                            {% endif %}
+                            {% if documents|length > 1 %}
+                            <span class="px-3 py-1.5 bg-white/20 text-white text-sm font-medium rounded-full">
+                                Document {{ loop.index }} of {{ documents|length }}
+                            </span>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
 
                 <!-- Document preview body -->
                 <div class="p-6">
-                    {% if mock_mode %}
-                    <!-- Mock mode placeholder -->
+                    {% if preview.pdf_url %}
+                    <!-- Static/External document - PDF iframe preview -->
+                    <div class="docuseal-embed-container" style="min-height: 700px;">
+                        <iframe src="{{ preview.pdf_url }}" 
+                                style="width: 100%; height: 700px; border: none; border-radius: 8px;"
+                                title="{{ doc.template_name }}">
+                        </iframe>
+                    </div>
+                    {% if preview.is_static %}
+                    <div class="mt-4 p-4 bg-teal-50 border border-teal-200 rounded-lg">
+                        <p class="text-sm text-teal-800 flex items-center gap-2">
+                            <i class="fas fa-info-circle"></i>
+                            This document is included as-is and does not require signatures.
+                        </p>
+                    </div>
+                    {% elif preview.is_external %}
+                    <div class="mt-4 p-4 bg-purple-50 border border-purple-200 rounded-lg">
+                        <p class="text-sm text-purple-800 flex items-center gap-2">
+                            <i class="fas fa-info-circle"></i>
+                            This external document has signature fields placed and will be sent for e-signature.
+                        </p>
+                    </div>
+                    {% endif %}
+                    {% elif mock_mode and not preview.is_static and not preview.is_external %}
+                    <!-- Mock mode placeholder for template docs -->
                     <div class="mock-preview-placeholder">
                         <div class="w-20 h-20 rounded-full bg-amber-100 flex items-center justify-center mb-4">
                             <i class="fas fa-file-alt text-4xl text-amber-500"></i>
@@ -408,6 +470,9 @@
         </div>
 
         <!-- Summary Card -->
+        {% set static_count = preview_docs|selectattr('is_static')|list|length %}
+        {% set external_count = preview_docs|selectattr('is_external')|list|length %}
+        {% set template_count = documents|length - static_count - external_count %}
         <div class="bg-gradient-to-r from-emerald-500 to-emerald-600 rounded-2xl shadow-lg p-6 text-white">
             <div class="flex items-start gap-4">
                 <div class="w-12 h-12 rounded-xl bg-white/20 flex items-center justify-center">
@@ -415,10 +480,27 @@
                 </div>
                 <div class="flex-1">
                     <h3 class="font-bold text-lg mb-1">Ready to Send</h3>
-                    <p class="text-emerald-100 text-sm">
+                    <p class="text-emerald-100 text-sm mb-3">
                         When you send, {{ signers|length }} signer(s) will receive an email with a link to sign
-                        all {{ documents|length }} document(s) in one session. They can sign from any device.
+                        all documents in one session. They can sign from any device.
                     </p>
+                    <div class="flex flex-wrap gap-2">
+                        {% if template_count > 0 %}
+                        <span class="px-2 py-1 bg-white/20 rounded text-xs font-medium">
+                            <i class="fas fa-file-signature mr-1"></i>{{ template_count }} Template Doc{{ 's' if template_count > 1 else '' }}
+                        </span>
+                        {% endif %}
+                        {% if external_count > 0 %}
+                        <span class="px-2 py-1 bg-purple-400/40 rounded text-xs font-medium">
+                            <i class="fas fa-file-import mr-1"></i>{{ external_count }} External Doc{{ 's' if external_count > 1 else '' }}
+                        </span>
+                        {% endif %}
+                        {% if static_count > 0 %}
+                        <span class="px-2 py-1 bg-teal-400/40 rounded text-xs font-medium">
+                            <i class="fas fa-file-pdf mr-1"></i>{{ static_count }} Static PDF{{ 's' if static_count > 1 else '' }} (no signature)
+                        </span>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Add is_placeholder column to transaction_documents model
- Update intake schema with special tax district notice and referral agreement placeholders
- Add upload-static and upload-for-signature endpoints for placeholder documents
- Implement placeholder-to-template conversion when adding existing document
- Add view-static endpoint to preview uploaded static PDFs
- Update preview-all page to show static/external docs alongside template docs
- Add visual distinction for placeholder docs (amber highlight, badges)
- Include static PDFs in Fill All Documents preview section

Placeholders are created when questionnaire answers trigger conditional documents. Agents can upload static PDFs (no signature) or prep documents for e-signature.