### PR TITLE
fix: seed task types and transaction types for multi-tenant orgs

### DIFF
--- a/routes/platform_admin.py
+++ b/routes/platform_admin.py
@@ -211,15 +211,34 @@ def approve_org(org_id):
     
     db.session.commit()
     
-    # Create default contact groups for the new org
-    from services.tenant_service import create_default_groups_for_org
+    # Create default data for the new org
+    from services.tenant_service import (
+        create_default_groups_for_org,
+        create_default_task_types_for_org,
+        create_default_transaction_types_for_org
+    )
+    import logging
+    
+    # Create default contact groups
     try:
         created_groups = create_default_groups_for_org(org.id)
         log_platform_action('org_groups_created', org.id, {'groups_count': len(created_groups)})
     except Exception as e:
-        # Log error but don't fail the approval
-        import logging
         logging.error(f"Failed to create default groups for org {org.id}: {e}")
+    
+    # Create default task types and subtypes
+    try:
+        created_task_types = create_default_task_types_for_org(org.id)
+        log_platform_action('org_task_types_created', org.id, {'task_types_count': len(created_task_types)})
+    except Exception as e:
+        logging.error(f"Failed to create default task types for org {org.id}: {e}")
+    
+    # Create default transaction types
+    try:
+        created_tx_types = create_default_transaction_types_for_org(org.id)
+        log_platform_action('org_transaction_types_created', org.id, {'transaction_types_count': len(created_tx_types)})
+    except Exception as e:
+        logging.error(f"Failed to create default transaction types for org {org.id}: {e}")
     
     # Notify org owner via email
     from services.org_notifications import send_org_approved_email

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -91,9 +91,11 @@ def list_transactions():
                 'contact_id': primary_participant.contact_id
             }
     
