### PR TITLE
fix: resolve org approval failure due to transaction_types constraint

### DIFF
--- a/migrations/versions/fix_transaction_types_constraint.py
+++ b/migrations/versions/fix_transaction_types_constraint.py
@@ -1,0 +1,53 @@
+"""Fix transaction_types unique constraint to be org-scoped
+
+Revision ID: fix_transaction_types_constraint
+Revises: (run manage_db.py status to get current head)
+Create Date: 2026-01-25
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fix_transaction_types_constraint'
+down_revision = 'add_google_calendar_sync'  # Current head
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Remove the global unique constraint on transaction_types.name
+    and add a composite unique constraint on (organization_id, name)
+    """
+    op.execute("""
+        -- Drop the old unique constraint on name (if it exists)
+        ALTER TABLE transaction_types 
+        DROP CONSTRAINT IF EXISTS transaction_types_name_key;
+        
+        -- Add composite unique constraint on (organization_id, name)
+        -- This allows same name across different orgs but prevents duplicates within an org
+        ALTER TABLE transaction_types 
+        DROP CONSTRAINT IF EXISTS uq_transaction_types_org_name;
+        
+        ALTER TABLE transaction_types 
+        ADD CONSTRAINT uq_transaction_types_org_name 
+        UNIQUE (organization_id, name);
+    """)
+
+
+def downgrade():
+    """
+    Restore the global unique constraint (not recommended)
+    """
+    op.execute("""
+        -- Remove composite constraint
+        ALTER TABLE transaction_types 
+        DROP CONSTRAINT IF EXISTS uq_transaction_types_org_name;
+        
+        -- This downgrade may fail if there are duplicate names across orgs
+        -- In that case, manual cleanup is required
+        ALTER TABLE transaction_types 
+        ADD CONSTRAINT transaction_types_name_key UNIQUE (name);
+    """)

--- a/services/tenant_service.py
+++ b/services/tenant_service.py
@@ -339,6 +339,7 @@ def create_default_groups_for_org(org_id: int):
     """
     Create default contact groups for a new organization.
     Called when an organization is approved.
+    Idempotent - safe to call multiple times.
     
     Args:
         org_id: The organization ID to create groups for
@@ -347,6 +348,12 @@ def create_default_groups_for_org(org_id: int):
         List of created ContactGroup objects
     """
     from models import db, ContactGroup
+    
+    # Check if any groups already exist for this org
+    existing_count = ContactGroup.query.filter_by(organization_id=org_id).count()
+    if existing_count > 0:
+        # Already created, return existing groups
+        return ContactGroup.query.filter_by(organization_id=org_id).all()
     
     # Default groups for real estate CRM
     default_groups = [
@@ -394,6 +401,7 @@ def create_default_task_types_for_org(org_id: int):
     """
     Create default task types and subtypes for a new organization.
     Called when an organization is approved.
+    Idempotent - safe to call multiple times.
     
     Args:
         org_id: The organization ID to create task types for
@@ -402,6 +410,12 @@ def create_default_task_types_for_org(org_id: int):
         List of created TaskType objects
     """
     from models import db, TaskType, TaskSubtype
+    
+    # Check if any task types already exist for this org
+    existing_count = TaskType.query.filter_by(organization_id=org_id).count()
+    if existing_count > 0:
+        # Already created, return existing types
+        return TaskType.query.filter_by(organization_id=org_id).all()
     
     # Default task types with their subtypes for real estate CRM
     default_task_types = [
@@ -478,6 +492,7 @@ def create_default_transaction_types_for_org(org_id: int):
     """
     Create default transaction types for a new organization.
     Called when an organization is approved.
+    Idempotent - safe to call multiple times.
     
     Args:
         org_id: The organization ID to create transaction types for
@@ -495,6 +510,12 @@ def create_default_transaction_types_for_org(org_id: int):
         {'name': 'tenant', 'display_name': 'Tenant Representation', 'sort_order': 4},
         {'name': 'referral', 'display_name': 'Referral', 'sort_order': 5},
     ]
+    
+    # Check if any transaction types already exist for this org
+    existing_count = TransactionType.query.filter_by(organization_id=org_id).count()
+    if existing_count > 0:
+        # Already created, return existing types
+        return TransactionType.query.filter_by(organization_id=org_id).all()
     
     created_types = []
     for type_data in default_transaction_types:

--- a/templates/platform_admin/org_detail.html
+++ b/templates/platform_admin/org_detail.html
@@ -126,6 +126,15 @@
                     </button>
                 </form>
                 {% endif %}
+                
+                <!-- Repair button - creates missing default data and sends approval email -->
+                <form action="{{ url_for('platform.repair_org', org_id=org.id) }}" method="POST" class="mt-4 pt-4 border-t border-gray-200">
+                    <button type="submit" class="w-full bg-amber-500 text-white px-4 py-2 rounded-md hover:bg-amber-600" 
+                            onclick="return confirm('This will create any missing default data and send the approval email to the org owner. Continue?')">
+                        Repair Organization
+                    </button>
+                    <p class="text-xs text-gray-500 mt-1">Creates missing default data and sends approval email to owner</p>
+                </form>
             </div>
             
             <!-- Org Info -->


### PR DESCRIPTION
- Fix database constraint: changed unique constraint on transaction_types.name to composite constraint on (organization_id, name) to allow same type names across different orgs
- Make default data creation idempotent: check for existing records before inserting to handle partial approval failures
- Improve error handling in approval route with proper session rollback
- Add org repair feature with "Repair Organization" button that:
  - Creates any missing default groups, task types, and transaction types
  - Sends the approval email to org owner (in case it failed before)