### PR TITLE
perf: cache external dependency checks for 60s to avoid excessive API…

### DIFF
--- a/templates/health.html
+++ b/templates/health.html
@@ -675,7 +675,7 @@
         </div>
 
         <div class="footer">
-            ORIGEN TECHNOLOG // SYSTEM TELEMETRY v2.0 // POLL INTERVAL 10s // <span id="poll-count">0</span> SAMPLES
+            ORIGEN TECHNOLOG // SYSTEM TELEMETRY v2.0 // CORE METRICS 10s // EXTERNAL DEPS 60s // <span id="poll-count">0</span> SAMPLES
         </div>
     </div>
 


### PR DESCRIPTION
External services (DocuSeal, SendGrid, Google OAuth) are now only checked every 60 seconds instead of every poll. Core metrics (DB, memory, CPU) still refresh at 10s intervals.