### PR TITLE
feat: Auto-update last_contact_date when logging activities or syncin…

### DIFF
--- a/models.py
+++ b/models.py
@@ -331,8 +331,18 @@ class Contact(db.Model):
                            lazy='joined')
 
     def update_last_contact_date(self):
-        """Update the last_contact_date based on the most recent contact date"""
-        dates = [d for d in [self.last_email_date, self.last_text_date, self.last_phone_call_date] if d is not None]
+        """Update the last_contact_date based on the most recent contact date.
+        
+        Includes email, text, phone call dates AND the current last_contact_date
+        (which may have been set directly by meeting/other activity types).
+        """
+        # Include current last_contact_date to preserve meeting/other activity dates
+        dates = [d for d in [
+            self.last_email_date, 
+            self.last_text_date, 
+            self.last_phone_call_date,
+            self.last_contact_date  # Preserve existing value from meeting/other
+        ] if d is not None]
         self.last_contact_date = max(dates) if dates else None
 
     def __repr__(self):

--- a/routes/contacts.py
+++ b/routes/contacts.py
@@ -415,8 +415,12 @@ def log_activity(contact_id):
         elif activity_type == 'text':
             if contact.last_text_date is None or activity_date_obj > contact.last_text_date:
                 contact.last_text_date = activity_date_obj
+        elif activity_type in ('meeting', 'other'):
+            # Meeting/other don't have dedicated date fields, update last_contact_date directly
+            if contact.last_contact_date is None or activity_date_obj > contact.last_contact_date:
+                contact.last_contact_date = activity_date_obj
         
-        # Update the overall last contact date
+        # Update the overall last contact date (recalculates from all date fields)
         contact.update_last_contact_date()
         
         db.session.commit()

--- a/services/gmail_service.py
+++ b/services/gmail_service.py
@@ -507,6 +507,13 @@ def _process_message(service, msg_id: str, integration, result: Dict):
             )
             db.session.add(contact_email)
             result['contacts_matched'] += 1
+            
+            # Update contact's last_email_date if this email is more recent
+            email_date = sent_at.date() if sent_at else None
+            if email_date:
+                if contact.last_email_date is None or email_date > contact.last_email_date:
+                    contact.last_email_date = email_date
+                    contact.update_last_contact_date()
         
         db.session.commit()
         


### PR DESCRIPTION
…g Gmail

- Add handling for meeting/other activity types in log_activity route
- Update last_contact_date directly for meeting/other (no dedicated date fields)
- Update last_email_date when Gmail emails are synced
- Preserve meeting/other dates in update_last_contact_date() method
- last_contact_date now reflects max of ALL activity types