### PR TITLE
feat: add automatic Gmail fallback for SendGrid email delivery

### DIFF
--- a/documentation/gmail_fallback.md
+++ b/documentation/gmail_fallback.md
@@ -1,0 +1,138 @@
+# Gmail Fallback for SendGrid Email Delivery
+
+## Problem
+SendGrid shared IP pools can get blacklisted (RBL), causing legitimate emails to bounce even though you're paying for the service. This happened with an org approval email that was blocked due to SendGrid's IP being on SpamCop's blacklist.
+
+## Solution
+Implemented automatic Gmail fallback in the `EmailService` class. When SendGrid fails to send an email, the system automatically retries using Gmail SMTP.
+
+## How It Works
+
+### Automatic Fallback Flow
+1. **Try SendGrid first** - Attempt to send via SendGrid API with dynamic template
+2. **Detect failure** - If SendGrid returns non-200 status or throws exception
+3. **Load HTML template** - Read the local HTML template file from `email_templates/`
+4. **Replace variables** - Substitute `{{variable_name}}` placeholders with actual data
+5. **Send via Gmail** - Use Gmail SMTP (SSL on port 465) to deliver the email
+6. **Log results** - Track which method succeeded for monitoring
+
+### Code Location
+- **Main implementation**: `services/email_service.py`
+- **Standalone script**: `send_gmail_html.py` (for manual/emergency use)
+
+### Configuration
+Gmail fallback uses existing `.env` variables:
+```bash
+MAIL_USERNAME=ogtechnolog@gmail.com
+MAIL_PASSWORD=flblrqlmyvfxfqkx  # Gmail App Password
+```
+
+### Supported Templates
+All 6 email templates have Gmail fallback support:
+1. ✓ Password Reset (`1_password_reset.html`)
+2. ✓ Org Approved (`2_org_approved.html`)
+3. ✓ Org Rejected (`3_org_rejected.html`)
+4. ✓ Team Invitation (`4_team_invitation.html`)
+5. ✓ Contact Form (`5_contact_form.html`)
+6. ✓ Task Reminder (`6_task_reminder.html`)
+
+## Usage
+
+### In the App (Automatic)
+No code changes needed! Existing email methods automatically use fallback:
+
+```python
+from services.email_service import get_email_service
+
+email_service = get_email_service()
+
+# This will automatically try Gmail if SendGrid fails
+email_service.send_org_approved(
+    org=organization,
+    owner_email="user@example.com",
+    login_url="https://app.origentechnolog.com/login"
+)
+```
+
+### Manual Script (Emergency Use Only)
+If you need to send an email completely outside the app:
+
+```bash
+python3 send_gmail_html.py
+```
+
+The script will:
+- Prompt for Gmail App Password
+- Show preview of email details
+- Ask for confirmation
+- Send directly via Gmail
+
+## Monitoring
+
+### Log Messages
+Check application logs for these indicators:
+
+**Success via SendGrid:**
+```
+✓ SendGrid email sent: template=org_approved, to=user@example.com, status=202
+```
+
+**Fallback triggered:**
+```
+SendGrid failed: template=org_approved, to=user@example.com, status=550
+Attempting Gmail fallback for user@example.com
+✓ Gmail fallback successful: template=org_approved, to=user@example.com
+```
+
+**Complete failure:**
+```
+SendGrid error: template=org_approved, to=user@example.com, error=...
+Gmail fallback failed for user@example.com: ...
+✗ All email methods failed: template=org_approved, to=user@example.com
+```
+
+## Benefits
+
+1. **Zero downtime** - Emails still deliver when SendGrid has IP reputation issues
+2. **No code changes** - Existing email-sending code works unchanged
+3. **Transparent** - Logging shows which delivery method was used
+4. **Cost effective** - Only uses Gmail when necessary (SendGrid preferred)
+5. **Better UX** - Users get their emails even during SendGrid outages
+
+## SendGrid IP Reputation Issues
+
+### What Happened
+```json
+{
+  "bounce_classification": "Reputation",
+  "reason": "550 JunkMail rejected - s.wrqvtzvf.outbound-mail.sendgrid.net [149.72.126.143]:11742 is in an RBL on rbl.websitewelcome.com",
+  "status": "550",
+  "type": "blocked"
+}
+```
+
+### Long-term Solutions to Consider
+1. **Dedicated IP** - Upgrade SendGrid plan to get isolated IP ($90-150/month)
+2. **Contact SendGrid Support** - Report the blocked IP for rotation
+3. **Multiple providers** - Consider AWS SES or Mailgun as additional fallback
+4. **Monitor deliverability** - Set up SendGrid webhook alerts for bounces
+
+## Testing
+
+To test the Gmail fallback locally:
+
+1. Temporarily break SendGrid (e.g., use invalid API key)
+2. Trigger an email send (e.g., org approval)
+3. Check logs for Gmail fallback activation
+4. Verify email delivered with proper HTML formatting
+5. Restore SendGrid API key
+
+## Notes
+
+- Gmail App Password required (not regular password)
+- Gmail has sending limits (~500 emails/day for free accounts)
+- SendGrid is still the primary/preferred method
+- HTML templates must be kept in sync between SendGrid and local files
+- From address defaults to `info@origentechnolog.com` (verified in Gmail)
+
+## Updated: January 27, 2026

