### PR TITLE
style: replace landing page logo text with larger logo image

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -206,11 +206,8 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 md:h-20">
                 <!-- Logo -->
-                <a href="/" class="flex items-center gap-3">
-                    <div class="w-10 h-10 md:w-12 md:h-12 bg-gradient-to-br from-brand-800 to-brand-900 rounded-xl flex items-center justify-center shadow-lg">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" />
-                    </div>
-                    <span class="text-xl md:text-2xl font-bold text-brand-900 hidden sm:block">Origen TechnolOG</span>
+                <a href="/" class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-20 md:h-24 w-auto object-contain" />
                 </a>
                 
                 <!-- Desktop Nav Links -->
@@ -923,11 +920,8 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex flex-col md:flex-row items-center justify-between gap-6">
                 <!-- Logo -->
-                <div class="flex items-center gap-3">
-                    <div class="w-10 h-10 bg-brand-800 rounded-xl flex items-center justify-center">
-                        <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 w-auto object-contain" />
-                    </div>
-                    <span class="text-xl font-bold text-white">Origen TechnolOG</span>
+                <div class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-28 w-auto object-contain" />
                 </div>
                 
                 <!-- Links -->


### PR DESCRIPTION
Use the actual logo image in the header and footer instead of plain text. This provides consistent branding that matches the logo design with proper sizing (h-20/h-24 for header, h-28 for footer).