### PR TITLE
chore: increase max-requests-jitter from 50 to 500

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120 --max-requests 10000 --max-requests-jitter 50
+web: gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120 --max-requests 10000 --max-requests-jitter 500


### PR DESCRIPTION
## Summary
- Increases `--max-requests-jitter` from 50 to 500 in the Procfile
- With `--max-requests` at 10000, a jitter of only 50 means all 4 workers could recycle within a narrow window (9950-10000), causing simultaneous restarts and latency spikes
- Jitter of 500 spreads recycling across 9500-10000 requests so workers restart at staggered intervals

## Test plan
- [ ] Deploy and verify workers start normally
- [ ] Monitor `/health` to confirm no simultaneous worker restarts


Made with [Cursor](https://cursor.com)