### PR TITLE
fix: add honeypot spam protection to contact us form

### DIFF
--- a/routes/contact_us.py
+++ b/routes/contact_us.py
@@ -13,6 +13,16 @@ def contact_us():
     try:
         data = request.get_json()
         
+        # Honeypot check - bots fill this hidden field, humans don't see it
+        honeypot = data.get('company_name', '').strip()
+        if honeypot:
+            # Bot detected! Return fake success to not tip them off
+            current_app.logger.warning(f"Bot contact form blocked (honeypot): {data.get('email', 'unknown')}")
+            return jsonify({
+                'success': True,
+                'message': 'Message sent successfully! We\'ll get back to you soon.'
+            }), 200
+        
         subject = data.get('subject', '').strip()
         message = data.get('message', '').strip()
         user_email = data.get('email', '').strip()

--- a/templates/modals/contact_us_modal.html
+++ b/templates/modals/contact_us_modal.html
@@ -20,6 +20,12 @@
             
             <!-- Form -->
             <form id="contactUsForm" class="px-8 py-6">
+                <!-- Honeypot field - invisible to humans, bots will fill it -->
+                <div style="position: absolute; left: -9999px; top: -9999px;" aria-hidden="true">
+                    <label for="contactCompanyName">Leave this field empty</label>
+                    <input type="text" name="company_name" id="contactCompanyName" tabindex="-1" autocomplete="off" value="">
+                </div>
+                
                 <!-- Subject Field -->
                 <div class="mb-5">
                     <label for="contactSubject" class="block text-sm font-semibold text-brand-700 mb-2">
@@ -180,7 +186,8 @@ document.getElementById('contactUsForm')?.addEventListener('submit', async funct
     const data = {
         subject: formData.get('subject'),
         message: formData.get('message'),
-        email: formData.get('email')
+        email: formData.get('email'),
+        company_name: formData.get('company_name')
     };
     
     try {


### PR DESCRIPTION
## Summary
- Adds a hidden honeypot field (`company_name`) to the Contact Us modal to block bot spam submissions
- Server-side check returns a fake success response so bots don't know they were caught, and logs blocked attempts for monitoring
- Matches the same pattern already used on the registration form (`referral_code` honeypot)

## Test plan
- [ ] Open the landing page and submit a real Contact Us message — should work normally
- [ ] Verify the honeypot field is not visible in the modal
- [ ] Simulate a bot by manually adding a value to the `company_name` field — should return fake success without sending an email

Made with [Cursor](https://cursor.com)