### PR TITLE
feat: add honeypot field to block spam bot registrations

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -55,7 +55,7 @@ def register():
     form = RegistrationForm()
     if form.validate_on_submit():
         # Honeypot check - bots fill this hidden field, humans don't see it
-        honeypot = request.form.get('website', '')
+        honeypot = request.form.get('website', '').strip()
         if honeypot:
             # Bot detected! Return fake success to not tip them off
             current_app.logger.warning(f"Bot registration blocked (honeypot): {form.email.data}")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -54,6 +54,17 @@ def register():
 
     form = RegistrationForm()
     if form.validate_on_submit():
+        # Honeypot check - bots fill this hidden field, humans don't see it
+        honeypot = request.form.get('website', '')
+        if honeypot:
+            # Bot detected! Return fake success to not tip them off
+            current_app.logger.warning(f"Bot registration blocked (honeypot): {form.email.data}")
+            flash(
+                'Registration submitted! You will receive an email once approved '
+                '(typically within 24 hours).', 
+                'success'
+            )
+            return redirect(url_for('auth.login'))
         # Get or use company name (add to form if not present)
         company_name = request.form.get('company_name', '').strip()
         if not company_name:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -55,7 +55,7 @@ def register():
     form = RegistrationForm()
     if form.validate_on_submit():
         # Honeypot check - bots fill this hidden field, humans don't see it
-        honeypot = request.form.get('website', '').strip()
+        honeypot = request.form.get('referral_code', '').strip()
         if honeypot:
             # Bot detected! Return fake success to not tip them off
             current_app.logger.warning(f"Bot registration blocked (honeypot): {form.email.data}")

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -346,8 +346,8 @@
                         
                         <!-- Honeypot field - invisible to humans, bots will fill it -->
                         <div style="position: absolute; left: -9999px; top: -9999px;" aria-hidden="true">
-                            <label for="website">Leave this field empty</label>
-                            <input type="text" name="website" id="website" tabindex="-1" autocomplete="off" value="">
+                            <label for="referral_code">Leave this field empty</label>
+                            <input type="text" name="referral_code" id="referral_code" tabindex="-1" autocomplete="off" value="">
                         </div>
                         
                         <!-- Organization Name -->

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -344,6 +344,12 @@
                     <form method="POST" action="{{ url_for('auth.register') }}" class="space-y-4">
                         {{ form.hidden_tag() }}
                         
+                        <!-- Honeypot field - invisible to humans, bots will fill it -->
+                        <div style="position: absolute; left: -9999px; top: -9999px;" aria-hidden="true">
+                            <label for="website">Leave this field empty</label>
+                            <input type="text" name="website" id="website" tabindex="-1" autocomplete="off" value="">
+                        </div>
+                        
                         <!-- Organization Name -->
                         <div class="input-group">
                             <input type="text" name="company_name" required


### PR DESCRIPTION
- Add invisible honeypot field to registration form (bots fill it, humans don't see it)
- Silently reject registrations where honeypot is filled
- Return fake success message to not tip off bots
- Log blocked attempts for monitoring

Reduces spam in Pending Approvals without requiring CAPTCHA.