### PR TITLE
feat: add Wire Fraud Warning document with org-level broker info

### DIFF
--- a/documentation/create_doc.md
+++ b/documentation/create_doc.md
@@ -1,0 +1,635 @@
+# Document Creation Guide for CRM
+
+This guide explains how to add new documents to the CRM system. Documents are integrated with DocuSeal for e-signatures and can be either **PDF-preview** (auto-populated, no UI) or **form-driven** (custom form UI with field mapping).
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Document Types](#document-types)
+3. [Key Files & Locations](#key-files--locations)
+4. [Creating a PDF-Preview Document](#creating-a-pdf-preview-document)
+5. [Creating a Form-Driven Document](#creating-a-form-driven-document)
+6. [YAML Definition Reference](#yaml-definition-reference)
+7. [Field Resolution System](#field-resolution-system)
+8. [Role Configuration](#role-configuration)
+9. [Document Registry](#document-registry)
+10. [Context & Organization Data](#context--organization-data)
+11. [Testing Checklist](#testing-checklist)
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Document Flow                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  1. YAML Definition (documents/*.yml)                           │
+│           ↓                                                      │
+│  2. DocumentLoader (loads on app startup)                       │
+│           ↓                                                      │
+│  3. FieldResolver (resolves field values from context)          │
+│           ↓                                                      │
+│  4. RoleBuilder (builds DocuSeal submitters with fields)        │
+│           ↓                                                      │
+│  5. DocuSealClient (creates preview/submission)                 │
+│           ↓                                                      │
+│  6. E-signature flow (Seller, Agent, etc.)                      │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow Context
+
+When a document is rendered/previewed, a **context** dict is built:
+
+```python
+context = {
+    'user': current_user,           # The logged-in agent (User model)
+    'transaction': transaction,      # The Transaction model
+    'form': doc.field_data or {},   # Saved form field values (JSON)
+    'organization': current_user.organization  # Org-level settings
+}
+```
+
+Fields in the YAML use **source paths** to reference this context:
+- `user.email` → Agent's email
+- `user.full_name` → Agent's first + last name
+- `transaction.property_address` → Property street address
+- `transaction.primary_seller.display_name` → Primary seller's name
+- `form.list_price` → Value saved from a form field
+- `organization.broker_name` → Org's broker name (for documents like Wire Fraud Warning)
+- `static:Origen Realty` → Hardcoded literal value
+
+---
+
+## Document Types
+
+### 1. PDF-Preview Documents
+
+**Use when:** The document only needs auto-populated fields (no user input required).
+
+**Examples:** IABS, Lead-Based Paint Disclosure, Wire Fraud Warning
+
+**Characteristics:**
+- `type: pdf-preview` in YAML
+- No form template needed
+- Fields auto-populate from user/transaction/organization data
+- Appears as an embedded PDF preview in "Fill All Documents" view
+- Status is set to `'filled'` automatically when created
+
+### 2. Form-Driven Documents
+
+**Use when:** The document needs custom form fields for user input.
+
+**Examples:** Listing Agreement, HOA Addendum, Seller's Net Proceeds
+
+**Characteristics:**
+- `type: form-driven` in YAML
+- Requires a form partial template (`templates/transactions/partials/{slug}_fields.html`)
+- Fields map from form inputs to DocuSeal fields
+- User fills out form, then document is generated with their values
+- Status progresses: `pending` → `filled` → `generated` → `sent` → `signed`
+
+---
+
+## Key Files & Locations
+
+| File/Directory | Purpose |
+|----------------|---------|
+| `documents/*.yml` | YAML document definitions (main config) |
+| `documents/schema/v1.0.json` | JSON schema for validation |
+| `services/documents/loader.py` | Loads & validates YAML on startup |
+| `services/documents/field_resolver.py` | Resolves source paths to values |
+| `services/documents/role_builder.py` | Builds DocuSeal submitters |
+| `services/documents/types.py` | Type definitions (DocumentDefinition, etc.) |
+| `services/documents/docuseal_client.py` | DocuSeal API wrapper |
+| `services/document_registry.py` | UI config for documents (colors, icons) |
+| `routes/transactions/documents.py` | Fill form routes |
+| `routes/transactions/signing.py` | Preview & send routes |
+| `routes/transactions/intake.py` | Document package generation |
+| `templates/transactions/partials/` | Form field templates (form-driven only) |
+| `templates/transactions/fill_all_documents.html` | Combined fill view |
+| `templates/transactions/preview_all_documents.html` | Preview before sending |
+
+---
+
+## Creating a PDF-Preview Document
+
+### Step-by-Step Example: Wire Fraud Warning
+
+#### Step 1: Get DocuSeal Template Info
+
+Get the template ID and field/role names from DocuSeal:
+- Template ID: `2661511`
+- Roles: `Broker's Agent`, `Seller`, `Seller 2`
+- Fields: `Broker's Printed Name` (text), signature fields, date fields
+
+#### Step 2: Create YAML Definition
+
+Create `documents/wire-fraud-warning.yml`:
+
+```yaml
+schema_version: "1.0"
+slug: wire-fraud-warning
+name: "Wire Fraud Warning"
+docuseal_template_id: 2661511
+type: pdf-preview
+
+display:
+  color: "#F43F5E"  # Rose/red color (hex)
+  icon: "fas fa-exclamation-triangle"  # FontAwesome icon
+  sort_order: 7  # Display order in lists
+
+roles:
+  # Agent role - must sign (NOT auto_complete)
+  - role_key: agent
+    docuseal_role: "Broker's Agent"  # Exact DocuSeal role name
+    email_source: user.email
+    name_source: user.full_name
+    # auto_complete: false (default) - agent must sign
+
+  # Primary seller - signs the document
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  # Optional second seller
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true  # Skip if no second seller
+
+fields:
+  # Pre-fill broker name from organization settings
+  - field_key: broker_printed_name
+    docuseal_field: "Broker's Printed Name"  # Exact DocuSeal field name
+    role_key: agent
+    source: organization.broker_name
+```
+
+#### Step 3: Add to Preview Document Registry
+
+In `services/document_registry.py`, add to `PREVIEW_DOCUMENT_REGISTRY`:
+
+```python
+'wire-fraud-warning': PreviewDocumentConfig(
+    slug='wire-fraud-warning',
+    name='Wire Fraud Warning',
+    docuseal_template_id=2661511,
+    color='rose',  # Tailwind color name
+    icon='fa-exclamation-triangle',
+    sort_order=102,
+    description='Wire Fraud Warning for Sellers'
+),
+```
+
+#### Step 4: Restart App
+
+The `DocumentLoader.load_all()` runs on app startup. Restart Flask to load the new YAML.
+
+#### Step 5: Test
+
+1. Create a seller transaction
+2. The document should appear in "Fill All Documents" as a PDF preview
+3. Verify fields are populated correctly
+4. Test preview and send flow
+
+---
+
+## Creating a Form-Driven Document
+
+### Step-by-Step Example: Listing Agreement
+
+#### Step 1: Get DocuSeal Template Info
+
+- Template ID: `2468023`
+- Roles: `Seller`, `Seller 2`, `Agent`
+- Fields: Many form fields (list price, address, dates, etc.)
+
+#### Step 2: Create YAML Definition
+
+Create `documents/listing-agreement.yml`:
+
+```yaml
+schema_version: "1.0"
+slug: listing-agreement
+name: "Listing Agreement"
+docuseal_template_id: 2468023
+type: form-driven
+
+display:
+  color: "#F97316"  # Orange
+  icon: "fas fa-file-contract"
+  sort_order: 1
+
+form:
+  template: listing_agreement_form.html  # Full form template (optional)
+  partial: listing_agreement_fields.html  # Fields partial for fill-all view
+
+roles:
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+  - role_key: agent
+    docuseal_role: Agent
+    email_source: user.email
+    name_source: user.full_name
+    auto_complete: true  # Agent fields are pre-filled, auto-sign
+
+fields:
+  # From form inputs
+  - field_key: list_price
+    docuseal_field: "List Price"
+    role_key: seller
+    source: form.list_price
+    transform: currency  # Apply currency formatting
+
+  - field_key: property_address
+    docuseal_field: "Property Address"
+    role_key: seller
+    source: transaction.full_address
+
+  # Combined field example (multiple sources)
+  - field_key: city_state_zip
+    docuseal_field: "City, State, Zip"
+    role_key: seller
+    sources:
+      - transaction.city
+      - transaction.state
+      - transaction.zip_code
+    template: "{0}, {1} {2}"  # Positional placeholders
+
+  # Conditional field (only if doc_responsibility == 'seller')
+  - field_key: seller_pays_checkbox
+    docuseal_field: "Seller Pays"
+    role_key: seller
+    source: form.doc_responsibility
+    transform: checkbox
+    condition_field: form.doc_responsibility
+    condition_equals: seller
+```
+
+#### Step 3: Create Form Partial Template
+
+Create `templates/transactions/partials/listing_agreement_fields.html`:
+
+```html
+<!-- Listing Agreement Fields -->
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div>
+        <label class="form-label">List Price</label>
+        <input type="text" 
+               name="doc_{{ doc.id }}_field_list_price" 
+               value="{{ doc.field_data.list_price or prefill_data.list_price or '' }}"
+               class="form-input"
+               placeholder="$0.00">
+    </div>
+    
+    <div>
+        <label class="form-label">Listing Period (Days)</label>
+        <input type="number" 
+               name="doc_{{ doc.id }}_field_listing_days" 
+               value="{{ doc.field_data.listing_days or '180' }}"
+               class="form-input">
+    </div>
+    
+    <!-- More fields... -->
+</div>
+```
+
+**Important naming convention:** Form fields must be named `doc_{{ doc.id }}_field_{field_key}` for the save handler to properly parse them.
+
+#### Step 4: Add to Document Registry
+
+In `services/document_registry.py`, add to `DOCUMENT_REGISTRY`:
+
+```python
+'listing-agreement': DocumentConfig(
+    slug='listing-agreement',
+    name='Listing Agreement',
+    partial_template='transactions/partials/listing_agreement_fields.html',
+    color='orange',
+    icon='fa-file-contract',
+    sort_order=1,
+),
+```
+
+#### Step 5: Restart and Test
+
+---
+
+## YAML Definition Reference
+
+### Required Fields
+
+```yaml
+schema_version: "1.0"        # Always "1.0" for now
+slug: my-document            # Unique kebab-case identifier
+name: "My Document"          # Display name
+docuseal_template_id: 123456 # DocuSeal template ID
+type: pdf-preview            # or "form-driven"
+
+display:
+  color: "#HEX"              # Hex color for UI
+  icon: "fas fa-icon"        # FontAwesome icon class
+  sort_order: 1              # Lower = appears first
+
+roles: [...]                 # At least one role
+fields: [...]                # Zero or more fields
+```
+
+### Role Definition
+
+```yaml
+- role_key: seller           # Internal identifier (snake_case)
+  docuseal_role: "Seller"    # EXACT name in DocuSeal template
+  email_source: transaction.primary_seller.display_email
+  name_source: transaction.primary_seller.display_name
+  optional: false            # Default false. If true, skip when no email
+  auto_complete: false       # Default false. If true, auto-sign (no email sent)
+```
+
+### Field Definition
+
+```yaml
+# Simple field
+- field_key: my_field
+  docuseal_field: "My Field"  # EXACT name in DocuSeal template
+  role_key: seller
+  source: form.my_field       # Source path (see below)
+  transform: null             # Optional: currency, date_short, checkbox, phone
+
+# Static value
+- field_key: broker_name
+  docuseal_field: "Broker"
+  role_key: agent
+  source: static:Origen Realty  # Literal value
+
+# Manual entry (user fills in DocuSeal)
+- field_key: seller_initials
+  docuseal_field: "Seller Initials"
+  role_key: seller
+  source: null                # null = manual entry during signing
+
+# Combined field (multiple sources)
+- field_key: full_address
+  docuseal_field: "Address"
+  role_key: seller
+  sources:
+    - transaction.street_address
+    - transaction.city
+    - transaction.state
+    - transaction.zip_code
+  template: "{0}, {1}, {2} {3}"
+
+# Conditional field
+- field_key: option_checkbox
+  docuseal_field: "Option A"
+  role_key: seller
+  source: form.selected_option
+  transform: checkbox
+  condition_field: form.selected_option
+  condition_equals: option_a
+```
+
+### Source Path Syntax
+
+| Path | Resolves To |
+|------|-------------|
+| `user.email` | Current user's email |
+| `user.full_name` | Computed: `{first_name} {last_name}` |
+| `user.phone` | User's phone |
+| `user.license_number` | User's license number |
+| `user.licensed_supervisor` | Supervisor name |
+| `transaction.property_address` | Street address |
+| `transaction.full_address` | Computed: full formatted address |
+| `transaction.city` | City |
+| `transaction.state` | State |
+| `transaction.county` | County |
+| `transaction.primary_seller.display_email` | Primary seller's email |
+| `transaction.primary_seller.display_name` | Primary seller's name |
+| `transaction.sellers[0]` | First seller (same as primary) |
+| `transaction.sellers[1]` | Second seller |
+| `form.field_name` | Value from `TransactionDocument.field_data` |
+| `organization.broker_name` | Org's broker name |
+| `organization.broker_license_number` | Org's broker license |
+| `organization.broker_address` | Org's broker address |
+| `static:literal value` | Hardcoded string |
+| `null` | Manual entry (user fills during signing) |
+
+### Transforms
+
+| Transform | Description |
+|-----------|-------------|
+| `currency` | Formats as currency ($1,234.56) |
+| `date_short` | Formats as MM/DD/YYYY |
+| `checkbox` | Converts to "X" if truthy |
+| `phone` | Formats phone number |
+
+---
+
+## Field Resolution System
+
+The `FieldResolver` class (`services/documents/field_resolver.py`) handles:
+
+1. **Parsing source paths** - Dot notation and bracket notation
+2. **Resolving values** - Gets values from context dict
+3. **Applying transforms** - Currency, date, checkbox formatting
+4. **Handling conditions** - Only includes field if condition matches
+5. **Combined fields** - Merges multiple sources with template
+
+Example resolution:
+
+```python
+# Source: "transaction.sellers[1].display_email"
+# Parses to: ['transaction', 'sellers[1]', 'display_email']
+# Resolves: context['transaction'].sellers[1].display_email
+```
+
+---
+
+## Role Configuration
+
+### When to use `auto_complete: true`
+
+Use for roles where ALL fields are:
+- Pre-filled with readonly values
+- Don't require manual signature
+
+Example: Broker role in IABS where all broker info is static.
+
+### When to use `optional: true`
+
+Use for roles that may not exist:
+- Seller 2 (only if there's a co-seller)
+- Co-Buyer
+
+The system checks if `email_source` resolves to a value. If not, the role is skipped.
+
+### Role Mapping to Participants
+
+| Transaction Participant | Typical DocuSeal Role |
+|------------------------|----------------------|
+| Primary seller (`role='seller', is_primary=True`) | "Seller" |
+| Co-seller (`role='seller', is_primary=False`) | "Seller 2" |
+| Listing agent (`role='listing_agent'`) | "Agent" or "Broker" |
+| Buyer's agent | "Buyer's Agent" |
+
+---
+
+## Document Registry
+
+Two registries in `services/document_registry.py`:
+
+### DOCUMENT_REGISTRY (Form-Driven)
+
+```python
+'slug': DocumentConfig(
+    slug='slug',
+    name='Display Name',
+    partial_template='transactions/partials/slug_fields.html',
+    color='orange',  # Tailwind color
+    icon='fa-icon',
+    sort_order=1,
+)
+```
+
+### PREVIEW_DOCUMENT_REGISTRY (PDF-Preview)
+
+```python
+'slug': PreviewDocumentConfig(
+    slug='slug',
+    name='Display Name',
+    docuseal_template_id=123456,
+    color='indigo',
+    icon='fa-icon',
+    sort_order=100,
+    description='Optional description'
+)
+```
+
+---
+
+## Context & Organization Data
+
+### Adding Organization-Level Fields
+
+If your document needs org-level data (like broker info):
+
+1. **Add fields to Organization model** (`models.py`):
+   ```python
+   broker_name = db.Column(db.String(200))
+   ```
+
+2. **Create migration** (`migrations/versions/add_xyz.py`)
+
+3. **Add admin UI** to update the fields (profile page or org settings)
+
+4. **Use in YAML**:
+   ```yaml
+   source: organization.broker_name
+   ```
+
+### Ensuring Context Includes Organization
+
+**CRITICAL:** All places that build the field resolution context must include organization:
+
+```python
+context = {
+    'user': current_user,
+    'transaction': transaction,
+    'form': doc.field_data or {},
+    'organization': current_user.organization  # DON'T FORGET THIS!
+}
+```
+
+Locations to check (search for `'form': doc.field_data`):
+- `routes/transactions/documents.py` - Fill form views
+- `routes/transactions/signing.py` - Preview and send
+- `routes/transactions/intake.py` - Package generation
+- `routes/transactions/download.py` - PDF download
+
+---
+
+## Testing Checklist
+
+### For PDF-Preview Documents
+
+- [ ] YAML file created in `documents/` folder
+- [ ] Added to `PREVIEW_DOCUMENT_REGISTRY`
+- [ ] App restarted to load YAML
+- [ ] Document appears in "Fill All Documents" as PDF preview
+- [ ] Fields are populated correctly from context
+- [ ] Single document preview shows correct values
+- [ ] Preview All shows correct values
+- [ ] Send flow works - correct roles receive signing request
+- [ ] Optional roles (Seller 2) handled correctly
+
+### For Form-Driven Documents
+
+- [ ] YAML file created in `documents/` folder
+- [ ] Form partial template created in `templates/transactions/partials/`
+- [ ] Added to `DOCUMENT_REGISTRY`
+- [ ] App restarted
+- [ ] Document appears in "Fill All Documents" with form fields
+- [ ] Prefill data populates form correctly
+- [ ] Save works - values stored in `field_data`
+- [ ] Preview shows filled values
+- [ ] Send flow works
+
+### Common Issues
+
+1. **Document not loading**: Check YAML syntax, restart app
+2. **Fields not populated**: Check source path, ensure context includes organization
+3. **Role not appearing**: Check `optional` flag, verify email resolves
+4. **Wrong field in DocuSeal**: Verify `docuseal_field` matches EXACTLY
+5. **Transform not working**: Check transform name is valid
+
+---
+
+## Quick Reference: Adding a New Document
+
+### PDF-Preview (No UI)
+
+1. Create `documents/{slug}.yml` with `type: pdf-preview`
+2. Add to `PREVIEW_DOCUMENT_REGISTRY` in `services/document_registry.py`
+3. Restart app
+4. Test
+
+### Form-Driven (With UI)
+
+1. Create `documents/{slug}.yml` with `type: form-driven`
+2. Create `templates/transactions/partials/{slug}_fields.html`
+3. Add to `DOCUMENT_REGISTRY` in `services/document_registry.py`
+4. Restart app
+5. Test
+
+---
+
+## Example: Complete PDF-Preview Document
+
+See `documents/wire-fraud-warning.yml` for a complete example of a PDF-preview document that:
+- Uses organization data (`organization.broker_name`)
+- Has multiple roles (Agent, Seller, Seller 2)
+- Agent must sign (not auto-complete)
+- Seller 2 is optional
+
+See `documents/iabs.yml` for a more complex example with:
+- Static values for broker info
+- User profile data for agent/supervisor
+- Auto-complete for broker and agent roles
+- Multiple pre-filled fields

--- a/documents/wire-fraud-warning.yml
+++ b/documents/wire-fraud-warning.yml
@@ -1,0 +1,71 @@
+# =============================================================================
+# WIRE FRAUD WARNING (SELLER)
+# =============================================================================
+# Warning document alerting sellers about wire fraud risks in real estate
+# transactions.
+#
+# This is a PDF-preview document - no custom form UI.
+# - Broker's Printed Name is auto-populated from organization settings
+# - Agent must sign (signature + date fields are manual)
+# - Seller(s) must sign
+#
+# Template ID: 2661511
+# =============================================================================
+
+schema_version: "1.0"
+slug: wire-fraud-warning
+name: "Wire Fraud Warning"
+docuseal_template_id: 2661511
+type: pdf-preview
+
+display:
+  color: "#F43F5E"
+  icon: "fas fa-exclamation-triangle"
+  sort_order: 7
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Broker's Agent, Seller, Seller 2
+#
+# - Broker's Agent: Agent signs (NOT auto-complete), broker name pre-filled
+# - Seller: Signs the warning acknowledgment
+# - Seller 2: Optional second seller (signs if present)
+# =============================================================================
+
+roles:
+  # Broker's Agent: Must sign (NOT auto-complete)
+  # - "Broker's Printed Name" field is pre-filled from org settings
+  # - Agent must manually provide signature and date
+  - role_key: agent
+    docuseal_role: "Broker's Agent"
+    email_source: user.email
+    name_source: user.full_name
+    # auto_complete: false (default) - agent must sign
+
+  # Seller: Signs the warning acknowledgment
+  - role_key: seller
+    docuseal_role: Seller
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  # Seller 2: Optional second seller
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Only the "Broker's Printed Name" text field is pre-filled.
+# Signature and Date fields are manual entry in DocuSeal during signing.
+# =============================================================================
+
+fields:
+  # Broker's Printed Name - TEXT field, pre-filled from org settings
+  - field_key: broker_printed_name
+    docuseal_field: "Broker's Printed Name"
+    role_key: agent
+    source: organization.broker_name

--- a/migrations/versions/add_org_broker_fields.py
+++ b/migrations/versions/add_org_broker_fields.py
@@ -1,0 +1,61 @@
+"""Add broker fields to organizations table
+
+Revision ID: add_org_broker_fields
+Revises: add_gmail_signature_fields
+Create Date: 2026-01-25
+
+Adds broker/brokerage information fields to organizations for document generation:
+- broker_name: Brokerage company name (e.g., "Origen Realty")
+- broker_license_number: Broker license number
+- broker_address: Full broker address string
+
+These fields are used to pre-fill document fields like "Broker's Printed Name"
+in seller transaction documents (e.g., Wire Fraud Warning).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_org_broker_fields'
+down_revision = 'add_gmail_signature_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add broker_name column
+    op.execute("""
+        ALTER TABLE organizations
+        ADD COLUMN IF NOT EXISTS broker_name VARCHAR(200);
+    """)
+    
+    # Add broker_license_number column
+    op.execute("""
+        ALTER TABLE organizations
+        ADD COLUMN IF NOT EXISTS broker_license_number VARCHAR(50);
+    """)
+    
+    # Add broker_address column
+    op.execute("""
+        ALTER TABLE organizations
+        ADD COLUMN IF NOT EXISTS broker_address VARCHAR(500);
+    """)
+
+
+def downgrade():
+    # Remove the broker columns
+    op.execute("""
+        ALTER TABLE organizations
+        DROP COLUMN IF EXISTS broker_name;
+    """)
+    
+    op.execute("""
+        ALTER TABLE organizations
+        DROP COLUMN IF EXISTS broker_license_number;
+    """)
+    
+    op.execute("""
+        ALTER TABLE organizations
+        DROP COLUMN IF EXISTS broker_address;
+    """)

--- a/models.py
+++ b/models.py
@@ -60,6 +60,11 @@ class Organization(db.Model):
     
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     
+    # Broker/Brokerage information (for document generation)
+    broker_name = db.Column(db.String(200))  # e.g., "Origen Realty"
+    broker_license_number = db.Column(db.String(50))  # e.g., "9003104"
+    broker_address = db.Column(db.String(500))  # Full address string
+    
     # Relationships defined via backref in User model
     
     def upgrade_to_pro(self, max_users=25):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -353,6 +353,43 @@ def update_profile():
 
     return redirect(url_for('auth.view_user_profile'))
 
+
+@auth_bp.route('/profile/update-broker', methods=['POST'])
+@login_required
+def update_broker_info():
+    """Update organization broker information (admin/owner only)."""
+    # Check if user has permission
+    if current_user.org_role not in ('admin', 'owner'):
+        flash('You do not have permission to update brokerage information.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    
+    if not current_user.organization:
+        flash('No organization found.', 'error')
+        return redirect(url_for('auth.view_user_profile'))
+    
+    try:
+        org = current_user.organization
+        
+        # Update broker fields
+        broker_name = request.form.get('broker_name', '').strip()
+        org.broker_name = broker_name if broker_name else None
+        
+        broker_license = request.form.get('broker_license_number', '').strip()
+        org.broker_license_number = broker_license if broker_license else None
+        
+        broker_address = request.form.get('broker_address', '').strip()
+        org.broker_address = broker_address if broker_address else None
+        
+        db.session.commit()
+        flash('Brokerage information updated successfully.', 'success')
+        
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Error updating brokerage info: {str(e)}', 'error')
+    
+    return redirect(url_for('auth.view_user_profile'))
+
+
 # Debug route removed for multi-tenant security
 
 @auth_bp.route('/test_password/<username>/<password>')

--- a/routes/transactions/documents.py
+++ b/routes/transactions/documents.py
@@ -163,7 +163,8 @@ def document_form(id, doc_id):
         context = {
             'user': current_user,
             'transaction': transaction,
-            'form': doc.field_data or {}
+            'form': doc.field_data or {},
+            'organization': current_user.organization
         }
         
         # Resolve fields from definition
@@ -462,7 +463,8 @@ def fill_all_documents(id):
         context = {
             'user': current_user,
             'transaction': transaction,
-            'form': doc.field_data or {}
+            'form': doc.field_data or {},
+            'organization': current_user.organization
         }
         
         # Resolve fields from definition

--- a/routes/transactions/download.py
+++ b/routes/transactions/download.py
@@ -224,7 +224,8 @@ def get_all_documents_print_pdf(id):
             context = {
                 'user': current_user,
                 'transaction': transaction,
-                'form': doc.field_data or {}
+                'form': doc.field_data or {},
+                'organization': current_user.organization
             }
             
             # Resolve fields

--- a/routes/transactions/intake.py
+++ b/routes/transactions/intake.py
@@ -423,7 +423,8 @@ def generate_document_package(id):
                 context = {
                     'user': current_user,
                     'transaction': transaction,
-                    'form': {}
+                    'form': {},
+                    'organization': current_user.organization
                 }
                 resolved_fields = FieldResolver.resolve(definition, context)
                 field_data = {}

--- a/routes/transactions/signing.py
+++ b/routes/transactions/signing.py
@@ -200,7 +200,8 @@ def preview_all_documents(id):
                 context = {
                     'user': current_user,
                     'transaction': transaction,
-                    'form': doc.field_data or {}
+                    'form': doc.field_data or {},
+                    'organization': current_user.organization
                 }
                 
                 # Resolve fields using new system
@@ -350,7 +351,8 @@ def send_all_for_signature(id):
             context = {
                 'user': current_user,
                 'transaction': transaction,
-                'form': doc.field_data or {}
+                'form': doc.field_data or {},
+                'organization': current_user.organization
             }
             
             # Resolve fields using new system
@@ -722,7 +724,8 @@ def document_preview(id, doc_id):
         context = {
             'user': current_user,
             'transaction': transaction,
-            'form': doc.field_data or {}
+            'form': doc.field_data or {},
+            'organization': current_user.organization
         }
         
         # Resolve fields using new system
@@ -808,7 +811,8 @@ def send_for_signature(id, doc_id):
         context = {
             'user': current_user,
             'transaction': transaction,
-            'form': doc.field_data or {}
+            'form': doc.field_data or {},
+            'organization': current_user.organization
         }
         
         # Resolve fields using new system

--- a/services/document_registry.py
+++ b/services/document_registry.py
@@ -313,8 +313,15 @@ PREVIEW_DOCUMENT_REGISTRY: Dict[str, PreviewDocumentConfig] = {
         sort_order=101,
         description='Addendum for Seller\'s Disclosure of Information on Lead-Based Paint'
     ),
-    # Future preview-only documents can be added here:
-    # 'wire-fraud-warning': PreviewDocumentConfig(...),
+    'wire-fraud-warning': PreviewDocumentConfig(
+        slug='wire-fraud-warning',
+        name='Wire Fraud Warning',
+        docuseal_template_id=2661511,
+        color='rose',
+        icon='fa-exclamation-triangle',
+        sort_order=102,
+        description='Wire Fraud Warning for Sellers'
+    ),
 }
 
 

--- a/templates/auth/user_profile.html
+++ b/templates/auth/user_profile.html
@@ -402,6 +402,59 @@
                 </div>
                 {% endif %}
 
+                {% if not is_admin_edit and current_user.org_role in ('admin', 'owner') %}
+                <!-- Brokerage Information Card (Admin/Owner Only) -->
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-rose-500 to-pink-600 flex items-center justify-center">
+                                <i class="fas fa-building text-white text-sm"></i>
+                            </div>
+                            <h2 class="text-lg font-semibold text-slate-800">Brokerage Information</h2>
+                        </div>
+                    </div>
+                    
+                    <form method="POST" action="{{ url_for('auth.update_broker_info') }}" class="p-6">
+                        <p class="text-xs text-slate-500 mb-4">
+                            <i class="fas fa-info-circle mr-1"></i>
+                            Used for document generation (e.g., Wire Fraud Warning)
+                        </p>
+                        
+                        <div class="space-y-4">
+                            <div>
+                                <label class="form-label">Broker Name</label>
+                                <input type="text" name="broker_name" 
+                                       value="{{ current_user.organization.broker_name or '' }}" 
+                                       class="premium-input" 
+                                       placeholder="e.g., Origen Realty">
+                            </div>
+                            <div>
+                                <label class="form-label">Broker License Number</label>
+                                <input type="text" name="broker_license_number" 
+                                       value="{{ current_user.organization.broker_license_number or '' }}" 
+                                       class="premium-input" 
+                                       placeholder="e.g., 9003104">
+                            </div>
+                            <div>
+                                <label class="form-label">Broker Address</label>
+                                <input type="text" name="broker_address" 
+                                       value="{{ current_user.organization.broker_address or '' }}" 
+                                       class="premium-input" 
+                                       placeholder="Full address">
+                            </div>
+                        </div>
+                        
+                        <div class="mt-5">
+                            <button type="submit"
+                                    class="w-full inline-flex items-center justify-center px-4 py-2.5 bg-gradient-to-r from-rose-500 to-pink-600 text-white font-semibold rounded-xl shadow-lg shadow-rose-500/25 hover:shadow-xl hover:shadow-rose-500/30 transition-all duration-200">
+                                <i class="fas fa-save mr-2"></i>
+                                Save Brokerage Info
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                {% endif %}
+
                 <!-- Quick Stats Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">


### PR DESCRIPTION
- Add wire-fraud-warning.yml document definition for DocuSeal template 2661511
- Add broker info fields to Organization model (name, license, address)
- Add Brokerage Information card to admin profile page for org settings
- Add dedicated /profile/update-broker endpoint for broker info updates
- Add wire-fraud-warning to PREVIEW_DOCUMENT_REGISTRY
- Ensure all document resolution contexts include organization for field resolution
- Add comprehensive create_doc.md documentation for future document additions

The Wire Fraud Warning document auto-populates broker name from org settings and requires agent signature (plus seller/seller 2 signatures).