### PR TITLE
docs: update landing page Gmail messaging to clarify send-only feature

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -522,14 +522,14 @@
                     </div>
                     <h3 class="text-xl font-bold text-brand-900 mb-3">Google Integration</h3>
                     <p class="text-brand-600 mb-4">
-                        Seamlessly connect with Google Workspace. Your email conversations and calendar sync automatically with your CRM.
+                        Connect your Gmail to send emails directly from the CRM. Your tasks sync automatically to Google Calendar.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24">
                                 <path fill="#EA4335" d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"/>
                             </svg>
-                            Gmail email sync on contacts
+                            Send emails from the CRM
                         </li>
                         <li class="flex items-center gap-2">
                             <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24">
@@ -826,7 +826,7 @@
                                         <svg class="w-3 h-3" viewBox="0 0 24 24">
                                             <path fill="#EA4335" d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"/>
                                         </svg>
-                                        Gmail sync for contacts
+                                        Send emails via Gmail
                                     </div>
                                     <div class="flex items-center gap-1.5">
                                         <svg class="w-3 h-3" viewBox="0 0 24 24">


### PR DESCRIPTION
Clarify that Gmail integration allows sending emails from the CRM rather than implying full inbox sync, since we removed the email inbox page.