### PR TITLE
feat: add attachment display in chat history and file upload support

### DIFF
--- a/migrations/versions/add_chat_file_attachments.py
+++ b/migrations/versions/add_chat_file_attachments.py
@@ -1,0 +1,47 @@
+"""Add file attachment columns to chat_messages table
+
+Revision ID: add_chat_file_attachments
+Revises: add_chat_history
+Create Date: 2026-01-31
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_chat_file_attachments'
+down_revision = 'add_chat_history'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add file attachment columns to chat_messages table
+    op.execute("""
+        ALTER TABLE chat_messages 
+        ADD COLUMN IF NOT EXISTS file_url VARCHAR(500);
+    """)
+    op.execute("""
+        ALTER TABLE chat_messages 
+        ADD COLUMN IF NOT EXISTS file_name VARCHAR(255);
+    """)
+    op.execute("""
+        ALTER TABLE chat_messages 
+        ADD COLUMN IF NOT EXISTS file_type VARCHAR(100);
+    """)
+    op.execute("""
+        ALTER TABLE chat_messages 
+        ADD COLUMN IF NOT EXISTS file_size INTEGER;
+    """)
+    op.execute("""
+        ALTER TABLE chat_messages 
+        ADD COLUMN IF NOT EXISTS file_storage_path VARCHAR(500);
+    """)
+
+
+def downgrade():
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS file_storage_path;")
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS file_size;")
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS file_type;")
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS file_name;")
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS file_url;")

--- a/services/supabase_storage.py
+++ b/services/supabase_storage.py
@@ -19,6 +19,7 @@ CONTACT_FILES_BUCKET = 'contact-files'
 COMPANY_UPDATES_BUCKET = 'company-updates'
 TRANSACTION_DOCUMENTS_BUCKET = 'transaction-documents'
 VOICE_MEMOS_BUCKET = 'voice-memos'
+CHAT_ATTACHMENTS_BUCKET = 'chat-attachments'
 
 
 def get_supabase_client() -> Client:

--- a/static/css/ai_chat.css
+++ b/static/css/ai_chat.css
@@ -651,6 +651,75 @@
     display: block;
 }
 
+/* File Preview (for non-image attachments before sending) */
+.bob-file-preview {
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    margin-bottom: 12px;
+    background: #f8fafc;
+    border: 1px solid var(--bob-border);
+    border-radius: 10px;
+    position: relative;
+    width: fit-content;
+    max-width: 300px;
+}
+
+.bob-file-preview.visible {
+    display: flex;
+}
+
+.bob-file-preview i:first-child {
+    font-size: 24px;
+    color: var(--bob-orange);
+    flex-shrink: 0;
+}
+
+.bob-file-preview-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bob-file-preview-info span:first-child {
+    font-weight: 500;
+    font-size: 13px;
+    color: var(--bob-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.bob-file-preview-info span:last-child {
+    font-size: 11px;
+    color: #64748b;
+}
+
+.bob-file-preview-remove {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: #ef4444;
+    color: white;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease;
+}
+
+.bob-file-preview-remove:hover {
+    transform: scale(1.1);
+}
+
 .bob-image-preview img {
     max-height: 100px;
     border-radius: 10px;
@@ -1361,4 +1430,187 @@ body.bob-fullscreen-open {
         width: calc(100vw - 40px);
         max-width: 320px;
     }
+}
+
+/* ===== Message Attachments ===== */
+.bob-message-attachment {
+    margin-bottom: 8px;
+}
+
+.bob-message-image {
+    max-width: 100%;
+    max-height: 200px;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    display: block;
+}
+
+.bob-message-image:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.bob-message-text {
+    word-wrap: break-word;
+}
+
+/* User message with attachment - adjust styling */
+.bob-message.user .bob-message-attachment {
+    text-align: right;
+}
+
+.bob-message.user .bob-message-image {
+    margin-left: auto;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+}
+
+/* ===== File Card ===== */
+.bob-file-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 10px;
+    margin-bottom: 8px;
+    max-width: 280px;
+}
+
+.bob-message.user .bob-file-card {
+    margin-left: auto;
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.bob-message.assistant .bob-file-card {
+    background: #f1f5f9;
+    border: 1px solid var(--bob-border);
+}
+
+.bob-file-icon {
+    font-size: 24px;
+    flex-shrink: 0;
+    opacity: 0.9;
+}
+
+.bob-message.user .bob-file-icon {
+    color: white;
+}
+
+.bob-message.assistant .bob-file-icon {
+    color: var(--bob-orange);
+}
+
+.bob-file-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bob-file-name {
+    font-weight: 500;
+    font-size: 13px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.bob-file-size {
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+.bob-file-download {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    transition: background 0.15s ease;
+    flex-shrink: 0;
+}
+
+.bob-message.user .bob-file-download {
+    color: white;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.bob-message.user .bob-file-download:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.bob-message.assistant .bob-file-download {
+    color: var(--bob-orange);
+    background: transparent;
+}
+
+.bob-message.assistant .bob-file-download:hover {
+    background: rgba(249, 115, 22, 0.1);
+}
+
+/* ===== Image Modal ===== */
+.bob-image-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 10001;
+    display: none;
+    align-items: center;
+    justify-content: center;
+}
+
+.bob-image-modal.visible {
+    display: flex;
+}
+
+.bob-image-modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(4px);
+}
+
+.bob-image-modal-content {
+    position: relative;
+    z-index: 1;
+    max-width: 90vw;
+    max-height: 90vh;
+}
+
+.bob-image-modal-content img {
+    max-width: 90vw;
+    max-height: 90vh;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.bob-image-modal-close {
+    position: absolute;
+    top: -40px;
+    right: 0;
+    width: 36px;
+    height: 36px;
+    border: none;
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.bob-image-modal-close:hover {
+    background: rgba(255, 255, 255, 0.2);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -137,6 +137,52 @@
             scrollbar-width: thin;
             scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
         }
+
+        /* B.O.B. Assistant Button - Header */
+        .bob-assistant-btn {
+            background: linear-gradient(135deg, #f97316 0%, #fb7185 50%, #f43f5e 100%);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            border: none;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(249, 115, 22, 0.35);
+            transition: all 0.2s ease;
+        }
+        .bob-assistant-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(249, 115, 22, 0.45);
+        }
+        .bob-assistant-btn:active {
+            transform: translateY(0);
+        }
+        .bob-assistant-icon {
+            width: 18px;
+            height: 18px;
+        }
+        /* Mobile version */
+        .bob-assistant-btn-mobile {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #f97316 0%, #fb7185 50%, #f43f5e 100%);
+            color: white;
+            border: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 2px 8px rgba(249, 115, 22, 0.35);
+            transition: all 0.2s ease;
+        }
+        .bob-assistant-btn-mobile:hover {
+            transform: scale(1.05);
+            box-shadow: 0 4px 12px rgba(249, 115, 22, 0.45);
+        }
+        .bob-assistant-btn-mobile svg {
+            width: 20px;
+            height: 20px;
+        }
     </style>
     <!-- Initialize sidebar state immediately before DOM loads -->
     <script>
@@ -170,8 +216,12 @@
         <div class="flex items-center space-x-4 pr-4 relative">
             {% if current_user.is_authenticated %}
             {% if org_has_feature('AI_CHAT') %}
-            <button id="bob-toggle-desktop" class="text-white hover:text-orange-300 flex items-center gap-2 text-sm font-medium transition-colors">
-                <i class="fas fa-wand-magic-sparkles"></i>
+            <button id="bob-toggle-desktop" class="bob-assistant-btn flex items-center gap-2 text-sm font-semibold transition-all">
+                <svg class="bob-assistant-icon" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M16 2L18.5 12L28 14L18.5 16.5L16 28L13.5 16.5L4 14L13.5 12L16 2Z" fill="currentColor"/>
+                    <path d="M8 6L9 9L12 10L9 11L8 14L7 11L4 10L7 9L8 6Z" fill="currentColor" opacity="0.7"/>
+                    <path d="M24 20L25 23L28 24L25 25L24 28L23 25L20 24L23 23L24 20Z" fill="currentColor" opacity="0.7"/>
+                </svg>
                 <span>Assistant</span>
             </button>
             <span class="text-gray-500 mx-3">|</span>
@@ -204,8 +254,12 @@
         <div class="flex items-center space-x-3">
             {% if current_user.is_authenticated %}
             {% if org_has_feature('AI_CHAT') %}
-            <button id="bob-toggle-mobile" class="w-8 h-8 rounded-full bg-[#3d4d63] text-white flex items-center justify-center text-sm hover:bg-orange-500 transition-colors">
-                <i class="fas fa-wand-magic-sparkles"></i>
+            <button id="bob-toggle-mobile" class="bob-assistant-btn-mobile">
+                <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M16 2L18.5 12L28 14L18.5 16.5L16 28L13.5 16.5L4 14L13.5 12L16 2Z" fill="currentColor"/>
+                    <path d="M8 6L9 9L12 10L9 11L8 14L7 11L4 10L7 9L8 6Z" fill="currentColor" opacity="0.7"/>
+                    <path d="M24 20L25 23L28 24L25 25L24 28L23 25L20 24L23 23L24 20Z" fill="currentColor" opacity="0.7"/>
+                </svg>
             </button>
             {% endif %}
             <button id="mobileUserIcon" onclick="toggleMobileUserMenu()"


### PR DESCRIPTION
- Display image thumbnails in chat messages instead of [Image attached] text
- Add click-to-expand image modal for fullscreen viewing
- Support file uploads (CSV, PDF, TXT, DOC/DOCX, XLS/XLSX) with 10MB limit
- Show file cards with icon, name, size, and download link in chat
- Send full CSV/TXT content to AI for analysis
- Clean up files from Supabase Storage when conversations are deleted
- Update Assistant button with sparkle logo and gradient styling