### PR TITLE
feat: add T-47.1 Residential Real Property Affidavit document

### DIFF
--- a/documents/t47-affidavit.yml
+++ b/documents/t47-affidavit.yml
@@ -1,0 +1,100 @@
+# =============================================================================
+# T-47.1 RESIDENTIAL REAL PROPERTY AFFIDAVIT
+# =============================================================================
+# T-47.1 Residential Real Property Declaration In Lieu of Affidavit
+#
+# This is a form-driven document with a custom UI for data entry.
+# Used when seller has a survey or is unsure about survey availability.
+#
+# Template ID: 2668621
+# =============================================================================
+
+schema_version: "1.0"
+slug: t47-affidavit
+name: "T-47.1 Residential Real Property Affidavit"
+docuseal_template_id: 2668621
+type: form-driven
+
+display:
+  color: "#F59E0B"  # amber
+  icon: "fas fa-file-signature"
+  sort_order: 5
+
+form:
+  template: t47_affidavit_form.html
+  partial: t47_affidavit_fields.html
+
+# =============================================================================
+# ROLES
+# =============================================================================
+# DocuSeal roles: Broker, Seller, Seller 2
+#
+# - Broker: Agent fills form UI, fields are auto-completed (no manual signing)
+# - Seller: Fills their fields during e-signature
+# - Seller 2: Optional second seller, fills fields during e-signature
+# =============================================================================
+
+roles:
+  - role_key: broker
+    docuseal_role: "Broker"
+    email_source: user.email
+    name_source: user.full_name
+    auto_complete: true  # Agent fills form UI, no manual signing needed
+
+  - role_key: seller
+    docuseal_role: "Seller"
+    email_source: transaction.primary_seller.display_email
+    name_source: transaction.primary_seller.display_name
+
+  - role_key: seller_2
+    docuseal_role: "Seller 2"
+    email_source: transaction.sellers[1].display_email
+    name_source: transaction.sellers[1].display_name
+    optional: true
+
+# =============================================================================
+# FIELDS
+# =============================================================================
+# Broker role fields are filled by agent in the form UI.
+# Seller fields are left null (filled during DocuSeal signing).
+#
+# NOTE: Verify docuseal_field names match exactly what's in the DocuSeal template.
+# =============================================================================
+
+fields:
+  # Date field - pre-populated with today's date, agent can adjust
+  - field_key: date
+    docuseal_field: "Date"
+    role_key: broker
+    source: form.date
+    transform: date_short
+
+  # GF Number - optional field for agents
+  - field_key: gf_no
+    docuseal_field: "GF No"
+    role_key: broker
+    source: form.gf_no
+
+  # Declarant - seller's full name, pre-populated but editable
+  - field_key: declarant
+    docuseal_field: "Declarant"
+    role_key: broker
+    source: form.declarant
+
+  # Property Description - concatenated from listing agreement data
+  - field_key: property_description
+    docuseal_field: "Property Description"
+    role_key: broker
+    source: form.property_description
+
+  # County - pre-populated from transaction, editable
+  - field_key: county
+    docuseal_field: "County"
+    role_key: broker
+    source: form.county
+
+  # Seller Name - uses same value as Declarant (populated from form.declarant)
+  - field_key: seller_name
+    docuseal_field: "Seller Name"
+    role_key: broker
+    source: form.declarant

--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -60,7 +60,7 @@
             {"value": "no", "label": "No"},
             {"value": "not_sure", "label": "Not Sure"}
           ],
-          "help_text": "A T-47.1 affidavit may be required if no survey is available.",
+          "help_text": "A T-47.1 affidavit will be included if a survey is available or seller is unsure.",
           "required": true
         }
       ]

--- a/services/document_registry.py
+++ b/services/document_registry.py
@@ -134,6 +134,14 @@ DOCUMENT_REGISTRY: Dict[str, DocumentConfig] = {
         icon='fa-calculator',
         sort_order=4,
     ),
