### PR TITLE
feat: add Gmail integration for email sync on contact records

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from routes.transactions import transactions_bp
 from routes.organization import org_bp
 from routes.platform_admin import platform_bp
 from routes.contact_us import contact_bp
+from routes.gmail_integration import gmail_bp
 
 def create_app():
     app = Flask(__name__)
@@ -73,6 +74,32 @@ def create_app():
         return utc_dt.astimezone(CENTRAL_TZ)
     
     app.jinja_env.filters['to_central'] = to_central_time
+    
+    def timeago(dt):
+        """Convert datetime to human-readable 'time ago' string."""
+        if dt is None:
+            return 'Never'
+        now = datetime.utcnow()
+        diff = now - dt
+        
+        seconds = diff.total_seconds()
+        if seconds < 60:
+            return 'Just now'
+        elif seconds < 3600:
+            mins = int(seconds / 60)
+            return f'{mins} minute{"s" if mins != 1 else ""} ago'
+        elif seconds < 86400:
+            hours = int(seconds / 3600)
+            return f'{hours} hour{"s" if hours != 1 else ""} ago'
+        elif seconds < 604800:
+            days = int(seconds / 86400)
+            if days == 1:
+                return 'Yesterday'
+            return f'{days} days ago'
+        else:
+            return dt.strftime('%b %d, %Y')
+    
+    app.jinja_env.filters['timeago'] = timeago
 
     # Context processor to make feature flags available in templates
     @app.context_processor
@@ -104,6 +131,7 @@ def create_app():
     app.register_blueprint(org_bp)
     app.register_blueprint(platform_bp)
     app.register_blueprint(contact_bp)