-    # Get transaction types for filter dropdown
-    transaction_types = TransactionType.query.filter_by(is_active=True)\
-        .order_by(TransactionType.sort_order).all()
+    # Get transaction types for filter dropdown (org-scoped)
+    transaction_types = TransactionType.query.filter_by(
+        organization_id=current_user.organization_id,
+        is_active=True
+    ).order_by(TransactionType.sort_order).all()
     
     return render_template(
         'transactions/list.html',
@@ -116,9 +118,11 @@ def list_transactions():
 @transactions_required
 def new_transaction():
     """Show the create transaction form."""
-    # Get transaction types for selection
-    transaction_types = TransactionType.query.filter_by(is_active=True)\
-        .order_by(TransactionType.sort_order).all()
+    # Get transaction types for selection (org-scoped)
+    transaction_types = TransactionType.query.filter_by(
+        organization_id=current_user.organization_id,
+        is_active=True
+    ).order_by(TransactionType.sort_order).all()
     
     # Get contacts for the current user (for contact selection)
     contacts = Contact.query.filter_by(user_id=current_user.id)\
@@ -371,8 +375,11 @@ def edit_transaction(id):
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
     
-    transaction_types = TransactionType.query.filter_by(is_active=True)\
-        .order_by(TransactionType.sort_order).all()
+    # Get transaction types (org-scoped)
+    transaction_types = TransactionType.query.filter_by(
+        organization_id=current_user.organization_id,
+        is_active=True
+    ).order_by(TransactionType.sort_order).all()
     
     return render_template(
         'transactions/edit.html',

--- a/services/tenant_service.py
+++ b/services/tenant_service.py
@@ -388,3 +388,125 @@ def create_default_groups_for_org(org_id: int):
     
     db.session.commit()
     return created_groups
+
+
+def create_default_task_types_for_org(org_id: int):
+    """
+    Create default task types and subtypes for a new organization.
+    Called when an organization is approved.
+    
+    Args:
+        org_id: The organization ID to create task types for
+        
+    Returns:
+        List of created TaskType objects
+    """
+    from models import db, TaskType, TaskSubtype
+    
+    # Default task types with their subtypes for real estate CRM
+    default_task_types = [
+        {
+            'name': 'Call',
+            'sort_order': 10,
+            'subtypes': [
+                {'name': 'Check-in', 'sort_order': 1},
+                {'name': 'Schedule Showing', 'sort_order': 2},
+                {'name': 'Discuss Offer', 'sort_order': 3},
+                {'name': 'Follow-up', 'sort_order': 4}
+            ]
+        },
+        {
+            'name': 'Meeting',
+            'sort_order': 20,
+            'subtypes': [
+                {'name': 'Initial Consultation', 'sort_order': 1},
+                {'name': 'Property Showing', 'sort_order': 2},
+                {'name': 'Contract Review', 'sort_order': 3},
+                {'name': 'Home Inspection', 'sort_order': 4}
+            ]
+        },
+        {
+            'name': 'Email',
+            'sort_order': 30,
+            'subtypes': [
+                {'name': 'Send Listings', 'sort_order': 1},
+                {'name': 'Send Documents', 'sort_order': 2},
+                {'name': 'Market Update', 'sort_order': 3},
+                {'name': 'General Follow-up', 'sort_order': 4}
+            ]
+        },
+        {
+            'name': 'Document',
+            'sort_order': 40,
+            'subtypes': [
+                {'name': 'Prepare Contract', 'sort_order': 1},
+                {'name': 'Review Documents', 'sort_order': 2},
+                {'name': 'Submit Offer', 'sort_order': 3},
+                {'name': 'Process Paperwork', 'sort_order': 4}
+            ]
+        }
+    ]
+    
+    created_types = []
+    for type_data in default_task_types:
+        # Create the task type
+        task_type = TaskType(
+            organization_id=org_id,
+            name=type_data['name'],
+            sort_order=type_data['sort_order']
+        )
+        db.session.add(task_type)
+        db.session.flush()  # Get the task_type.id
+        
+        # Create subtypes for this type
+        for subtype_data in type_data.get('subtypes', []):
+            subtype = TaskSubtype(
+                organization_id=org_id,
+                task_type_id=task_type.id,
+                name=subtype_data['name'],
+                sort_order=subtype_data['sort_order']
+            )
+            db.session.add(subtype)
+        
+        created_types.append(task_type)
+    
+    db.session.commit()
+    return created_types
+
+
+def create_default_transaction_types_for_org(org_id: int):
+    """
+    Create default transaction types for a new organization.
+    Called when an organization is approved.
+    
+    Args:
+        org_id: The organization ID to create transaction types for
+        
+    Returns:
+        List of created TransactionType objects
+    """
+    from models import db, TransactionType
+    
+    # Default transaction types for real estate CRM
+    default_transaction_types = [
+        {'name': 'seller', 'display_name': 'Seller Representation', 'sort_order': 1},
+        {'name': 'buyer', 'display_name': 'Buyer Representation', 'sort_order': 2},
+        {'name': 'landlord', 'display_name': 'Landlord Representation', 'sort_order': 3},
+        {'name': 'tenant', 'display_name': 'Tenant Representation', 'sort_order': 4},
+        {'name': 'referral', 'display_name': 'Referral', 'sort_order': 5},
+    ]
+    
+    created_types = []
+    for type_data in default_transaction_types:
+        tx_type = TransactionType(
+            organization_id=org_id,
+            name=type_data['name'],
+            display_name=type_data['display_name'],
+            sort_order=type_data['sort_order'],
+            is_active=True
+        )
+        db.session.add(tx_type)
+        created_types.append(tx_type)
+    
+    db.session.commit()
+    return created_types


### PR DESCRIPTION
When non-Origen organizations tried to create tasks, the type and subtype dropdowns were empty because these records were never seeded for new orgs.

Changes:
- Add create_default_task_types_for_org() to seed 4 task types with subtypes
- Add create_default_transaction_types_for_org() to seed 5 transaction types
- Call seeding functions when org is approved in platform admin
- Fix TransactionType queries to filter by organization_id
- Add manage_db.py seed_orgs command to backfill existing orgs