+    't47-affidavit': DocumentConfig(
+        slug='t47-affidavit',
+        name='T-47.1 Affidavit',
+        partial_template='transactions/partials/t47_affidavit_fields.html',
+        color='amber',
+        icon='fa-file-signature',
+        sort_order=5,
+    ),
     # Future documents - uncomment and create partials/YAMLs as needed:
     #
     # 'sellers-disclosure': DocumentConfig(

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -1050,7 +1050,177 @@
             el.addEventListener('change', updateProgress);
             el.addEventListener('input', updateProgress);
         });
+
+        // Initialize T-47.1 property description sync from Listing Agreement
+        initializeT47PropertyDescSync();
     });
+
+    // =============================================================================
+    // T-47.1 PROPERTY DESCRIPTION SYNC FROM LISTING AGREEMENT
+    // =============================================================================
+
+    function initializeT47PropertyDescSync() {
+        // Find all Listing Agreement property description source fields
+        const laFieldPatterns = [
+            'legal_lot',
+            'legal_block', 
+            'legal_subdivision',
+            'property_city',
+            'property_county',
+            'property_address'
+        ];
+
+        // Find all T-47.1 property description fields
+        const t47PropDescFields = document.querySelectorAll('[name*="_field_property_description"]');
+        
+        // Find the T-47 document's property description field specifically
+        // (it will have a name like doc_123_field_property_description where 123 is the T-47 doc ID)
+        let t47Field = null;
+        t47PropDescFields.forEach(field => {
+            // Check if this is inside a T-47 section (amber colored)
+            const section = field.closest('.doc-section');
+            if (section) {
+                const sectionColor = section.style.getPropertyValue('--section-color');
+                // Amber color is #f59e0b
+                if (sectionColor && sectionColor.includes('f59e0b')) {
+                    t47Field = field;
+                }
+            }
+        });
+
+        // Alternative: look for field in the t47 partial by checking nearby labels
+        if (!t47Field) {
+            t47PropDescFields.forEach(field => {
+                const card = field.closest('.premium-card');
+                if (card) {
+                    const header = card.querySelector('.section-title, h2');
+                    if (header && (header.textContent.includes('T-47') || header.textContent.includes('Property Declaration'))) {
+                        t47Field = field;
+                    }
+                }
+            });
+        }
+
+        if (!t47Field) {
+            // No T-47 form found on this page
+            return;
+        }
+
+        // Find all Listing Agreement source fields
+        const laFields = {};
+        laFieldPatterns.forEach(pattern => {
+            const field = document.querySelector(`[name*="_field_${pattern}"]`);
+            if (field) {
+                laFields[pattern] = field;
+            }
+        });
+
+        // If we have LA fields, set up listeners
+        if (Object.keys(laFields).length > 0) {
+            // Function to build the property description
+            function buildPropertyDescription() {
+                const lot = laFields.legal_lot?.value || '';
+                const block = laFields.legal_block?.value || '';
+                const subdivision = laFields.legal_subdivision?.value || '';
+                const city = laFields.property_city?.value || '';
+                const county = laFields.property_county?.value || '';
+                const address = laFields.property_address?.value || '';
+
+                const parts = [];
+                
+                if (lot) parts.push(`Lot ${lot}`);
+                if (block) parts.push(`Block ${block}`);
+                if (subdivision) parts.push(`${subdivision} Addition`);
+                if (city) parts.push(`City of ${city}`);
+                if (county) parts.push(`${county} County, TX`);
+                if (address) parts.push(`known as ${address}`);
+
+                return parts.join(', ');
+            }
+
+            // Function to update T-47 field
+            function updateT47PropertyDesc() {
+                const newValue = buildPropertyDescription();
+                // Update if we have content AND user hasn't manually edited
+                // (autoSynced is 'true' by default, becomes 'false' only on manual keydown)
+                if (newValue && t47Field.dataset.autoSynced !== 'false') {
+                    t47Field.value = newValue;
+                    // Trigger change event for any listeners (but not our own)
+                    t47Field.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            }
+
+            // Add listeners to all LA fields
+            Object.values(laFields).forEach(field => {
+                if (field) {
+                    field.addEventListener('input', updateT47PropertyDesc);
+                    field.addEventListener('change', updateT47PropertyDesc);
+                }
+            });
+
+            // Track if user manually types in the T-47 field (not via our sync)
+            let userIsTyping = false;
+            t47Field.addEventListener('keydown', function() {
+                userIsTyping = true;
+            });
+            t47Field.addEventListener('blur', function() {
+                if (userIsTyping) {
+                    // User manually edited, stop auto-syncing
+                    this.dataset.autoSynced = 'false';
+                    userIsTyping = false;
+                }
+            });
+
+            // Mark as auto-synced since it was pre-populated from server
+            t47Field.dataset.autoSynced = 'true';
+            
+            // Initial sync - always update to include any LA fields that may be filled
+            updateT47PropertyDesc();
+        }
+
+        // Also sync the county field
+        syncT47CountyField();
+    }
+
+    function syncT47CountyField() {
+        // Find Listing Agreement county field
+        const laCountyField = document.querySelector('[name*="_field_property_county"]');
+        
+        // Find T-47 county field
+        const t47CountyFields = document.querySelectorAll('[name*="_field_county"]');
+        let t47CountyField = null;
+        
+        t47CountyFields.forEach(field => {
+            const card = field.closest('.premium-card');
+            if (card) {
+                const header = card.querySelector('.section-title, h2');
+                if (header && (header.textContent.includes('T-47') || header.textContent.includes('Property Declaration'))) {
+                    t47CountyField = field;
+                }
+            }
+        });
+
+        if (laCountyField && t47CountyField) {
+            // Mark as auto-synced by default
+            t47CountyField.dataset.autoSynced = 'true';
+            
+            laCountyField.addEventListener('input', function() {
+                if (t47CountyField.dataset.autoSynced !== 'false') {
+                    t47CountyField.value = this.value;
+                }
+            });
+
+            // Track manual edits
+            t47CountyField.addEventListener('keydown', function() {
+                this.dataset.autoSynced = 'false';
+            });
+
+            // Initial sync
+            if (laCountyField.value) {
+                t47CountyField.value = laCountyField.value;
+            }
+        }
+    }
 
     function initializeConditionalSections() {
         // Check all radio buttons and apply their conditional logic

--- a/templates/transactions/partials/t47_affidavit_fields.html
+++ b/templates/transactions/partials/t47_affidavit_fields.html
@@ -1,0 +1,79 @@
+{# 
+T-47.1 Affidavit Form Fields Partial
+T-47.1 Residential Real Property Declaration In Lieu of Affidavit
+
+This document is used when seller has a survey or is unsure about survey availability.
+Agent fills out the broker fields (Date, GF No, Declarant, Property Description, County).
+Sellers sign the document through DocuSeal.
+
+Variables expected: prefill_data (dict), doc (optional - for field prefixing in combined view)
+#}
+
+{% set field_prefix = 'doc_' ~ (doc.id if doc else 't47') ~ '_field_' %}
+
+<!-- ============================================================== -->
+<!-- T-47.1 AFFIDAVIT - PROPERTY DECLARATION -->
+<!-- ============================================================== -->
+<div class="premium-card p-6 mb-6 form-section animate-fade-in-up" data-section="1">
+    <div class="section-header">
+        <div class="section-number bg-gradient-to-br from-amber-500 to-amber-600 text-white">
+            <i class="fas fa-file-signature text-xs"></i>
+        </div>
+        <div>
+            <h2 class="section-title">T-47.1 Property Declaration</h2>
+            <p class="section-subtitle">Residential Real Property Declaration In Lieu of Affidavit</p>
+        </div>
+    </div>
+    
+    <div class="space-y-6">
+        <!-- Date and GF Number Row -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="form-label form-label-required">Date</label>
+                <input type="date" name="{{ field_prefix }}date" 
+                       value="{{ prefill_data.get('date', '') or prefill_data.get('t47_date', '') }}"
+                       class="premium-input">
+                <p class="help-text">Date of the declaration</p>
+            </div>
+            <div>
+                <label class="form-label">GF No.</label>
+                <input type="text" name="{{ field_prefix }}gf_no" 
+                       value="{{ prefill_data.get('gf_no', '') or prefill_data.get('t47_gf_no', '') }}"
+                       class="premium-input" placeholder="Optional">
+                <p class="help-text">Optional general file number</p>
+            </div>
+        </div>
+
+        <!-- Declarant (Seller Name) -->
+        <div>
+            <label class="form-label form-label-required">Declarant</label>
+            <input type="text" name="{{ field_prefix }}declarant" 
+                   value="{{ prefill_data.get('declarant', '') or prefill_data.get('t47_declarant', '') or prefill_data.get('seller_legal_name', '') }}"
+                   class="premium-input" placeholder="Seller's full legal name">
+            <p class="help-text">Full legal name of the property owner(s) making the declaration</p>
+        </div>
+
+        <!-- Property Description -->
+        <div>
+            <label class="form-label form-label-required">Property Description</label>
+            <textarea name="{{ field_prefix }}property_description" 
+                      class="premium-input" rows="3" style="resize: vertical; min-height: 80px;"
+                      placeholder="Lot, Block, Addition, City, County...">{{ prefill_data.get('property_description', '') or prefill_data.get('t47_property_description', '') }}</textarea>
+            <p class="help-text">Legal description of the property (Lot, Block, Subdivision/Addition, City, County, known address)</p>
+        </div>
+
+        <!-- County -->
+        <div class="md:w-1/2">
+            <label class="form-label form-label-required">County</label>
+            <input type="text" name="{{ field_prefix }}county" 
+                   value="{{ prefill_data.get('county', '') or prefill_data.get('t47_county', '') or prefill_data.get('property_county', '') }}"
+                   class="premium-input" placeholder="County name">
+            <p class="help-text">County where the property is located</p>
+        </div>
+
+        <div class="callout-info">
+            <i class="fas fa-info-circle"></i>
+            <p>This declaration is used in lieu of a formal affidavit regarding the survey of the property. The seller(s) will review and sign this document through DocuSeal. The information above will be pre-filled on the document.</p>
+        </div>
+    </div>
+</div>

--- a/templates/transactions/t47_affidavit_form.html
+++ b/templates/transactions/t47_affidavit_form.html
@@ -1,0 +1,444 @@
+{% extends "base.html" %}
+
+{% block title %}T-47.1 Affidavit - {{ transaction.street_address }} - Origen TechnolOG{% endblock %}
+
+{% block content %}
+<style>
+    /* Premium animations */
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(20px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .animate-fade-in-up {
+        animation: fadeInUp 0.6s ease-out forwards;
+    }
+
+    /* Premium card styling */
+    .premium-card {
+        background: white;
+        border-radius: 1rem;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        transition: all 0.3s ease-out;
+    }
+
+    .premium-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+
+    /* Section styling */
+    .form-section {
+        border-left: 4px solid transparent;
+        transition: all 0.3s ease-out;
+    }
+
+    .form-section:hover {
+        border-left-color: #f59e0b;
+    }
+
+    .form-section.active {
+        border-left-color: #f59e0b;
+        background: linear-gradient(to right, rgba(245, 158, 11, 0.02), transparent);
+    }
+
+    /* Section header */
+    .section-header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+    }
+
+    .section-number {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.75rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 0.875rem;
+        flex-shrink: 0;
+    }
+
+    .section-title {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: #1e293b;
+    }
+
+    .section-subtitle {
+        font-size: 0.875rem;
+        color: #64748b;
+        margin-top: 0.25rem;
+    }
+
+    /* Premium input styling */
+    .premium-input {
+        border: 2px solid #e2e8f0;
+        border-radius: 0.625rem;
+        background-color: #f8fafc;
+        transition: all 0.2s ease-out;
+        padding: 0.75rem 1rem;
+        font-size: 0.9375rem;
+        width: 100%;
+    }
+
+    .premium-input:focus {
+        border-color: #f59e0b;
+        background-color: #ffffff;
+        box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+        outline: none;
+    }
+
+    .premium-input::placeholder {
+        color: #94a3b8;
+    }
+
+    .premium-input[readonly] {
+        background-color: #f1f5f9;
+        color: #64748b;
+        cursor: not-allowed;
+    }
+
+    .premium-input[readonly]:focus {
+        border-color: #e2e8f0;
+        box-shadow: none;
+    }
+
+    /* Form label */
+    .form-label {
+        display: block;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        color: #334155;
+        margin-bottom: 0.5rem;
+    }
+
+    .form-label-required::after {
+        content: ' *';
+        color: #ef4444;
+    }
+
+    /* Help text */
+    .help-text {
+        font-size: 0.8125rem;
+        color: #64748b;
+        margin-top: 0.5rem;
+        line-height: 1.5;
+    }
+
+    /* Callouts */
+    .callout-info {
+        background: linear-gradient(135deg, #fffbeb, #fef3c7);
+        border: 1px solid #fcd34d;
+        border-radius: 0.75rem;
+        padding: 1rem 1.25rem;
+        margin-top: 0.75rem;
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .callout-info i {
+        color: #f59e0b;
+        flex-shrink: 0;
+        margin-top: 0.125rem;
+    }
+
+    .callout-info p {
+        font-size: 0.875rem;
+        color: #92400e;
+        line-height: 1.6;
+        margin: 0;
+    }
+
+    /* Progress bar */
+    .progress-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 4px;
+        background: #e2e8f0;
+        z-index: 1000;
+    }
+
+    .progress-bar-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #f59e0b, #d97706);
+        transition: width 0.3s ease-out;
+    }
+
+    /* Status badge */
+    .status-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.375rem 0.875rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .status-draft { background: #f1f5f9; color: #64748b; }
+    .status-pending { background: #fef3c7; color: #92400e; }
+    .status-filled { background: #dbeafe; color: #1d4ed8; }
+    .status-completed { background: #d1fae5; color: #047857; }
+    .status-sent { background: #dbeafe; color: #1d4ed8; }
+    .status-signed { background: #d1fae5; color: #047857; }
+
+    /* Floating action bar */
+    .floating-action-bar {
+        position: fixed;
+        bottom: 1.5rem;
+        left: 50%;
+        transform: translateX(-50%);
+        background: white;
+        padding: 0.875rem 1.25rem;
+        border-radius: 1rem;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+        border: 1px solid rgba(0, 0, 0, 0.06);
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .premium-btn {
+        transition: all 0.2s ease-out;
+        border-radius: 0.75rem;
+    }
+
+    .premium-btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .form-bottom-spacer {
+        height: 100px;
+    }
+</style>
+
+<!-- Progress Bar -->
+<div class="progress-bar">
+    <div class="progress-bar-fill" id="progressFill" style="width: 0%"></div>
+</div>
+
+<!-- Premium gradient background -->
+<div class="min-h-full bg-gradient-to-br from-slate-50 via-white to-amber-50/30">
+    <div class="p-4 md:p-6 max-w-4xl mx-auto">
+        <!-- Back Link -->
+        <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+           class="inline-flex items-center text-slate-500 hover:text-amber-600 text-sm mb-4 transition-colors animate-fade-in-up">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Transaction
+        </a>
+        
+        <!-- Header Section -->
+        <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6 animate-fade-in-up">
+            <div class="flex items-start space-x-4">
+                <div class="hidden md:flex w-14 h-14 rounded-2xl bg-gradient-to-br from-amber-500 to-amber-600 items-center justify-center shadow-lg flex-shrink-0">
+                    <i class="fas fa-file-signature text-white text-xl"></i>
+                </div>
+                <div>
+                    <h1 class="text-2xl md:text-3xl font-bold text-slate-800">T-47.1 Affidavit</h1>
+                    <p class="text-slate-500 mt-1">{{ transaction.street_address }}</p>
+                    <p class="text-xs text-slate-400 mt-1">Residential Real Property Declaration In Lieu of Affidavit</p>
+                </div>
+            </div>
+            <span class="status-badge status-{{ document.status }}">
+                {{ document.status|title }}
+            </span>
+        </div>
+
+        <!-- Main Form -->
+        <form id="t47AffidavitForm" method="POST" action="{{ url_for('transactions.save_document_form', id=transaction.id, doc_id=document.id) }}">
+            
+            <!-- ============================================================== -->
+            <!-- SECTION 1: PROPERTY DECLARATION -->
+            <!-- ============================================================== -->
+            <div class="premium-card p-6 mb-6 form-section animate-fade-in-up" data-section="1">
+                <div class="section-header">
+                    <div class="section-number bg-gradient-to-br from-amber-500 to-amber-600 text-white">1</div>
+                    <div>
+                        <h2 class="section-title">Property Declaration</h2>
+                        <p class="section-subtitle">Declaration information for the affidavit</p>
+                    </div>
+                </div>
+                
+                <div class="space-y-6">
+                    <!-- Date and GF Number Row -->
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="form-label form-label-required">Date</label>
+                            <input type="date" name="field_date" 
+                                   value="{{ prefill_data.get('date', '') or prefill_data.get('t47_date', '') }}"
+                                   class="premium-input">
+                            <p class="help-text">Date of the declaration</p>
+                        </div>
+                        <div>
+                            <label class="form-label">GF No.</label>
+                            <input type="text" name="field_gf_no" 
+                                   value="{{ prefill_data.get('gf_no', '') or prefill_data.get('t47_gf_no', '') }}"
+                                   class="premium-input" placeholder="Optional">
+                            <p class="help-text">Optional general file number</p>
+                        </div>
+                    </div>
+
+                    <!-- Declarant (Seller Name) -->
+                    <div>
+                        <label class="form-label form-label-required">Declarant</label>
+                        <input type="text" name="field_declarant" 
+                               value="{{ prefill_data.get('declarant', '') or prefill_data.get('t47_declarant', '') or prefill_data.get('seller_legal_name', '') }}"
+                               class="premium-input" placeholder="Seller's full legal name">
+                        <p class="help-text">Full legal name of the property owner(s) making the declaration</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ============================================================== -->
+            <!-- SECTION 2: PROPERTY INFORMATION -->
+            <!-- ============================================================== -->
+            <div class="premium-card p-6 mb-6 form-section" data-section="2">
+                <div class="section-header">
+                    <div class="section-number bg-gradient-to-br from-orange-500 to-orange-600 text-white">2</div>
+                    <div>
+                        <h2 class="section-title">Property Information</h2>
+                        <p class="section-subtitle">Legal description and location</p>
+                    </div>
+                </div>
+                
+                <div class="space-y-6">
+                    <!-- Property Description -->
+                    <div>
+                        <label class="form-label form-label-required">Property Description</label>
+                        <textarea name="field_property_description" 
+                                  class="premium-input" rows="3" style="resize: vertical; min-height: 80px;"
+                                  placeholder="Lot, Block, Addition, City, County...">{{ prefill_data.get('property_description', '') or prefill_data.get('t47_property_description', '') }}</textarea>
+                        <p class="help-text">Legal description of the property (Lot, Block, Subdivision/Addition, City, County, known address)</p>
+                    </div>
+
+                    <!-- County -->
+                    <div class="md:w-1/2">
+                        <label class="form-label form-label-required">County</label>
+                        <input type="text" name="field_county" 
+                               value="{{ prefill_data.get('county', '') or prefill_data.get('t47_county', '') or prefill_data.get('property_county', '') }}"
+                               class="premium-input" placeholder="County name">
+                        <p class="help-text">County where the property is located</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ============================================================== -->
+            <!-- SECTION 3: DOCUMENT OVERVIEW -->
+            <!-- ============================================================== -->
+            <div class="premium-card p-6 mb-6 form-section" data-section="3">
+                <div class="section-header">
+                    <div class="section-number bg-gradient-to-br from-slate-500 to-slate-600 text-white">
+                        <i class="fas fa-info text-xs"></i>
+                    </div>
+                    <div>
+                        <h2 class="section-title">Document Overview</h2>
+                        <p class="section-subtitle">What this declaration covers</p>
+                    </div>
+                </div>
+                
+                <div class="space-y-4">
+                    <p class="text-slate-600 text-sm leading-relaxed">
+                        The T-47.1 Residential Real Property Declaration is used in lieu of a formal affidavit regarding the survey of the property. By signing this document, the declarant(s) affirm:
+                    </p>
+                    
+                    <ul class="list-disc list-inside text-slate-600 text-sm space-y-2 pl-2">
+                        <li>There have been no changes to the property boundaries since the survey was prepared</li>
+                        <li>No improvements have been made that would affect the survey</li>
+                        <li>There are no encroachments or boundary disputes known to the declarant</li>
+                        <li>The property information provided is accurate to the best of their knowledge</li>
+                    </ul>
+
+                    <div class="callout-info">
+                        <i class="fas fa-signature"></i>
+                        <div>
+                            <p><strong>Signatures Required:</strong> The seller(s) will sign this declaration through DocuSeal. All information entered above will be pre-filled on the document before sending for signature.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Spacer for floating action bar -->
+            <div class="form-bottom-spacer"></div>
+        </form>
+        
+        <!-- Floating Action Bar -->
+        <div class="floating-action-bar">
+            <a href="{{ url_for('transactions.view_transaction', id=transaction.id) }}" 
+               class="premium-btn px-5 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-lg transition-colors">
+                Cancel
+            </a>
+            <div class="w-px h-8 bg-slate-200"></div>
+            <button type="submit" form="t47AffidavitForm" name="submit_action" value="save" 
+                    class="premium-btn px-5 py-2.5 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg flex items-center gap-2 transition-colors">
+                <i class="fas fa-save text-slate-500"></i>
+                Save Draft
+            </button>
+            <button type="submit" form="t47AffidavitForm" name="submit_action" value="continue" 
+                    class="premium-btn px-5 py-2.5 text-sm font-medium text-white bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 rounded-lg flex items-center gap-2 shadow-sm transition-colors">
+                <i class="fas fa-check-circle"></i>
+                Save & Continue
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- Toast Notification -->
+<div id="toast" class="fixed bottom-6 right-6 z-50 hidden">
+    <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-2xl shadow-2xl border border-slate-200">
+        <i id="toastIcon" class="fas fa-info-circle text-amber-500"></i>
+        <span id="toastMessage" class="text-sm font-medium text-slate-700"></span>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Calculate form progress based on filled fields
+    function updateProgress() {
+        const requiredFields = document.querySelectorAll('[name^="field_"]:not([name$="_gf_no"])');
+        let filledCount = 0;
+        let totalCount = 0;
+        
+        requiredFields.forEach(field => {
+            if (field.name.includes('date') || field.name.includes('declarant') || 
+                field.name.includes('property_description') || field.name.includes('county')) {
+                totalCount++;
+                if (field.value && field.value.trim() !== '') {
+                    filledCount++;
+                }
+            }
+        });
+        
+        const progress = totalCount > 0 ? (filledCount / totalCount) * 100 : 0;
+        document.getElementById('progressFill').style.width = progress + '%';
+    }
+    
+    // Update progress on input
+    document.querySelectorAll('[name^="field_"]').forEach(field => {
+        field.addEventListener('input', updateProgress);
+        field.addEventListener('change', updateProgress);
+    });
+    
+    // Initial progress calculation
+    updateProgress();
+    
+    // Set today's date if date field is empty
+    const dateField = document.querySelector('[name="field_date"]');
+    if (dateField && !dateField.value) {
+        const today = new Date().toISOString().split('T')[0];
+        dateField.value = today;
+        updateProgress();
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
- Add YAML definition for T-47.1 with Broker, Seller, Seller 2 roles
- Create form partial and full form templates with amber theming
- Add to DOCUMENT_REGISTRY for Fill All Forms support
- Add property description prefill from Listing Agreement data
- Add real-time cross-document field sync in Fill All Forms
- Update intake schema help text for survey question
- Update create_doc.md with advanced patterns documentation

The document is triggered when seller has survey or is unsure. Broker fields are filled by agent in form UI (auto_complete). Property Description auto-syncs from Listing Agreement fields.