### PR TITLE
style: redesign platform admin pages to match main dashboard

### DIFF
--- a/templates/platform_admin/audit_log.html
+++ b/templates/platform_admin/audit_log.html
@@ -1,92 +1,243 @@
 {% extends "base.html" %}
 
+{% block head_scripts %}
+<style>
+    :root {
+        --brand-navy: #2d3e50;
+        --brand-orange: #f97316;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+        --shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    }
+
+    @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .page-fade-in {
+        animation: fadeIn 0.4s ease-out forwards;
+    }
+
+    .admin-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: var(--shadow-sm);
+    }
+
+    .admin-table thead {
+        background: linear-gradient(to bottom, #f8fafc, #f1f5f9);
+    }
+
+    .admin-table thead th {
+        color: #475569;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        border-bottom: 2px solid var(--border);
+    }
+
+    .admin-table tbody tr {
+        transition: background-color 0.15s ease;
+    }
+
+    .admin-table tbody tr:hover {
+        background-color: #fff7ed;
+    }
+
+    .icon-tile {
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-admin-secondary {
+        background: #f8fafc;
+        border: 1px solid var(--border);
+        color: #64748b;
+        font-weight: 500;
+        border-radius: 10px;
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-secondary:hover {
+        background: #fff7ed;
+        border-color: #fed7aa;
+        color: #ea580c;
+    }
+
+    /* Mobile card layout */
+    .audit-mobile-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        transition: box-shadow 0.15s ease;
+    }
+
+    .audit-mobile-card:hover {
+        box-shadow: var(--shadow);
+    }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="max-w-6xl mx-auto">
+<div class="page-fade-in max-w-6xl mx-auto p-4 md:p-6" style="background: radial-gradient(ellipse at top, rgba(45,62,80,0.03), transparent 70%);">
     <div class="mb-8">
-        <a href="{{ url_for('platform.dashboard') }}" class="text-blue-600 hover:underline text-sm">
-            ← Back to Dashboard
+        <a href="{{ url_for('platform.dashboard') }}" class="text-slate-400 hover:text-orange-500 transition-colors text-sm inline-flex items-center">
+            <i class="fas fa-arrow-left mr-1.5"></i> Back to Dashboard
         </a>
-        <h1 class="text-3xl font-bold text-gray-900 mt-2">Platform Audit Log</h1>
-        <p class="text-gray-600">All platform admin actions</p>
+        <div class="flex items-center mt-3">
+            <div class="icon-tile w-12 h-12 mr-4" style="background: linear-gradient(135deg, var(--brand-navy), #475569);">
+                <i class="fas fa-history text-white text-xl"></i>
+            </div>
+            <div>
+                <h1 class="text-3xl font-bold text-slate-800">Platform Audit Log</h1>
+                <p class="text-slate-500">All platform admin actions</p>
+            </div>
+        </div>
     </div>
-    
-    <div class="bg-white rounded-lg shadow">
+
+    <!-- Desktop Table -->
+    <div class="admin-card overflow-hidden hidden md:block">
         <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
+            <table class="admin-table min-w-full divide-y divide-slate-200">
+                <thead>
                     <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Admin</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Action</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Target Org</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Details</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Date</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Admin</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Action</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Target Org</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Details</th>
                     </tr>
                 </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
+                <tbody class="bg-white divide-y divide-slate-100">
                     {% for log in logs.items %}
                     <tr>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
                             {{ log.created_at.strftime('%b %d, %Y %I:%M %p') }}
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-700 font-medium">
                             {{ log.admin.first_name }} {{ log.admin.last_name if log.admin else 'Unknown' }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 py-1 text-xs font-medium rounded-full
+                            <span class="px-2.5 py-1 text-xs font-medium rounded-full
                                 {% if 'approved' in log.action %}bg-green-100 text-green-800
                                 {% elif 'suspended' in log.action or 'rejected' in log.action %}bg-red-100 text-red-800
                                 {% elif 'changed' in log.action %}bg-blue-100 text-blue-800
-                                {% else %}bg-gray-100 text-gray-800{% endif %}">
+                                {% else %}bg-slate-100 text-slate-600{% endif %}">
                                 {{ log.action|replace('_', ' ')|title }}
                             </span>
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm">
                             {% if log.target_org %}
-                                <a href="{{ url_for('platform.view_org', org_id=log.target_org_id) }}" class="text-blue-600 hover:underline">
+                                <a href="{{ url_for('platform.view_org', org_id=log.target_org_id) }}" class="text-blue-600 hover:text-orange-500 transition-colors">
                                     {{ log.target_org.name }}
                                 </a>
                             {% else %}
-                                <span class="text-gray-400">Deleted</span>
+                                <span class="text-slate-300">Deleted</span>
                             {% endif %}
                         </td>
-                        <td class="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                        <td class="px-6 py-4 text-sm text-slate-500 max-w-xs truncate">
                             {{ log.details if log.details else '-' }}
                         </td>
                     </tr>
                     {% else %}
                     <tr>
-                        <td colspan="5" class="px-6 py-4 text-center text-gray-500">
-                            No audit log entries yet.
+                        <td colspan="5" class="px-6 py-12 text-center text-slate-400">
+                            <i class="fas fa-history text-4xl text-slate-200 mb-3 block"></i>
+                            <p>No audit log entries yet.</p>
                         </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
         </div>
-        
+
         {% if logs.pages > 1 %}
-        <div class="px-6 py-4 border-t border-gray-200">
+        <div class="px-6 py-4 border-t border-slate-100" style="background: #fafafa; border-radius: 0 0 16px 16px;">
             <nav class="flex items-center justify-between">
                 <div>
-                    <p class="text-sm text-gray-700">
-                        Page {{ logs.page }} of {{ logs.pages }}
+                    <p class="text-sm text-slate-500">
+                        Page <span class="font-medium text-slate-700">{{ logs.page }}</span> of <span class="font-medium text-slate-700">{{ logs.pages }}</span>
                     </p>
                 </div>
-                <div class="flex space-x-2">
+                <div class="flex gap-2">
                     {% if logs.has_prev %}
-                    <a href="{{ url_for('platform.audit_log', page=logs.prev_num) }}" 
-                       class="px-3 py-1 border border-gray-300 rounded text-sm hover:bg-gray-50">
-                        Previous
+                    <a href="{{ url_for('platform.audit_log', page=logs.prev_num) }}"
+                       class="btn-admin-secondary px-4 py-1.5 text-sm inline-flex items-center">
+                        <i class="fas fa-chevron-left mr-1.5 text-xs"></i> Previous
                     </a>
                     {% endif %}
                     {% if logs.has_next %}
-                    <a href="{{ url_for('platform.audit_log', page=logs.next_num) }}" 
-                       class="px-3 py-1 border border-gray-300 rounded text-sm hover:bg-gray-50">
-                        Next
+                    <a href="{{ url_for('platform.audit_log', page=logs.next_num) }}"
+                       class="btn-admin-secondary px-4 py-1.5 text-sm inline-flex items-center">
+                        Next <i class="fas fa-chevron-right ml-1.5 text-xs"></i>
                     </a>
                     {% endif %}
                 </div>
             </nav>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Mobile Card Layout -->
+    <div class="md:hidden space-y-3">
+        {% for log in logs.items %}
+        <div class="audit-mobile-card">
+            <div class="flex items-center justify-between mb-2">
+                <span class="px-2.5 py-1 text-xs font-medium rounded-full
+                    {% if 'approved' in log.action %}bg-green-100 text-green-800
+                    {% elif 'suspended' in log.action or 'rejected' in log.action %}bg-red-100 text-red-800
+                    {% elif 'changed' in log.action %}bg-blue-100 text-blue-800
+                    {% else %}bg-slate-100 text-slate-600{% endif %}">
+                    {{ log.action|replace('_', ' ')|title }}
+                </span>
+                <span class="text-xs text-slate-400">{{ log.created_at.strftime('%b %d, %Y') }}</span>
+            </div>
+            <p class="text-sm text-slate-700 font-medium">
+                {{ log.admin.first_name }} {{ log.admin.last_name if log.admin else 'Unknown' }}
+            </p>
+            {% if log.target_org %}
+            <p class="text-sm text-slate-500 mt-1">
+                Target: <a href="{{ url_for('platform.view_org', org_id=log.target_org_id) }}" class="text-blue-600 hover:text-orange-500 transition-colors">{{ log.target_org.name }}</a>
+            </p>
+            {% endif %}
+            {% if log.details %}
+            <p class="text-xs text-slate-400 mt-1">{{ log.details }}</p>
+            {% endif %}
+        </div>
+        {% else %}
+        <div class="text-center py-12 text-slate-400">
+            <i class="fas fa-history text-4xl text-slate-200 mb-3 block"></i>
+            <p>No audit log entries yet.</p>
+        </div>
+        {% endfor %}
+
+        {% if logs.pages > 1 %}
+        <div class="flex items-center justify-between pt-4">
+            <p class="text-sm text-slate-500">
+                Page {{ logs.page }} of {{ logs.pages }}
+            </p>
+            <div class="flex gap-2">
+                {% if logs.has_prev %}
+                <a href="{{ url_for('platform.audit_log', page=logs.prev_num) }}"
+                   class="btn-admin-secondary px-3 py-1.5 text-sm">
+                    <i class="fas fa-chevron-left text-xs"></i>
+                </a>
+                {% endif %}
+                {% if logs.has_next %}
+                <a href="{{ url_for('platform.audit_log', page=logs.next_num) }}"
+                   class="btn-admin-secondary px-3 py-1.5 text-sm">
+                    <i class="fas fa-chevron-right text-xs"></i>
+                </a>
+                {% endif %}
+            </div>
         </div>
         {% endif %}
     </div>

--- a/templates/platform_admin/dashboard.html
+++ b/templates/platform_admin/dashboard.html
@@ -1,36 +1,196 @@
 {% extends "base.html" %}
 
+{% block head_scripts %}
+<style>
+    :root {
+        --brand-navy: #2d3e50;
+        --brand-navy-2: #1a2634;
+        --brand-orange: #f97316;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+        --shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    }
+
+    @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .page-fade-in {
+        animation: fadeIn 0.4s ease-out forwards;
+    }
+
+    .admin-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: var(--shadow-sm);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .admin-card:hover {
+        border-color: #cbd5e1;
+        box-shadow: var(--shadow);
+    }
+
+    .admin-table thead {
+        background: linear-gradient(to bottom, #f8fafc, #f1f5f9);
+    }
+
+    .admin-table thead th {
+        color: #475569;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        border-bottom: 2px solid var(--border);
+    }
+
+    .admin-table tbody tr {
+        transition: background-color 0.15s ease;
+    }
+
+    .admin-table tbody tr:hover {
+        background-color: #fff7ed;
+    }
+
+    .stat-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        box-shadow: var(--shadow-sm);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .stat-card:hover {
+        border-color: #cbd5e1;
+        box-shadow: var(--shadow);
+    }
+
+    .btn-admin-primary {
+        background: linear-gradient(135deg, #f97316, #ea580c);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(249, 115, 22, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-primary:hover {
+        background: linear-gradient(135deg, #ea580c, #dc2626);
+        box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
+    }
+
+    .btn-admin-secondary {
+        background: #f8fafc;
+        border: 1px solid var(--border);
+        color: #64748b;
+        font-weight: 500;
+        border-radius: 10px;
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-secondary:hover {
+        background: #fff7ed;
+        border-color: #fed7aa;
+        color: #ea580c;
+    }
+
+    .btn-admin-danger {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(239, 68, 68, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-danger:hover {
+        background: linear-gradient(135deg, #dc2626, #b91c1c);
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+    }
+
+    .btn-admin-success {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(34, 197, 94, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-success:hover {
+        background: linear-gradient(135deg, #16a34a, #15803d);
+        box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+    }
+
+    .icon-tile {
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .section-header {
+        background: #fafafa;
+        border-radius: 16px 16px 0 0;
+    }
+
+    .admin-select:focus {
+        outline: none;
+        border-color: #f97316;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+    }
+
+    .aggregate-card {
+        border-radius: 16px;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .aggregate-card:hover {
+        box-shadow: var(--shadow);
+    }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="max-w-7xl mx-auto">
+<div class="page-fade-in max-w-7xl mx-auto p-4 md:p-6" style="background: radial-gradient(ellipse at top, rgba(45,62,80,0.03), transparent 70%);">
     <!-- Header -->
-    <div class="mb-8 flex justify-between items-start">
-        <div>
-            <h1 class="text-3xl font-bold text-gray-900">Platform Admin Dashboard</h1>
-            <p class="mt-2 text-gray-600">Complete visibility across all organizations</p>
+    <div class="mb-8 flex flex-col md:flex-row md:justify-between md:items-start gap-4">
+        <div class="flex items-center">
+            <div class="icon-tile w-12 h-12 mr-4" style="background: linear-gradient(135deg, var(--brand-navy), #475569);">
+                <i class="fas fa-shield-alt text-white text-xl"></i>
+            </div>
+            <div>
+                <h1 class="text-3xl font-bold text-slate-800">Platform Admin Dashboard</h1>
+                <p class="mt-1 text-slate-500">Complete visibility across all organizations</p>
+            </div>
         </div>
-        <div class="flex space-x-3">
-            <a href="{{ url_for('platform.pending_orgs') }}" class="bg-amber-500 text-white px-4 py-2 rounded-md hover:bg-amber-600 flex items-center">
+        <div class="flex flex-wrap gap-3">
+            <a href="{{ url_for('platform.pending_orgs') }}" class="btn-admin-primary px-4 py-2 flex items-center text-sm">
                 <i class="fas fa-inbox mr-2"></i>
                 Pending
                 {% if pending_approval_orgs > 0 %}
-                <span class="ml-2 bg-white text-amber-600 rounded-full px-2 py-0.5 text-xs font-bold">{{ pending_approval_orgs }}</span>
+                <span class="ml-2 bg-white/30 rounded-full px-2 py-0.5 text-xs font-bold">{{ pending_approval_orgs }}</span>
                 {% endif %}
             </a>
-            <a href="{{ url_for('platform.audit_log') }}" class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 flex items-center">
+            <a href="{{ url_for('platform.audit_log') }}" class="btn-admin-secondary px-4 py-2 flex items-center text-sm">
                 <i class="fas fa-history mr-2"></i>Audit Log
             </a>
             <form action="{{ url_for('platform.refresh_metrics') }}" method="POST" class="inline">
-                <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 flex items-center">
+                <button type="submit" class="btn-admin-success px-4 py-2 flex items-center text-sm">
                     <i class="fas fa-sync mr-2"></i>Refresh All Metrics
                 </button>
             </form>
         </div>
     </div>
-    
+
     <!-- =========================================================================== -->
     <!-- ORIGEN REALTY (Platform Owner) Section -->
     <!-- =========================================================================== -->
-    <div class="bg-gradient-to-r from-blue-600 to-blue-800 rounded-xl shadow-lg p-6 mb-8 text-white">
+    <div class="bg-gradient-to-r from-blue-600 to-blue-800 shadow-lg p-6 mb-8 text-white" style="border-radius: 16px;">
         <div class="flex items-center justify-between mb-4">
             <div class="flex items-center">
                 <div class="bg-white/20 p-3 rounded-lg mr-4">
@@ -38,280 +198,280 @@
                 </div>
                 <div>
                     <h2 class="text-xl font-bold">{{ origen_stats.name }}</h2>
-                    <p class="text-blue-200 text-sm">Platform Owner • Enterprise Tier</p>
+                    <p class="text-blue-200 text-sm">Platform Owner &bull; Enterprise Tier</p>
                 </div>
             </div>
             <span class="bg-yellow-400 text-yellow-900 px-3 py-1 rounded-full text-xs font-bold uppercase">Platform Admin</span>
         </div>
-        <div class="grid grid-cols-3 gap-6">
-            <div class="bg-white/10 rounded-lg p-4">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 md:gap-6">
+            <div class="bg-white/10 rounded-xl p-4">
                 <p class="text-blue-200 text-sm">Users</p>
                 <p class="text-3xl font-bold">{{ origen_stats.users }}</p>
             </div>
-            <div class="bg-white/10 rounded-lg p-4">
+            <div class="bg-white/10 rounded-xl p-4">
                 <p class="text-blue-200 text-sm">Contacts</p>
                 <p class="text-3xl font-bold">{{ "{:,}".format(origen_stats.contacts) }}</p>
             </div>
-            <div class="bg-white/10 rounded-lg p-4">
+            <div class="bg-white/10 rounded-xl p-4">
                 <p class="text-blue-200 text-sm">Transactions</p>
                 <p class="text-3xl font-bold">{{ origen_stats.transactions }}</p>
             </div>
         </div>
     </div>
-    
+
     <!-- =========================================================================== -->
     <!-- CUSTOMER ORGANIZATIONS Section -->
     <!-- =========================================================================== -->
     <div class="mb-6">
-        <h2 class="text-2xl font-bold text-gray-900 mb-4">
-            <i class="fas fa-building text-gray-400 mr-2"></i>Customer Organizations
+        <h2 class="text-2xl font-bold text-slate-800 mb-4 flex items-center">
+            <i class="fas fa-building text-slate-400 mr-2"></i>Customer Organizations
         </h2>
     </div>
-    
+
     <!-- Customer Stats Cards -->
-    <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 mb-6">
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
         <!-- Status Cards -->
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-green-500">
-            <p class="text-xs font-medium text-gray-500 uppercase">Active</p>
-            <p class="text-2xl font-bold text-gray-900">{{ active_customer_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-green-500">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Active</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ active_customer_orgs }}</p>
         </div>
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-amber-500">
-            <p class="text-xs font-medium text-gray-500 uppercase">Pending</p>
-            <p class="text-2xl font-bold text-gray-900">{{ pending_approval_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-amber-500">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Pending</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ pending_approval_orgs }}</p>
         </div>
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-red-500">
-            <p class="text-xs font-medium text-gray-500 uppercase">Suspended</p>
-            <p class="text-2xl font-bold text-gray-900">{{ suspended_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-red-500">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Suspended</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ suspended_orgs }}</p>
         </div>
         <!-- Tier Cards -->
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-gray-400">
-            <p class="text-xs font-medium text-gray-500 uppercase">Free Tier</p>
-            <p class="text-2xl font-bold text-gray-900">{{ free_tier_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-slate-400">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Free Tier</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ free_tier_orgs }}</p>
         </div>
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-blue-500">
-            <p class="text-xs font-medium text-gray-500 uppercase">Pro Tier</p>
-            <p class="text-2xl font-bold text-gray-900">{{ pro_tier_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-blue-500">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Pro Tier</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ pro_tier_orgs }}</p>
         </div>
-        <div class="bg-white rounded-lg shadow p-4 border-l-4 border-purple-500">
-            <p class="text-xs font-medium text-gray-500 uppercase">Enterprise</p>
-            <p class="text-2xl font-bold text-gray-900">{{ enterprise_tier_orgs }}</p>
+        <div class="stat-card p-4 border-l-4 border-purple-500">
+            <p class="text-xs font-medium text-slate-500 uppercase tracking-wide">Enterprise</p>
+            <p class="text-2xl font-bold text-slate-800 mt-1">{{ enterprise_tier_orgs }}</p>
         </div>
     </div>
-    
+
     <!-- Customer Aggregate Metrics -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-        <div class="bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-5 border border-purple-200">
+        <div class="aggregate-card bg-gradient-to-br from-purple-50 to-purple-100 p-5 border border-purple-200" style="border-radius: 16px;">
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-sm text-purple-600 font-medium">Customer Users</p>
                     <p class="text-3xl font-bold text-purple-900">{{ customer_stats.users }}</p>
                 </div>
-                <div class="bg-purple-200 p-3 rounded-full">
-                    <i class="fas fa-users text-purple-600 text-xl"></i>
+                <div class="icon-tile w-12 h-12" style="background: linear-gradient(135deg, #c084fc, #9333ea);">
+                    <i class="fas fa-users text-white text-lg"></i>
                 </div>
             </div>
             <p class="text-xs text-purple-500 mt-2">Across {{ total_customer_orgs }} customer org{{ 's' if total_customer_orgs != 1 }}</p>
         </div>
-        <div class="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-5 border border-green-200">
+        <div class="aggregate-card bg-gradient-to-br from-green-50 to-green-100 p-5 border border-green-200" style="border-radius: 16px;">
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-sm text-green-600 font-medium">Customer Contacts</p>
                     <p class="text-3xl font-bold text-green-900">{{ "{:,}".format(customer_stats.contacts) }}</p>
                 </div>
-                <div class="bg-green-200 p-3 rounded-full">
-                    <i class="fas fa-address-book text-green-600 text-xl"></i>
+                <div class="icon-tile w-12 h-12" style="background: linear-gradient(135deg, #4ade80, #16a34a);">
+                    <i class="fas fa-address-book text-white text-lg"></i>
                 </div>
             </div>
         </div>
-        <div class="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-5 border border-blue-200">
+        <div class="aggregate-card bg-gradient-to-br from-blue-50 to-blue-100 p-5 border border-blue-200" style="border-radius: 16px;">
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-sm text-blue-600 font-medium">Customer Transactions</p>
                     <p class="text-3xl font-bold text-blue-900">{{ customer_stats.transactions }}</p>
                 </div>
-                <div class="bg-blue-200 p-3 rounded-full">
-                    <i class="fas fa-file-contract text-blue-600 text-xl"></i>
+                <div class="icon-tile w-12 h-12" style="background: linear-gradient(135deg, #60a5fa, #2563eb);">
+                    <i class="fas fa-file-contract text-white text-lg"></i>
                 </div>
             </div>
         </div>
     </div>
-    
+
     <!-- =========================================================================== -->
     <!-- PLATFORM TOTALS (Combined) -->
     <!-- =========================================================================== -->
-    <div class="bg-gray-800 rounded-xl p-6 mb-8 text-white">
+    <div class="bg-gradient-to-r from-slate-800 to-slate-900 p-6 mb-8 text-white" style="border-radius: 16px;">
         <h3 class="text-lg font-semibold mb-4 flex items-center">
-            <i class="fas fa-chart-line mr-2 text-gray-400"></i>
+            <i class="fas fa-chart-line mr-2 text-slate-400"></i>
             Platform Totals (Origen + All Customers)
         </h3>
-        <div class="grid grid-cols-4 gap-6">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
             <div>
-                <p class="text-gray-400 text-sm">Total Organizations</p>
+                <p class="text-slate-400 text-sm">Total Organizations</p>
                 <p class="text-2xl font-bold">{{ platform_stats.total_orgs }}</p>
             </div>
             <div>
-                <p class="text-gray-400 text-sm">Total Users</p>
+                <p class="text-slate-400 text-sm">Total Users</p>
                 <p class="text-2xl font-bold">{{ platform_stats.users }}</p>
             </div>
             <div>
-                <p class="text-gray-400 text-sm">Total Contacts</p>
+                <p class="text-slate-400 text-sm">Total Contacts</p>
                 <p class="text-2xl font-bold">{{ "{:,}".format(platform_stats.contacts) }}</p>
             </div>
             <div>
-                <p class="text-gray-400 text-sm">Total Transactions</p>
+                <p class="text-slate-400 text-sm">Total Transactions</p>
                 <p class="text-2xl font-bold">{{ platform_stats.transactions }}</p>
             </div>
         </div>
     </div>
-    
+
     <!-- =========================================================================== -->
     <!-- ORGANIZATION LIST with Filters -->
     <!-- =========================================================================== -->
-    <div class="bg-white rounded-lg shadow">
-        <div class="px-6 py-4 border-b border-gray-200">
+    <div class="admin-card overflow-hidden">
+        <div class="section-header px-6 py-4 border-b border-slate-200">
             <div class="flex flex-wrap items-center justify-between gap-4">
-                <h2 class="text-xl font-semibold text-gray-800">All Organizations</h2>
-                
+                <h2 class="text-xl font-semibold text-slate-800">All Organizations</h2>
+
                 <!-- Filters -->
                 <form method="GET" class="flex flex-wrap items-center gap-3">
                     <!-- Status Filter -->
-                    <select name="status" onchange="this.form.submit()" 
-                            class="text-sm border border-gray-300 rounded-md px-3 py-1.5 focus:ring-blue-500 focus:border-blue-500">
+                    <select name="status" onchange="this.form.submit()"
+                            class="admin-select text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-600">
                         <option value="all" {% if status_filter == 'all' %}selected{% endif %}>All Statuses</option>
                         <option value="active" {% if status_filter == 'active' %}selected{% endif %}>Active</option>
                         <option value="pending_approval" {% if status_filter == 'pending_approval' %}selected{% endif %}>Pending Approval</option>
                         <option value="suspended" {% if status_filter == 'suspended' %}selected{% endif %}>Suspended</option>
                         <option value="pending_deletion" {% if status_filter == 'pending_deletion' %}selected{% endif %}>Pending Deletion</option>
                     </select>
-                    
+
                     <!-- Tier Filter -->
                     <select name="tier" onchange="this.form.submit()"
-                            class="text-sm border border-gray-300 rounded-md px-3 py-1.5 focus:ring-blue-500 focus:border-blue-500">
+                            class="admin-select text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-600">
                         <option value="all" {% if tier_filter == 'all' %}selected{% endif %}>All Tiers</option>
                         <option value="free" {% if tier_filter == 'free' %}selected{% endif %}>Free</option>
                         <option value="pro" {% if tier_filter == 'pro' %}selected{% endif %}>Pro</option>
                         <option value="enterprise" {% if tier_filter == 'enterprise' %}selected{% endif %}>Enterprise</option>
                     </select>
-                    
+
                     <!-- Include Origen Toggle -->
-                    <label class="flex items-center text-sm text-gray-600 cursor-pointer">
-                        <input type="checkbox" name="include_origen" value="true" 
+                    <label class="flex items-center text-sm text-slate-500 cursor-pointer">
+                        <input type="checkbox" name="include_origen" value="true"
                                {% if include_origen %}checked{% endif %}
                                onchange="this.form.submit()"
-                               class="mr-2 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                               class="mr-2 rounded border-slate-300 text-orange-500 focus:ring-orange-400">
                         Include Origen
                     </label>
-                    
+
                     {% if status_filter != 'all' or tier_filter != 'all' or include_origen %}
-                    <a href="{{ url_for('platform.dashboard') }}" class="text-sm text-gray-500 hover:text-gray-700">
+                    <a href="{{ url_for('platform.dashboard') }}" class="text-sm text-slate-400 hover:text-orange-500 transition-colors">
                         <i class="fas fa-times mr-1"></i>Clear Filters
                     </a>
                     {% endif %}
                 </form>
             </div>
         </div>
-        
+
         <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
+            <table class="admin-table min-w-full divide-y divide-slate-200">
+                <thead>
                     <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Organization</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Admin Email</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tier</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Users</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Contacts</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Transactions</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Active</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Organization</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Admin Email</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Type</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Tier</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Users</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Contacts</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Transactions</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Last Active</th>
+                        <th class="px-6 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
+                <tbody class="bg-white divide-y divide-slate-100">
                     {% for org in orgs %}
-                    <tr class="{% if org.is_platform_admin %}bg-blue-50{% endif %} hover:bg-gray-50">
+                    <tr class="{% if org.is_platform_admin %}bg-blue-50/50{% endif %}">
                         <td class="px-6 py-4 whitespace-nowrap">
                             <div class="flex items-center">
                                 {% if org.is_platform_admin %}
                                 <i class="fas fa-crown text-yellow-500 mr-2" title="Platform Admin"></i>
                                 {% endif %}
                                 <div>
-                                    <div class="text-sm font-medium text-gray-900">{{ org.name }}</div>
-                                    <div class="text-sm text-gray-500">{{ org.slug }}</div>
+                                    <div class="text-sm font-medium text-slate-800">{{ org.name }}</div>
+                                    <div class="text-sm text-slate-400">{{ org.slug }}</div>
                                 </div>
                             </div>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             {% if org_owners.get(org.id) %}
-                            <div class="text-sm text-gray-900">{{ org_owners.get(org.id) }}</div>
+                            <div class="text-sm text-slate-700">{{ org_owners.get(org.id) }}</div>
                             {% else %}
-                            <span class="text-sm text-gray-400">No owner</span>
+                            <span class="text-sm text-slate-300">No owner</span>
                             {% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             {% if org.is_platform_admin %}
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
                                 Platform
                             </span>
                             {% else %}
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full bg-slate-100 text-slate-600">
                                 Customer
                             </span>
                             {% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full
                                 {% if org.subscription_tier == 'enterprise' %}bg-purple-100 text-purple-800
                                 {% elif org.subscription_tier == 'pro' %}bg-blue-100 text-blue-800
-                                {% else %}bg-gray-100 text-gray-800{% endif %}">
+                                {% else %}bg-slate-100 text-slate-600{% endif %}">
                                 {{ (org.subscription_tier or 'free')|capitalize }}
                             </span>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                            <span class="px-2.5 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full
                                 {% if org.status == 'active' %}bg-green-100 text-green-800
                                 {% elif org.status == 'pending_approval' %}bg-amber-100 text-amber-800
                                 {% elif org.status == 'suspended' %}bg-red-100 text-red-800
-                                {% else %}bg-gray-100 text-gray-800{% endif %}">
+                                {% else %}bg-slate-100 text-slate-600{% endif %}">
                                 {{ org.status|replace('_', ' ')|title }}
                             </span>
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
                             <span class="{% if org.user_count and org.max_users and org.user_count >= org.max_users %}text-red-600 font-semibold{% endif %}">
                                 {{ org.user_count or 0 }}
                             </span>
-                            <span class="text-gray-400">/ {{ org.max_users if org.max_users else '∞' }}</span>
+                            <span class="text-slate-300">/ {{ org.max_users if org.max_users else '∞' }}</span>
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
                             {{ "{:,}".format(org.contact_count or 0) }}
                             {% if org.max_contacts %}
-                            <span class="text-gray-400">/ {{ "{:,}".format(org.max_contacts) }}</span>
+                            <span class="text-slate-300">/ {{ "{:,}".format(org.max_contacts) }}</span>
                             {% endif %}
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
                             {{ org.transaction_count or 0 }}
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-500">
                             {% if org.last_user_login_at %}
                                 {{ org.last_user_login_at.strftime('%b %d, %Y') }}
                             {% else %}
-                                <span class="text-gray-400">Never</span>
+                                <span class="text-slate-300">Never</span>
                             {% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                            <a href="{{ url_for('platform.view_org', org_id=org.id) }}" 
-                               class="text-blue-600 hover:text-blue-900 mr-3">
+                            <a href="{{ url_for('platform.view_org', org_id=org.id) }}"
+                               class="text-blue-600 hover:text-orange-500 transition-colors mr-3">
                                 View
                             </a>
                             {% if not org.is_platform_admin %}
                             {% if org.status == 'active' %}
-                            <button onclick="confirmSuspend({{ org.id }}, '{{ org.name }}')" 
-                                    class="text-red-600 hover:text-red-900">
+                            <button onclick="confirmSuspend({{ org.id }}, '{{ org.name }}')"
+                                    class="text-red-500 hover:text-red-700 transition-colors">
                                 Suspend
                             </button>
                             {% elif org.status == 'suspended' %}
                             <form action="{{ url_for('platform.reactivate_org', org_id=org.id) }}" method="POST" class="inline">
-                                <button type="submit" class="text-green-600 hover:text-green-900">
+                                <button type="submit" class="text-green-600 hover:text-green-800 transition-colors">
                                     Reactivate
                                 </button>
                             </form>
@@ -320,11 +480,11 @@
                         </td>
                     </tr>
                     {% endfor %}
-                    
+
                     {% if not orgs %}
                     <tr>
-                        <td colspan="10" class="px-6 py-12 text-center text-gray-500">
-                            <i class="fas fa-building text-4xl text-gray-300 mb-3"></i>
+                        <td colspan="10" class="px-6 py-12 text-center text-slate-400">
+                            <i class="fas fa-building text-4xl text-slate-200 mb-3 block"></i>
                             <p>No organizations found matching your filters.</p>
                         </td>
                     </tr>
@@ -332,28 +492,33 @@
                 </tbody>
             </table>
         </div>
-        
-        <div class="px-6 py-4 border-t border-gray-200 bg-gray-50 text-sm text-gray-500">
+
+        <div class="px-6 py-4 border-t border-slate-100 text-sm text-slate-400" style="background: #fafafa; border-radius: 0 0 16px 16px;">
             Showing {{ orgs|length }} organization{{ 's' if orgs|length != 1 }}
         </div>
     </div>
 </div>
 
 <!-- Suspend Modal -->
-<div id="suspendModal" class="hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-    <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4">Suspend Organization</h3>
-        <p class="text-gray-600 mb-4">Are you sure you want to suspend <strong id="suspendOrgName"></strong>? All users will be logged out immediately.</p>
+<div id="suspendModal" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center" style="transition: opacity 0.2s ease;">
+    <div class="bg-white max-w-md w-full mx-4 p-6" style="border-radius: 16px; box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);">
+        <div class="flex items-center mb-4">
+            <div class="icon-tile w-10 h-10 mr-3" style="background: linear-gradient(135deg, #ef4444, #dc2626);">
+                <i class="fas fa-exclamation-triangle text-white"></i>
+            </div>
+            <h3 class="text-lg font-semibold text-slate-800">Suspend Organization</h3>
+        </div>
+        <p class="text-slate-500 mb-4">Are you sure you want to suspend <strong class="text-slate-700" id="suspendOrgName"></strong>? All users will be logged out immediately.</p>
         <form id="suspendForm" method="POST">
             <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Reason (optional)</label>
-                <textarea name="reason" rows="2" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"></textarea>
+                <label class="block text-sm font-medium text-slate-600 mb-1">Reason (optional)</label>
+                <textarea name="reason" rows="2" class="admin-select w-full border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-700"></textarea>
             </div>
-            <div class="flex justify-end space-x-3">
-                <button type="button" onclick="closeSuspendModal()" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">
+            <div class="flex justify-end gap-3">
+                <button type="button" onclick="closeSuspendModal()" class="btn-admin-secondary px-4 py-2 text-sm">
                     Cancel
                 </button>
-                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700">
+                <button type="submit" class="btn-admin-danger px-4 py-2 text-sm">
                     Suspend Organization
                 </button>
             </div>

--- a/templates/platform_admin/org_detail.html
+++ b/templates/platform_admin/org_detail.html
@@ -1,157 +1,360 @@
 {% extends "base.html" %}
 
+{% block head_scripts %}
+<style>
+    :root {
+        --brand-navy: #2d3e50;
+        --brand-orange: #f97316;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+        --shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    }
+
+    @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .page-fade-in {
+        animation: fadeIn 0.4s ease-out forwards;
+    }
+
+    .admin-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: var(--shadow-sm);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .admin-card:hover {
+        border-color: #cbd5e1;
+        box-shadow: var(--shadow);
+    }
+
+    .icon-tile {
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-admin-primary {
+        background: linear-gradient(135deg, #3b82f6, #2563eb);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(59, 130, 246, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-primary:hover {
+        background: linear-gradient(135deg, #2563eb, #1d4ed8);
+        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    }
+
+    .btn-admin-danger {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(239, 68, 68, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-danger:hover {
+        background: linear-gradient(135deg, #dc2626, #b91c1c);
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+    }
+
+    .btn-admin-success {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(34, 197, 94, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-success:hover {
+        background: linear-gradient(135deg, #16a34a, #15803d);
+        box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+    }
+
+    .btn-admin-warning {
+        background: linear-gradient(135deg, #f59e0b, #d97706);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(245, 158, 11, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-warning:hover {
+        background: linear-gradient(135deg, #d97706, #b45309);
+        box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
+    }
+
+    .metric-card {
+        border-radius: 12px;
+        transition: box-shadow 0.15s ease;
+    }
+
+    .metric-card:hover {
+        box-shadow: var(--shadow);
+    }
+
+    .admin-select:focus {
+        outline: none;
+        border-color: #f97316;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+    }
+
+    .timeline-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+        margin-top: 6px;
+    }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="max-w-6xl mx-auto">
+<div class="page-fade-in max-w-6xl mx-auto p-4 md:p-6" style="background: radial-gradient(ellipse at top, rgba(45,62,80,0.03), transparent 70%);">
     <!-- Header -->
-    <div class="mb-8 flex items-center justify-between">
+    <div class="mb-8 flex flex-col md:flex-row md:items-start md:justify-between gap-4">
         <div>
-            <a href="{{ url_for('platform.dashboard') }}" class="text-blue-600 hover:underline text-sm">
-                ← Back to Dashboard
+            <a href="{{ url_for('platform.dashboard') }}" class="text-slate-400 hover:text-orange-500 transition-colors text-sm inline-flex items-center">
+                <i class="fas fa-arrow-left mr-1.5"></i> Back to Dashboard
             </a>
-            <h1 class="text-3xl font-bold text-gray-900 mt-2">{{ org.name }}</h1>
-            <p class="text-gray-600">{{ org.slug }}</p>
+            <div class="flex items-center mt-3">
+                <div class="icon-tile w-12 h-12 mr-4" style="background: linear-gradient(135deg, var(--brand-navy), #475569);">
+                    <i class="fas fa-building text-white text-xl"></i>
+                </div>
+                <div>
+                    <h1 class="text-3xl font-bold text-slate-800">{{ org.name }}</h1>
+                    <p class="text-slate-400">{{ org.slug }}</p>
+                </div>
+            </div>
             {% if owner_email %}
-            <p class="text-sm text-gray-500 mt-1">
-                <i class="fas fa-user-shield text-gray-400 mr-1"></i>
-                Admin: <a href="mailto:{{ owner_email }}" class="text-blue-600 hover:underline">{{ owner_email }}</a>
+            <p class="text-sm text-slate-500 mt-2 ml-16">
+                <i class="fas fa-user-shield text-slate-400 mr-1"></i>
+                Admin: <a href="mailto:{{ owner_email }}" class="text-blue-600 hover:text-orange-500 transition-colors">{{ owner_email }}</a>
             </p>
             {% endif %}
         </div>
-        <div>
-            <span class="px-3 py-1 inline-flex text-sm font-semibold rounded-full
+        <div class="md:mt-4">
+            <span class="px-4 py-1.5 inline-flex text-sm font-semibold rounded-full
                 {% if org.status == 'active' %}bg-green-100 text-green-800
                 {% elif org.status == 'pending_approval' %}bg-amber-100 text-amber-800
                 {% elif org.status == 'suspended' %}bg-red-100 text-red-800
-                {% else %}bg-gray-100 text-gray-800{% endif %}">
+                {% else %}bg-slate-100 text-slate-600{% endif %}">
                 {{ org.status|replace('_', ' ')|title }}
             </span>
         </div>
     </div>
-    
+
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <!-- Main Info -->
         <div class="lg:col-span-2 space-y-6">
-            <!-- Metrics (from organization_metrics table only) -->
-            <div class="bg-white rounded-lg shadow p-6">
-                <h3 class="text-lg font-semibold mb-4">Usage Metrics</h3>
+            <!-- Metrics -->
+            <div class="admin-card p-6">
+                <h3 class="text-lg font-semibold text-slate-800 mb-4 flex items-center">
+                    <i class="fas fa-chart-bar text-slate-400 mr-2"></i>Usage Metrics
+                </h3>
                 {% if metrics %}
                 <div class="grid grid-cols-2 gap-4">
-                    <div class="bg-gray-50 rounded p-4">
-                        <p class="text-sm text-gray-500">Users</p>
-                        <p class="text-2xl font-semibold">{{ metrics.user_count }}</p>
+                    <div class="metric-card bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 p-4">
+                        <div class="flex items-center">
+                            <div class="icon-tile w-8 h-8 mr-3" style="background: linear-gradient(135deg, #60a5fa, #2563eb);">
+                                <i class="fas fa-users text-white text-xs"></i>
+                            </div>
+                            <div>
+                                <p class="text-xs text-blue-600 font-medium">Users</p>
+                                <p class="text-2xl font-semibold text-blue-900">{{ metrics.user_count }}</p>
+                            </div>
+                        </div>
                     </div>
-                    <div class="bg-gray-50 rounded p-4">
-                        <p class="text-sm text-gray-500">Contacts</p>
-                        <p class="text-2xl font-semibold">{{ metrics.contact_count }}</p>
+                    <div class="metric-card bg-gradient-to-br from-green-50 to-green-100 border border-green-200 p-4">
+                        <div class="flex items-center">
+                            <div class="icon-tile w-8 h-8 mr-3" style="background: linear-gradient(135deg, #4ade80, #16a34a);">
+                                <i class="fas fa-address-book text-white text-xs"></i>
+                            </div>
+                            <div>
+                                <p class="text-xs text-green-600 font-medium">Contacts</p>
+                                <p class="text-2xl font-semibold text-green-900">{{ metrics.contact_count }}</p>
+                            </div>
+                        </div>
                     </div>
-                    <div class="bg-gray-50 rounded p-4">
-                        <p class="text-sm text-gray-500">Tasks</p>
-                        <p class="text-2xl font-semibold">{{ metrics.task_count }}</p>
+                    <div class="metric-card bg-gradient-to-br from-purple-50 to-purple-100 border border-purple-200 p-4">
+                        <div class="flex items-center">
+                            <div class="icon-tile w-8 h-8 mr-3" style="background: linear-gradient(135deg, #c084fc, #9333ea);">
+                                <i class="fas fa-tasks text-white text-xs"></i>
+                            </div>
+                            <div>
+                                <p class="text-xs text-purple-600 font-medium">Tasks</p>
+                                <p class="text-2xl font-semibold text-purple-900">{{ metrics.task_count }}</p>
+                            </div>
+                        </div>
                     </div>
-                    <div class="bg-gray-50 rounded p-4">
-                        <p class="text-sm text-gray-500">Transactions</p>
-                        <p class="text-2xl font-semibold">{{ metrics.transaction_count }}</p>
+                    <div class="metric-card bg-gradient-to-br from-amber-50 to-amber-100 border border-amber-200 p-4">
+                        <div class="flex items-center">
+                            <div class="icon-tile w-8 h-8 mr-3" style="background: linear-gradient(135deg, #fbbf24, #d97706);">
+                                <i class="fas fa-file-contract text-white text-xs"></i>
+                            </div>
+                            <div>
+                                <p class="text-xs text-amber-600 font-medium">Transactions</p>
+                                <p class="text-2xl font-semibold text-amber-900">{{ metrics.transaction_count }}</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <p class="text-xs text-gray-400 mt-4">Last updated: {{ metrics.updated_at.strftime('%b %d, %Y %I:%M %p') if metrics.updated_at else 'Never' }}</p>
+                <p class="text-xs text-slate-400 mt-4">
+                    <i class="fas fa-clock mr-1"></i>Last updated: {{ metrics.updated_at.strftime('%b %d, %Y %I:%M %p') if metrics.updated_at else 'Never' }}
+                </p>
                 {% else %}
-                <p class="text-gray-500">No metrics available yet.</p>
+                <p class="text-slate-400">No metrics available yet.</p>
                 {% endif %}
             </div>
-            
+
             <!-- Audit Log -->
-            <div class="bg-white rounded-lg shadow p-6">
-                <h3 class="text-lg font-semibold mb-4">Recent Admin Actions</h3>
+            <div class="admin-card p-6">
+                <h3 class="text-lg font-semibold text-slate-800 mb-4 flex items-center">
+                    <i class="fas fa-history text-slate-400 mr-2"></i>Recent Admin Actions
+                </h3>
                 {% if audit_logs %}
                 <div class="space-y-3">
                     {% for log in audit_logs %}
-                    <div class="border-b border-gray-100 pb-2">
-                        <div class="flex items-center justify-between">
-                            <span class="text-sm font-medium text-gray-900">{{ log.action|replace('_', ' ')|title }}</span>
-                            <span class="text-xs text-gray-500">{{ log.created_at.strftime('%b %d, %Y') }}</span>
+                    <div class="flex gap-3 {% if not loop.last %}pb-3 border-b border-slate-100{% endif %}">
+                        <div class="timeline-dot mt-1.5
+                            {% if 'approved' in log.action %}bg-green-400
+                            {% elif 'suspended' in log.action or 'rejected' in log.action %}bg-red-400
+                            {% elif 'changed' in log.action %}bg-blue-400
+                            {% else %}bg-slate-300{% endif %}">
                         </div>
-                        {% if log.details %}
-                        <p class="text-xs text-gray-500">{{ log.details }}</p>
-                        {% endif %}
+                        <div class="flex-1">
+                            <div class="flex items-center justify-between">
+                                <span class="text-sm font-medium text-slate-700">{{ log.action|replace('_', ' ')|title }}</span>
+                                <span class="text-xs text-slate-400">{{ log.created_at.strftime('%b %d, %Y') }}</span>
+                            </div>
+                            {% if log.details %}
+                            <p class="text-xs text-slate-400 mt-0.5">{{ log.details }}</p>
+                            {% endif %}
+                        </div>
                     </div>
                     {% endfor %}
                 </div>
                 {% else %}
-                <p class="text-gray-500">No admin actions yet.</p>
+                <p class="text-slate-400">No admin actions yet.</p>
                 {% endif %}
             </div>
         </div>
-        
+
         <!-- Actions Sidebar -->
         <div class="space-y-6">
             <!-- Subscription -->
-            <div class="bg-white rounded-lg shadow p-6">
-                <h3 class="text-lg font-semibold mb-4">Subscription</h3>
-                <p class="text-sm text-gray-600 mb-2">
-                    Current Tier: <span class="font-semibold capitalize">{{ org.subscription_tier }}</span>
-                </p>
-                <p class="text-sm text-gray-600 mb-4">
-                    Max Users: {{ org.max_users or 'Unlimited' }}<br>
-                    Max Contacts: {{ org.max_contacts or 'Unlimited' }}<br>
-                    Can Invite: {{ 'Yes' if org.can_invite_users else 'No' }}
-                </p>
+            <div class="admin-card p-6">
+                <h3 class="text-lg font-semibold text-slate-800 mb-4 flex items-center">
+                    <i class="fas fa-tag text-slate-400 mr-2"></i>Subscription
+                </h3>
+                <div class="mb-4">
+                    <span class="inline-flex px-3 py-1.5 text-sm font-semibold rounded-full
+                        {% if org.subscription_tier == 'enterprise' %}bg-purple-100 text-purple-800
+                        {% elif org.subscription_tier == 'pro' %}bg-blue-100 text-blue-800
+                        {% else %}bg-slate-100 text-slate-600{% endif %}">
+                        {{ org.subscription_tier|capitalize }} Tier
+                    </span>
+                </div>
+                <div class="text-sm text-slate-500 space-y-1 mb-4">
+                    <p><i class="fas fa-users text-slate-300 w-5 text-center mr-1"></i> Max Users: <span class="text-slate-700 font-medium">{{ org.max_users or 'Unlimited' }}</span></p>
+                    <p><i class="fas fa-address-book text-slate-300 w-5 text-center mr-1"></i> Max Contacts: <span class="text-slate-700 font-medium">{{ org.max_contacts or 'Unlimited' }}</span></p>
+                    <p><i class="fas fa-user-plus text-slate-300 w-5 text-center mr-1"></i> Can Invite: <span class="text-slate-700 font-medium">{{ 'Yes' if org.can_invite_users else 'No' }}</span></p>
+                </div>
                 <form action="{{ url_for('platform.update_org_tier', org_id=org.id) }}" method="POST">
-                    <select name="tier" class="w-full rounded-md border-gray-300 mb-3">
+                    <select name="tier" class="admin-select w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-600 mb-3">
                         {% for tier_name in tier_defaults.keys() %}
                         <option value="{{ tier_name }}" {% if tier_name == org.subscription_tier %}selected{% endif %}>
                             {{ tier_name|capitalize }}
                         </option>
                         {% endfor %}
                     </select>
-                    <button type="submit" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700">
-                        Update Tier
+                    <button type="submit" class="btn-admin-primary w-full px-4 py-2 text-sm">
+                        <i class="fas fa-save mr-1"></i> Update Tier
                     </button>
                 </form>
             </div>
-            
+
             <!-- Status Actions -->
-            <div class="bg-white rounded-lg shadow p-6">
-                <h3 class="text-lg font-semibold mb-4">Status Actions</h3>
+            <div class="admin-card p-6">
+                <h3 class="text-lg font-semibold text-slate-800 mb-4 flex items-center">
+                    <i class="fas fa-cog text-slate-400 mr-2"></i>Status Actions
+                </h3>
                 {% if org.status == 'pending_approval' %}
                 <form action="{{ url_for('platform.approve_org', org_id=org.id) }}" method="POST" class="mb-2">
-                    <button type="submit" class="w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700">
-                        Approve Organization
+                    <button type="submit" class="btn-admin-success w-full px-4 py-2 text-sm">
+                        <i class="fas fa-check mr-1"></i> Approve Organization
                     </button>
                 </form>
                 {% elif org.status == 'active' %}
                 <form action="{{ url_for('platform.suspend_org', org_id=org.id) }}" method="POST" class="mb-2">
                     <input type="hidden" name="reason" value="Admin action">
-                    <button type="submit" class="w-full bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700">
-                        Suspend Organization
+                    <button type="submit" class="btn-admin-danger w-full px-4 py-2 text-sm">
+                        <i class="fas fa-ban mr-1"></i> Suspend Organization
                     </button>
                 </form>
                 {% elif org.status in ['suspended', 'pending_deletion'] %}
                 <form action="{{ url_for('platform.reactivate_org', org_id=org.id) }}" method="POST" class="mb-2">
-                    <button type="submit" class="w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700">
-                        Reactivate Organization
+                    <button type="submit" class="btn-admin-success w-full px-4 py-2 text-sm">
+                        <i class="fas fa-redo mr-1"></i> Reactivate Organization
                     </button>
                 </form>
                 {% endif %}
-                
-                <!-- Repair button - creates missing default data and sends approval email -->
-                <form action="{{ url_for('platform.repair_org', org_id=org.id) }}" method="POST" class="mt-4 pt-4 border-t border-gray-200">
-                    <button type="submit" class="w-full bg-amber-500 text-white px-4 py-2 rounded-md hover:bg-amber-600" 
+
+                <!-- Repair button -->
+                <form action="{{ url_for('platform.repair_org', org_id=org.id) }}" method="POST" class="mt-4 pt-4 border-t border-slate-100">
+                    <button type="submit" class="btn-admin-warning w-full px-4 py-2 text-sm"
                             onclick="return confirm('This will create any missing default data and send the approval email to the org owner. Continue?')">
-                        Repair Organization
+                        <i class="fas fa-wrench mr-1"></i> Repair Organization
                     </button>
-                    <p class="text-xs text-gray-500 mt-1">Creates missing default data and sends approval email to owner</p>
+                    <p class="text-xs text-slate-400 mt-2">Creates missing default data and sends approval email to owner</p>
                 </form>
             </div>
-            
+
             <!-- Org Info -->
-            <div class="bg-gray-50 rounded-lg p-6 text-sm">
-                <p class="text-gray-600"><strong>Created:</strong> {{ org.created_at.strftime('%B %d, %Y') }}</p>
-                {% if org.approved_at %}
-                <p class="text-gray-600 mt-1"><strong>Approved:</strong> {{ org.approved_at.strftime('%B %d, %Y') }}</p>
-                {% endif %}
-                {% if org.deletion_scheduled_at %}
-                <p class="text-red-600 mt-1"><strong>Deletion Date:</strong> {{ org.deletion_scheduled_at.strftime('%B %d, %Y') }}</p>
-                {% endif %}
+            <div class="admin-card p-6" style="background: linear-gradient(135deg, #fafafa, #f1f5f9);">
+                <h3 class="text-sm font-semibold text-slate-600 uppercase tracking-wide mb-3">Organization Info</h3>
+                <div class="space-y-3 text-sm">
+                    <div class="flex items-start gap-2">
+                        <i class="fas fa-calendar-plus text-slate-300 mt-0.5"></i>
+                        <div>
+                            <p class="text-slate-400 text-xs">Created</p>
+                            <p class="text-slate-700 font-medium">{{ org.created_at.strftime('%B %d, %Y') }}</p>
+                        </div>
+                    </div>
+                    {% if org.approved_at %}
+                    <div class="flex items-start gap-2">
+                        <i class="fas fa-check-circle text-green-400 mt-0.5"></i>
+                        <div>
+                            <p class="text-slate-400 text-xs">Approved</p>
+                            <p class="text-slate-700 font-medium">{{ org.approved_at.strftime('%B %d, %Y') }}</p>
+                        </div>
+                    </div>
+                    {% endif %}
+                    {% if org.deletion_scheduled_at %}
+                    <div class="flex items-start gap-2">
+                        <i class="fas fa-trash-alt text-red-400 mt-0.5"></i>
+                        <div>
+                            <p class="text-red-400 text-xs">Deletion Scheduled</p>
+                            <p class="text-red-600 font-medium">{{ org.deletion_scheduled_at.strftime('%B %d, %Y') }}</p>
+                        </div>
+                    </div>
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/platform_admin/pending.html
+++ b/templates/platform_admin/pending.html
@@ -1,37 +1,155 @@
 {% extends "base.html" %}
 
+{% block head_scripts %}
+<style>
+    :root {
+        --brand-navy: #2d3e50;
+        --brand-orange: #f97316;
+        --bg: #f8fafc;
+        --panel: #ffffff;
+        --text: #0f172a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+        --shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    }
+
+    @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .page-fade-in {
+        animation: fadeIn 0.4s ease-out forwards;
+    }
+
+    .admin-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: var(--shadow-sm);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .admin-card:hover {
+        border-color: #cbd5e1;
+        box-shadow: var(--shadow);
+    }
+
+    .icon-tile {
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-admin-approve {
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(34, 197, 94, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-approve:hover {
+        background: linear-gradient(135deg, #16a34a, #15803d);
+        box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+    }
+
+    .btn-admin-danger {
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: #fff;
+        font-weight: 600;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(239, 68, 68, 0.2);
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-danger:hover {
+        background: linear-gradient(135deg, #dc2626, #b91c1c);
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+    }
+
+    .btn-admin-secondary {
+        background: #f8fafc;
+        border: 1px solid var(--border);
+        color: #64748b;
+        font-weight: 500;
+        border-radius: 10px;
+        transition: all 0.2s ease;
+    }
+
+    .btn-admin-secondary:hover {
+        background: #fff7ed;
+        border-color: #fed7aa;
+        color: #ea580c;
+    }
+
+    .admin-select:focus {
+        outline: none;
+        border-color: #f97316;
+        box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
+    }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="max-w-6xl mx-auto">
+<div class="page-fade-in max-w-6xl mx-auto p-4 md:p-6" style="background: radial-gradient(ellipse at top, rgba(45,62,80,0.03), transparent 70%);">
     <div class="mb-8">
-        <h1 class="text-3xl font-bold text-gray-900">Pending Approvals</h1>
-        <p class="mt-2 text-gray-600">Review and approve new organization registrations</p>
+        <a href="{{ url_for('platform.dashboard') }}" class="text-slate-400 hover:text-orange-500 transition-colors text-sm inline-flex items-center">
+            <i class="fas fa-arrow-left mr-1.5"></i> Back to Dashboard
+        </a>
+        <div class="flex items-center mt-3">
+            <div class="icon-tile w-12 h-12 mr-4" style="background: linear-gradient(135deg, var(--brand-orange), #ea580c);">
+                <i class="fas fa-inbox text-white text-xl"></i>
+            </div>
+            <div>
+                <h1 class="text-3xl font-bold text-slate-800">Pending Approvals</h1>
+                <p class="text-slate-500">Review and approve new organization registrations</p>
+            </div>
+            {% if orgs %}
+            <span class="ml-3 bg-amber-100 text-amber-700 px-3 py-1 rounded-full text-sm font-semibold">{{ orgs|length }}</span>
+            {% endif %}
+        </div>
     </div>
-    
+
     {% if orgs %}
     <div class="space-y-4">
         {% for org in orgs %}
-        <div class="bg-white rounded-lg shadow p-6">
-            <div class="flex items-start justify-between">
-                <div>
-                    <h3 class="text-lg font-semibold text-gray-900">{{ org.name }}</h3>
-                    <p class="text-sm text-gray-500">{{ org.slug }}</p>
-                    <p class="text-sm text-gray-500 mt-1">
-                        Registered: {{ org.created_at.strftime('%B %d, %Y at %I:%M %p') }}
-                    </p>
-                    {% if org.id in org_owners %}
-                    <p class="text-sm text-gray-600 mt-2">
-                        <i class="fas fa-envelope mr-1"></i>{{ org_owners[org.id] }}
-                    </p>
-                    {% endif %}
+        <div class="admin-card p-6">
+            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                <div class="flex-1">
+                    <div class="flex items-center gap-3">
+                        <div class="icon-tile w-10 h-10 flex-shrink-0" style="background: linear-gradient(135deg, var(--brand-navy), #475569);">
+                            <i class="fas fa-building text-white"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-800">{{ org.name }}</h3>
+                            <p class="text-sm text-slate-400">{{ org.slug }}</p>
+                        </div>
+                    </div>
+                    <div class="mt-3 ml-13 space-y-1">
+                        <p class="text-sm text-slate-500 flex items-center">
+                            <i class="fas fa-calendar text-slate-300 w-5 text-center mr-2"></i>
+                            Registered: {{ org.created_at.strftime('%B %d, %Y at %I:%M %p') }}
+                        </p>
+                        {% if org.id in org_owners %}
+                        <p class="text-sm text-slate-500 flex items-center">
+                            <i class="fas fa-envelope text-slate-300 w-5 text-center mr-2"></i>
+                            {{ org_owners[org.id] }}
+                        </p>
+                        {% endif %}
+                    </div>
                 </div>
-                <div class="flex space-x-3">
+                <div class="flex gap-3 md:flex-shrink-0">
                     <form action="{{ url_for('platform.approve_org', org_id=org.id) }}" method="POST">
-                        <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700">
+                        <button type="submit" class="btn-admin-approve px-5 py-2.5 text-sm inline-flex items-center">
                             <i class="fas fa-check mr-2"></i>Approve
                         </button>
                     </form>
-                    <button onclick="showRejectModal({{ org.id }}, '{{ org.name }}')" 
-                            class="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700">
+                    <button onclick="showRejectModal({{ org.id }}, '{{ org.name }}')"
+                            class="btn-admin-danger px-5 py-2.5 text-sm inline-flex items-center">
                         <i class="fas fa-times mr-2"></i>Reject
                     </button>
                 </div>
@@ -40,31 +158,37 @@
         {% endfor %}
     </div>
     {% else %}
-    <div class="bg-white rounded-lg shadow p-8 text-center">
-        <div class="text-gray-400 mb-4">
-            <i class="fas fa-check-circle text-6xl"></i>
+    <div class="admin-card p-12 text-center">
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-2xl mb-4" style="background: linear-gradient(135deg, #dcfce7, #bbf7d0);">
+            <i class="fas fa-check-circle text-4xl text-green-500"></i>
         </div>
-        <p class="text-gray-600">No pending approvals</p>
-        <a href="{{ url_for('platform.dashboard') }}" class="mt-4 inline-block text-blue-600 hover:underline">
-            ← Back to Dashboard
+        <h3 class="text-lg font-semibold text-slate-700 mb-1">All Caught Up</h3>
+        <p class="text-slate-400 mb-4">No pending approvals at this time</p>
+        <a href="{{ url_for('platform.dashboard') }}" class="btn-admin-secondary inline-flex items-center px-4 py-2 text-sm">
+            <i class="fas fa-arrow-left mr-2"></i> Back to Dashboard
         </a>
     </div>
     {% endif %}
 </div>
 
 <!-- Reject Modal -->
-<div id="rejectModal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center">
-    <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-        <h3 class="text-lg font-medium mb-4">Reject Organization</h3>
-        <p class="text-sm text-gray-600 mb-4">Are you sure you want to reject <strong id="rejectOrgName"></strong>?</p>
+<div id="rejectModal" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div class="bg-white max-w-md w-full mx-4 p-6" style="border-radius: 16px; box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);">
+        <div class="flex items-center mb-4">
+            <div class="icon-tile w-10 h-10 mr-3" style="background: linear-gradient(135deg, #ef4444, #dc2626);">
+                <i class="fas fa-exclamation-triangle text-white"></i>
+            </div>
+            <h3 class="text-lg font-semibold text-slate-800">Reject Organization</h3>
+        </div>
+        <p class="text-sm text-slate-500 mb-4">Are you sure you want to reject <strong class="text-slate-700" id="rejectOrgName"></strong>?</p>
         <form id="rejectForm" method="POST">
             <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700">Reason (optional)</label>
-                <textarea name="reason" rows="3" class="mt-1 block w-full rounded-md border-gray-300"></textarea>
+                <label class="block text-sm font-medium text-slate-600 mb-1">Reason (optional)</label>
+                <textarea name="reason" rows="3" class="admin-select w-full border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-700"></textarea>
             </div>
-            <div class="flex justify-end space-x-3">
-                <button type="button" onclick="hideRejectModal()" class="px-4 py-2 border border-gray-300 rounded-md">Cancel</button>
-                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700">Reject</button>
+            <div class="flex justify-end gap-3">
+                <button type="button" onclick="hideRejectModal()" class="btn-admin-secondary px-4 py-2 text-sm">Cancel</button>
+                <button type="submit" class="btn-admin-danger px-4 py-2 text-sm">Reject</button>
             </div>
         </form>
     </div>
@@ -79,5 +203,8 @@ function showRejectModal(orgId, orgName) {
 function hideRejectModal() {
     document.getElementById('rejectModal').classList.add('hidden');
 }
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') hideRejectModal();
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Redesigned all 4 platform admin templates (dashboard, org detail, audit log, pending approvals) to match the polished design system used by the main dashboard
- Added consistent CSS variables, page fade-in animations, gradient icon tiles, admin-card/admin-table classes, gradient buttons, and `text-slate-*` palette across all pages
- Improved mobile responsiveness with stacking headers, responsive grids, and a mobile card layout for the audit log table
- Upgraded modals (suspend/reject) with backdrop-blur, 16px radius, and icon tiles

## Test plan
- [ ] Navigate to `/platform/dashboard` — verify fade-in animation, gradient background, card hover effects, stat cards, table styling, responsive layout at mobile widths
- [ ] Click into an org — verify org detail page with gradient metric cards, timeline audit log, styled buttons, org info card
- [ ] Visit `/platform/audit-log` — verify table styling on desktop, card layout on mobile, pagination buttons
- [ ] Visit `/platform/pending` — verify org cards, approve/reject buttons, empty state, reject modal
- [ ] Test suspend modal on dashboard opens/closes correctly (click + Escape key)
- [ ] Test reject modal on pending page opens/closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)