--- a/send_gmail_html.py
+++ b/send_gmail_html.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Quick script to send HTML email templates via Gmail when SendGrid has issues.
+
+NOTE: As of Jan 2026, the main EmailService in services/email_service.py
+now has automatic Gmail fallback built-in. This standalone script is kept
+for manual/emergency sending when you need to bypass the app entirely.
+
+Usage:
+    python3 send_gmail_html.py
+
+You'll need a Gmail App Password (not your regular password):
+1. Go to myaccount.google.com
+2. Security → 2-Step Verification → App passwords
+3. Generate new app password for "Mail"
+"""
+
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from datetime import datetime
+
+def send_html_email(
+    from_email: str,
+    app_password: str,
+    to_email: str,
+    subject: str,
+    html_template_path: str,
+    template_vars: dict
+):
+    """
+    Send an HTML email via Gmail SMTP.
+    
+    Args:
+        from_email: Your Gmail address (e.g., info@origentechnolog.com)
+        app_password: Gmail app password (NOT your regular password)
+        to_email: Recipient email
+        subject: Email subject line
+        html_template_path: Path to HTML template file
+        template_vars: Dict of variables to replace in template (e.g., {"org_name": "Acme Realty"})
+    """
+    # Read and process template
+    with open(html_template_path, 'r', encoding='utf-8') as f:
+        html_content = f.read()
+    
+    # Replace template variables
+    for key, value in template_vars.items():
+        placeholder = f"{{{{{key}}}}}"  # {{variable_name}}
+        html_content = html_content.replace(placeholder, str(value))
+    
+    # Create message
+    msg = MIMEMultipart('alternative')
+    msg['From'] = from_email
+    msg['To'] = to_email
+    msg['Subject'] = subject
+    
+    # Attach HTML content
+    html_part = MIMEText(html_content, 'html')
+    msg.attach(html_part)
+    
+    # Send via Gmail SMTP
+    try:
+        print(f"Connecting to Gmail SMTP...")
+        with smtplib.SMTP_SSL('smtp.gmail.com', 465) as server:
+            print(f"Logging in as {from_email}...")
+            server.login(from_email, app_password)
+            print(f"Sending email to {to_email}...")
+            server.send_message(msg)
+            print(f"✓ Email sent successfully!")
+    except Exception as e:
+        print(f"✗ Error sending email: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    # ============================================================
+    # CONFIGURE YOUR EMAIL HERE
+    # ============================================================
+    
+    FROM_EMAIL = "info@origentechnolog.com"
+    
+    # Get your Gmail App Password:
+    # 1. Go to myaccount.google.com
+    # 2. Security → 2-Step Verification → App passwords
+    # 3. Generate new app password for "Mail"
+    APP_PASSWORD = input("Enter your Gmail App Password: ").strip()
+    
+    # Recipient details
+    TO_EMAIL = "james@jameswoodrealty.com"
+    ORG_NAME = "No Place Like Home Realty"
+    
+    # Email configuration
+    SUBJECT = "Welcome to Origen TechnolOG! Your organization has been approved"
+    TEMPLATE_PATH = "email_templates/2_org_approved.html"
+    
+    # Template variables
+    template_vars = {
+        "org_name": ORG_NAME,
+        "login_url": "https://app.origentechnolog.com/login",
+        "current_year": str(datetime.now().year)
+    }
+    
+    # ============================================================
+    # SEND EMAIL
+    # ============================================================
+    
+    print("\n" + "="*60)
+    print("GMAIL HTML EMAIL SENDER")
+    print("="*60)
+    print(f"From: {FROM_EMAIL}")
+    print(f"To: {TO_EMAIL}")
+    print(f"Subject: {SUBJECT}")
+    print(f"Template: {TEMPLATE_PATH}")
+    print(f"Variables: {template_vars}")
+    print("="*60 + "\n")
+    
+    confirm = input("Send this email? (yes/no): ").strip().lower()
+    if confirm == 'yes':
+        send_html_email(
+            from_email=FROM_EMAIL,
+            app_password=APP_PASSWORD,
+            to_email=TO_EMAIL,
+            subject=SUBJECT,
+            html_template_path=TEMPLATE_PATH,
+            template_vars=template_vars
+        )
+    else:
+        print("Cancelled.")


### PR DESCRIPTION
Add automatic Gmail SMTP fallback when SendGrid fails due to IP reputation issues or other delivery failures. This ensures critical transactional emails (org approvals, password resets, etc.) are delivered even when SendGrid's shared IP pool is blacklisted.

Changes:
- Updated EmailService class with automatic Gmail fallback logic
- Added _send_via_gmail() method for SMTP delivery
- Added _get_template_html() to load local HTML templates
- Modified send() to try Gmail when SendGrid returns non-200 status
- Created send_gmail_html.py standalone script for manual sending
- Added comprehensive documentation in gmail_fallback.md


All 6 email templates supported:
- Password Reset
- Organization Approved
- Organization Rejected
- Team Invitation
- Contact Form
- Task Reminder

Logging clearly indicates which delivery method succeeded for monitoring.