### PR TITLE
fix: correct T-47 affidavit generation logic for survey question

### DIFF
--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -138,8 +138,8 @@
     {
       "slug": "t47-affidavit",
       "name": "T-47.1 Residential Real Property Affidavit",
-      "condition": {"field": "has_survey", "in": ["no", "not_sure"]},
-      "reason": "Seller does not have survey or is unsure"
+      "condition": {"field": "has_survey", "in": ["yes", "not_sure"]},
+      "reason": "Seller has survey or is unsure"
     }
   ]
 }


### PR DESCRIPTION
The T-47 affidavit should only be generated when the seller HAS a survey or is unsure (not when they don't have one). Updated the condition from ["no", "not_sure"] to ["yes", "not_sure"] to match the correct business logic.

This ensures the T-47 document appears in the document package only when appropriate based on the survey availability question response.