### PR TITLE
feat: enable AI chat for free tier with 10 messages/day limit

### DIFF
--- a/feature_flags.py
+++ b/feature_flags.py
@@ -22,8 +22,8 @@ TIER_FEATURES = {
         'DASHBOARD': True,
         'TEAM_UPDATES': True,
         
-        # Premium features - disabled on free tier
-        'AI_CHAT': False,
+        # Premium features - limited on free tier
+        'AI_CHAT': True,  # Enabled with daily message limit (see tier_limits.py)
         'AI_DAILY_TODO': False,
         'AI_ACTION_PLAN': False,
         'TRANSACTIONS': False,

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -573,27 +573,27 @@
                 </div>
                 
                 <!-- Feature 4: AI Tools -->
-                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
-                    <span class="feature-badge badge-pro">Pro · Coming Soon</span>
+                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden">
+                    <span class="feature-badge badge-free">Free</span>
                     <div class="w-14 h-14 bg-gradient-to-br from-accent-500 to-amber-500 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-accent-500/20">
                         <i class="fas fa-brain text-white text-xl"></i>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">AI-Powered Tools</h3>
+                    <h3 class="text-xl font-bold text-brand-900 mb-3">AI-Powered B.O.B.</h3>
                     <p class="text-brand-600 mb-4">
-                        Meet B.O.B., your Business Optimization Buddy. Get AI-generated daily tasks, action plans, and smart suggestions.
+                        Meet B.O.B., your Business Optimization Buddy. Get real estate advice, email drafts, and smart suggestions—free.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Daily AI task lists
+                            AI chat assistant (10/day free)
                         </li>
                         <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Action plan generator
+                            <i class="fas fa-lock text-brand-300"></i>
+                            <span class="text-brand-400">Unlimited chat (Pro)</span>
                         </li>
                         <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Smart chat assistant
+                            <i class="fas fa-lock text-brand-300"></i>
+                            <span class="text-brand-400">Daily AI todo & action plans (Pro)</span>
                         </li>
                     </ul>
                 </div>
@@ -840,9 +840,22 @@
                             </div>
                         </li>
                         
+                        <!-- B.O.B. AI Chat Highlight -->
+                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-gradient-to-r from-amber-50 via-white to-orange-50 border border-amber-100">
+                            <div class="flex-shrink-0 mt-0.5">
+                                <i class="fas fa-brain text-accent-500"></i>
+                            </div>
+                            <div class="flex-1">
+                                <span class="font-semibold text-brand-800">B.O.B. AI Assistant</span>
+                                <div class="text-xs text-brand-600 mt-1">
+                                    10 messages/day included free
+                                </div>
+                            </div>
+                        </li>
+                        
                         <li class="flex items-center gap-3 text-brand-400">
                             <i class="fas fa-lock text-brand-300"></i>
-                            AI features (Pro)
+                            Unlimited AI + daily todo (Pro)
                         </li>
                         <li class="flex items-center gap-3 text-brand-400">
                             <i class="fas fa-lock text-brand-300"></i>
@@ -904,7 +917,11 @@
                         </li>
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>
-                            AI-powered tools (B.O.B.)
+                            <strong>Unlimited</strong> B.O.B. AI chat
+                        </li>
+                        <li class="flex items-center gap-3 text-white">
+                            <i class="fas fa-check text-accent-400"></i>
+                            AI daily todo & action plans
                         </li>
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>

--- a/templates/organization/upgrade.html
+++ b/templates/organization/upgrade.html
@@ -1,256 +1,250 @@
 {% extends "base.html" %}
 
 {% block content %}
-<!-- Premium Upgrade Page - Coming Soon -->
-<div class="min-h-screen bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 py-12 px-4 -mt-4 -mx-4 sm:-mx-6 lg:-mx-8">
-    
-    <!-- Floating orbs background -->
-    <div class="fixed inset-0 overflow-hidden pointer-events-none">
-        <div class="absolute top-20 left-10 w-72 h-72 bg-blue-500/20 rounded-full blur-3xl animate-pulse"></div>
-        <div class="absolute bottom-20 right-10 w-96 h-96 bg-purple-500/20 rounded-full blur-3xl animate-pulse" style="animation-delay: 1s;"></div>
-        <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-indigo-500/10 rounded-full blur-3xl"></div>
-    </div>
+<!-- Premium Upgrade Page - Matching Landing Page Style -->
+<div class="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 py-12 px-4 -mt-4 -mx-4 sm:-mx-6 lg:-mx-8">
     
     <div class="max-w-5xl mx-auto relative">
         
         <!-- Header -->
         <div class="text-center mb-12">
-            <div class="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-amber-500/20 to-orange-500/20 border border-amber-500/30 rounded-full text-amber-300 text-sm font-medium mb-6 backdrop-blur-sm">
+            <span class="inline-flex items-center gap-2 px-4 py-2 bg-amber-100 text-amber-700 rounded-full text-sm font-semibold mb-6">
                 <i class="fas fa-clock"></i>
                 Coming Soon
-            </div>
-            <h1 class="text-4xl sm:text-5xl font-bold text-white mb-4">
-                Upgrade to <span class="bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">Pro</span>
+            </span>
+            <h1 class="text-4xl sm:text-5xl font-bold text-slate-900 mb-4">
+                Upgrade to <span class="text-orange-500">Pro</span>
             </h1>
-            <p class="text-xl text-slate-400 max-w-2xl mx-auto">
+            <p class="text-xl text-slate-600 max-w-2xl mx-auto">
                 Unlock the full power of your CRM with advanced features designed for growing teams and serious agents.
             </p>
         </div>
         
-        <!-- Main Content Grid -->
-        <div class="grid lg:grid-cols-2 gap-8 mb-12">
+        <!-- Pricing Cards -->
+        <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto items-stretch mb-16">
             
-            <!-- Your Current Plan -->
-            <div class="bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 p-8 relative overflow-hidden">
-                <div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-slate-500 to-slate-600"></div>
+            <!-- Free Plan (Current) -->
+            <div class="bg-white rounded-2xl p-8 border-2 border-slate-200 shadow-lg flex flex-col h-full relative overflow-hidden">
+                <div class="absolute top-4 right-4">
+                    <span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 text-slate-600 text-xs font-bold rounded-full">
+                        CURRENT PLAN
+                    </span>
+                </div>
                 
-                <div class="flex items-center gap-3 mb-6">
-                    <div class="w-12 h-12 bg-slate-700/50 rounded-xl flex items-center justify-center">
-                        <i class="fas fa-seedling text-slate-400 text-xl"></i>
+                <div class="flex items-center gap-3 mb-4">
+                    <div class="w-12 h-12 bg-slate-100 rounded-xl flex items-center justify-center">
+                        <i class="fas fa-seedling text-slate-600 text-xl"></i>
                     </div>
                     <div>
-                        <p class="text-slate-500 text-sm font-medium">Your Current Plan</p>
-                        <h3 class="text-2xl font-bold text-white">Free</h3>
+                        <h3 class="text-2xl font-bold text-slate-900">Free</h3>
+                        <p class="text-slate-500 text-sm">For individual agents</p>
                     </div>
                 </div>
                 
-                <ul class="space-y-4 mb-6">
-                    <li class="flex items-center gap-3 text-slate-300">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>1 user</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-300">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>Up to 200 contacts</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-300">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>Task management</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-300">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>Dashboard & reporting</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-500">
-                        <div class="w-6 h-6 rounded-full bg-slate-700/50 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-lock text-slate-500 text-xs"></i>
-                        </div>
-                        <span>AI features</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-500">
-                        <div class="w-6 h-6 rounded-full bg-slate-700/50 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-lock text-slate-500 text-xs"></i>
-                        </div>
-                        <span>Transaction management</span>
-                </li>
-                    <li class="flex items-center gap-3 text-slate-500">
-                        <div class="w-6 h-6 rounded-full bg-slate-700/50 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-lock text-slate-500 text-xs"></i>
-                        </div>
-                        <span>Document generation</span>
-                </li>
-            </ul>
-            
-                <div class="pt-4 border-t border-white/10">
-                    <p class="text-3xl font-bold text-white">$0<span class="text-lg text-slate-500 font-normal">/month</span></p>
-                    <p class="text-sm text-slate-500">Forever free</p>
-        </div>
+                <div class="mb-6">
+                    <span class="text-4xl font-bold text-slate-900">$0</span>
+                    <span class="text-slate-500">/month</span>
+                    <p class="text-sm text-slate-500 mt-1">Forever free</p>
+                </div>
+                
+                <ul class="space-y-3 flex-grow">
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        1 user account
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        Up to 10,000 contacts
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        Task management
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        Dashboard & analytics
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        Google Integration (Gmail & Calendar)
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-700">
+                        <i class="fas fa-check text-green-500"></i>
+                        B.O.B. AI Chat (10/day)
+                    </li>
+                    
+                    <li class="flex items-center gap-3 text-slate-400">
+                        <i class="fas fa-lock text-slate-300"></i>
+                        Unlimited AI chat (Pro)
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-400">
+                        <i class="fas fa-lock text-slate-300"></i>
+                        AI daily todo & action plans (Pro)
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-400">
+                        <i class="fas fa-lock text-slate-300"></i>
+                        Transaction management (Pro)
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-400">
+                        <i class="fas fa-lock text-slate-300"></i>
+                        Document generation (Pro)
+                    </li>
+                    <li class="flex items-center gap-3 text-slate-400">
+                        <i class="fas fa-lock text-slate-300"></i>
+                        Team invitations (Pro)
+                    </li>
+                </ul>
             </div>
             
             <!-- Pro Plan -->
-            <div class="bg-gradient-to-br from-blue-600/20 via-indigo-600/20 to-purple-600/20 backdrop-blur-xl rounded-2xl border border-blue-400/30 p-8 relative overflow-hidden">
-                <!-- Shimmer accent -->
-                <div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400"></div>
-                
+            <div class="bg-gradient-to-br from-slate-800 to-slate-900 rounded-2xl p-8 shadow-xl relative overflow-hidden flex flex-col h-full border-2 border-slate-700">
                 <!-- Recommended badge -->
                 <div class="absolute top-4 right-4">
-                    <span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gradient-to-r from-blue-500 to-indigo-500 text-white text-xs font-bold rounded-full shadow-lg">
+                    <span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-orange-500 text-white text-xs font-bold rounded-full">
                         <i class="fas fa-star text-[10px]"></i> RECOMMENDED
                     </span>
                 </div>
                 
-                <div class="flex items-center gap-3 mb-6">
-                    <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl flex items-center justify-center shadow-lg shadow-blue-500/30">
+                <div class="flex items-center gap-3 mb-4">
+                    <div class="w-12 h-12 bg-orange-500 rounded-xl flex items-center justify-center">
                         <i class="fas fa-rocket text-white text-xl"></i>
                     </div>
                     <div>
-                        <p class="text-blue-300 text-sm font-medium">Upgrade to</p>
                         <h3 class="text-2xl font-bold text-white">Pro</h3>
+                        <p class="text-slate-400 text-sm">For teams & power users</p>
                     </div>
                 </div>
                 
-                <ul class="space-y-4 mb-6">
+                <div class="mb-6">
+                    <span class="text-3xl font-bold text-white">Coming Soon</span>
+                    <p class="text-sm text-slate-400 mt-1">Be the first to know</p>
+                </div>
+                
+                <ul class="space-y-3 flex-grow">
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span><strong>Up to 25 users</strong></span>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Everything in Free
                     </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span><strong>Unlimited</strong> contacts</span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Up to 25 users
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>Task management</span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Unlimited contacts
+                    </li>
+                    <li class="flex items-center gap-3 text-white font-semibold">
+                        <i class="fas fa-infinity text-orange-400"></i>
+                        <strong>Unlimited</strong> B.O.B. AI chat
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-emerald-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-check text-emerald-400 text-xs"></i>
-                        </div>
-                        <span>Dashboard & reporting</span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        AI daily todo generator
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-blue-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-sparkles text-blue-400 text-xs"></i>
-                        </div>
-                        <span><strong>AI Features</strong> — B.O.B., Daily Todo, Action Plan</span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        AI action plan builder
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-blue-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-sparkles text-blue-400 text-xs"></i>
-                        </div>
-                        <span><strong>Transaction management</strong></span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Transaction management
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-blue-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-sparkles text-blue-400 text-xs"></i>
-                        </div>
-                        <span><strong>Document generation & e-signing</strong></span>
-                </li>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Document generation & e-signing
+                    </li>
                     <li class="flex items-center gap-3 text-white">
-                        <div class="w-6 h-6 rounded-full bg-blue-500/30 flex items-center justify-center flex-shrink-0">
-                            <i class="fas fa-sparkles text-blue-400 text-xs"></i>
-                        </div>
-                        <span><strong>Team invites</strong> & member management</span>
-                </li>
-            </ul>
+                        <i class="fas fa-check text-orange-400"></i>
+                        Team invites & member management
+                    </li>
+                </ul>
                 
-                <div class="pt-4 border-t border-white/10">
-                    <div class="flex items-center gap-3 mb-2">
-                        <span class="text-2xl font-bold text-white">Pricing Coming Soon</span>
-                    </div>
-                    <p class="text-sm text-blue-200">Be the first to know when Pro launches</p>
+                <div class="mt-auto pt-8">
+                    <button onclick="openContactUsModal('app')" 
+                       class="block w-full text-center px-6 py-3 bg-orange-500 text-white font-semibold rounded-xl hover:bg-orange-600 transition-colors cursor-pointer">
+                        Contact Us About Pro
+                    </button>
                 </div>
             </div>
         </div>
         
         <!-- Pro Features Showcase -->
-        <div class="mb-12">
-            <h2 class="text-2xl font-bold text-white text-center mb-8">What's included in Pro</h2>
+        <div class="mb-16">
+            <h2 class="text-2xl font-bold text-slate-900 text-center mb-8">What you'll unlock with Pro</h2>
             
             <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                <!-- AI Features -->
-                <div class="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-5 hover:border-blue-400/50 hover:bg-white/10 transition-all duration-300">
+                <!-- Unlimited AI -->
+                <div class="bg-white rounded-xl border border-slate-200 p-5 shadow-sm hover:shadow-md hover:border-orange-200 transition-all duration-300">
                     <div class="w-12 h-12 bg-gradient-to-br from-purple-500 to-pink-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-purple-500/20">
-                        <i class="fas fa-brain text-white text-xl"></i>
+                        <i class="fas fa-infinity text-white text-xl"></i>
                     </div>
-                    <h3 class="font-bold text-white mb-2">AI-Powered Tools</h3>
-                    <p class="text-sm text-slate-400">B.O.B. assistant, smart daily todos, and personalized action plans.</p>
+                    <h3 class="font-bold text-slate-900 mb-2">Unlimited AI</h3>
+                    <p class="text-sm text-slate-600">Unlimited B.O.B. conversations, plus AI daily todos and action plans.</p>
                 </div>
                 
                 <!-- Transactions -->
-                <div class="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-5 hover:border-blue-400/50 hover:bg-white/10 transition-all duration-300">
+                <div class="bg-white rounded-xl border border-slate-200 p-5 shadow-sm hover:shadow-md hover:border-orange-200 transition-all duration-300">
                     <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-blue-500/20">
                         <i class="fas fa-file-contract text-white text-xl"></i>
                     </div>
-                    <h3 class="font-bold text-white mb-2">Transaction Management</h3>
-                    <p class="text-sm text-slate-400">Track deals from listing to close with full timeline visibility.</p>
+                    <h3 class="font-bold text-slate-900 mb-2">Transaction Management</h3>
+                    <p class="text-sm text-slate-600">Track deals from listing to close with full timeline visibility.</p>
                 </div>
                 
                 <!-- Documents -->
-                <div class="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-5 hover:border-blue-400/50 hover:bg-white/10 transition-all duration-300">
+                <div class="bg-white rounded-xl border border-slate-200 p-5 shadow-sm hover:shadow-md hover:border-orange-200 transition-all duration-300">
                     <div class="w-12 h-12 bg-gradient-to-br from-emerald-500 to-teal-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-emerald-500/20">
                         <i class="fas fa-file-signature text-white text-xl"></i>
                     </div>
-                    <h3 class="font-bold text-white mb-2">Document Generation</h3>
-                    <p class="text-sm text-slate-400">Auto-generate contracts and collect e-signatures seamlessly.</p>
+                    <h3 class="font-bold text-slate-900 mb-2">Document Generation</h3>
+                    <p class="text-sm text-slate-600">Auto-generate contracts and collect e-signatures seamlessly.</p>
                 </div>
                 
                 <!-- Team -->
-                <div class="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-5 hover:border-blue-400/50 hover:bg-white/10 transition-all duration-300">
+                <div class="bg-white rounded-xl border border-slate-200 p-5 shadow-sm hover:shadow-md hover:border-orange-200 transition-all duration-300">
                     <div class="w-12 h-12 bg-gradient-to-br from-amber-500 to-orange-500 rounded-xl flex items-center justify-center mb-4 shadow-lg shadow-amber-500/20">
                         <i class="fas fa-users text-white text-xl"></i>
                     </div>
-                    <h3 class="font-bold text-white mb-2">Team Collaboration</h3>
-                    <p class="text-sm text-slate-400">Invite team members with role-based access and permissions.</p>
+                    <h3 class="font-bold text-slate-900 mb-2">Team Collaboration</h3>
+                    <p class="text-sm text-slate-600">Invite team members with role-based access and permissions.</p>
                 </div>
             </div>
         </div>
         
         <!-- Contact CTA -->
-        <div class="bg-gradient-to-r from-blue-600/30 via-indigo-600/30 to-purple-600/30 backdrop-blur-xl rounded-2xl border border-blue-400/30 p-8 text-center relative overflow-hidden">
-            <!-- Background glow -->
-            <div class="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-transparent to-purple-500/10"></div>
+        <div class="bg-gradient-to-r from-orange-500 via-orange-600 to-amber-500 rounded-2xl p-8 text-center relative overflow-hidden">
+            <!-- Background pattern -->
+            <div class="absolute inset-0 opacity-10">
+                <div class="absolute top-0 left-0 w-64 h-64 bg-white rounded-full -translate-x-1/2 -translate-y-1/2"></div>
+                <div class="absolute bottom-0 right-0 w-80 h-80 bg-white rounded-full translate-x-1/4 translate-y-1/4"></div>
+            </div>
             
             <div class="relative">
-                <div class="w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-lg shadow-blue-500/30">
+                <div class="w-16 h-16 bg-white/20 backdrop-blur rounded-2xl flex items-center justify-center mx-auto mb-6">
                     <i class="fas fa-envelope text-white text-2xl"></i>
                 </div>
                 
                 <h2 class="text-2xl font-bold text-white mb-3">Interested in Pro?</h2>
-                <p class="text-slate-300 mb-6 max-w-lg mx-auto">
+                <p class="text-white/90 mb-6 max-w-lg mx-auto">
                     We're finalizing Pro pricing and would love to hear from you. 
                     Reach out to learn more or get notified when Pro becomes available.
                 </p>
                 
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-                    <a href="mailto:chris@origenrealty.com?subject=Interested%20in%20Pro%20Plan" 
-                       class="inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-bold rounded-xl shadow-lg shadow-blue-500/30 hover:shadow-xl hover:shadow-blue-500/40 hover:-translate-y-0.5 transition-all duration-200">
+                    <button onclick="openContactUsModal('app')" 
+                       class="inline-flex items-center gap-2 px-8 py-4 bg-white text-orange-600 font-bold rounded-xl shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all duration-200 cursor-pointer">
                         <i class="fas fa-paper-plane"></i>
                         Contact Us
-                    </a>
-                    <a href="{{ url_for('org.settings') }}" 
-                       class="inline-flex items-center gap-2 px-6 py-4 bg-white/10 text-white font-semibold rounded-xl border border-white/20 hover:bg-white/20 transition-all duration-200">
+                    </button>
+                    <a href="#" id="backButton"
+                       class="inline-flex items-center gap-2 px-6 py-4 bg-white/10 text-white font-semibold rounded-xl border-2 border-white/30 hover:bg-white/20 transition-all duration-200">
                         <i class="fas fa-arrow-left"></i>
-                        Back to Settings
+                        <span id="backButtonText">Back to Settings</span>
                     </a>
                 </div>
+            </div>
         </div>
-    </div>
-    
+        
         <!-- Footer note -->
         <div class="mt-8 text-center">
             <p class="text-slate-500 text-sm">
@@ -261,10 +255,28 @@
     </div>
 </div>
 
-<style>
-@keyframes pulse {
-    0%, 100% { opacity: 0.3; }
-    50% { opacity: 0.6; }
-}
-</style>
+<!-- Contact Us Modal -->
+{% include 'modals/contact_us_modal.html' %}
+
+<script>
+// Dynamic back button based on referrer
+document.addEventListener('DOMContentLoaded', function() {
+    const backButton = document.getElementById('backButton');
+    const backButtonText = document.getElementById('backButtonText');
+    const referrer = document.referrer;
+    
+    // Check if user came from a page with BOB chat (any page really, but we can also check URL param)
+    const urlParams = new URLSearchParams(window.location.search);
+    const fromChat = urlParams.get('from') === 'chat';
+    
+    // If from chat or referrer doesn't include 'settings', go to dashboard
+    if (fromChat || (referrer && !referrer.includes('/org/settings'))) {
+        backButton.href = "{{ url_for('main.dashboard') }}";
+        backButtonText.textContent = "Back to Dashboard";
+    } else {
+        backButton.href = "{{ url_for('org.settings') }}";
+        backButtonText.textContent = "Back to Settings";
+    }
+});
+</script>
 {% endblock %}

--- a/tier_config/tier_limits.py
+++ b/tier_config/tier_limits.py
@@ -9,16 +9,19 @@ TIER_DEFAULTS = {
         'max_users': 1,
         'max_contacts': 10000,
         'can_invite_users': False,
+        'daily_ai_chat_messages': 10,  # Free tier: 10 messages/day to B.O.B.
     },
     'pro': {
         'max_users': 25,  # Default, can be overridden per-org
         'max_contacts': None,  # Unlimited
         'can_invite_users': True,
+        'daily_ai_chat_messages': None,  # Unlimited
     },
     'enterprise': {
         'max_users': 1000,
         'max_contacts': None,
         'can_invite_users': True,
+        'daily_ai_chat_messages': None,  # Unlimited
     }
 }
 


### PR DESCRIPTION
- Enable AI_CHAT feature flag for free tier users
- Add daily_ai_chat_messages limit (10 for free, unlimited for pro/enterprise)
- Add rate limiting to chat routes with clean upgrade message when limit hit
- Update landing page to show B.O.B. AI as free feature with 10/day limit
- Redesign upgrade page to match landing page style with accurate features
- Add contact modal to upgrade page (replaces mailto links)
- Dynamic back button on upgrade page (dashboard if from chat, settings otherwise)