### PR TITLE
Codebase security scan

### DIFF
--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -173,9 +173,7 @@ def create_task():
 @tasks_bp.route('/tasks/<int:task_id>/edit', methods=['POST'])
 @login_required
 def edit_task(task_id):
-    task = db.session.get(Task, task_id)
-    if not task:
-        abort(404)
+    task = Task.query.filter_by(id=task_id, organization_id=current_user.organization_id).first_or_404()
 
     try:
         user_tz = get_user_timezone()
@@ -209,7 +207,7 @@ def edit_task(task_id):
         if new_type_id:
             task.type_id = int(new_type_id)
             if new_subtype_id:
-                subtype = db.session.get(TaskSubtype, int(new_subtype_id))
+                subtype = TaskSubtype.query.filter_by(id=int(new_subtype_id), organization_id=current_user.organization_id).first()
                 if subtype and str(subtype.task_type_id) == new_type_id:
                     task.subtype_id = int(new_subtype_id)
 
@@ -235,9 +233,7 @@ def edit_task(task_id):
 @tasks_bp.route('/tasks/<int:task_id>/delete', methods=['POST'])
 @login_required
 def delete_task(task_id):
-    task = db.session.get(Task, task_id)
-    if not task:
-        abort(404)
+    task = Task.query.filter_by(id=task_id, organization_id=current_user.organization_id).first_or_404()
 
     if not current_user.role == 'admin' and task.assigned_to_id != current_user.id:
         abort(403)
@@ -261,7 +257,7 @@ def delete_task(task_id):
 @tasks_bp.route('/tasks/types/<int:type_id>/subtypes')
 @login_required
 def get_task_subtypes(type_id):
