### PR TITLE
feat: redesign profile page and email history section

### DIFF
--- a/templates/auth/user_profile.html
+++ b/templates/auth/user_profile.html
@@ -1,186 +1,337 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-8">
-    <div class="max-w-3xl mx-auto">
-        <!-- Back button -->
-        <button onclick="history.back()" class="flex items-center text-gray-600 hover:text-gray-800">
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
-            </svg>
-            Back
-        </button>
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
 
-        <!-- Profile Card -->
-        <div class="bg-white rounded-lg shadow-md mt-6 p-6">
-            <h1 class="text-2xl font-bold text-gray-900 mb-6">{% if is_admin_edit %}Edit User{% else %}User Profile{% endif %}</h1>
+    .animate-fade-in-up { animation: fadeInUp 0.5s ease-out forwards; }
+    .animate-fade-in-up-delay-1 { animation: fadeInUp 0.5s ease-out 0.1s forwards; opacity: 0; }
+    .animate-fade-in-up-delay-2 { animation: fadeInUp 0.5s ease-out 0.2s forwards; opacity: 0; }
 
-            <!-- Profile Form -->
-            <form method="POST" action="{% if is_admin_edit %}{{ url_for('auth.edit_user', user_id=user.id) }}{% else %}{{ url_for('auth.update_profile') }}{% endif %}" class="space-y-6">
-                {{ form.csrf_token if form }}
-                <div>
-                    <label for="username" class="block text-sm font-medium text-gray-700">Username</label>
-                    <input type="text" name="username" id="username" value="{{ user.username }}" readonly
-                           class="mt-1 block w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-md shadow-sm text-gray-700">
+    /* Premium input styling */
+    .premium-input {
+        display: block;
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 2px solid #e2e8f0;
+        border-radius: 0.75rem;
+        background-color: #f8fafc;
+        font-size: 0.9375rem;
+        transition: all 0.2s ease-out;
+        color: #1e293b;
+    }
+
+    .premium-input:hover { border-color: #cbd5e1; }
+    .premium-input:focus {
+        outline: none;
+        border-color: #3b82f6;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
+    .premium-input:read-only {
+        background-color: #f1f5f9;
+        cursor: not-allowed;
+        color: #64748b;
+    }
+
+    .premium-input::placeholder { color: #94a3b8; }
+
+    /* Premium card */
+    .premium-card {
+        transition: all 0.3s ease;
+    }
+
+    .premium-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 12px 40px -12px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Form label styling */
+    .form-label {
+        display: block;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: #475569;
+        margin-bottom: 0.5rem;
+        text-transform: uppercase;
+        letter-spacing: 0.025em;
+    }
+
+    /* Section divider */
+    .section-divider {
+        height: 1px;
+        background: linear-gradient(to right, transparent, #e2e8f0, transparent);
+        margin: 1.5rem 0;
+    }
+</style>
+
+<div class="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-100 py-8 px-4">
+    <div class="max-w-5xl mx-auto">
+        
+        <!-- Back Button & Title -->
+        <div class="flex items-center justify-between mb-6 animate-fade-in-up">
+            <a href="{{ url_for('main.dashboard') }}" class="inline-flex items-center gap-2 text-slate-600 hover:text-slate-800 transition-colors group">
+                <div class="w-8 h-8 rounded-lg bg-white shadow-sm border border-slate-200 flex items-center justify-center group-hover:bg-slate-50 transition-colors">
+                    <i class="fas fa-arrow-left text-sm"></i>
                 </div>
-
-                <div>
-                    <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
-                    <input type="email" name="email" id="email" value="{{ user.email }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="first_name" class="block text-sm font-medium text-gray-700">First Name</label>
-                    <input type="text" name="first_name" id="first_name" value="{{ user.first_name }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="last_name" class="block text-sm font-medium text-gray-700">Last Name</label>
-                    <input type="text" name="last_name" id="last_name" value="{{ user.last_name }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="phone" class="block text-sm font-medium text-gray-700">Phone</label>
-                    <input type="tel" name="phone" id="phone" value="{{ user.phone }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="license_number" class="block text-sm font-medium text-gray-700">License Number</label>
-                    <input type="text" name="license_number" id="license_number" maxlength="16" value="{{ user.license_number }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="licensed_supervisor" class="block text-sm font-medium text-gray-700">Licensed Supervisor of Associate</label>
-                    <input type="text" name="licensed_supervisor" id="licensed_supervisor" value="{{ user.licensed_supervisor }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="licensed_supervisor_license" class="block text-sm font-medium text-gray-700">Licensed Supervisor License Number</label>
-                    <input type="text" name="licensed_supervisor_license" id="licensed_supervisor_license" maxlength="16" value="{{ user.licensed_supervisor_license }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="licensed_supervisor_email" class="block text-sm font-medium text-gray-700">Licensed Supervisor Email</label>
-                    <input type="email" name="licensed_supervisor_email" id="licensed_supervisor_email" value="{{ user.licensed_supervisor_email }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                <div>
-                    <label for="licensed_supervisor_phone" class="block text-sm font-medium text-gray-700">Licensed Supervisor Phone</label>
-                    <input type="tel" name="licensed_supervisor_phone" id="licensed_supervisor_phone" value="{{ user.licensed_supervisor_phone }}"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-                {% if not is_admin_edit %}
-
-                <div>
-                    <label for="current_password" class="block text-sm font-medium text-gray-700">Current Password (required for changes)</label>
-                    <input type="password" name="current_password" id="current_password"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-                {% endif %}
-
-                <div>
-                    <label for="new_password" class="block text-sm font-medium text-gray-700">
-                        {% if is_admin_edit %}Set New Password{% else %}New Password (optional){% endif %}
-                    </label>
-                    <input type="password" name="new_password" id="new_password"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-
-                {% if not is_admin_edit %}
-                <div>
-                    <label for="confirm_password" class="block text-sm font-medium text-gray-700">Confirm New Password</label>
-                    <input type="password" name="confirm_password" id="confirm_password"
-                           class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-                </div>
-                {% endif %}
-
-                <div class="flex justify-end">
-                    <button type="submit"
-                            class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                        {% if is_admin_edit %}Save Changes{% else %}Update Profile{% endif %}
-                    </button>
-                </div>
-            </form>
+                <span class="font-medium">Back</span>
+            </a>
         </div>
 
-        {% if not is_admin_edit %}
-        <!-- Email Integration Section -->
-        <div class="bg-white rounded-lg shadow-md mt-6 p-6">
-            <h2 class="text-xl font-bold text-gray-900 mb-4">Email Integration</h2>
-            
-            {% if gmail_integration and gmail_integration.sync_status == 'error' %}
-                <!-- Error State -->
-                <div class="border border-amber-200 bg-amber-50 rounded-lg p-4 mb-4">
-                    <div class="flex items-center gap-2">
-                        <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                        </svg>
-                        <span class="font-medium text-gray-900">{{ gmail_integration.connected_email }}</span>
+        <!-- Profile Header Card -->
+        <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden mb-6 animate-fade-in-up">
+            <div class="bg-gradient-to-r from-blue-600 via-blue-500 to-indigo-600 px-8 py-10">
+                <div class="flex items-center gap-6">
+                    <!-- Avatar -->
+                    <div class="w-20 h-20 rounded-2xl bg-white/20 backdrop-blur-sm flex items-center justify-center text-white text-2xl font-bold shadow-lg">
+                        {{ user.first_name[0] if user.first_name else user.username[0]|upper }}{{ user.last_name[0] if user.last_name else '' }}
                     </div>
-                    <p class="text-sm text-amber-700 mt-1">Connection issue - Reconnect to continue syncing</p>
-                </div>
-                <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
-                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                    </svg>
-                    Reconnect Gmail
-                </a>
-                
-            {% elif gmail_integration and gmail_integration.sync_enabled %}
-                <!-- Connected State -->
-                <div class="border border-green-200 bg-green-50 rounded-lg p-4 mb-4">
-                    <div class="flex items-center gap-2">
-                        <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                        </svg>
-                        <span class="font-medium text-gray-900">{{ gmail_integration.connected_email }}</span>
-                    </div>
-                    <p class="text-sm text-gray-500 mt-1">
-                        {% if gmail_integration.last_sync_at %}
-                            Synced {{ gmail_integration.last_sync_at|timeago }}
-                        {% else %}
-                            Sync pending...
+                    <div>
+                        <h1 class="text-2xl font-bold text-white">
+                            {% if is_admin_edit %}Edit User{% else %}{{ user.first_name }} {{ user.last_name }}{% endif %}
+                        </h1>
+                        <p class="text-blue-100 mt-1">{{ user.email }}</p>
+                        {% if user.license_number %}
+                        <p class="text-blue-200 text-sm mt-1">License: {{ user.license_number }}</p>
                         {% endif %}
-                    </p>
+                    </div>
                 </div>
-                <form method="POST" action="{{ url_for('gmail.disconnect') }}" class="inline">
-                    <button type="submit" class="text-gray-500 hover:text-gray-700 text-sm transition-colors">
-                        Disconnect
-                    </button>
-                </form>
-                
-            {% else %}
-                <!-- Disconnected State -->
-                <p class="text-gray-600 mb-4">Connect your Gmail to see email history on contact records. We'll automatically sync conversations with your contacts.</p>
-                <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 transition-colors">
-                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
-                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                    </svg>
-                    Connect Gmail
-                </a>
-                <p class="text-xs text-gray-400 mt-3 flex items-center gap-1">
-                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
-                    </svg>
-                    Read-only access - We never send emails on your behalf
-                </p>
-            {% endif %}
+            </div>
         </div>
-        {% endif %}
+
+        <!-- Main Content Grid -->
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            
+            <!-- Left Column - Profile Form -->
+            <div class="lg:col-span-2 space-y-6">
+                
+                <!-- Personal Information Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-1">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
+                                <i class="fas fa-user text-white text-sm"></i>
+                            </div>
+                            <h2 class="text-lg font-semibold text-slate-800">Personal Information</h2>
+                        </div>
+                    </div>
+                    
+                    <form method="POST" action="{% if is_admin_edit %}{{ url_for('auth.edit_user', user_id=user.id) }}{% else %}{{ url_for('auth.update_profile') }}{% endif %}" class="p-6">
+                        {{ form.csrf_token if form }}
+                        
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                            <div>
+                                <label class="form-label">Username</label>
+                                <input type="text" name="username" value="{{ user.username }}" readonly class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Email</label>
+                                <input type="email" name="email" value="{{ user.email }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">First Name</label>
+                                <input type="text" name="first_name" value="{{ user.first_name }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Last Name</label>
+                                <input type="text" name="last_name" value="{{ user.last_name }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Phone</label>
+                                <input type="tel" name="phone" value="{{ user.phone }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">License Number</label>
+                                <input type="text" name="license_number" maxlength="16" value="{{ user.license_number }}" class="premium-input">
+                            </div>
+                        </div>
+
+                        <div class="section-divider"></div>
+
+                        <!-- Supervisor Information -->
+                        <h3 class="text-sm font-semibold text-slate-600 uppercase tracking-wide mb-4">Supervisor Information</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                            <div>
+                                <label class="form-label">Supervisor Name</label>
+                                <input type="text" name="licensed_supervisor" value="{{ user.licensed_supervisor }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Supervisor License</label>
+                                <input type="text" name="licensed_supervisor_license" maxlength="16" value="{{ user.licensed_supervisor_license }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Supervisor Email</label>
+                                <input type="email" name="licensed_supervisor_email" value="{{ user.licensed_supervisor_email }}" class="premium-input">
+                            </div>
+                            <div>
+                                <label class="form-label">Supervisor Phone</label>
+                                <input type="tel" name="licensed_supervisor_phone" value="{{ user.licensed_supervisor_phone }}" class="premium-input">
+                            </div>
+                        </div>
+
+                        <div class="section-divider"></div>
+
+                        <!-- Password Section -->
+                        <h3 class="text-sm font-semibold text-slate-600 uppercase tracking-wide mb-4">Change Password</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                            {% if not is_admin_edit %}
+                            <div>
+                                <label class="form-label">Current Password</label>
+                                <input type="password" name="current_password" class="premium-input" placeholder="Required for changes">
+                            </div>
+                            {% endif %}
+                            <div>
+                                <label class="form-label">{% if is_admin_edit %}Set New Password{% else %}New Password{% endif %}</label>
+                                <input type="password" name="new_password" class="premium-input" placeholder="Leave blank to keep current">
+                            </div>
+                            {% if not is_admin_edit %}
+                            <div>
+                                <label class="form-label">Confirm Password</label>
+                                <input type="password" name="confirm_password" class="premium-input" placeholder="Confirm new password">
+                            </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mt-8 flex justify-end">
+                            <button type="submit" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold rounded-xl shadow-lg shadow-blue-500/25 hover:shadow-xl hover:shadow-blue-500/30 hover:from-blue-700 hover:to-indigo-700 transition-all duration-200">
+                                <i class="fas fa-save mr-2"></i>
+                                {% if is_admin_edit %}Save Changes{% else %}Update Profile{% endif %}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <!-- Right Column - Integrations -->
+            <div class="space-y-6">
+                
+                {% if not is_admin_edit %}
+                <!-- Email Integration Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center">
+                                <i class="fas fa-envelope text-white text-sm"></i>
+                            </div>
+                            <h2 class="text-lg font-semibold text-slate-800">Email Integration</h2>
+                        </div>
+                    </div>
+                    
+                    <div class="p-6">
+                        {% if gmail_integration and gmail_integration.sync_status == 'error' %}
+                            <!-- Error State -->
+                            <div class="rounded-xl bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 p-4 mb-4">
+                                <div class="flex items-center gap-3">
+                                    <div class="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
+                                        <i class="fas fa-exclamation-triangle text-amber-600"></i>
+                                    </div>
+                                    <div>
+                                        <p class="font-semibold text-slate-800">{{ gmail_integration.connected_email }}</p>
+                                        <p class="text-sm text-amber-700">Connection issue</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <a href="{{ url_for('gmail.connect') }}" class="w-full inline-flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl transition-all duration-200">
+                                <i class="fab fa-google"></i>
+                                Reconnect Gmail
+                            </a>
+                            
+                        {% elif gmail_integration and gmail_integration.sync_enabled %}
+                            <!-- Connected State -->
+                            <div class="rounded-xl bg-gradient-to-br from-emerald-50 to-green-50 border border-emerald-200 p-4 mb-4">
+                                <div class="flex items-center gap-3">
+                                    <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                                        <i class="fas fa-check text-emerald-600"></i>
+                                    </div>
+                                    <div>
+                                        <p class="font-semibold text-slate-800">{{ gmail_integration.connected_email }}</p>
+                                        <p class="text-sm text-emerald-700">
+                                            {% if gmail_integration.last_sync_at %}
+                                                Synced {{ gmail_integration.last_sync_at|timeago }}
+                                            {% else %}
+                                                Sync pending...
+                                            {% endif %}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="flex items-center justify-between text-sm">
+                                <span class="text-slate-500">Emails auto-sync every 5 min</span>
+                                <form method="POST" action="{{ url_for('gmail.disconnect') }}" class="inline">
+                                    <button type="submit" class="text-slate-400 hover:text-red-500 transition-colors">
+                                        Disconnect
+                                    </button>
+                                </form>
+                            </div>
+                            
+                        {% else %}
+                            <!-- Disconnected State -->
+                            <div class="text-center py-4">
+                                <div class="w-16 h-16 rounded-2xl bg-gradient-to-br from-slate-100 to-slate-50 flex items-center justify-center mx-auto mb-4">
+                                    <i class="fas fa-envelope text-slate-400 text-2xl"></i>
+                                </div>
+                                <h3 class="font-semibold text-slate-800 mb-2">Connect Gmail</h3>
+                                <p class="text-sm text-slate-500 mb-6">See your email history directly on contact records. We sync conversations automatically.</p>
+                                
+                                <a href="{{ url_for('gmail.connect') }}" class="w-full inline-flex items-center justify-center gap-3 px-4 py-3 bg-white border-2 border-slate-200 rounded-xl font-semibold text-slate-700 hover:border-slate-300 hover:bg-slate-50 transition-all duration-200 group">
+                                    <svg class="w-5 h-5" viewBox="0 0 24 24">
+                                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                                    </svg>
+                                    <span class="group-hover:translate-x-0.5 transition-transform">Connect with Google</span>
+                                </a>
+                                
+                                <p class="text-xs text-slate-400 mt-4 flex items-center justify-center gap-1.5">
+                                    <i class="fas fa-lock text-slate-300"></i>
+                                    Read-only access - We never send emails
+                                </p>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                {% endif %}
+
+                <!-- Quick Stats Card -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
+                                <i class="fas fa-chart-bar text-white text-sm"></i>
+                            </div>
+                            <h2 class="text-lg font-semibold text-slate-800">Account Info</h2>
+                        </div>
+                    </div>
+                    
+                    <div class="p-6 space-y-4">
+                        <div class="flex items-center justify-between py-2 border-b border-slate-100">
+                            <span class="text-sm text-slate-500">Organization</span>
+                            <span class="font-semibold text-slate-800">{{ user.organization.name if user.organization else 'N/A' }}</span>
+                        </div>
+                        <div class="flex items-center justify-between py-2 border-b border-slate-100">
+                            <span class="text-sm text-slate-500">Role</span>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold 
+                                {% if user.org_role == 'owner' %}bg-amber-100 text-amber-800
+                                {% elif user.org_role == 'admin' %}bg-purple-100 text-purple-800
+                                {% else %}bg-blue-100 text-blue-800{% endif %}">
+                                {{ user.org_role|capitalize if user.org_role else 'Agent' }}
+                            </span>
+                        </div>
+                        <div class="flex items-center justify-between py-2">
+                            <span class="text-sm text-slate-500">Member Since</span>
+                            <span class="font-semibold text-slate-800">{{ user.created_at.strftime('%b %Y') if user.created_at else 'N/A' }}</span>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/contacts/view.html
+++ b/templates/contacts/view.html
@@ -837,111 +837,6 @@
                     </div>
                 </div>
 
-                <!-- Email History Card -->
-                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card">
-                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
-                        <div class="flex items-center justify-between">
-                            <div class="flex items-center gap-3">
-                                <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
-                                    <i class="fas fa-envelope text-white text-sm"></i>
-                                </div>
-                                <h2 class="text-lg font-semibold text-slate-800">Email History</h2>
-                                {% if email_threads %}
-                                <span class="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">{{ email_threads|length }} conversation{{ 's' if email_threads|length != 1 else '' }}</span>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="divide-y divide-slate-100 max-h-96 overflow-y-auto">
-                        {% if not gmail_connected %}
-                        <!-- Gmail Not Connected State -->
-                        <div class="p-8 text-center">
-                            <div class="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-3">
-                                <i class="fas fa-envelope text-blue-400 text-xl"></i>
-                            </div>
-                            <p class="text-slate-700 font-medium mb-1">See your email history with this contact</p>
-                            <p class="text-slate-500 text-sm mb-4">Connect Gmail to automatically sync conversations</p>
-                            <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 transition-colors text-sm">
-                                <svg class="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                                </svg>
-                                Connect Gmail
-                            </a>
-                        </div>
-                        {% elif email_threads|length == 0 %}
-                        <!-- No Emails State -->
-                        <div class="p-8 text-center">
-                            <div class="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
-                                <i class="fas fa-envelope text-slate-400 text-xl"></i>
-                            </div>
-                            <p class="text-slate-500 text-sm">No emails with this contact yet</p>
-                            <p class="text-slate-400 text-xs mt-1">Emails you send or receive will appear here automatically</p>
-                        </div>
-                        {% else %}
-                        <!-- Email Threads List -->
-                        {% for thread in email_threads %}
-                        <div class="email-thread-item" data-thread-id="{{ thread.thread_id }}">
-                            <button onclick="toggleEmailThread('{{ thread.thread_id }}')" class="w-full p-4 hover:bg-slate-50 transition-colors text-left">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div class="flex-1 min-w-0">
-                                        <p class="font-medium text-slate-800 truncate">{{ thread.subject or '(No subject)' }}</p>
-                                        <p class="text-sm text-slate-500 mt-0.5">
-                                            {{ thread.message_count }} message{{ 's' if thread.message_count != 1 else '' }}
-                                            <span class="mx-1">·</span>
-                                            <span class="thread-date" data-date="{{ thread.latest_at }}">{{ thread.latest_at }}</span>
-                                        </p>
-                                    </div>
-                                    <i class="fas fa-chevron-down text-slate-400 transition-transform thread-chevron-{{ thread.thread_id }}"></i>
-                                </div>
-                            </button>
-                            <!-- Expanded Thread Messages -->
-                            <div id="thread-messages-{{ thread.thread_id }}" class="hidden border-t border-slate-100 bg-slate-50">
-                                {% for msg in thread.messages %}
-                                <div class="p-4 border-b border-slate-100 last:border-b-0">
-                                    <div class="flex items-center justify-between mb-2">
-                                        <div class="flex items-center gap-2">
-                                            <span class="font-medium text-slate-800 text-sm">
-                                                {% if msg.direction == 'outbound' %}You{% else %}{{ msg.from_name or msg.from_email }}{% endif %}
-                                            </span>
-                                            {% if msg.direction == 'outbound' %}
-                                            <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded uppercase font-semibold">Sent</span>
-                                            {% else %}
-                                            <span class="text-xs bg-slate-200 text-slate-600 px-2 py-0.5 rounded uppercase font-semibold">Received</span>
-                                            {% endif %}
-                                        </div>
-                                        <span class="text-xs text-slate-400 msg-date" data-date="{{ msg.sent_at }}">{{ msg.sent_at }}</span>
-                                    </div>
-                                    <p class="text-sm text-slate-600 line-clamp-3">{{ msg.snippet }}</p>
-                                    {% if msg.has_attachments %}
-                                    <p class="text-xs text-slate-400 mt-2 flex items-center gap-1">
-                                        <i class="fas fa-paperclip"></i> Has attachments
-                                    </p>
-                                    {% endif %}
-                                    {% if msg.body_text or msg.body_html %}
-                                    <button onclick="toggleFullEmail('{{ msg.id }}')" class="text-xs text-blue-600 hover:text-blue-700 mt-2">
-                                        Show full message
-                                    </button>
-                                    <div id="full-email-{{ msg.id }}" class="hidden mt-3 p-3 bg-white rounded-lg border border-slate-200 text-sm text-slate-700 email-body-content">
-                                        {% if msg.body_html %}
-                                        {{ msg.body_html|safe }}
-                                        {% else %}
-                                        <pre class="whitespace-pre-wrap font-sans">{{ msg.body_text }}</pre>
-                                        {% endif %}
-                                    </div>
-                                    {% endif %}
-                                </div>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        {% endfor %}
-                        {% endif %}
-                    </div>
-                </div>
-
                 {% if show_transactions %}
                 <!-- Related Transactions Card -->
                 <div
@@ -1411,6 +1306,177 @@
                     </div>
                     {% endif %}
                 </div>
+            </div>
+        </div>
+
+        <!-- Full Width Email History Section -->
+        <div class="mt-8 animate-fade-in-up-delay-3">
+            <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden">
+                <!-- Header -->
+                <div class="px-6 py-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-3">
+                            <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-blue-500/20">
+                                <i class="fas fa-envelope text-white"></i>
+                            </div>
+                            <div>
+                                <h2 class="text-xl font-bold text-slate-800">Email Conversations</h2>
+                                <p class="text-sm text-slate-500">
+                                    {% if email_threads %}{{ email_threads|length }} thread{{ 's' if email_threads|length != 1 else '' }} with {{ contact.first_name }}{% else %}Your email history with this contact{% endif %}
+                                </p>
+                            </div>
+                        </div>
+                        {% if gmail_connected %}
+                        <div class="flex items-center gap-2">
+                            <span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-emerald-50 text-emerald-700 rounded-lg text-sm">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+                                Gmail connected
+                            </span>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+
+                {% if not gmail_connected %}
+                <!-- Gmail Not Connected State -->
+                <div class="py-16 px-6 text-center">
+                    <div class="max-w-md mx-auto">
+                        <div class="w-20 h-20 rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-100 flex items-center justify-center mx-auto mb-6">
+                            <i class="fas fa-envelope text-blue-500 text-3xl"></i>
+                        </div>
+                        <h3 class="text-xl font-semibold text-slate-800 mb-2">Connect Gmail to see email history</h3>
+                        <p class="text-slate-500 mb-6">Automatically sync your conversations with {{ contact.first_name }} and never lose track of important communications.</p>
+                        <a href="{{ url_for('gmail.connect') }}" class="inline-flex items-center gap-3 px-6 py-3 bg-white border-2 border-slate-200 rounded-xl font-semibold text-slate-700 hover:border-slate-300 hover:bg-slate-50 transition-all duration-200 shadow-sm">
+                            <svg class="w-5 h-5" viewBox="0 0 24 24">
+                                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                            </svg>
+                            Connect with Google
+                        </a>
+                        <p class="text-xs text-slate-400 mt-4 flex items-center justify-center gap-1.5">
+                            <i class="fas fa-lock"></i>
+                            Read-only access - We never send emails on your behalf
+                        </p>
+                    </div>
+                </div>
+
+                {% elif email_threads|length == 0 %}
+                <!-- No Emails Yet -->
+                <div class="py-16 px-6 text-center">
+                    <div class="max-w-md mx-auto">
+                        <div class="w-20 h-20 rounded-2xl bg-gradient-to-br from-slate-100 to-slate-50 flex items-center justify-center mx-auto mb-6">
+                            <i class="fas fa-inbox text-slate-400 text-3xl"></i>
+                        </div>
+                        <h3 class="text-xl font-semibold text-slate-800 mb-2">No emails yet</h3>
+                        <p class="text-slate-500">Once you exchange emails with {{ contact.first_name }}, they'll appear here automatically.</p>
+                    </div>
+                </div>
+
+                {% else %}
+                <!-- Email Threads -->
+                <div class="divide-y divide-slate-100">
+                    {% for thread in email_threads %}
+                    <div class="email-thread-container" data-thread-id="{{ thread.thread_id }}">
+                        <!-- Thread Header (Clickable) -->
+                        <button onclick="toggleEmailThread('{{ thread.thread_id }}')" class="w-full px-6 py-4 hover:bg-slate-50/50 transition-colors text-left group">
+                            <div class="flex items-center gap-4">
+                                <!-- Thread Icon -->
+                                <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-slate-100 to-slate-50 flex items-center justify-center flex-shrink-0 group-hover:from-blue-100 group-hover:to-indigo-50 transition-colors">
+                                    <i class="fas fa-comments text-slate-400 group-hover:text-blue-500 transition-colors"></i>
+                                </div>
+                                
+                                <!-- Thread Info -->
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex items-center gap-3">
+                                        <h3 class="font-semibold text-slate-800 truncate">{{ thread.subject or '(No subject)' }}</h3>
+                                        <span class="flex-shrink-0 inline-flex items-center px-2 py-0.5 bg-slate-100 text-slate-600 rounded-md text-xs font-medium">
+                                            {{ thread.message_count }} message{{ 's' if thread.message_count != 1 else '' }}
+                                        </span>
+                                    </div>
+                                    <p class="text-sm text-slate-500 mt-1 truncate">
+                                        {% set latest = thread.messages[0] %}
+                                        {% if latest.direction == 'outbound' %}You: {% else %}{{ latest.from_name or latest.from_email.split('@')[0] }}: {% endif %}{{ latest.snippet[:100] }}{% if latest.snippet|length > 100 %}...{% endif %}
+                                    </p>
+                                </div>
+                                
+                                <!-- Date & Expand Icon -->
+                                <div class="flex items-center gap-4 flex-shrink-0">
+                                    <span class="text-sm text-slate-400 thread-date" data-date="{{ thread.latest_at }}">{{ thread.latest_at }}</span>
+                                    <i class="fas fa-chevron-down text-slate-300 transition-transform duration-200 thread-chevron-{{ thread.thread_id }}"></i>
+                                </div>
+                            </div>
+                        </button>
+                        
+                        <!-- Expanded Messages -->
+                        <div id="thread-messages-{{ thread.thread_id }}" class="hidden">
+                            <div class="px-6 pb-6 space-y-4">
+                                {% for msg in thread.messages %}
+                                <div class="relative pl-14">
+                                    <!-- Avatar -->
+                                    <div class="absolute left-0 top-0 w-10 h-10 rounded-xl flex items-center justify-center text-white text-sm font-semibold shadow-sm
+                                        {% if msg.direction == 'outbound' %}bg-gradient-to-br from-blue-500 to-indigo-600{% else %}bg-gradient-to-br from-orange-400 to-amber-500{% endif %}">
+                                        {% if msg.direction == 'outbound' %}
+                                            You
+                                        {% else %}
+                                            {{ (msg.from_name or msg.from_email)[0]|upper }}
+                                        {% endif %}
+                                    </div>
+                                    
+                                    <!-- Message Card -->
+                                    <div class="bg-slate-50 rounded-xl border border-slate-100 overflow-hidden">
+                                        <!-- Message Header -->
+                                        <div class="px-4 py-3 bg-white border-b border-slate-100 flex items-center justify-between">
+                                            <div class="flex items-center gap-3">
+                                                <span class="font-medium text-slate-800">
+                                                    {% if msg.direction == 'outbound' %}You{% else %}{{ msg.from_name or msg.from_email }}{% endif %}
+                                                </span>
+                                                {% if msg.direction == 'outbound' %}
+                                                <span class="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-md uppercase font-semibold">Sent</span>
+                                                {% else %}
+                                                <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-md uppercase font-semibold">Received</span>
+                                                {% endif %}
+                                                {% if msg.has_attachments %}
+                                                <span class="text-xs text-slate-400 flex items-center gap-1">
+                                                    <i class="fas fa-paperclip"></i> Attachments
+                                                </span>
+                                                {% endif %}
+                                            </div>
+                                            <span class="text-xs text-slate-400 msg-date" data-date="{{ msg.sent_at }}">{{ msg.sent_at }}</span>
+                                        </div>
+                                        
+                                        <!-- Message Preview -->
+                                        <div class="px-4 py-3">
+                                            <p class="text-sm text-slate-600 leading-relaxed" id="msg-snippet-{{ msg.id }}">{{ msg.snippet }}</p>
+                                            
+                                            {% if msg.body_text or msg.body_html %}
+                                            <!-- Full Message (Hidden by default) -->
+                                            <div id="full-email-{{ msg.id }}" class="hidden mt-4 pt-4 border-t border-slate-200">
+                                                <div class="prose prose-sm prose-slate max-w-none email-body-content">
+                                                    {% if msg.body_html %}
+                                                    {{ msg.body_html|safe }}
+                                                    {% else %}
+                                                    <pre class="whitespace-pre-wrap font-sans text-slate-700 text-sm">{{ msg.body_text }}</pre>
+                                                    {% endif %}
+                                                </div>
+                                            </div>
+                                            
+                                            <button onclick="toggleFullEmail('{{ msg.id }}')" id="toggle-btn-{{ msg.id }}" class="mt-3 text-sm text-blue-600 hover:text-blue-700 font-medium flex items-center gap-1">
+                                                <i class="fas fa-chevron-down text-xs"></i>
+                                                <span>Show full message</span>
+                                            </button>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -3083,26 +3149,36 @@
     function toggleEmailThread(threadId) {
         const messagesDiv = document.getElementById('thread-messages-' + threadId);
         const chevron = document.querySelector('.thread-chevron-' + threadId);
+        const container = document.querySelector(`[data-thread-id="${threadId}"]`);
         
         if (messagesDiv.classList.contains('hidden')) {
             messagesDiv.classList.remove('hidden');
             chevron.classList.add('rotate-180');
+            if (container) container.classList.add('bg-slate-50/30');
         } else {
             messagesDiv.classList.add('hidden');
             chevron.classList.remove('rotate-180');
+            if (container) container.classList.remove('bg-slate-50/30');
         }
     }
 
     function toggleFullEmail(msgId) {
         const fullEmailDiv = document.getElementById('full-email-' + msgId);
-        const button = event.target;
+        const snippetDiv = document.getElementById('msg-snippet-' + msgId);
+        const toggleBtn = document.getElementById('toggle-btn-' + msgId);
         
         if (fullEmailDiv.classList.contains('hidden')) {
             fullEmailDiv.classList.remove('hidden');
-            button.textContent = 'Hide full message';
+            if (snippetDiv) snippetDiv.classList.add('hidden');
+            if (toggleBtn) {
+                toggleBtn.innerHTML = '<i class="fas fa-chevron-up text-xs"></i><span>Hide full message</span>';
+            }
         } else {
             fullEmailDiv.classList.add('hidden');
-            button.textContent = 'Show full message';
+            if (snippetDiv) snippetDiv.classList.remove('hidden');
+            if (toggleBtn) {
+                toggleBtn.innerHTML = '<i class="fas fa-chevron-down text-xs"></i><span>Show full message</span>';
+            }
         }
     }
 


### PR DESCRIPTION
- Redesign user profile page with premium styling to match contacts view
  - Two-column layout with form on left, integrations on right
  - Gradient header with user avatar initials
  - Clean Gmail integration card with status indicator
  - Account info card showing org, role, and member since
  - Fix role display to use org_role (owner/admin/agent)

- Redesign contact email history as full-width section
  - Move from cramped sidebar to full-width section below contact details
  - Thread list with subject, message count, and preview snippet
  - Expandable threads with message cards and avatars
  - Sent/Received direction badges with color coding
  - Show full message toggle with improved UX

- Fix Gmail sync job bug where sync_status never reset after success
  - Add sync_status = 'active' after successful sync
  - Add auto-reset for syncs stuck > 10 minutes
  - Update last_sync_at timestamp on completion