### PR TITLE
feat: add admin email display to platform organization views

### DIFF
--- a/templates/platform_admin/dashboard.html
+++ b/templates/platform_admin/dashboard.html
@@ -216,6 +216,7 @@
                 <thead class="bg-gray-50">
                     <tr>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Organization</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Admin Email</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tier</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
@@ -239,6 +240,13 @@
                                     <div class="text-sm text-gray-500">{{ org.slug }}</div>
                                 </div>
                             </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            {% if org_owners.get(org.id) %}
+                            <div class="text-sm text-gray-900">{{ org_owners.get(org.id) }}</div>
+                            {% else %}
+                            <span class="text-sm text-gray-400">No owner</span>
+                            {% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             {% if org.is_platform_admin %}
@@ -315,7 +323,7 @@
                     
                     {% if not orgs %}
                     <tr>
-                        <td colspan="9" class="px-6 py-12 text-center text-gray-500">
+                        <td colspan="10" class="px-6 py-12 text-center text-gray-500">
                             <i class="fas fa-building text-4xl text-gray-300 mb-3"></i>
                             <p>No organizations found matching your filters.</p>
                         </td>

--- a/templates/platform_admin/org_detail.html
+++ b/templates/platform_admin/org_detail.html
@@ -10,6 +10,12 @@
             </a>
             <h1 class="text-3xl font-bold text-gray-900 mt-2">{{ org.name }}</h1>
             <p class="text-gray-600">{{ org.slug }}</p>
+            {% if owner_email %}
+            <p class="text-sm text-gray-500 mt-1">
+                <i class="fas fa-user-shield text-gray-400 mr-1"></i>
+                Admin: <a href="mailto:{{ owner_email }}" class="text-blue-600 hover:underline">{{ owner_email }}</a>
+            </p>
+            {% endif %}
         </div>
         <div>
             <span class="px-3 py-1 inline-flex text-sm font-semibold rounded-full


### PR DESCRIPTION
Add admin (owner) email address to organization list and detail views to improve organization identification for platform admins.

Changes:
- Display admin email in All Organizations table
- Show admin email with mailto link on org detail page
- Query owner email efficiently for all orgs in dashboard