-    subtypes = TaskSubtype.query.filter_by(task_type_id=type_id).all()
+    subtypes = TaskSubtype.query.filter_by(task_type_id=type_id, organization_id=current_user.organization_id).all()
     return jsonify([{
         'id': subtype.id,
         'name': subtype.name
@@ -330,9 +326,7 @@ def view_task(task_id):
 @tasks_bp.route('/tasks/<int:task_id>/quick-update', methods=['POST'])
 @login_required
 def quick_update_task(task_id):
-    task = db.session.get(Task, task_id)
-    if not task:
-        abort(404)
+    task = Task.query.filter_by(id=task_id, organization_id=current_user.organization_id).first_or_404()
     
     if not current_user.role == 'admin' and task.assigned_to_id != current_user.id:
         abort(403)

--- a/routes/transactions/api.py
+++ b/routes/transactions/api.py
@@ -53,7 +53,7 @@ def search_contacts():
 @transactions_required
 def get_signers(id):
     """Get list of signers for a transaction document."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'signers': [], 'error': 'Unauthorized'}), 403
@@ -88,7 +88,7 @@ def get_signers(id):
 @transactions_required
 def update_status(id):
     """Update transaction status via AJAX."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -120,7 +120,7 @@ def update_status(id):
 @transactions_required
 def update_lockbox_combo(id):
     """Update the lockbox combo for a seller transaction."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -172,7 +172,7 @@ def fetch_rentcast_data(id):
     """
     from services.rentcast_service import fetch_property_data
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     # Authorization check
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
@@ -252,7 +252,7 @@ def get_rentcast_data(id):
     Get cached RentCast data for a transaction (if available).
     Does not trigger a new API fetch - use POST for that.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     # Authorization check
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':

--- a/routes/transactions/documents.py
+++ b/routes/transactions/documents.py
@@ -21,7 +21,7 @@ from .helpers import build_prefill_data
 @transactions_required
 def add_document(id):
     """Add a document to a transaction."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -113,15 +113,12 @@ def add_document(id):
 @transactions_required
 def remove_document(id, doc_id):
     """Remove a document from a transaction."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
 
-    doc = TransactionDocument.query.get_or_404(doc_id)
-
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
 
     try:
         # Log audit event before deletion
@@ -144,15 +141,12 @@ def document_form(id, doc_id):
         DocumentLoader, DocumentType, FieldResolver, RoleBuilder, DocuSealClient
     )
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        abort(404)
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Get document definition from new system
     definition = DocumentLoader.get(doc.template_slug)
@@ -307,15 +301,12 @@ def document_form(id, doc_id):
 @transactions_required
 def save_document_form(id, doc_id):
     """Save the document form data."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        abort(404)
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     try:
         # Get form data
@@ -381,7 +372,7 @@ def fill_all_documents(id):
         DocumentLoader, DocumentType, FieldResolver, RoleBuilder, DocuSealClient
     )
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -544,7 +535,7 @@ def save_all_documents(id):
     """
     from services.documents import DocumentLoader
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -611,15 +602,12 @@ def upload_scanned_document(id, doc_id):
     from datetime import datetime
     from services.supabase_storage import upload_scanned_document as upload_scan
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Document must be filled/generated to upload a scan
     if doc.status not in ['filled', 'generated']:
@@ -720,15 +708,12 @@ def upload_static_document(id, doc_id):
     from datetime import datetime
     from services.supabase_storage import upload_external_document as upload_static
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Document must be a placeholder in pending status
     if not doc.is_placeholder:
@@ -834,15 +819,12 @@ def upload_placeholder_for_signature(id, doc_id):
     from datetime import datetime
     from services.supabase_storage import upload_external_document as upload_external
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Document must be a placeholder in pending status
     if not doc.is_placeholder:
@@ -954,7 +936,7 @@ def upload_external_document(id):
     from datetime import datetime
     from services.supabase_storage import upload_external_document as upload_external
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -1072,7 +1054,7 @@ def upload_completed_document(id):
     from datetime import datetime
     from services.supabase_storage import upload_external_document as upload_storage
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -1179,17 +1161,13 @@ def document_field_editor(id, doc_id):
     
     Used for external documents and hybrid wet+esign flows.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         flash('Unauthorized access.', 'error')
         return redirect(url_for('transactions.view_transaction', id=id))
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        flash('Document not found.', 'error')
-        return redirect(url_for('transactions.view_transaction', id=id))
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Get participants for the signer dropdown
     participants = transaction.participants.all()
@@ -1223,15 +1201,12 @@ def save_field_placements(id, doc_id):
     
     Called from the visual field editor when the user saves their work.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     try:
         data = request.get_json()
@@ -1279,15 +1254,12 @@ def send_adhoc_document(id, doc_id):
     from services.documents.docuseal_client import DocuSealClient
     from services.documents.types import Submitter
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Extract field placements data
     # Handle both old format (list) and new format (dict with fields, page_dimensions, render_scale)
@@ -1513,15 +1485,12 @@ def convert_to_hybrid(id, doc_id):
     This allows a document that was printed, wet-signed by one party, and scanned
     to be sent for e-signature to remaining parties.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Document must be wet-signed with a stored file
     if doc.signing_method != 'physical':

--- a/routes/transactions/download.py
+++ b/routes/transactions/download.py
@@ -27,15 +27,12 @@ def download_signed_document(id, doc_id):
     from services.docuseal_service import get_signed_document_urls, DOCUSEAL_MOCK_MODE
     from services.supabase_storage import get_transaction_document_url
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if doc.status != 'signed':
         return jsonify({
@@ -83,15 +80,12 @@ def view_stored_signed_document(id, doc_id):
     """
     from services.supabase_storage import get_transaction_document_url, format_file_size
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if not doc.signed_file_path:
         return jsonify({
@@ -127,15 +121,12 @@ def view_static_document(id, doc_id):
     """
     from services.supabase_storage import get_transaction_document_url, format_file_size
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if not doc.source_file_path:
         return jsonify({
@@ -176,7 +167,7 @@ def get_all_documents_print_pdf(id):
     )
     from services.documents.types import Submitter
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -421,15 +412,12 @@ def get_document_print_pdf(id, doc_id):
     """
     from services.documents.docuseal_client import DocuSealClient
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Check if document has been filled
     if doc.status == 'pending':

--- a/routes/transactions/history.py
+++ b/routes/transactions/history.py
@@ -23,7 +23,7 @@ def transaction_history(id):
     Get the audit history for a transaction.
     Returns a paginated list of all events related to this transaction.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -65,7 +65,7 @@ def view_transaction_history(id):
     """
     Render the transaction history page.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -83,15 +83,12 @@ def document_history(id, doc_id):
     """
     Get the audit history for a specific document.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
 
-    doc = TransactionDocument.query.get_or_404(doc_id)
-
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
 
     # Get events for this document
     events = audit_service.get_document_history(document_id=doc_id)

--- a/routes/transactions/intake.py
+++ b/routes/transactions/intake.py
@@ -22,7 +22,7 @@ def intake_questionnaire(id):
     """Show the intake questionnaire for a transaction."""
     from services.intake_service import get_intake_schema
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -52,7 +52,7 @@ def save_intake(id):
     """Save intake questionnaire answers."""
     from services.intake_service import get_intake_schema, validate_intake_data
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -119,7 +119,7 @@ def preview_document_changes(id):
     """
     from services.intake_service import get_intake_schema, evaluate_document_rules, validate_intake_data
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
@@ -308,7 +308,7 @@ def generate_document_package(id):
     from services.intake_service import get_intake_schema, evaluate_document_rules, validate_intake_data
     from services.documents import DocumentLoader, FieldResolver
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)

--- a/routes/transactions/participants.py
+++ b/routes/transactions/participants.py
@@ -20,7 +20,7 @@ from .decorators import transactions_required
 @transactions_required
 def add_participant(id):
     """Add a participant to a transaction."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -91,15 +91,14 @@ def add_participant(id):
 @transactions_required
 def remove_participant(id, participant_id):
     """Remove a participant from a transaction."""
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
 
-    participant = TransactionParticipant.query.get_or_404(participant_id)
-
-    if participant.transaction_id != transaction.id:
-        abort(404)
+    participant = TransactionParticipant.query.filter_by(
+        id=participant_id, transaction_id=transaction.id
+    ).first_or_404()
 
     try:
         # Log audit event before deletion

--- a/routes/transactions/signing.py
+++ b/routes/transactions/signing.py
@@ -29,7 +29,7 @@ def preview_all_documents(id):
         DocumentLoader, FieldResolver, RoleBuilder, DocuSealClient
     )
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -272,7 +272,7 @@ def send_all_for_signature(id):
     from services.documents.types import Submitter
     from services.documents.exceptions import DocuSealAPIError
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
@@ -692,15 +692,12 @@ def document_preview(id, doc_id):
         DocumentLoader, DocumentType, FieldResolver, RoleBuilder, DocuSealClient
     )
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        abort(404)
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Document must be filled to preview
     if doc.status not in ['filled', 'generated', 'draft']:
@@ -780,15 +777,12 @@ def send_for_signature(id, doc_id):
         DocumentLoader, FieldResolver, RoleBuilder, DocuSealClient
     )
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     # Check document is ready to send (must be filled or generated/previewed)
     if doc.status not in ['filled', 'generated']:
@@ -899,15 +893,12 @@ def check_signature_status(id, doc_id):
     """Check the signature status of a document."""
     from services.docuseal_service import get_submission, DOCUSEAL_MOCK_MODE
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if not doc.docuseal_submission_id:
         return jsonify({
@@ -959,15 +950,12 @@ def void_document(id, doc_id):
     Void a sent document and reset it to 'filled' status so it can be re-sent.
     This clears the DocuSeal submission and allows the agent to preview/send again.
     """
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if doc.status not in ['sent', 'generated']:
         return jsonify({
@@ -1011,15 +999,12 @@ def resend_signature_request(id, doc_id):
     """
     from services.docuseal_service import resend_signature_emails, DOCUSEAL_MOCK_MODE
 
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
 
-    doc = TransactionDocument.query.get_or_404(doc_id)
-
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
 
     if doc.status != 'sent':
         return jsonify({
@@ -1075,15 +1060,12 @@ def simulate_signature(id, doc_id):
             'error': 'Simulation only available in mock mode'
         }), 400
     
-    transaction = Transaction.query.get_or_404(id)
+    transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    doc = TransactionDocument.query.get_or_404(doc_id)
-    
-    if doc.transaction_id != transaction.id:
-        return jsonify({'success': False, 'error': 'Document not found'}), 404
+    doc = TransactionDocument.query.filter_by(id=doc_id, transaction_id=transaction.id).first_or_404()
     
     if not doc.docuseal_submission_id:
         return jsonify({

--- a/tests/test_idor_protection.py
+++ b/tests/test_idor_protection.py
@@ -1,0 +1,376 @@
+"""
+IDOR Protection Tests
+
+Verifies that organization_id filtering is enforced on all transaction
+and task routes. Creates two separate organizations with users and data,
+then verifies that user A cannot access user B's data.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from app import create_app
+from models import (
+    db, User, Organization, Transaction, TransactionType,
+    TransactionDocument, Task, TaskType, TaskSubtype, Contact, ContactGroup
+)
+
+os.environ['DATABASE_URL'] = 'sqlite:////tmp/test_idor.db'
+
+
+@pytest.fixture(scope='module')
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test_idor.db'
+    app.config['SERVER_NAME'] = 'localhost'
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+    if os.path.exists('/tmp/test_idor.db'):
+        os.remove('/tmp/test_idor.db')
+
+
+@pytest.fixture(scope='module')
+def seed_data(app):
+    """Create two orgs with users, contacts, tasks, and transactions."""
+    with app.app_context():
+        # Org A
+        org_a = Organization(name='Org A', slug='org-a', subscription_tier='pro', status='active', max_users=5, max_contacts=1000)
+        db.session.add(org_a)
+        db.session.flush()
+
+        user_a = User(
+            organization_id=org_a.id, username='user_a', email='a@test.com',
+            first_name='Alice', last_name='Anderson', role='admin', org_role='owner'
+        )
+        user_a.set_password('password123')
+        db.session.add(user_a)
+        db.session.flush()
+
+        # Org B
+        org_b = Organization(name='Org B', slug='org-b', subscription_tier='pro', status='active', max_users=5, max_contacts=1000)
+        db.session.add(org_b)
+        db.session.flush()
+
+        user_b = User(
+            organization_id=org_b.id, username='user_b', email='b@test.com',
+            first_name='Bob', last_name='Builder', role='admin', org_role='owner'
+        )
+        user_b.set_password('password123')
+        db.session.add(user_b)
+        db.session.flush()
+
+        # Contact groups for both orgs
+        group_a = ContactGroup(name='Default', organization_id=org_a.id, category='general', sort_order=0)
+        group_b = ContactGroup(name='Default', organization_id=org_b.id, category='general', sort_order=0)
+        db.session.add_all([group_a, group_b])
+        db.session.flush()
+
+        # Contacts
+        contact_a = Contact(
+            organization_id=org_a.id, user_id=user_a.id,
+            first_name='Alice Contact', last_name='Smith', email='ac@test.com'
+        )
+        contact_b = Contact(
+            organization_id=org_b.id, user_id=user_b.id,
+            first_name='Bob Contact', last_name='Jones', email='bc@test.com'
+        )
+        db.session.add_all([contact_a, contact_b])
+        db.session.flush()
+
+        # Transaction types
+        tx_type_a = TransactionType(name='seller', display_name='Seller', organization_id=org_a.id)
+        tx_type_b = TransactionType(name='seller', display_name='Seller', organization_id=org_b.id)
+        db.session.add_all([tx_type_a, tx_type_b])
+        db.session.flush()
+
+        # Transactions
+        tx_a = Transaction(
+            organization_id=org_a.id, created_by_id=user_a.id,
+            transaction_type_id=tx_type_a.id, street_address='123 Org A St',
+            city='Austin', state='TX', status='active'
+        )
+        tx_b = Transaction(
+            organization_id=org_b.id, created_by_id=user_b.id,
+            transaction_type_id=tx_type_b.id, street_address='456 Org B St',
+            city='Dallas', state='TX', status='active'
+        )
+        db.session.add_all([tx_a, tx_b])
+        db.session.flush()
+
+        # Transaction documents
+        doc_a = TransactionDocument(
+            organization_id=org_a.id, transaction_id=tx_a.id,
+            template_slug='listing-agreement', template_name='Listing Agreement',
+            status='pending'
+        )
+        doc_b = TransactionDocument(
+            organization_id=org_b.id, transaction_id=tx_b.id,
+            template_slug='listing-agreement', template_name='Listing Agreement',
+            status='pending'
+        )
+        db.session.add_all([doc_a, doc_b])
+        db.session.flush()
+
+        # Task types
+        task_type_a = TaskType(name='Call', organization_id=org_a.id, sort_order=0)
+        task_type_b = TaskType(name='Call', organization_id=org_b.id, sort_order=0)
+        db.session.add_all([task_type_a, task_type_b])
+        db.session.flush()
+
+        # Task subtypes
+        subtype_a = TaskSubtype(name='Follow Up', task_type_id=task_type_a.id, organization_id=org_a.id, sort_order=0)
+        subtype_b = TaskSubtype(name='Follow Up', task_type_id=task_type_b.id, organization_id=org_b.id, sort_order=0)
+        db.session.add_all([subtype_a, subtype_b])
+        db.session.flush()
+
+        # Tasks
+        task_a = Task(
+            organization_id=org_a.id, contact_id=contact_a.id,
+            assigned_to_id=user_a.id, created_by_id=user_a.id,
+            type_id=task_type_a.id, subtype_id=subtype_a.id,
+            subject='Task A', priority='medium', status='pending',
+            due_date=db.func.now()
+        )
+        task_b = Task(
+            organization_id=org_b.id, contact_id=contact_b.id,
+            assigned_to_id=user_b.id, created_by_id=user_b.id,
+            type_id=task_type_b.id, subtype_id=subtype_b.id,
+            subject='Task B', priority='medium', status='pending',
+            due_date=db.func.now()
+        )
+        db.session.add_all([task_a, task_b])
+        db.session.commit()
+
+        return {
+            'org_a': org_a.id, 'org_b': org_b.id,
+            'user_a': user_a.id, 'user_b': user_b.id,
+            'tx_a': tx_a.id, 'tx_b': tx_b.id,
+            'doc_a': doc_a.id, 'doc_b': doc_b.id,
+            'task_a': task_a.id, 'task_b': task_b.id,
+            'subtype_a': subtype_a.id, 'subtype_b': subtype_b.id,
+            'task_type_a': task_type_a.id, 'task_type_b': task_type_b.id,
+        }
+
+
+def login(client, username, password='password123'):
+    client.get('/logout')
+    return client.post('/login', data={
+        'username': username,
+        'password': password,
+    }, follow_redirects=True)
+
+
+class TestTransactionIDOR:
+    """Verify user A cannot access user B's transactions."""
+
+    def test_user_a_can_access_own_transaction(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_a']}")
+            assert resp.status_code == 200, f"User A should access own tx, got {resp.status_code}"
+
+    def test_user_a_cannot_access_org_b_transaction(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}")
+            assert resp.status_code == 404, f"User A should NOT access Org B tx, got {resp.status_code}"
+
+    def test_user_b_cannot_access_org_a_transaction(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_b')
+            resp = client.get(f"/transactions/{seed_data['tx_a']}")
+            assert resp.status_code == 404, f"User B should NOT access Org A tx, got {resp.status_code}"
+
+
+class TestTransactionDocumentIDOR:
+    """Verify user A cannot access user B's transaction documents."""
+
+    def test_user_a_can_access_own_doc_form(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_a']}/documents/{seed_data['doc_a']}/form")
+            assert resp.status_code == 200, f"User A should access own doc form, got {resp.status_code}"
+
+    def test_user_a_cannot_access_org_b_doc_form(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/documents/{seed_data['doc_b']}/form")
+            assert resp.status_code == 404, f"User A should NOT access Org B doc, got {resp.status_code}"
+
+    def test_cross_org_doc_on_own_tx_url(self, app, seed_data):
+        """Try accessing Org B's doc ID using Org A's transaction ID."""
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_a']}/documents/{seed_data['doc_b']}/form")
+            assert resp.status_code == 404, f"Cross-org doc access should fail, got {resp.status_code}"
+
+
+class TestTransactionAPIIDOR:
+    """Verify API endpoints enforce org filtering."""
+
+    def test_status_update_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(
+                f"/transactions/{seed_data['tx_b']}/status",
+                json={'status': 'closed'},
+                content_type='application/json'
+            )
+            assert resp.status_code == 404, f"Cross-org status update should fail, got {resp.status_code}"
+
+    def test_lockbox_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(
+                f"/transactions/{seed_data['tx_b']}/lockbox-combo",
+                json={'lockbox_combo': '1234'},
+                content_type='application/json'
+            )
+            assert resp.status_code == 404, f"Cross-org lockbox update should fail, got {resp.status_code}"
+
+    def test_signers_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/api/{seed_data['tx_b']}/signers")
+            assert resp.status_code == 404, f"Cross-org signers access should fail, got {resp.status_code}"
+
+    def test_rentcast_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/rentcast-data")
+            assert resp.status_code == 404, f"Cross-org rentcast access should fail, got {resp.status_code}"
+
+
+class TestTransactionHistoryIDOR:
+    """Verify history endpoints enforce org filtering."""
+
+    def test_history_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/history")
+            assert resp.status_code == 404, f"Cross-org history should fail, got {resp.status_code}"
+
+    def test_history_view_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/history/view")
+            assert resp.status_code == 404, f"Cross-org history view should fail, got {resp.status_code}"
+
+
+class TestTransactionIntakeIDOR:
+    """Verify intake endpoints enforce org filtering."""
+
+    def test_intake_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/intake")
+            assert resp.status_code == 404, f"Cross-org intake should fail, got {resp.status_code}"
+
+
+class TestTransactionDownloadIDOR:
+    """Verify download endpoints enforce org filtering."""
+
+    def test_download_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/documents/{seed_data['doc_b']}/download")
+            assert resp.status_code == 404, f"Cross-org download should fail, got {resp.status_code}"
+
+    def test_print_all_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/documents/print-all-pdf")
+            assert resp.status_code == 404, f"Cross-org print-all should fail, got {resp.status_code}"
+
+
+class TestTransactionSigningIDOR:
+    """Verify signing endpoints enforce org filtering."""
+
+    def test_preview_all_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/transactions/{seed_data['tx_b']}/documents/preview-all")
+            assert resp.status_code == 404, f"Cross-org preview-all should fail, got {resp.status_code}"
+
+
+class TestTransactionParticipantsIDOR:
+    """Verify participant endpoints enforce org filtering."""
+
+    def test_add_participant_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(
+                f"/transactions/{seed_data['tx_b']}/participants",
+                data={'role': 'buyer', 'contact_id': '999'}
+            )
+            assert resp.status_code == 404, f"Cross-org participant add should fail, got {resp.status_code}"
+
+
+class TestTaskIDOR:
+    """Verify task routes enforce org filtering."""
+
+    def test_user_a_can_view_own_task(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/tasks/{seed_data['task_a']}")
+            assert resp.status_code == 200, f"User A should access own task, got {resp.status_code}"
+
+    def test_user_a_cannot_view_org_b_task(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/tasks/{seed_data['task_b']}")
+            assert resp.status_code == 404, f"User A should NOT access Org B task, got {resp.status_code}"
+
+    def test_edit_task_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(
+                f"/tasks/{seed_data['task_b']}/edit",
+                data={'subject': 'hacked', 'status': 'completed', 'priority': 'high',
+                      'due_date': '2026-12-31'}
+            )
+            assert resp.status_code == 404, f"Cross-org task edit should fail, got {resp.status_code}"
+
+    def test_delete_task_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(f"/tasks/{seed_data['task_b']}/delete")
+            assert resp.status_code == 404, f"Cross-org task delete should fail, got {resp.status_code}"
+
+    def test_quick_update_task_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.post(
+                f"/tasks/{seed_data['task_b']}/quick-update",
+                data={'status': 'completed'}
+            )
+            assert resp.status_code == 404, f"Cross-org task quick-update should fail, got {resp.status_code}"
+
+
+class TestTaskSubtypeIDOR:
+    """Verify task subtype endpoint enforces org filtering."""
+
+    def test_subtypes_returns_own_org_only(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/tasks/types/{seed_data['task_type_a']}/subtypes")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data) == 1
+            assert data[0]['name'] == 'Follow Up'
+
+    def test_subtypes_blocked_cross_org(self, app, seed_data):
+        with app.test_client() as client:
+            login(client, 'user_a')
+            resp = client.get(f"/tasks/types/{seed_data['task_type_b']}/subtypes")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data) == 0, f"Cross-org subtypes should return empty, got {len(data)} items"


### PR DESCRIPTION
Add `organization_id` filtering to all transaction and task routes to prevent Insecure Direct Object Reference (IDOR) vulnerabilities.

This addresses critical IDOR vulnerabilities where routes were fetching objects without filtering by the current user's organization. While PostgreSQL RLS provides a safety net, it silently fails on SQLite and could fail in production, leading to unauthorized cross-organization data access.

---
<p><a href="https://cursor.com/agents/bc-9877d698-254b-4c5c-af06-c6132a3bef79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9877d698-254b-4c5c-af06-c6132a3bef79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