+    app.register_blueprint(gmail_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/config.py
+++ b/config.py
@@ -37,3 +37,9 @@ class Config:
     # RentCast API configuration
     RENTCAST_API_KEY = os.getenv('RENTCAST_API_KEY')
     RENTCAST_REFRESH_HOURS = int(os.getenv('RENTCAST_REFRESH_HOURS', 48))  # Hours before allowing re-fetch
+
+    # Google Gmail Integration (OAuth)
+    GOOGLE_CLIENT_ID = os.getenv('GOOGLE_CLIENT_ID')
+    GOOGLE_CLIENT_SECRET = os.getenv('GOOGLE_CLIENT_SECRET')
+    GMAIL_TOKEN_ENCRYPTION_KEY = os.getenv('GMAIL_TOKEN_ENCRYPTION_KEY')
+    GMAIL_SYNC_DAYS = int(os.getenv('GMAIL_SYNC_DAYS', 30))  # Initial sync window

--- a/jobs/gmail_sync.py
+++ b/jobs/gmail_sync.py
@@ -1,0 +1,130 @@
+# jobs/gmail_sync.py
+"""
+Gmail Email Sync Background Job
+
+Syncs emails from Gmail for all users with active integrations.
+Runs every 5 minutes via Railway Cron Job.
+
+Usage:
+    python jobs/gmail_sync.py
+"""
+
+import os
+import sys
+import logging
+from datetime import datetime
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def sync_gmail_for_all_users():
+    """
+    Sync emails for all users with active Gmail integrations.
+    
+    For each organization with active integrations:
+    1. Set org context for RLS
+    2. For each user's integration:
+       a. Check if sync is needed (not already syncing)
+       b. Refresh token if needed
+       c. Fetch new emails via Gmail API
+       d. Match to contacts and store
+       e. Update sync status and timestamp
+    """
+    from models import db, Organization, UserEmailIntegration
+    from services import gmail_service
+    from jobs.base import set_job_org_context
+    
+    logger.info("Starting Gmail sync job")
+    
+    total_users_synced = 0
+    total_emails_fetched = 0
+    total_contacts_matched = 0
+    errors = []
+    
+    # Get all active integrations
+    integrations = UserEmailIntegration.query.filter(
+        UserEmailIntegration.sync_enabled == True,
+        UserEmailIntegration.access_token_encrypted.isnot(None)
+    ).all()
+    
+    logger.info(f"Found {len(integrations)} active Gmail integrations")
+    
+    for integration in integrations:
+        try:
+            # Set org context for RLS
+            set_job_org_context(integration.organization_id)
+            
+            # Skip if already syncing (prevent concurrent syncs)
+            if integration.sync_status == 'syncing':
+                logger.info(f"Skipping user {integration.user_id} - already syncing")
+                continue
+            
+            # Mark as syncing
+            integration.sync_status = 'syncing'
+            db.session.commit()
+            
+            logger.info(f"Syncing emails for user {integration.user_id} ({integration.connected_email})")
+            
+            # Perform incremental sync
+            result = gmail_service.fetch_emails_for_user(integration, initial=False)
+            
+            total_users_synced += 1
+            total_emails_fetched += result['emails_fetched']
+            total_contacts_matched += result['contacts_matched']
+            
+            if result['errors']:
+                errors.extend(result['errors'])
+            
+            logger.info(
+                f"User {integration.user_id}: "
+                f"{result['emails_fetched']} emails, "
+                f"{result['contacts_matched']} contacts matched"
+            )
+            
+        except Exception as e:
+            logger.exception(f"Error syncing user {integration.user_id}: {e}")
+            errors.append(f"User {integration.user_id}: {str(e)}")
+            
+            # Mark as error
+            try:
+                integration.sync_status = 'error'
+                integration.sync_error = str(e)
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+    
+    logger.info(
+        f"Gmail sync job completed: "
+        f"{total_users_synced} users synced, "
+        f"{total_emails_fetched} emails fetched, "
+        f"{total_contacts_matched} contacts matched, "
+        f"{len(errors)} errors"
+    )
+    
+    return {
+        'users_synced': total_users_synced,
+        'emails_fetched': total_emails_fetched,
+        'contacts_matched': total_contacts_matched,
+        'errors': errors
+    }
+
+
+def run_gmail_sync():
+    """Entry point for scheduler/cron - creates app context and runs job."""
+    from app import create_app
+    
+    app = create_app()
+    with app.app_context():
+        sync_gmail_for_all_users()
+
+
+if __name__ == '__main__':
+    run_gmail_sync()

--- a/migrations/versions/4fc5aacd858e_merge_heads.py
+++ b/migrations/versions/4fc5aacd858e_merge_heads.py
@@ -1,0 +1,24 @@
+"""Merge heads
+
+Revision ID: 4fc5aacd858e
+Revises: add_contact_voice_memos, add_placeholder_support
+Create Date: 2026-01-21 19:39:48.411516
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4fc5aacd858e'
+down_revision = ('add_contact_voice_memos', 'add_placeholder_support')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,11 @@ openai==2.14.0
 sendgrid==6.11.0
 requests==2.32.5
 
+# Google Gmail Integration
+google-auth==2.29.0
+google-auth-oauthlib==1.2.0
+google-api-python-client==2.125.0
+
 # Database driver
 psycopg2-binary==2.9.11
 
@@ -29,6 +34,8 @@ supabase==2.11.0
 itsdangerous==2.2.0
 PyYAML==6.0.3
 jsonschema==4.26.0
+cryptography==42.0.5
+bleach==6.1.0
 
 # Server
 gunicorn==23.0.0

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -309,7 +309,9 @@ def complete_invite(token):
 @auth_bp.route('/profile')
 @login_required
 def view_user_profile():
-    return render_template('auth/user_profile.html', user=current_user)
+    from models import UserEmailIntegration
+    gmail_integration = UserEmailIntegration.query.filter_by(user_id=current_user.id).first()
+    return render_template('auth/user_profile.html', user=current_user, gmail_integration=gmail_integration)
 
 @auth_bp.route('/profile/update', methods=['POST'])
 @login_required

--- a/routes/gmail_integration.py
+++ b/routes/gmail_integration.py
@@ -1,0 +1,206 @@
+"""
+Gmail Integration Routes
+
+Handles OAuth flow for Gmail connection and integration management.
+"""
+
+from flask import Blueprint, redirect, url_for, flash, request, session, jsonify
+from flask_login import login_required, current_user
+import secrets
+import logging
+
+from models import db, UserEmailIntegration
+from services import gmail_service
+
+logger = logging.getLogger(__name__)
+
+gmail_bp = Blueprint('gmail', __name__, url_prefix='/integrations/gmail')
+
+
+@gmail_bp.route('/connect')
+@login_required
+def connect():
+    """
+    Initiate Gmail OAuth flow.
+    Redirects user to Google's consent screen.
+    """
+    try:
+        # Generate CSRF state token
+        state = secrets.token_urlsafe(32)
+        session['gmail_oauth_state'] = state
+        
+        # Get authorization URL
+        auth_url = gmail_service.get_oauth_url(state)
+        
+        logger.info(f"User {current_user.id} initiating Gmail OAuth")
+        return redirect(auth_url)
+        
+    except ValueError as e:
+        logger.error(f"Gmail OAuth configuration error: {e}")
+        flash('Gmail integration is not configured. Please contact support.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    except Exception as e:
+        logger.exception(f"Error initiating Gmail OAuth: {e}")
+        flash('Unable to connect to Gmail. Please try again.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+
+
+@gmail_bp.route('/callback')
+@login_required
+def callback():
+    """
+    Handle OAuth callback from Google.
+    Exchange authorization code for tokens and store integration.
+    """
+    # Verify state token (CSRF protection)
+    state = request.args.get('state')
+    stored_state = session.pop('gmail_oauth_state', None)
+    
+    if not state or state != stored_state:
+        logger.warning(f"Invalid OAuth state for user {current_user.id}")
+        flash('Invalid authentication state. Please try again.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    
+    # Check for errors from Google
+    error = request.args.get('error')
+    if error:
+        logger.warning(f"OAuth error for user {current_user.id}: {error}")
+        if error == 'access_denied':
+            flash('Gmail access was denied. You can try again anytime.', 'info')
+        else:
+            flash(f'Gmail connection failed: {error}', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    
+    # Get authorization code
+    code = request.args.get('code')
+    if not code:
+        flash('No authorization code received. Please try again.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    
+    try:
+        # Exchange code for tokens
+        token_data = gmail_service.exchange_code_for_tokens(code)
+        
+        # Check if integration already exists
+        integration = UserEmailIntegration.query.filter_by(user_id=current_user.id).first()
+        
+        if integration:
+            # Update existing integration
+            integration.connected_email = token_data['email']
+            integration.access_token_encrypted = gmail_service.encrypt_token(token_data['access_token'])
+            integration.refresh_token_encrypted = gmail_service.encrypt_token(token_data['refresh_token'])
+            integration.token_expires_at = token_data['expires_at']
+            integration.sync_enabled = True
+            integration.sync_status = 'pending'
+            integration.sync_error = None
+        else:
+            # Create new integration
+            integration = UserEmailIntegration(
+                user_id=current_user.id,
+                organization_id=current_user.organization_id,
+                provider='gmail',
+                connected_email=token_data['email'],
+                access_token_encrypted=gmail_service.encrypt_token(token_data['access_token']),
+                refresh_token_encrypted=gmail_service.encrypt_token(token_data['refresh_token']),
+                token_expires_at=token_data['expires_at'],
+                sync_enabled=True,
+                sync_status='pending'
+            )
+            db.session.add(integration)
+        
+        db.session.commit()
+        logger.info(f"Gmail connected for user {current_user.id}: {token_data['email']}")
+        
+        # Trigger initial sync in background (or inline for now)
+        flash(f'Gmail connected successfully! Syncing emails from {token_data["email"]}...', 'success')
+        
+        # Do initial sync
+        try:
+            result = gmail_service.fetch_emails_for_user(integration, initial=True)
+            if result['emails_fetched'] > 0:
+                flash(f'Synced {result["emails_fetched"]} emails matching {result["contacts_matched"]} contacts.', 'success')
+            else:
+                flash('No emails found matching your contacts. New emails will sync automatically.', 'info')
+        except Exception as sync_error:
+            db.session.rollback()  # Rollback any pending transaction
+            logger.error(f"Initial sync failed for user {current_user.id}: {sync_error}")
+            flash('Gmail connected but initial sync had issues. Emails will sync in background.', 'warning')
+        
+        return redirect(url_for('auth.view_user_profile'))
+        
+    except Exception as e:
+        db.session.rollback()  # Rollback any pending transaction
+        logger.exception(f"Error completing Gmail OAuth: {e}")
+        flash('Failed to complete Gmail connection. Please try again.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+
+
+@gmail_bp.route('/disconnect', methods=['POST'])
+@login_required
+def disconnect():
+    """
+    Disconnect Gmail integration.
+    Disables sync but keeps previously synced emails.
+    """
+    integration = UserEmailIntegration.query.filter_by(user_id=current_user.id).first()
+    
+    if integration:
+        integration.sync_enabled = False
+        integration.access_token_encrypted = None
+        integration.refresh_token_encrypted = None
+        integration.token_expires_at = None
+        integration.sync_status = 'pending'
+        db.session.commit()
+        
+        logger.info(f"Gmail disconnected for user {current_user.id}")
+        flash('Gmail disconnected. Previously synced emails are still available.', 'info')
+    else:
+        flash('No Gmail integration found.', 'info')
+    
+    return redirect(url_for('auth.view_user_profile'))
+
+
+@gmail_bp.route('/status')
+@login_required
+def status():
+    """
+    Get Gmail integration status (JSON endpoint for AJAX).
+    """
+    integration = UserEmailIntegration.query.filter_by(user_id=current_user.id).first()
+    
+    if not integration or not integration.sync_enabled:
+        return jsonify({
+            'connected': False
+        })
+    
+    return jsonify({
+        'connected': True,
+        'email': integration.connected_email,
+        'sync_status': integration.sync_status,
+        'last_sync_at': integration.last_sync_at.isoformat() if integration.last_sync_at else None,
+        'sync_error': integration.sync_error
+    })
+
+
+@gmail_bp.route('/resync', methods=['POST'])
+@login_required
+def resync():
+    """
+    Manually trigger email resync.
+    """
+    integration = UserEmailIntegration.query.filter_by(user_id=current_user.id).first()
+    
+    if not integration or not integration.sync_enabled:
+        return jsonify({'success': False, 'error': 'Gmail not connected'}), 400
+    
+    try:
+        result = gmail_service.fetch_emails_for_user(integration, initial=False)
+        return jsonify({
+            'success': True,
+            'emails_fetched': result['emails_fetched'],
+            'contacts_matched': result['contacts_matched'],
+            'errors': result['errors']
+        })
+    except Exception as e:
+        logger.exception(f"Resync failed for user {current_user.id}: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/services/gmail_service.py
+++ b/services/gmail_service.py
@@ -1,0 +1,564 @@
+"""
+Gmail Integration Service
+
+Handles OAuth flow, token management, and Gmail API interactions.
+Provides email sync functionality for contact email history.
+
+Usage:
+    from services.gmail_service import (
+        get_oauth_url,
+        exchange_code_for_tokens,
+        sync_emails_for_user
+    )
+"""
+
+import os
+import logging
+import base64
+from datetime import datetime, timedelta
+from typing import Optional, Dict, List, Tuple
+from email.utils import parseaddr
+
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import Flow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from cryptography.fernet import Fernet
+import bleach
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+# Gmail API scopes - read-only
+GMAIL_SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
+
+# OAuth redirect URIs
+REDIRECT_URI_LOCAL = 'http://127.0.0.1:5011/integrations/gmail/callback'
+REDIRECT_URI_PROD = 'https://www.origentechnolog.com/integrations/gmail/callback'
+
+# HTML sanitization for email body display
+ALLOWED_TAGS = ['p', 'br', 'b', 'i', 'strong', 'em', 'a', 'ul', 'ol', 'li', 'blockquote', 'div', 'span']
+ALLOWED_ATTRS = {'a': ['href', 'title']}
+
+
+def _get_redirect_uri() -> str:
+    """Get the appropriate redirect URI based on environment."""
+    if Config.FLASK_ENV == 'production':
+        return REDIRECT_URI_PROD
+    return REDIRECT_URI_LOCAL
+
+
+def _get_fernet() -> Fernet:
+    """Get Fernet instance for token encryption."""
+    key = Config.GMAIL_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError("GMAIL_TOKEN_ENCRYPTION_KEY not configured")
+    return Fernet(key.encode())
+
+
+def encrypt_token(token: str) -> str:
+    """Encrypt an OAuth token for storage."""
+    f = _get_fernet()
+    return f.encrypt(token.encode()).decode()
+
+
+def decrypt_token(encrypted_token: str) -> str:
+    """Decrypt an OAuth token from storage."""
+    f = _get_fernet()
+    return f.decrypt(encrypted_token.encode()).decode()
+
+
+def get_oauth_url(state: str) -> str:
+    """
+    Generate Google OAuth authorization URL.
+    
+    Args:
+        state: CSRF state token (store in session for verification)
+    
+    Returns:
+        Authorization URL to redirect user to
+    """
+    if not Config.GOOGLE_CLIENT_ID or not Config.GOOGLE_CLIENT_SECRET:
+        raise ValueError("Google OAuth credentials not configured")
+    
+    flow = Flow.from_client_config(
+        {
+            "web": {
+                "client_id": Config.GOOGLE_CLIENT_ID,
+                "client_secret": Config.GOOGLE_CLIENT_SECRET,
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "redirect_uris": [_get_redirect_uri()]
+            }
+        },
+        scopes=GMAIL_SCOPES
+    )
+    flow.redirect_uri = _get_redirect_uri()
+    
+    auth_url, _ = flow.authorization_url(
+        state=state,
+        access_type='offline',  # Get refresh token
+        include_granted_scopes='true',
+        prompt='consent'  # Always show consent to get refresh token
+    )
+    
+    return auth_url
+
+
+def exchange_code_for_tokens(code: str) -> Dict:
+    """
+    Exchange authorization code for access/refresh tokens.
+    
+    Args:
+        code: Authorization code from OAuth callback
+    
+    Returns:
+        Dict with keys: access_token, refresh_token, expires_at, email
+    """
+    flow = Flow.from_client_config(
+        {
+            "web": {
+                "client_id": Config.GOOGLE_CLIENT_ID,
+                "client_secret": Config.GOOGLE_CLIENT_SECRET,
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "redirect_uris": [_get_redirect_uri()]
+            }
+        },
+        scopes=GMAIL_SCOPES
+    )
+    flow.redirect_uri = _get_redirect_uri()
+    
+    # Exchange code for tokens
+    flow.fetch_token(code=code)
+    credentials = flow.credentials
+    
+    # Get user's email address
+    service = build('gmail', 'v1', credentials=credentials)
+    profile = service.users().getProfile(userId='me').execute()
+    email = profile.get('emailAddress')
+    
+    # Calculate expiration time
+    expires_at = datetime.utcnow() + timedelta(seconds=credentials.expiry.timestamp() - datetime.now().timestamp()) if credentials.expiry else datetime.utcnow() + timedelta(hours=1)
+    
+    return {
+        'access_token': credentials.token,
+        'refresh_token': credentials.refresh_token,
+        'expires_at': expires_at,
+        'email': email
+    }
+
+
+def refresh_access_token(integration) -> bool:
+    """
+    Refresh expired access token using refresh token.
+    
+    Args:
+        integration: UserEmailIntegration model instance
+    
+    Returns:
+        True if refresh successful, False otherwise
+    """
+    from models import db
+    
+    try:
+        refresh_token = decrypt_token(integration.refresh_token_encrypted)
+        
+        credentials = Credentials(
+            token=None,
+            refresh_token=refresh_token,
+            token_uri='https://oauth2.googleapis.com/token',
+            client_id=Config.GOOGLE_CLIENT_ID,
+            client_secret=Config.GOOGLE_CLIENT_SECRET,
+            scopes=GMAIL_SCOPES
+        )
+        
+        # Force refresh
+        from google.auth.transport.requests import Request
+        credentials.refresh(Request())
+        
+        # Update integration with new token
+        integration.access_token_encrypted = encrypt_token(credentials.token)
+        integration.token_expires_at = datetime.utcnow() + timedelta(hours=1)
+        integration.sync_status = 'active'
+        integration.sync_error = None
+        db.session.commit()
+        
+        logger.info(f"Refreshed access token for user {integration.user_id}")
+        return True
+        
+    except Exception as e:
+        logger.error(f"Failed to refresh token for user {integration.user_id}: {e}")
+        integration.sync_status = 'error'
+        integration.sync_error = str(e)
+        db.session.commit()
+        return False
+
+
+def _get_gmail_service(integration):
+    """
+    Get authenticated Gmail API service.
+    
+    Args:
+        integration: UserEmailIntegration model instance
+    
+    Returns:
+        Gmail API service object
+    """
+    # Check if token needs refresh
+    if integration.token_expires_at and integration.token_expires_at < datetime.utcnow():
+        if not refresh_access_token(integration):
+            raise Exception("Failed to refresh access token")
+    
+    access_token = decrypt_token(integration.access_token_encrypted)
+    
+    credentials = Credentials(
+        token=access_token,
+        refresh_token=decrypt_token(integration.refresh_token_encrypted),
+        token_uri='https://oauth2.googleapis.com/token',
+        client_id=Config.GOOGLE_CLIENT_ID,
+        client_secret=Config.GOOGLE_CLIENT_SECRET,
+        scopes=GMAIL_SCOPES
+    )
+    
+    return build('gmail', 'v1', credentials=credentials)
+
+
+def _parse_email_address(email_str: str) -> Tuple[str, str]:
+    """Parse email string to extract name and address."""
+    name, address = parseaddr(email_str)
+    return name or '', address or email_str
+
+
+def _extract_body(payload: dict) -> Tuple[str, str]:
+    """
+    Extract plain text and HTML body from email payload.
+    
+    Returns:
+        Tuple of (body_text, body_html)
+    """
+    body_text = ''
+    body_html = ''
+    
+    def extract_parts(parts):
+        nonlocal body_text, body_html
+        for part in parts:
+            mime_type = part.get('mimeType', '')
+            body = part.get('body', {})
+            data = body.get('data', '')
+            
+            if mime_type == 'text/plain' and data:
+                body_text = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
+            elif mime_type == 'text/html' and data:
+                body_html = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
+            elif 'parts' in part:
+                extract_parts(part['parts'])
+    
+    # Check if single part message
+    body = payload.get('body', {})
+    if body.get('data'):
+        mime_type = payload.get('mimeType', '')
+        data = body['data']
+        decoded = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
+        if mime_type == 'text/html':
+            body_html = decoded
+        else:
+            body_text = decoded
+    
+    # Check for multipart
+    if 'parts' in payload:
+        extract_parts(payload['parts'])
+    
+    return body_text, body_html
+
+
+def sanitize_html(html_content: str) -> str:
+    """Sanitize HTML content for safe display."""
+    if not html_content:
+        return ''
+    return bleach.clean(html_content, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS, strip=True)
+
+
+def fetch_emails_for_user(integration, initial: bool = False) -> Dict:
+    """
+    Fetch emails from Gmail for a user.
+    
+    Args:
+        integration: UserEmailIntegration model instance
+        initial: If True, fetch last 30 days. If False, use incremental sync.
+    
+    Returns:
+        Dict with: emails_fetched (int), contacts_matched (int), errors (list)
+    """
+    from models import db, Contact, ContactEmail
+    
+    result = {
+        'emails_fetched': 0,
+        'contacts_matched': 0,
+        'errors': []
+    }
+    
+    try:
+        service = _get_gmail_service(integration)
+        
+        # Build query
+        if initial:
+            # Initial sync: last 30 days
+            after_date = (datetime.utcnow() - timedelta(days=Config.GMAIL_SYNC_DAYS)).strftime('%Y/%m/%d')
+            query = f'after:{after_date}'
+        else:
+            # Incremental sync using history API
+            if integration.last_history_id:
+                try:
+                    history = service.users().history().list(
+                        userId='me',
+                        startHistoryId=integration.last_history_id,
+                        historyTypes=['messageAdded']
+                    ).execute()
+                    
+                    message_ids = set()
+                    for record in history.get('history', []):
+                        for msg in record.get('messagesAdded', []):
+                            message_ids.add(msg['message']['id'])
+                    
+                    if not message_ids:
+                        logger.info(f"No new messages for user {integration.user_id}")
+                        integration.last_sync_at = datetime.utcnow()
+                        db.session.commit()
+                        return result
+                    
+                    # Fetch these specific messages
+                    for msg_id in message_ids:
+                        _process_message(service, msg_id, integration, result)
+                    
+                    # Update history ID
+                    integration.last_history_id = history.get('historyId')
+                    integration.last_sync_at = datetime.utcnow()
+                    integration.sync_status = 'active'
+                    db.session.commit()
+                    return result
+                    
+                except HttpError as e:
+                    if e.resp.status == 404:
+                        # History expired, do a full sync
+                        logger.warning(f"History expired for user {integration.user_id}, doing full sync")
+                        after_date = (datetime.utcnow() - timedelta(days=7)).strftime('%Y/%m/%d')
+                        query = f'after:{after_date}'
+                    else:
+                        raise
+            else:
+                # No history ID, do initial sync
+                after_date = (datetime.utcnow() - timedelta(days=Config.GMAIL_SYNC_DAYS)).strftime('%Y/%m/%d')
+                query = f'after:{after_date}'
+        
+        # List messages matching query
+        messages = []
+        page_token = None
+        
+        while True:
+            response = service.users().messages().list(
+                userId='me',
+                q=query,
+                maxResults=100,
+                pageToken=page_token
+            ).execute()
+            
+            messages.extend(response.get('messages', []))
+            page_token = response.get('nextPageToken')
+            
+            # Limit initial sync to 50 emails for fast OAuth callback
+            # Background job will sync the rest
+            if not page_token or len(messages) >= 50:
+                break
+        
+        logger.info(f"Found {len(messages)} messages for user {integration.user_id}")
+        
+        # Process each message
+        for msg in messages:
+            _process_message(service, msg['id'], integration, result)
+        
+        # Update sync status
+        profile = service.users().getProfile(userId='me').execute()
+        integration.last_history_id = profile.get('historyId')
+        integration.last_sync_at = datetime.utcnow()
+        integration.sync_status = 'active'
+        db.session.commit()
+        
+    except Exception as e:
+        logger.exception(f"Error fetching emails for user {integration.user_id}: {e}")
+        result['errors'].append(str(e))
+        try:
+            db.session.rollback()  # Rollback any failed transaction first
+            integration.sync_status = 'error'
+            integration.sync_error = str(e)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+    
+    return result
+
+
+def _process_message(service, msg_id: str, integration, result: Dict):
+    """Process a single email message."""
+    from models import db, Contact, ContactEmail
+    
+    try:
+        # Note: We don't skip based on gmail_message_id alone anymore
+        # The same email can be linked to multiple contacts
+        
+        # Get full message
+        msg = service.users().messages().get(
+            userId='me',
+            id=msg_id,
+            format='full'
+        ).execute()
+        
+        # Extract headers
+        headers = {h['name'].lower(): h['value'] for h in msg['payload'].get('headers', [])}
+        
+        subject = headers.get('subject', '(No subject)')
+        from_header = headers.get('from', '')
+        to_header = headers.get('to', '')
+        cc_header = headers.get('cc', '')
+        date_header = headers.get('date', '')
+        
+        # Parse sender
+        from_name, from_email = _parse_email_address(from_header)
+        
+        # Parse recipients
+        to_emails = [_parse_email_address(e)[1] for e in to_header.split(',') if e.strip()]
+        cc_emails = [_parse_email_address(e)[1] for e in cc_header.split(',') if e.strip()] if cc_header else []
+        
+        # Determine direction
+        agent_email = integration.connected_email.lower()
+        direction = 'outbound' if from_email.lower() == agent_email else 'inbound'
+        
+        # Collect all participant emails (excluding agent)
+        participant_emails = set()
+        if direction == 'outbound':
+            participant_emails.update(e.lower() for e in to_emails if e.lower() != agent_email)
+            participant_emails.update(e.lower() for e in cc_emails if e.lower() != agent_email)
+        else:
+            participant_emails.add(from_email.lower())
+        
+        # Match to contacts
+        contacts = Contact.query.filter(
+            Contact.organization_id == integration.organization_id,
+            Contact.email.isnot(None)
+        ).all()
+        
+        matched_contacts = [c for c in contacts if c.email and c.email.lower() in participant_emails]
+        
+        if not matched_contacts:
+            # No matching contacts, skip this email
+            return
+        
+        result['emails_fetched'] += 1
+        
+        # Extract body
+        body_text, body_html = _extract_body(msg['payload'])
+        
+        # Check for attachments
+        has_attachments = False
+        if 'parts' in msg['payload']:
+            for part in msg['payload']['parts']:
+                if part.get('filename'):
+                    has_attachments = True
+                    break
+        
+        # Parse date
+        sent_at = None
+        if date_header:
+            from email.utils import parsedate_to_datetime
+            try:
+                sent_at = parsedate_to_datetime(date_header)
+                sent_at = sent_at.replace(tzinfo=None)  # Store as naive UTC
+            except Exception:
+                sent_at = datetime.utcnow()
+        
+        # Create ContactEmail for each matched contact
+        for contact in matched_contacts:
+            # Check if this specific contact-message combo exists
+            existing = ContactEmail.query.filter_by(
+                gmail_message_id=msg_id,
+                contact_id=contact.id
+            ).first()
+            if existing:
+                continue
+            
+            contact_email = ContactEmail(
+                organization_id=integration.organization_id,
+                user_id=integration.user_id,
+                contact_id=contact.id,
+                gmail_message_id=msg_id,
+                gmail_thread_id=msg.get('threadId'),
+                subject=subject[:500] if subject else None,
+                snippet=msg.get('snippet', '')[:500],
+                from_email=from_email,
+                from_name=from_name,
+                to_emails=to_emails,
+                cc_emails=cc_emails if cc_emails else None,
+                direction=direction,
+                sent_at=sent_at,
+                has_attachments=has_attachments,
+                body_text=body_text,
+                body_html=sanitize_html(body_html)
+            )
+            db.session.add(contact_email)
+            result['contacts_matched'] += 1
+        
+        db.session.commit()
+        
+    except Exception as e:
+        logger.error(f"Error processing message {msg_id}: {e}")
+        result['errors'].append(f"Message {msg_id}: {str(e)}")
+
+
+def get_email_threads_for_contact(contact_id: int, user_id: int) -> List[Dict]:
+    """
+    Get email threads for a contact, grouped by thread_id.
+    
+    Args:
+        contact_id: Contact ID
+        user_id: Current user ID (for filtering)
+    
+    Returns:
+        List of thread dicts with messages
+    """
+    from models import ContactEmail
+    
+    # Get all emails for this contact from this user's sync
+    emails = ContactEmail.query.filter_by(
+        contact_id=contact_id,
+        user_id=user_id
+    ).order_by(ContactEmail.sent_at.asc()).all()
+    
+    # Group by thread
+    threads_map = {}
+    for email in emails:
+        thread_id = email.gmail_thread_id or email.gmail_message_id
+        if thread_id not in threads_map:
+            threads_map[thread_id] = {
+                'thread_id': thread_id,
+                'subject': email.subject,
+                'messages': [],
+                'latest_at': email.sent_at
+            }
+        
+        threads_map[thread_id]['messages'].append(email.to_dict())
+        
+        if email.sent_at and (not threads_map[thread_id]['latest_at'] or 
+                              email.sent_at > threads_map[thread_id]['latest_at']):
+            threads_map[thread_id]['latest_at'] = email.sent_at
+    
+    # Convert to list and sort by latest message
+    threads = list(threads_map.values())
+    threads.sort(key=lambda t: t['latest_at'] or datetime.min, reverse=True)
+    
+    # Add message count
+    for thread in threads:
+        thread['message_count'] = len(thread['messages'])
+        thread['latest_at'] = thread['latest_at'].isoformat() if thread['latest_at'] else None
+    
+    return threads

--- a/templates/auth/user_profile.html
+++ b/templates/auth/user_profile.html
@@ -110,6 +110,77 @@
                 </div>
             </form>
         </div>
+
+        {% if not is_admin_edit %}
+        <!-- Email Integration Section -->
+        <div class="bg-white rounded-lg shadow-md mt-6 p-6">
+            <h2 class="text-xl font-bold text-gray-900 mb-4">Email Integration</h2>
+            
+            {% if gmail_integration and gmail_integration.sync_status == 'error' %}
+                <!-- Error State -->
+                <div class="border border-amber-200 bg-amber-50 rounded-lg p-4 mb-4">
+                    <div class="flex items-center gap-2">
+                        <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                        </svg>
+                        <span class="font-medium text-gray-900">{{ gmail_integration.connected_email }}</span>
+                    </div>
+                    <p class="text-sm text-amber-700 mt-1">Connection issue - Reconnect to continue syncing</p>
+                </div>
+                <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
+                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                    </svg>
+                    Reconnect Gmail
+                </a>
+                
+            {% elif gmail_integration and gmail_integration.sync_enabled %}
+                <!-- Connected State -->
+                <div class="border border-green-200 bg-green-50 rounded-lg p-4 mb-4">
+                    <div class="flex items-center gap-2">
+                        <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        <span class="font-medium text-gray-900">{{ gmail_integration.connected_email }}</span>
+                    </div>
+                    <p class="text-sm text-gray-500 mt-1">
+                        {% if gmail_integration.last_sync_at %}
+                            Synced {{ gmail_integration.last_sync_at|timeago }}
+                        {% else %}
+                            Sync pending...
+                        {% endif %}
+                    </p>
+                </div>
+                <form method="POST" action="{{ url_for('gmail.disconnect') }}" class="inline">
+                    <button type="submit" class="text-gray-500 hover:text-gray-700 text-sm transition-colors">
+                        Disconnect
+                    </button>
+                </form>
+                
+            {% else %}
+                <!-- Disconnected State -->
+                <p class="text-gray-600 mb-4">Connect your Gmail to see email history on contact records. We'll automatically sync conversations with your contacts.</p>
+                <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 transition-colors">
+                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
+                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                    </svg>
+                    Connect Gmail
+                </a>
+                <p class="text-xs text-gray-400 mt-3 flex items-center gap-1">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+                    </svg>
+                    Read-only access - We never send emails on your behalf
+                </p>
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/templates/contacts/view.html
+++ b/templates/contacts/view.html
@@ -837,6 +837,111 @@
                     </div>
                 </div>
 
+                <!-- Email History Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-3">
+                                <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
+                                    <i class="fas fa-envelope text-white text-sm"></i>
+                                </div>
+                                <h2 class="text-lg font-semibold text-slate-800">Email History</h2>
+                                {% if email_threads %}
+                                <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">{{ email_threads|length }} conversation{{ 's' if email_threads|length != 1 else '' }}</span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="divide-y divide-slate-100 max-h-96 overflow-y-auto">
+                        {% if not gmail_connected %}
+                        <!-- Gmail Not Connected State -->
+                        <div class="p-8 text-center">
+                            <div class="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-3">
+                                <i class="fas fa-envelope text-blue-400 text-xl"></i>
+                            </div>
+                            <p class="text-slate-700 font-medium mb-1">See your email history with this contact</p>
+                            <p class="text-slate-500 text-sm mb-4">Connect Gmail to automatically sync conversations</p>
+                            <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors text-sm">
+                                <svg class="w-4 h-4 mr-2" viewBox="0 0 24 24">
+                                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                                </svg>
+                                Connect Gmail
+                            </a>
+                        </div>
+                        {% elif email_threads|length == 0 %}
+                        <!-- No Emails State -->
+                        <div class="p-8 text-center">
+                            <div class="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
+                                <i class="fas fa-envelope text-slate-400 text-xl"></i>
+                            </div>
+                            <p class="text-slate-500 text-sm">No emails with this contact yet</p>
+                            <p class="text-slate-400 text-xs mt-1">Emails you send or receive will appear here automatically</p>
+                        </div>
+                        {% else %}
+                        <!-- Email Threads List -->
+                        {% for thread in email_threads %}
+                        <div class="email-thread-item" data-thread-id="{{ thread.thread_id }}">
+                            <button onclick="toggleEmailThread('{{ thread.thread_id }}')" class="w-full p-4 hover:bg-slate-50 transition-colors text-left">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="flex-1 min-w-0">
+                                        <p class="font-medium text-slate-800 truncate">{{ thread.subject or '(No subject)' }}</p>
+                                        <p class="text-sm text-slate-500 mt-0.5">
+                                            {{ thread.message_count }} message{{ 's' if thread.message_count != 1 else '' }}
+                                            <span class="mx-1">·</span>
+                                            <span class="thread-date" data-date="{{ thread.latest_at }}">{{ thread.latest_at }}</span>
+                                        </p>
+                                    </div>
+                                    <i class="fas fa-chevron-down text-slate-400 transition-transform thread-chevron-{{ thread.thread_id }}"></i>
+                                </div>
+                            </button>
+                            <!-- Expanded Thread Messages -->
+                            <div id="thread-messages-{{ thread.thread_id }}" class="hidden border-t border-slate-100 bg-slate-50">
+                                {% for msg in thread.messages %}
+                                <div class="p-4 border-b border-slate-100 last:border-b-0">
+                                    <div class="flex items-center justify-between mb-2">
+                                        <div class="flex items-center gap-2">
+                                            <span class="font-medium text-slate-800 text-sm">
+                                                {% if msg.direction == 'outbound' %}You{% else %}{{ msg.from_name or msg.from_email }}{% endif %}
+                                            </span>
+                                            {% if msg.direction == 'outbound' %}
+                                            <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded uppercase font-semibold">Sent</span>
+                                            {% else %}
+                                            <span class="text-xs bg-slate-200 text-slate-600 px-2 py-0.5 rounded uppercase font-semibold">Received</span>
+                                            {% endif %}
+                                        </div>
+                                        <span class="text-xs text-slate-400 msg-date" data-date="{{ msg.sent_at }}">{{ msg.sent_at }}</span>
+                                    </div>
+                                    <p class="text-sm text-slate-600 line-clamp-3">{{ msg.snippet }}</p>
+                                    {% if msg.has_attachments %}
+                                    <p class="text-xs text-slate-400 mt-2 flex items-center gap-1">
+                                        <i class="fas fa-paperclip"></i> Has attachments
+                                    </p>
+                                    {% endif %}
+                                    {% if msg.body_text or msg.body_html %}
+                                    <button onclick="toggleFullEmail('{{ msg.id }}')" class="text-xs text-blue-600 hover:text-blue-700 mt-2">
+                                        Show full message
+                                    </button>
+                                    <div id="full-email-{{ msg.id }}" class="hidden mt-3 p-3 bg-white rounded-lg border border-slate-200 text-sm text-slate-700 email-body-content">
+                                        {% if msg.body_html %}
+                                        {{ msg.body_html|safe }}
+                                        {% else %}
+                                        <pre class="whitespace-pre-wrap font-sans">{{ msg.body_text }}</pre>
+                                        {% endif %}
+                                    </div>
+                                    {% endif %}
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
+
                 {% if show_transactions %}
                 <!-- Related Transactions Card -->
                 <div
@@ -2969,6 +3074,61 @@
             input.files = dataTransfer.files;
             uploadContactFile(input);
         }
+    });
+
+    // =========================================================================
+    // EMAIL HISTORY FUNCTIONS
+    // =========================================================================
+
+    function toggleEmailThread(threadId) {
+        const messagesDiv = document.getElementById('thread-messages-' + threadId);
+        const chevron = document.querySelector('.thread-chevron-' + threadId);
+        
+        if (messagesDiv.classList.contains('hidden')) {
+            messagesDiv.classList.remove('hidden');
+            chevron.classList.add('rotate-180');
+        } else {
+            messagesDiv.classList.add('hidden');
+            chevron.classList.remove('rotate-180');
+        }
+    }
+
+    function toggleFullEmail(msgId) {
+        const fullEmailDiv = document.getElementById('full-email-' + msgId);
+        const button = event.target;
+        
+        if (fullEmailDiv.classList.contains('hidden')) {
+            fullEmailDiv.classList.remove('hidden');
+            button.textContent = 'Hide full message';
+        } else {
+            fullEmailDiv.classList.add('hidden');
+            button.textContent = 'Show full message';
+        }
+    }
+
+    // Format email dates on page load
+    document.addEventListener('DOMContentLoaded', function() {
+        // Format thread dates
+        document.querySelectorAll('.thread-date, .msg-date').forEach(function(el) {
+            const dateStr = el.dataset.date;
+            if (dateStr) {
+                const date = new Date(dateStr);
+                const now = new Date();
+                const diffMs = now - date;
+                const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+                
+                if (diffDays === 0) {
+                    // Today - show time
+                    el.textContent = 'Today at ' + date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                } else if (diffDays === 1) {
+                    el.textContent = 'Yesterday';
+                } else if (diffDays < 7) {
+                    el.textContent = diffDays + ' days ago';
+                } else {
+                    el.textContent = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                }
+            }
+        });
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
- OAuth flow for Gmail connection (profile page)
- Sync emails matching contacts automatically
- Email History section on contact pages with thread view
- Full email body display (collapsible, sanitized HTML)
- Background job for periodic sync (jobs/gmail_sync.py)
- Token encryption at rest using Fernet
- Direction badges (Sent/Received) on emails

New files:
- services/gmail_service.py - OAuth + Gmail API logic
- routes/gmail_integration.py - Connect/disconnect endpoints
- jobs/gmail_sync.py - Cron job for periodic sync

Requires env vars:
- GOOGLE_CLIENT_ID
- GOOGLE_CLIENT_SECRET
- GMAIL_TOKEN_ENCRYPTION_KEY