### PR TITLE
Integration specs expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install -r tests/requirements.txt
 
       - name: Run pytest integration tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,19 +7,50 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  # -------------------------------------------------------------------
+  # Job 1: Pytest integration tests (Flask test client, no browser)
+  # -------------------------------------------------------------------
+  pytest:
     runs-on: ubuntu-latest
-    
+
     env:
-      # Test credentials - set these as GitHub Secrets
+      DATABASE_URL: sqlite:////tmp/test_integration.db
+      SECRET_KEY: ci-test-secret-key
+      FLASK_ENV: development
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run pytest integration tests
+        run: |
+          pytest tests/ -x -v --ignore=tests/run_tests.py --ignore=tests/run_scheduled_tests.py --ignore=tests/test_idor_protection.py --ignore=tests/test_sendgrid.py --tb=short
+          pytest tests/test_idor_protection.py -x -v --tb=short
+
+  # -------------------------------------------------------------------
+  # Job 2: Playwright browser tests (requires running app + secrets)
+  # -------------------------------------------------------------------
+  playwright:
+    runs-on: ubuntu-latest
+
+    env:
       TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
       TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-      # Database URL for tests (uses Supabase)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      # Optional: OpenAI key if AI features are tested
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      # Flask environment
       FLASK_ENV: development
 
     steps:
@@ -44,9 +75,7 @@ jobs:
       - name: Start Flask app
         run: |
           python app.py &
-          # Wait for server to start
           sleep 5
-          # Verify server is running
           curl --retry 5 --retry-delay 2 --retry-connrefused http://127.0.0.1:5011/login
 
       - name: Run integration tests
@@ -60,4 +89,3 @@ jobs:
           path: |
             tests/*.png
             tests/*.log
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,14 @@ def login(client, username, password='password123'):
     }, follow_redirects=True)
 
 
+@pytest.fixture(autouse=True)
+def _rollback_after_test(app):
+    """Roll back uncommitted DB changes after each test to prevent state leakage."""
+    yield
+    with app.app_context():
+        _db.session.rollback()
+
+
 @pytest.fixture()
 def client(app):
     """Provide a fresh test client per test."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,291 @@
+"""
+Shared pytest fixtures for integration tests.
+
+Provides a fully seeded SQLite-backed Flask app with two organizations,
+users at various permission levels, and seed data for contacts, tasks,
+transactions, groups, etc.
+"""
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_TEST_DB = 'sqlite:////tmp/test_integration.db'
+
+if 'DATABASE_URL' not in os.environ:
+    os.environ['DATABASE_URL'] = _TEST_DB
+
+from app import create_app
+from models import (
+    db as _db, User, Organization, Contact, ContactGroup,
+    Task, TaskType, TaskSubtype, Transaction, TransactionType,
+    TransactionDocument, TransactionParticipant, Interaction,
+    CompanyUpdate, CompanyUpdateComment, CompanyUpdateReaction,
+    UserTodo, ActionPlan, ChatConversation, ChatMessage,
+    AgentResource, contact_groups as contact_groups_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# App / DB fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='session')
+def app():
+    """Create the Flask application for testing."""
+    os.environ['DATABASE_URL'] = _TEST_DB
+    application = create_app()
+    application.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI=_TEST_DB,
+        SERVER_NAME='localhost',
+        SECRET_KEY='test-secret-key',
+    )
+
+    with application.app_context():
+        _db.create_all()
+        yield application
+        _db.session.remove()
+        _db.drop_all()
+
+    if os.path.exists('/tmp/test_integration.db'):
+        os.remove('/tmp/test_integration.db')
+
+
+@pytest.fixture(scope='session')
+def db(app):
+    """Return the SQLAlchemy database instance."""
+    return _db
+
+
+# ---------------------------------------------------------------------------
+# Seed data
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='session')
+def seed(app, db):
+    """Seed two organizations with users, contacts, tasks, transactions, etc."""
+    with app.app_context():
+        # ---- Org A (pro) ----
+        org_a = Organization(
+            name='Test Realty A', slug='test-realty-a',
+            subscription_tier='pro', status='active',
+            max_users=10, max_contacts=1000, can_invite_users=True,
+        )
+        db.session.add(org_a)
+        db.session.flush()
+
+        owner_a = _make_user(db, org_a, 'owner_a', 'owner_a@test.com',
+                             'Alice', 'Owner', role='admin', org_role='owner')
+        admin_a = _make_user(db, org_a, 'admin_a', 'admin_a@test.com',
+                             'Adam', 'Admin', role='admin', org_role='admin')
+        agent_a = _make_user(db, org_a, 'agent_a', 'agent_a@test.com',
+                             'Amy', 'Agent', role='agent', org_role='agent')
+
+        # ---- Org B (free) ----
+        org_b = Organization(
+            name='Test Realty B', slug='test-realty-b',
+            subscription_tier='free', status='active',
+            max_users=1, max_contacts=10000,
+        )
+        db.session.add(org_b)
+        db.session.flush()
+
+        owner_b = _make_user(db, org_b, 'owner_b', 'owner_b@test.com',
+                             'Bob', 'Owner', role='admin', org_role='owner')
+
+        # ---- Contact groups ----
+        group_a1 = ContactGroup(name='Buyers', organization_id=org_a.id, category='general', sort_order=0)
+        group_a2 = ContactGroup(name='Sellers', organization_id=org_a.id, category='general', sort_order=1)
+        group_b1 = ContactGroup(name='Leads', organization_id=org_b.id, category='general', sort_order=0)
+        db.session.add_all([group_a1, group_a2, group_b1])
+        db.session.flush()
+
+        # ---- Contacts ----
+        contact_a = Contact(
+            organization_id=org_a.id, user_id=owner_a.id, created_by_id=owner_a.id,
+            first_name='Jane', last_name='Doe', email='jane@test.com', phone='5551110000',
+        )
+        contact_a2 = Contact(
+            organization_id=org_a.id, user_id=agent_a.id, created_by_id=agent_a.id,
+            first_name='John', last_name='Smith', email='john@test.com', phone='5552220000',
+        )
+        contact_b = Contact(
+            organization_id=org_b.id, user_id=owner_b.id, created_by_id=owner_b.id,
+            first_name='Bob', last_name='Contact', email='bc@test.com',
+        )
+        db.session.add_all([contact_a, contact_a2, contact_b])
+        db.session.flush()
+
+        contact_a.groups.append(group_a1)
+        contact_a2.groups.append(group_a2)
+        contact_b.groups.append(group_b1)
+
+        # ---- Task types / subtypes ----
+        tt_a = TaskType(name='Call', organization_id=org_a.id, sort_order=0)
+        tt_a2 = TaskType(name='Email', organization_id=org_a.id, sort_order=1)
+        tt_b = TaskType(name='Call', organization_id=org_b.id, sort_order=0)
+        db.session.add_all([tt_a, tt_a2, tt_b])
+        db.session.flush()
+
+        st_a = TaskSubtype(name='Follow Up', task_type_id=tt_a.id, organization_id=org_a.id, sort_order=0)
+        st_a2 = TaskSubtype(name='Check-in', task_type_id=tt_a.id, organization_id=org_a.id, sort_order=1)
+        st_b = TaskSubtype(name='Follow Up', task_type_id=tt_b.id, organization_id=org_b.id, sort_order=0)
+        db.session.add_all([st_a, st_a2, st_b])
+        db.session.flush()
+
+        # ---- Tasks ----
+        from datetime import datetime, timedelta
+        task_a = Task(
+            organization_id=org_a.id, contact_id=contact_a.id,
+            assigned_to_id=owner_a.id, created_by_id=owner_a.id,
+            type_id=tt_a.id, subtype_id=st_a.id,
+            subject='Call Jane', priority='medium', status='pending',
+            due_date=datetime.utcnow() + timedelta(days=1),
+        )
+        task_a2 = Task(
+            organization_id=org_a.id, contact_id=contact_a2.id,
+            assigned_to_id=agent_a.id, created_by_id=admin_a.id,
+            type_id=tt_a.id, subtype_id=st_a.id,
+            subject='Follow up John', priority='high', status='pending',
+            due_date=datetime.utcnow() + timedelta(days=3),
+        )
+        task_b = Task(
+            organization_id=org_b.id, contact_id=contact_b.id,
+            assigned_to_id=owner_b.id, created_by_id=owner_b.id,
+            type_id=tt_b.id, subtype_id=st_b.id,
+            subject='Task B Only', priority='low', status='pending',
+            due_date=datetime.utcnow() + timedelta(days=2),
+        )
+        db.session.add_all([task_a, task_a2, task_b])
+        db.session.flush()
+
+        # ---- Transaction types ----
+        tx_type_a = TransactionType(name='seller', display_name='Seller', organization_id=org_a.id)
+        tx_type_a2 = TransactionType(name='buyer', display_name='Buyer', organization_id=org_a.id)
+        tx_type_b = TransactionType(name='seller', display_name='Seller', organization_id=org_b.id)
+        db.session.add_all([tx_type_a, tx_type_a2, tx_type_b])
+        db.session.flush()
+
+        # ---- Transactions ----
+        tx_a = Transaction(
+            organization_id=org_a.id, created_by_id=owner_a.id,
+            transaction_type_id=tx_type_a.id, street_address='100 Main St',
+            city='Austin', state='TX', status='active',
+        )
+        tx_b = Transaction(
+            organization_id=org_b.id, created_by_id=owner_b.id,
+            transaction_type_id=tx_type_b.id, street_address='200 Oak Ave',
+            city='Dallas', state='TX', status='active',
+        )
+        db.session.add_all([tx_a, tx_b])
+        db.session.flush()
+
+        # ---- Transaction documents ----
+        doc_a = TransactionDocument(
+            organization_id=org_a.id, transaction_id=tx_a.id,
+            template_slug='listing-agreement', template_name='Listing Agreement',
+            status='pending',
+        )
+        db.session.add(doc_a)
+        db.session.flush()
+
+        # ---- Company updates ----
+        update_a = CompanyUpdate(
+            organization_id=org_a.id, author_id=owner_a.id,
+            title='Welcome Update', content='<p>Welcome everyone!</p>',
+            excerpt='Welcome everyone!',
+        )
+        db.session.add(update_a)
+        db.session.flush()
+
+        # ---- Agent resources ----
+        resource_a = AgentResource(
+            organization_id=org_a.id, label='Training Guide',
+            url='https://example.com/guide', sort_order=0,
+        )
+        db.session.add(resource_a)
+        db.session.flush()
+
+        db.session.commit()
+
+        return {
+            'org_a': org_a.id, 'org_b': org_b.id,
+            'owner_a': owner_a.id, 'admin_a': admin_a.id, 'agent_a': agent_a.id,
+            'owner_b': owner_b.id,
+            'contact_a': contact_a.id, 'contact_a2': contact_a2.id, 'contact_b': contact_b.id,
+            'group_a1': group_a1.id, 'group_a2': group_a2.id, 'group_b1': group_b1.id,
+            'task_a': task_a.id, 'task_a2': task_a2.id, 'task_b': task_b.id,
+            'task_type_a': tt_a.id, 'task_type_a2': tt_a2.id, 'task_type_b': tt_b.id,
+            'subtype_a': st_a.id, 'subtype_a2': st_a2.id, 'subtype_b': st_b.id,
+            'tx_type_a': tx_type_a.id, 'tx_type_a2': tx_type_a2.id,
+            'tx_a': tx_a.id, 'tx_b': tx_b.id,
+            'doc_a': doc_a.id,
+            'update_a': update_a.id,
+            'resource_a': resource_a.id,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Client helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(database, org, username, email, first, last,
+               role='agent', org_role='agent'):
+    u = User(
+        organization_id=org.id, username=username, email=email,
+        first_name=first, last_name=last, role=role, org_role=org_role,
+    )
+    u.set_password('password123')
+    database.session.add(u)
+    database.session.flush()
+    return u
+
+
+def login(client, username, password='password123'):
+    """Log in via the auth route and return the response."""
+    client.get('/logout')
+    return client.post('/login', data={
+        'username': username,
+        'password': password,
+    }, follow_redirects=True)
+
+
+@pytest.fixture()
+def client(app):
+    """Provide a fresh test client per test."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def owner_a_client(app, seed):
+    """Test client pre-logged in as owner of Org A (pro)."""
+    with app.test_client() as c:
+        login(c, 'owner_a')
+        yield c
+
+
+@pytest.fixture()
+def admin_a_client(app, seed):
+    """Test client pre-logged in as admin of Org A (pro)."""
+    with app.test_client() as c:
+        login(c, 'admin_a')
+        yield c
+
+
+@pytest.fixture()
+def agent_a_client(app, seed):
+    """Test client pre-logged in as agent of Org A (pro)."""
+    with app.test_client() as c:
+        login(c, 'agent_a')
+        yield c
+
+
+@pytest.fixture()
+def owner_b_client(app, seed):
+    """Test client pre-logged in as owner of Org B (free)."""
+    with app.test_client() as c:
+        login(c, 'owner_b')
+        yield c

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 # Test dependencies for CRM Integration Tests
 playwright>=1.40.0
 python-dotenv>=1.0.0
+pytest>=7.0.0
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,115 @@
+"""
+Integration tests for admin routes.
+
+Covers: contact group management, agent resources, document mapping,
+and role-based access control (admin vs agent).
+"""
+import json
+import pytest
+from conftest import login
+
+
+class TestGroupManagement:
+    """Contact group CRUD (admin only)."""
+
+    def test_groups_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/admin/groups')
+        assert resp.status_code in (200, 302)
+        if resp.status_code == 200:
+            assert b'Buyers' in resp.data or b'group' in resp.data.lower()
+
+    def test_groups_page_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/admin/groups')
+        assert resp.status_code in (302, 403), f"Agent should be denied, got {resp.status_code}"
+
+    def test_add_group(self, owner_a_client, seed):
+        resp = owner_a_client.post('/admin/groups/add', data={
+            'name': 'TestNewGroup',
+            'category': 'general',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_add_group_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post('/admin/groups/add', data={
+            'name': 'AgentGroup',
+            'category': 'general',
+        })
+        assert resp.status_code in (302, 403), f"Agent should be denied, got {resp.status_code}"
+
+    def test_update_group(self, owner_a_client, seed):
+        resp = owner_a_client.put(
+            f'/admin/groups/{seed["group_a1"]}',
+            json={'name': 'Buyers Updated'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 302)
+
+    def test_update_group_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.put(
+            f'/admin/groups/{seed["group_b1"]}',
+            json={'name': 'Hacked'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (403, 404)
+
+    def test_reorder_groups(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            '/admin/groups/reorder',
+            json=[
+                {'id': seed['group_a2'], 'sort_order': 0},
+                {'id': seed['group_a1'], 'sort_order': 1},
+            ],
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 302, 400)
+
+
+class TestResourceManagement:
+    """Agent resource CRUD (admin only)."""
+
+    def test_resources_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/admin/resources')
+        assert resp.status_code in (200, 302)
+
+    def test_resources_page_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/admin/resources')
+        assert resp.status_code in (302, 403), f"Agent should be denied, got {resp.status_code}"
+
+    def test_add_resource(self, owner_a_client, seed):
+        resp = owner_a_client.post('/admin/resources/add', json={
+            'label': 'New Resource',
+            'url': 'https://example.com/new',
+        })
+        assert resp.status_code in (200, 400)
+
+    def test_update_resource(self, owner_a_client, seed):
+        resp = owner_a_client.put(
+            f'/admin/resources/{seed["resource_a"]}',
+            json={'label': 'Updated Guide', 'url': 'https://example.com/updated'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 302, 400)
+
+    def test_resources_api(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/resources')
+        assert resp.status_code == 200
+
+    def test_resources_api_agent_can_read(self, agent_a_client, seed):
+        resp = agent_a_client.get('/api/resources')
+        assert resp.status_code == 200
+
+
+class TestDocumentMapping:
+    """Document mapping admin routes."""
+
+    def test_mapping_list_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/admin/document-mapping')
+        assert resp.status_code in (200, 302)
+
+    def test_mapping_list_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/admin/document-mapping')
+        assert resp.status_code in (302, 403), f"Agent should be denied, got {resp.status_code}"
+
+    def test_mapper_v2_list(self, owner_a_client, seed):
+        resp = owner_a_client.get('/admin/document-mapper-v2')
+        assert resp.status_code in (200, 302)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -37,7 +37,7 @@ class TestAIChatAPI:
     def test_chat_unauthenticated(self, client, seed):
         client.get('/logout')
         resp = client.post('/api/ai-chat', json={'message': 'Hello'})
-        assert resp.status_code in (302, 401, 403, 500)
+        assert resp.status_code in (302, 401, 403)
 
 
 class TestActionPlanAPI:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,129 @@
+"""
+Integration tests for JSON API endpoints.
+
+Covers: AI chat, action plan, daily todo, and miscellaneous
+API endpoints. Tests both access control and basic response formats.
+"""
+import json
+import pytest
+from conftest import login
+
+
+class TestAIChatAPI:
+    """AI Chat (B.O.B.) API endpoints."""
+
+    def test_list_conversations(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/ai-chat/conversations')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, (list, dict))
+
+    def test_create_conversation(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            '/api/ai-chat/conversations',
+            json={'title': 'Test Conversation'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 201)
+
+    def test_clear_chat(self, owner_a_client, seed):
+        resp = owner_a_client.post('/api/ai-chat/clear')
+        assert resp.status_code == 200
+
+    def test_search_contacts_for_mentions(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/ai-chat/search-contacts?q=Jane')
+        assert resp.status_code == 200
+
+    def test_chat_unauthenticated(self, client, seed):
+        client.get('/logout')
+        resp = client.post('/api/ai-chat', json={'message': 'Hello'})
+        assert resp.status_code in (302, 401, 403, 500)
+
+
+class TestActionPlanAPI:
+    """Action plan API endpoints."""
+
+    def test_action_plan_page(self, owner_a_client, seed):
+        resp = owner_a_client.get('/action-plan')
+        assert resp.status_code == 200
+
+    def test_get_action_plan(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/action-plan/get')
+        assert resp.status_code == 200
+
+    def test_action_plan_unauthenticated(self, client, seed):
+        client.get('/logout')
+        resp = client.get('/action-plan')
+        assert resp.status_code in (302, 401, 403)
+
+
+class TestDailyTodoAPI:
+    """Daily todo API endpoints."""
+
+    def test_get_latest_todo(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/daily-todo/latest')
+        assert resp.status_code in (200, 404)
+
+    def test_daily_todo_unauthenticated(self, client, seed):
+        client.get('/logout')
+        resp = client.get('/api/daily-todo/latest')
+        assert resp.status_code in (302, 401, 403, 404)
+
+
+class TestTaskWindowAPI:
+    """Task window preference API."""
+
+    def test_update_valid_window(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            '/api/update-task-window',
+            json={'days': 30},
+            content_type='application/json',
+        )
+        assert resp.status_code == 200
+
+    def test_update_window_unauthenticated(self, client, seed):
+        client.get('/logout')
+        resp = client.post(
+            '/api/update-task-window',
+            json={'days': 30},
+            content_type='application/json',
+        )
+        assert resp.status_code in (302, 401, 403)
+
+
+class TestResourcesAPI:
+    """Agent resources API."""
+
+    def test_get_resources(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/resources')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, (list, dict))
+
+    def test_resources_unauthenticated(self, client, seed):
+        client.get('/logout')
+        resp = client.get('/api/resources')
+        assert resp.status_code in (302, 401, 403)
+
+
+class TestRegistrationStatusAPI:
+    """Registration status endpoint."""
+
+    def test_check_status(self, client, seed):
+        resp = client.get('/registration-status?email=owner_a@test.com')
+        assert resp.status_code == 200
+
+
+class TestHealthAPI:
+    """Health check endpoints."""
+
+    def test_health_json(self, client, seed):
+        resp = client.get('/health')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'status' in data
+        assert data['status'] == 'healthy'
+
+    def test_health_ui(self, client, seed):
+        resp = client.get('/health/ui')
+        assert resp.status_code == 200

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,147 @@
+"""
+Integration tests for authentication routes.
+
+Covers: login, logout, registration, profile view/update, password reset,
+user management (admin), and access control.
+"""
+import pytest
+from conftest import login
+
+
+class TestLogin:
+    """Login and session management."""
+
+    def test_login_page_loads(self, client, seed):
+        resp = client.get('/login')
+        assert resp.status_code in (200, 302)
+        if resp.status_code == 200:
+            assert b'login' in resp.data.lower() or b'Log In' in resp.data or b'Sign In' in resp.data
+
+    def test_login_success(self, client, seed):
+        resp = login(client, 'owner_a')
+        assert resp.status_code == 200
+        assert b'Dashboard' in resp.data or b'dashboard' in resp.data.lower()
+
+    def test_login_wrong_password(self, client, seed):
+        resp = client.post('/login', data={
+            'username': 'owner_a', 'password': 'wrongpassword',
+        }, follow_redirects=True)
+        assert b'Invalid' in resp.data or b'incorrect' in resp.data.lower() or resp.status_code == 200
+
+    def test_login_nonexistent_user(self, client, seed):
+        client.get('/logout')  # Ensure no session carryover from other tests
+        resp = client.post('/login', data={
+            'username': 'nonexistent_user_xyz_999', 'password': 'wrongpass',
+        }, follow_redirects=True)
+        # Should not reach dashboard (has dashboard-card). Expect error or login form.
+        assert b'dashboard-card' not in resp.data, "Should not reach dashboard with invalid creds"
+        assert (
+            b'Invalid' in resp.data or b'incorrect' in resp.data.lower()
+            or b'Sign in' in resp.data or b'sign in' in resp.data.lower()
+        )
+
+    def test_logout(self, client, seed):
+        login(client, 'owner_a')
+        resp = client.get('/logout', follow_redirects=True)
+        assert resp.status_code == 200
+        dash = client.get('/dashboard')
+        assert dash.status_code in (302, 401)
+
+
+class TestProtectedRoutes:
+    """Verify unauthenticated users are redirected to login."""
+
+    @pytest.mark.parametrize('url', [
+        '/dashboard', '/contacts', '/tasks', '/profile',
+        '/tasks/new', '/contacts/create', '/admin/groups',
+    ])
+    def test_unauthenticated_redirect(self, client, seed, url):
+        resp = client.get(url)
+        assert resp.status_code in (302, 401, 403)
+
+    def test_unauthenticated_post_blocked(self, client, seed):
+        resp = client.post('/profile/update', data={'first_name': 'Hacker'})
+        assert resp.status_code in (302, 401, 403)
+
+
+class TestProfile:
+    """Profile view and update."""
+
+    def test_view_profile(self, owner_a_client, seed):
+        resp = owner_a_client.get('/profile')
+        assert resp.status_code == 200
+        assert b'Alice' in resp.data or b'owner_a' in resp.data
+
+    def test_update_profile(self, owner_a_client, seed):
+        resp = owner_a_client.post('/profile/update', data={
+            'first_name': 'AliceUpdated',
+            'last_name': 'Owner',
+            'email': 'owner_a@test.com',
+            'phone': '5559999999',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_agent_can_view_own_profile(self, agent_a_client, seed):
+        resp = agent_a_client.get('/profile')
+        assert resp.status_code == 200
+        assert b'Amy' in resp.data or b'agent_a' in resp.data
+
+
+class TestRegistration:
+    """Registration form."""
+
+    def test_register_page_loads(self, client, seed):
+        resp = client.get('/register')
+        assert resp.status_code in (200, 302)
+
+    def test_terms_privacy_page(self, client, seed):
+        resp = client.get('/terms-privacy')
+        assert resp.status_code == 200
+
+
+class TestPasswordReset:
+    """Password reset flow."""
+
+    def test_reset_request_page_loads(self, client, seed):
+        resp = client.get('/reset_password')
+        assert resp.status_code in (200, 302)
+
+    def test_reset_with_invalid_token(self, client, seed):
+        resp = client.get('/reset_password/invalidtoken123')
+        assert resp.status_code in (200, 302)
+
+
+class TestUserManagement:
+    """Admin user management routes."""
+
+    def test_manage_users_admin(self, owner_a_client, seed):
+        resp = owner_a_client.get('/manage-users')
+        assert resp.status_code == 200
+
+    def test_manage_users_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/manage-users')
+        assert resp.status_code in (302, 403)
+
+    def test_update_user_role_admin(self, owner_a_client, seed):
+        resp = owner_a_client.post(f"/user/{seed['agent_a']}/role", data={
+            'role': 'admin',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        # Restore agent role so later tests (agent_admin_pages_denied) aren't affected
+        owner_a_client.post(f"/user/{seed['agent_a']}/role", data={
+            'role': 'agent',
+        }, follow_redirects=True)
+
+    def test_update_user_role_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post(f"/user/{seed['owner_a']}/role", data={
+            'role': 'agent',
+        })
+        assert resp.status_code in (302, 403)
+
+    def test_view_user_action_plan_admin(self, owner_a_client, seed):
+        resp = owner_a_client.get(f"/user/{seed['agent_a']}/action-plan")
+        assert resp.status_code in (200, 302)
+
+    def test_edit_user_page_admin(self, owner_a_client, seed):
+        resp = owner_a_client.get(f"/user/{seed['agent_a']}/edit")
+        assert resp.status_code in (200, 302)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,10 +23,12 @@ class TestLogin:
         assert b'Dashboard' in resp.data or b'dashboard' in resp.data.lower()
 
     def test_login_wrong_password(self, client, seed):
+        client.get('/logout')
         resp = client.post('/login', data={
             'username': 'owner_a', 'password': 'wrongpassword',
         }, follow_redirects=True)
-        assert b'Invalid' in resp.data or b'incorrect' in resp.data.lower() or resp.status_code == 200
+        assert resp.status_code == 200
+        assert b'Invalid' in resp.data or b'incorrect' in resp.data.lower()
 
     def test_login_nonexistent_user(self, client, seed):
         client.get('/logout')  # Ensure no session carryover from other tests

--- a/tests/test_company_updates.py
+++ b/tests/test_company_updates.py
@@ -1,0 +1,141 @@
+"""
+Integration tests for company updates routes.
+
+Covers: CRUD, reactions, comments, latest-update API, and access control.
+"""
+import json
+import pytest
+from conftest import login
+
+
+class TestUpdatesList:
+    """Company updates listing."""
+
+    def test_updates_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/updates')
+        assert resp.status_code == 200
+
+    def test_updates_visible_to_agent(self, agent_a_client, seed):
+        resp = agent_a_client.get('/updates')
+        assert resp.status_code == 200
+
+
+class TestUpdateView:
+    """View individual updates."""
+
+    def test_view_update(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/updates/{seed["update_a"]}')
+        assert resp.status_code == 200
+        assert b'Welcome' in resp.data
+
+    def test_view_cross_org_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.get(f'/updates/{seed["update_a"]}')
+        assert resp.status_code in (302, 403, 404)
+
+
+class TestUpdateCreate:
+    """Update creation (admin only)."""
+
+    def test_create_page_loads_admin(self, owner_a_client, seed):
+        resp = owner_a_client.get('/updates/new')
+        assert resp.status_code in (200, 302)
+
+    def test_create_update(self, owner_a_client, seed):
+        resp = owner_a_client.post('/updates/new', data={
+            'title': 'Test Update Created',
+            'content': '<p>Test content here.</p>',
+        }, follow_redirects=True)
+        assert resp.status_code in (200, 302)
+
+    def test_create_update_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/updates/new')
+        assert resp.status_code in (302, 403), f"Expected redirect/forbidden, got {resp.status_code}"
+
+    def test_create_update_agent_post_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post('/updates/new', data={
+            'title': 'Agent Update', 'content': 'Not allowed',
+        })
+        assert resp.status_code in (302, 403)
+
+
+class TestUpdateEdit:
+    """Update editing (admin only)."""
+
+    def test_edit_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/updates/{seed["update_a"]}/edit')
+        assert resp.status_code in (200, 302)
+
+    def test_edit_update(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/updates/{seed["update_a"]}/edit', data={
+            'title': 'Welcome Update Edited',
+            'content': '<p>Updated content.</p>',
+        }, follow_redirects=True)
+        assert resp.status_code in (200, 302)
+
+    def test_edit_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get(f'/updates/{seed["update_a"]}/edit')
+        assert resp.status_code in (302, 403), f"Expected redirect/forbidden, got {resp.status_code}"
+
+
+class TestUpdateDelete:
+    """Update deletion (admin only)."""
+
+    def test_delete_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post(f'/updates/{seed["update_a"]}/delete')
+        assert resp.status_code in (302, 403)
+
+
+class TestLatestUpdateAPI:
+    """Latest update API endpoint."""
+
+    def test_get_latest_update(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/updates/latest')
+        assert resp.status_code == 200
+
+
+class TestReactionsAPI:
+    """Reaction toggle and retrieval."""
+
+    def test_toggle_reaction(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/api/updates/{seed["update_a"]}/reactions',
+            json={'reaction_type': 'thumbs_up'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 400)
+
+    def test_get_reactions(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/api/updates/{seed["update_a"]}/reactions')
+        assert resp.status_code in (200, 404)
+
+    def test_reaction_cross_org_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.post(
+            f'/api/updates/{seed["update_a"]}/reactions',
+            json={'reaction_type': 'thumbs_up'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (403, 404)
+
+
+class TestCommentsAPI:
+    """Comment creation and retrieval."""
+
+    def test_add_comment(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/api/updates/{seed["update_a"]}/comments',
+            json={'content': 'Great update!'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 201, 400)
+
+    def test_get_comments(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/api/updates/{seed["update_a"]}/comments')
+        assert resp.status_code in (200, 404)
+
+    def test_comment_cross_org_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.post(
+            f'/api/updates/{seed["update_a"]}/comments',
+            json={'content': 'Hacked comment!'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (403, 404)

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,0 +1,218 @@
+"""
+Integration tests for contact routes.
+
+Covers: CRUD, search/filtering, interactions, import/export,
+group assignment, file operations, and cross-org isolation.
+"""
+import pytest
+from conftest import login
+
+
+class TestContactList:
+    """Contact listing, search, and filtering."""
+
+    def test_contacts_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contacts')
+        assert resp.status_code == 200
+        assert b'Jane' in resp.data or b'Contact' in resp.data
+
+    def test_contacts_search(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contacts?q=Jane')
+        assert resp.status_code == 200
+        assert b'Jane' in resp.data
+
+    def test_contacts_search_no_results(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contacts?q=NonExistentXYZ')
+        assert resp.status_code == 200
+
+    def test_contacts_group_filter(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contacts?group_id={seed["group_a1"]}')
+        assert resp.status_code == 200
+
+    def test_contacts_pagination(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contacts?page=1')
+        assert resp.status_code == 200
+
+
+class TestContactView:
+    """View individual contacts."""
+
+    def test_view_own_contact(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}')
+        assert resp.status_code == 200
+        assert b'Jane' in resp.data
+
+    def test_view_contact_ajax(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/contact/{seed["contact_a"]}',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        assert resp.status_code == 200
+
+    def test_view_cross_org_contact_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}')
+        assert resp.status_code == 404
+
+    def test_view_nonexistent_contact(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contact/99999')
+        assert resp.status_code == 404
+
+
+class TestContactCreate:
+    """Contact creation."""
+
+    def test_create_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/contacts/create')
+        assert resp.status_code == 200
+
+    def test_create_contact_success(self, owner_a_client, seed):
+        resp = owner_a_client.post('/contacts/create', data={
+            'first_name': 'NewContact',
+            'last_name': 'Test',
+            'email': 'newcontact@test.com',
+            'phone': '5553334444',
+            'group_ids': str(seed['group_a1']),
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_create_contact_missing_name(self, owner_a_client, seed):
+        resp = owner_a_client.post('/contacts/create', data={
+            'first_name': '',
+            'last_name': '',
+            'email': 'empty@test.com',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_create_contact_agent_can(self, agent_a_client, seed):
+        resp = agent_a_client.post('/contacts/create', data={
+            'first_name': 'AgentCreated',
+            'last_name': 'Contact',
+            'email': 'agentcreated@test.com',
+            'group_ids': str(seed['group_a1']),
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+
+class TestContactEdit:
+    """Contact editing."""
+
+    def test_edit_contact(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/contacts/{seed["contact_a"]}/edit', data={
+            'first_name': 'JaneEdited',
+            'last_name': 'Doe',
+            'email': 'jane@test.com',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_edit_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/contacts/{seed["contact_b"]}/edit', data={
+            'first_name': 'Hacked',
+        })
+        assert resp.status_code == 404
+
+    def test_edit_nonexistent_contact(self, owner_a_client, seed):
+        resp = owner_a_client.post('/contacts/99999/edit', data={
+            'first_name': 'Ghost',
+        })
+        assert resp.status_code == 404
+
+
+class TestContactDelete:
+    """Contact deletion."""
+
+    def test_delete_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/contacts/{seed["contact_b"]}/delete')
+        assert resp.status_code == 404
+
+
+class TestContactInteractions:
+    """Interaction logging on contacts."""
+
+    def test_log_activity(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/contact/{seed["contact_a"]}/log-activity', data={
+            'activity_type': 'call',
+            'notes': 'Called about listing',
+            'activity_date': '2026-02-27',
+        }, follow_redirects=True)
+        assert resp.status_code in (200, 302)
+
+    def test_get_interactions(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}/interactions')
+        assert resp.status_code == 200
+
+    def test_log_activity_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/contact/{seed["contact_b"]}/log-activity', data={
+            'activity_type': 'call', 'notes': 'Hacked',
+            'activity_date': '2026-01-01',
+        })
+        assert resp.status_code == 404
+
+    def test_get_interactions_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}/interactions')
+        assert resp.status_code == 404
+
+
+class TestContactTimeline:
+    """Contact timeline endpoint."""
+
+    def test_get_timeline(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}/timeline')
+        assert resp.status_code == 200
+
+    def test_timeline_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}/timeline')
+        assert resp.status_code == 404
+
+
+class TestContactExport:
+    """Contact import/export."""
+
+    def test_export_contacts(self, owner_a_client, seed):
+        resp = owner_a_client.get('/export-contacts')
+        assert resp.status_code == 200
+        assert b'first_name' in resp.data.lower() or resp.content_type == 'text/csv'
+
+
+class TestContactOnboarding:
+    """Onboarding dismissal."""
+
+    def test_dismiss_onboarding(self, owner_a_client, seed):
+        resp = owner_a_client.post('/contacts/dismiss-onboarding',
+                                   follow_redirects=True)
+        assert resp.status_code == 200
+
+
+class TestContactFiles:
+    """File upload/download/list endpoints."""
+
+    def test_list_files(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}/files')
+        assert resp.status_code == 200
+
+    def test_list_files_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}/files')
+        assert resp.status_code == 404
+
+
+class TestContactVoiceMemos:
+    """Voice memo endpoints."""
+
+    def test_list_voice_memos(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}/voice-memos')
+        assert resp.status_code == 200
+
+    def test_list_voice_memos_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}/voice-memos')
+        assert resp.status_code == 404
+
+
+class TestContactEmails:
+    """Contact email thread endpoints."""
+
+    def test_get_emails(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_a"]}/emails')
+        assert resp.status_code == 200
+
+    def test_get_emails_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/contact/{seed["contact_b"]}/emails')
+        assert resp.status_code == 404

--- a/tests/test_document_definitions.py
+++ b/tests/test_document_definitions.py
@@ -263,12 +263,12 @@ class TestTransforms:
     """Test field value transforms."""
     
     def test_currency_transform(self):
-        """Currency transform should format numbers."""
+        """Currency transform strips formatting for DocuSeal (raw numbers)."""
         from services.documents.transforms import transform_currency
         
-        assert transform_currency(500000) == "$500,000.00"
-        assert transform_currency("500000") == "$500,000.00"
-        assert transform_currency(1234.5) == "$1,234.50"
+        assert transform_currency(500000) == "500000"
+        assert transform_currency("$500,000.00") == "500000.00"
+        assert transform_currency("1,234.50") == "1234.50"
     
     def test_phone_transform(self):
         """Phone transform should format 10-digit numbers."""

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,74 @@
+"""
+Integration tests for feature flag enforcement.
+
+Verifies that free-tier orgs are blocked from premium features
+and pro-tier orgs can access them.
+"""
+import pytest
+from conftest import login
+
+
+class TestFreeTierRestrictions:
+    """Free-tier org (Org B) should be blocked from premium features."""
+
+    def test_ai_daily_todo_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.post('/api/daily-todo/generate',
+                                   follow_redirects=True)
+        assert resp.status_code in (200, 302, 403)
+        if resp.status_code == 200:
+            assert b'upgrade' in resp.data.lower() or b'subscription' in resp.data.lower() or resp.content_type == 'application/json'
+
+    def test_ai_daily_todo_latest_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.get('/api/daily-todo/latest',
+                                  follow_redirects=True)
+        assert resp.status_code in (200, 302, 403)
+
+    def test_action_plan_page_blocked(self, owner_b_client, seed):
+        resp = owner_b_client.get('/action-plan', follow_redirects=True)
+        assert resp.status_code in (200, 302, 403)
+        if resp.status_code == 200:
+            assert b'upgrade' in resp.data.lower() or b'action' in resp.data.lower()
+
+    def test_transactions_blocked_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/transactions/', follow_redirects=True)
+        assert resp.status_code in (200, 302, 403)
+
+
+class TestProTierAccess:
+    """Pro-tier org (Org A) should access premium features."""
+
+    def test_transactions_allowed(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/')
+        assert resp.status_code == 200
+
+    def test_action_plan_page_allowed(self, owner_a_client, seed):
+        resp = owner_a_client.get('/action-plan')
+        assert resp.status_code == 200
+
+    def test_ai_daily_todo_allowed(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/daily-todo/latest')
+        assert resp.status_code in (200, 404)
+
+
+class TestCoreFeatures:
+    """Core features available to all tiers."""
+
+    def test_contacts_available_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/contacts')
+        assert resp.status_code == 200
+
+    def test_tasks_available_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/tasks')
+        assert resp.status_code == 200
+
+    def test_dashboard_available_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/dashboard')
+        assert resp.status_code == 200
+
+    def test_user_todo_available_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/user_todo')
+        assert resp.status_code == 200
+
+    def test_updates_available_free(self, owner_b_client, seed):
+        resp = owner_b_client.get('/updates')
+        assert resp.status_code == 200

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,135 @@
+"""
+Integration tests for page loading and navigation.
+
+Covers: all major pages load without 500 errors, public routes,
+health check, dashboard, and key navigation flows.
+"""
+import pytest
+from conftest import login
+
+
+class TestPublicRoutes:
+    """Routes that should be accessible without login."""
+
+    def test_landing_page(self, client, seed):
+        resp = client.get('/')
+        assert resp.status_code in (200, 302)
+
+    def test_health_check(self, client, seed):
+        resp = client.get('/health')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['status'] == 'healthy'
+
+    def test_health_ui(self, client, seed):
+        resp = client.get('/health/ui')
+        assert resp.status_code == 200
+
+    def test_login_page(self, client, seed):
+        resp = client.get('/login')
+        assert resp.status_code in (200, 302)
+
+    def test_register_page(self, client, seed):
+        resp = client.get('/register')
+        assert resp.status_code in (200, 302)
+
+    def test_terms_privacy(self, client, seed):
+        resp = client.get('/terms-privacy')
+        assert resp.status_code == 200
+
+    def test_reset_password_page(self, client, seed):
+        resp = client.get('/reset_password')
+        assert resp.status_code in (200, 302)
+
+
+class TestAuthenticatedPageLoads:
+    """Verify authenticated pages load without 500 errors."""
+
+    @pytest.mark.parametrize('url', [
+        '/dashboard',
+        '/contacts',
+        '/tasks',
+        '/profile',
+        '/user_todo',
+        '/updates',
+    ])
+    def test_core_pages_load(self, owner_a_client, seed, url):
+        resp = owner_a_client.get(url)
+        assert resp.status_code == 200, f"{url} returned {resp.status_code}"
+
+    @pytest.mark.parametrize('url', [
+        '/transactions/',
+        '/transactions/new',
+        '/action-plan',
+    ])
+    def test_pro_pages_load(self, owner_a_client, seed, url):
+        resp = owner_a_client.get(url)
+        assert resp.status_code == 200, f"{url} returned {resp.status_code}"
+
+    @pytest.mark.parametrize('url', [
+        '/admin/groups',
+        '/admin/resources',
+        '/admin/document-mapping',
+        '/admin/document-mapper-v2',
+        '/manage-users',
+        '/org/settings',
+        '/org/members',
+        '/org/upgrade',
+        '/org/usage',
+    ])
+    def test_admin_pages_load(self, owner_a_client, seed, url):
+        resp = owner_a_client.get(url)
+        assert resp.status_code in (200, 302), f"{url} returned {resp.status_code}"
+
+
+class TestDashboard:
+    """Dashboard-specific tests."""
+
+    def test_dashboard_content(self, owner_a_client, seed):
+        resp = owner_a_client.get('/dashboard')
+        assert resp.status_code == 200
+        assert b'Dashboard' in resp.data or b'dashboard' in resp.data.lower()
+
+    def test_dashboard_dismiss_onboarding(self, owner_a_client, seed):
+        resp = owner_a_client.post('/dashboard/dismiss-onboarding',
+                                   follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_update_task_window(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            '/api/update-task-window',
+            json={'days': 7},
+            content_type='application/json',
+        )
+        assert resp.status_code == 200
+
+
+class TestContactUs:
+    """Contact form (public)."""
+
+    def test_contact_form_submit(self, client, seed):
+        resp = client.post('/contact-us', json={
+            'subject': 'Test Question',
+            'email': 'test@example.com',
+            'message': 'Hello, I have a question.',
+        })
+        assert resp.status_code in (200, 400, 500)
+
+
+class TestAgentNavigation:
+    """Agent-level navigation to core pages."""
+
+    @pytest.mark.parametrize('url', [
+        '/dashboard', '/contacts', '/tasks', '/profile',
+        '/user_todo', '/updates',
+    ])
+    def test_agent_core_pages(self, agent_a_client, seed, url):
+        resp = agent_a_client.get(url)
+        assert resp.status_code == 200, f"Agent denied from {url}"
+
+    @pytest.mark.parametrize('url', [
+        '/admin/groups', '/admin/resources', '/manage-users',
+    ])
+    def test_agent_admin_pages_denied(self, agent_a_client, seed, url):
+        resp = agent_a_client.get(url)
+        assert resp.status_code in (302, 403), f"Agent accessed admin {url}"

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -113,7 +113,18 @@ class TestContactUs:
             'email': 'test@example.com',
             'message': 'Hello, I have a question.',
         })
+        # 200 = success, 400 = validation, 500 = expected when SENDGRID_API_KEY absent
         assert resp.status_code in (200, 400, 500)
+        data = resp.get_json()
+        assert 'success' in data or 'message' in data
+
+    def test_contact_form_validation(self, client, seed):
+        resp = client.post('/contact-us', json={
+            'subject': '',
+            'email': '',
+            'message': '',
+        })
+        assert resp.status_code == 400
 
 
 class TestAgentNavigation:

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -31,8 +31,8 @@ class TestOrgSettings:
     def test_update_settings_admin_denied(self, admin_a_client, seed):
         resp = admin_a_client.post('/org/settings/update', data={
             'name': 'Admin Should Not Update',
-        }, follow_redirects=True)
-        assert resp.status_code in (200, 302, 403)
+        })
+        assert resp.status_code == 403
 
     def test_update_settings_agent_denied(self, agent_a_client, seed):
         resp = agent_a_client.post('/org/settings/update', data={
@@ -53,12 +53,19 @@ class TestOrgMembers:
         assert resp.status_code in (302, 403)
 
     def test_update_member_role(self, owner_a_client, seed):
-        resp = owner_a_client.post(
-            f'/org/members/{seed["agent_a"]}/update-role',
-            data={'role': 'admin'},
-            follow_redirects=True,
-        )
-        assert resp.status_code == 200
+        try:
+            resp = owner_a_client.post(
+                f'/org/members/{seed["agent_a"]}/update-role',
+                data={'role': 'admin'},
+                follow_redirects=True,
+            )
+            assert resp.status_code == 200
+        finally:
+            owner_a_client.post(
+                f'/org/members/{seed["agent_a"]}/update-role',
+                data={'role': 'agent'},
+                follow_redirects=True,
+            )
 
     def test_update_member_role_agent_denied(self, agent_a_client, seed):
         resp = agent_a_client.post(

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -1,0 +1,122 @@
+"""
+Integration tests for organization routes.
+
+Covers: settings, members, invites, deletion, upgrade, and usage.
+"""
+import pytest
+from conftest import login
+
+
+class TestOrgSettings:
+    """Organization settings."""
+
+    def test_settings_page_loads_owner(self, owner_a_client, seed):
+        resp = owner_a_client.get('/org/settings')
+        assert resp.status_code == 200
+
+    def test_settings_page_loads_admin(self, admin_a_client, seed):
+        resp = admin_a_client.get('/org/settings')
+        assert resp.status_code == 200
+
+    def test_settings_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/org/settings')
+        assert resp.status_code in (302, 403)
+
+    def test_update_settings_owner(self, owner_a_client, seed):
+        resp = owner_a_client.post('/org/settings/update', data={
+            'name': 'Test Realty A Updated',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_update_settings_admin_denied(self, admin_a_client, seed):
+        resp = admin_a_client.post('/org/settings/update', data={
+            'name': 'Admin Should Not Update',
+        }, follow_redirects=True)
+        assert resp.status_code in (200, 302, 403)
+
+    def test_update_settings_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post('/org/settings/update', data={
+            'name': 'Agent Hacked',
+        })
+        assert resp.status_code in (302, 403)
+
+
+class TestOrgMembers:
+    """Member management."""
+
+    def test_members_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/org/members')
+        assert resp.status_code == 200
+
+    def test_members_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/org/members')
+        assert resp.status_code in (302, 403)
+
+    def test_update_member_role(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/org/members/{seed["agent_a"]}/update-role',
+            data={'role': 'admin'},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    def test_update_member_role_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post(
+            f'/org/members/{seed["owner_a"]}/update-role',
+            data={'role': 'agent'},
+        )
+        assert resp.status_code in (302, 403)
+
+
+class TestOrgInvite:
+    """Member invitations."""
+
+    def test_send_invite(self, owner_a_client, seed):
+        resp = owner_a_client.post('/org/members/invite', data={
+            'email': 'newinvite@test.com',
+            'role': 'agent',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_send_invite_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.post('/org/members/invite', data={
+            'email': 'agentinvite@test.com',
+            'role': 'agent',
+        })
+        assert resp.status_code in (302, 403)
+
+
+class TestOrgDeletion:
+    """Organization deletion flow."""
+
+    def test_deletion_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/org/delete')
+        assert resp.status_code == 200
+
+    def test_deletion_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/org/delete')
+        assert resp.status_code in (302, 403)
+
+
+class TestOrgUpgrade:
+    """Upgrade options."""
+
+    def test_upgrade_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/org/upgrade')
+        assert resp.status_code in (200, 302)
+
+    def test_upgrade_agent_denied(self, agent_a_client, seed):
+        resp = agent_a_client.get('/org/upgrade')
+        assert resp.status_code in (302, 403)
+
+
+class TestOrgUsage:
+    """Usage and limits."""
+
+    def test_usage_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/org/usage')
+        assert resp.status_code == 200
+
+    def test_usage_agent_can_view(self, agent_a_client, seed):
+        resp = agent_a_client.get('/org/usage')
+        assert resp.status_code == 200

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,168 @@
+"""
+Integration tests for task routes.
+
+Covers: CRUD, filtering, quick-update, subtypes API, cross-org isolation.
+"""
+import pytest
+from conftest import login
+
+
+class TestTaskList:
+    """Task listing and filtering."""
+
+    def test_tasks_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks')
+        assert resp.status_code == 200
+        assert b'Call Jane' in resp.data or b'Task' in resp.data
+
+    def test_tasks_filter_status(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks?status=pending')
+        assert resp.status_code == 200
+
+    def test_tasks_filter_completed(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks?status=completed')
+        assert resp.status_code == 200
+
+    def test_tasks_filter_priority(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks?priority=high')
+        assert resp.status_code == 200
+
+    def test_tasks_no_cross_org_leakage(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks')
+        assert b'Task B Only' not in resp.data
+
+
+class TestTaskView:
+    """View individual tasks."""
+
+    def test_view_own_task(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/tasks/{seed["task_a"]}')
+        assert resp.status_code == 200
+        assert b'Call Jane' in resp.data or b'Jane' in resp.data
+
+    def test_view_task_ajax(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/tasks/{seed["task_a"]}',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        assert resp.status_code == 200
+
+    def test_view_cross_org_task_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/tasks/{seed["task_b"]}')
+        assert resp.status_code == 404
+
+    def test_view_nonexistent_task(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks/99999')
+        assert resp.status_code == 404
+
+
+class TestTaskCreate:
+    """Task creation."""
+
+    def test_create_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/tasks/new')
+        assert resp.status_code == 200
+
+    def test_create_task_success(self, owner_a_client, seed):
+        resp = owner_a_client.post('/tasks/new', data={
+            'contact_id': str(seed['contact_a']),
+            'type_id': str(seed['task_type_a']),
+            'subtype_id': str(seed['subtype_a']),
+            'subject': 'New Integration Test Task',
+            'description': 'Created by integration test',
+            'priority': 'low',
+            'due_date': '2026-03-15',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_create_task_missing_fields(self, owner_a_client, seed):
+        resp = owner_a_client.post('/tasks/new', data={
+            'subject': '',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+
+class TestTaskEdit:
+    """Task editing."""
+
+    def test_edit_task(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_a"]}/edit', data={
+            'subject': 'Edited Task Subject',
+            'status': 'pending',
+            'priority': 'high',
+            'due_date': '2026-04-01',
+            'contact_id': str(seed['contact_a']),
+            'type_id': str(seed['task_type_a']),
+            'subtype_id': str(seed['subtype_a']),
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_edit_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_b"]}/edit', data={
+            'subject': 'Hacked', 'status': 'completed',
+            'priority': 'high', 'due_date': '2026-12-31',
+        })
+        assert resp.status_code == 404
+
+
+class TestTaskQuickUpdate:
+    """Quick status/priority updates."""
+
+    def test_quick_update_status(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_a"]}/quick-update', data={
+            'status': 'completed',
+        })
+        assert resp.status_code in (200, 302)
+
+    def test_quick_update_priority(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_a"]}/quick-update', data={
+            'priority': 'low',
+        })
+        assert resp.status_code in (200, 302)
+
+    def test_quick_update_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_b"]}/quick-update', data={
+            'status': 'completed',
+        })
+        assert resp.status_code == 404
+
+
+class TestTaskDelete:
+    """Task deletion."""
+
+    def test_delete_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/tasks/{seed["task_b"]}/delete')
+        assert resp.status_code == 404
+
+
+class TestTaskSubtypes:
+    """Task subtypes API."""
+
+    def test_get_subtypes(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/tasks/types/{seed["task_type_a"]}/subtypes')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_subtypes_cross_org_returns_empty(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/tasks/types/{seed["task_type_b"]}/subtypes')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data) == 0
+
+
+class TestTaskAgentAccess:
+    """Agent-level access to tasks."""
+
+    def test_agent_sees_tasks_page(self, agent_a_client, seed):
+        resp = agent_a_client.get('/tasks')
+        assert resp.status_code == 200
+
+    def test_agent_can_create_task(self, agent_a_client, seed):
+        resp = agent_a_client.get('/tasks/new')
+        assert resp.status_code == 200
+
+    def test_agent_can_view_assigned_task(self, agent_a_client, seed):
+        resp = agent_a_client.get(f'/tasks/{seed["task_a2"]}')
+        assert resp.status_code == 200

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -102,7 +102,7 @@ class TestTransactionStatusAPI:
             json={'status': 'active'},
             content_type='application/json',
         )
-        assert resp.status_code in (200, 400)
+        assert resp.status_code == 200
 
     def test_update_status_cross_org_blocked(self, owner_a_client, seed):
         resp = owner_a_client.post(

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,264 @@
+"""
+Integration tests for transaction routes.
+
+Covers: CRUD, status updates, documents, participants, API endpoints,
+history, intake, download, signing, and cross-org isolation.
+"""
+import pytest
+from conftest import login
+
+
+class TestTransactionList:
+    """Transaction listing."""
+
+    def test_transactions_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/')
+        assert resp.status_code == 200
+
+    def test_transactions_no_cross_org(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/')
+        assert b'200 Oak Ave' not in resp.data
+
+    def test_free_tier_no_transactions(self, owner_b_client, seed):
+        resp = owner_b_client.get('/transactions/', follow_redirects=True)
+        assert resp.status_code == 200
+
+
+class TestTransactionView:
+    """View individual transactions."""
+
+    def test_view_own_transaction(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}')
+        assert resp.status_code == 200
+        assert b'100 Main St' in resp.data or b'Main' in resp.data
+
+    def test_view_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}')
+        assert resp.status_code == 404
+
+    def test_view_nonexistent(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/99999')
+        assert resp.status_code == 404
+
+
+class TestTransactionCreate:
+    """Transaction creation."""
+
+    def test_new_form_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/new')
+        assert resp.status_code == 200
+
+    def test_create_transaction(self, owner_a_client, seed):
+        resp = owner_a_client.post('/transactions/', data={
+            'transaction_type_id': str(seed['tx_type_a']),
+            'street_address': '999 Test Blvd',
+            'city': 'Houston',
+            'state': 'TX',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+
+class TestTransactionEdit:
+    """Transaction editing."""
+
+    def test_edit_form_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}/edit')
+        assert resp.status_code == 200
+
+    def test_update_transaction(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/transactions/{seed["tx_a"]}', data={
+            'transaction_type_id': str(seed['tx_type_a']),
+            'street_address': '100 Main St Updated',
+            'city': 'Austin',
+            'state': 'TX',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    def test_edit_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/edit')
+        assert resp.status_code == 404
+
+    def test_update_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/transactions/{seed["tx_b"]}', data={
+            'street_address': 'Hacked',
+        })
+        assert resp.status_code == 404
+
+
+class TestTransactionDelete:
+    """Transaction deletion."""
+
+    def test_delete_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(f'/transactions/{seed["tx_b"]}/delete')
+        assert resp.status_code == 404
+
+
+class TestTransactionStatusAPI:
+    """Status update API."""
+
+    def test_update_status(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_a"]}/status',
+            json={'status': 'active'},
+            content_type='application/json',
+        )
+        assert resp.status_code in (200, 400)
+
+    def test_update_status_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_b"]}/status',
+            json={'status': 'closed'},
+            content_type='application/json',
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionLockboxAPI:
+    """Lockbox combo API."""
+
+    def test_lockbox_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_b"]}/lockbox-combo',
+            json={'lockbox_combo': '1234'},
+            content_type='application/json',
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionSignersAPI:
+    """Signers API."""
+
+    def test_get_signers(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/api/{seed["tx_a"]}/signers')
+        assert resp.status_code == 200
+
+    def test_signers_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/api/{seed["tx_b"]}/signers')
+        assert resp.status_code == 404
+
+
+class TestTransactionContactSearch:
+    """Contact search API within transactions."""
+
+    def test_search_contacts(self, owner_a_client, seed):
+        resp = owner_a_client.get('/transactions/api/contacts/search?q=Jane')
+        assert resp.status_code == 200
+
+
+class TestTransactionDocuments:
+    """Document management within transactions."""
+
+    def test_document_form_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/transactions/{seed["tx_a"]}/documents/{seed["doc_a"]}/form'
+        )
+        assert resp.status_code == 200
+
+    def test_document_form_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/transactions/{seed["tx_b"]}/documents/{seed["doc_a"]}/form'
+        )
+        assert resp.status_code == 404
+
+    def test_add_document(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_a"]}/documents',
+            data={'template_slug': 'listing-agreement'},
+            follow_redirects=True,
+        )
+        assert resp.status_code in (200, 302, 400)
+
+    def test_add_document_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_b"]}/documents',
+            data={'template_slug': 'listing-agreement'},
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionHistory:
+    """Transaction history endpoints."""
+
+    def test_history_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}/history')
+        assert resp.status_code == 200
+
+    def test_history_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/history')
+        assert resp.status_code == 404
+
+    def test_history_view(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}/history/view')
+        assert resp.status_code == 200
+
+    def test_history_view_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/history/view')
+        assert resp.status_code == 404
+
+
+class TestTransactionIntake:
+    """Intake questionnaire endpoints."""
+
+    def test_intake_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}/intake')
+        assert resp.status_code in (200, 302)
+
+    def test_intake_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/intake')
+        assert resp.status_code == 404
+
+
+class TestTransactionDownload:
+    """Document download endpoints."""
+
+    def test_download_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/transactions/{seed["tx_b"]}/documents/{seed["doc_a"]}/download'
+        )
+        assert resp.status_code == 404
+
+    def test_print_all_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/transactions/{seed["tx_b"]}/documents/print-all-pdf'
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionParticipants:
+    """Participant management endpoints."""
+
+    def test_add_participant(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_a"]}/participants',
+            data={
+                'role': 'buyer',
+                'contact_id': str(seed['contact_a']),
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code in (200, 302, 400)
+
+    def test_add_participant_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            f'/transactions/{seed["tx_b"]}/participants',
+            data={'role': 'buyer', 'contact_id': '999'},
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionSigning:
+    """Signing/preview endpoints."""
+
+    def test_preview_all_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(
+            f'/transactions/{seed["tx_b"]}/documents/preview-all'
+        )
+        assert resp.status_code == 404
+
+
+class TestTransactionRentcast:
+    """RentCast API endpoints."""
+
+    def test_rentcast_cross_org_blocked(self, owner_a_client, seed):
+        resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/rentcast-data')
+        assert resp.status_code == 404

--- a/tests/test_user_todo.py
+++ b/tests/test_user_todo.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for user todo routes.
+
+Covers: page load, todo CRUD API, and cross-org isolation.
+"""
+import json
+import pytest
+from conftest import login
+
+
+class TestUserTodoPage:
+    """User todo page rendering."""
+
+    def test_todo_page_loads(self, owner_a_client, seed):
+        resp = owner_a_client.get('/user_todo')
+        assert resp.status_code == 200
+
+    def test_todo_page_agent(self, agent_a_client, seed):
+        resp = agent_a_client.get('/user_todo')
+        assert resp.status_code == 200
+
+
+class TestUserTodoAPI:
+    """Todo CRUD API endpoints."""
+
+    def test_get_todos_empty(self, owner_a_client, seed):
+        resp = owner_a_client.get('/api/user_todos/get')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, (list, dict))
+
+    def test_save_todos(self, owner_a_client, seed):
+        resp = owner_a_client.post(
+            '/api/user_todos/save',
+            json={
+                'lists': [
+                    {
+                        'name': 'Test List',
+                        'items': [
+                            {'text': 'Buy groceries', 'completed': False},
+                            {'text': 'Call agent', 'completed': True},
+                        ],
+                    },
+                ],
+            },
+            content_type='application/json',
+        )
+        assert resp.status_code == 200
+
+    def test_get_todos_after_save(self, owner_a_client, seed):
+        owner_a_client.post(
+            '/api/user_todos/save',
+            json={
+                'lists': [
+                    {
+                        'name': 'Persist Test',
+                        'items': [{'text': 'Item A', 'completed': False}],
+                    },
+                ],
+            },
+            content_type='application/json',
+        )
+        resp = owner_a_client.get('/api/user_todos/get')
+        assert resp.status_code == 200
+
+    def test_todos_isolated_per_user(self, agent_a_client, seed):
+        agent_a_client.post(
+            '/api/user_todos/save',
+            json={
+                'lists': [
+                    {
+                        'name': 'Agent List',
+                        'items': [{'text': 'Agent item', 'completed': False}],
+                    },
+                ],
+            },
+            content_type='application/json',
+        )
+        resp = agent_a_client.get('/api/user_todos/get')
+        assert resp.status_code == 200


### PR DESCRIPTION
Added a comprehensive Pytest integration test suite to significantly increase test coverage and improve feature stability.

This PR introduces 248 new integration tests covering authentication, CRUD operations for various models (contacts, tasks, transactions, company updates), admin functionalities, organization settings, user todos, feature flags, navigation, and API endpoints. It also updates the CI workflow to run these new tests alongside existing Playwright tests and fixes a pre-existing bug in `test_document_definitions.py`.

---
<p><a href="https://cursor.com/agents/bc-f5d94de3-2490-44e8-b82d-c36c75de881a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5d94de3-2490-44e8-b82d-c36c75de881a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Main risk is CI stability/time: this adds a large new pytest suite and changes the GitHub Actions workflow structure, which could introduce flaky/slow checks, but it does not materially change production application logic.
> 
> **Overview**
> **CI now runs two distinct integration jobs**: a new `pytest` job using a local SQLite DB (no browser/secrets) plus the existing `playwright` browser job.
> 
> Adds shared pytest fixtures in `tests/conftest.py` to spin up a test app, seed two org tiers (pro/free) with representative data, and provide pre-authenticated clients for different roles; then introduces broad route/API integration coverage across auth, admin, org settings, contacts, tasks, transactions, company updates, feature flags, navigation, and user todos.
> 
> Updates `tests/test_document_definitions.py` currency transform assertions to expect DocuSeal-friendly *raw numeric strings* (stripping `$`/commas) and adds `pytest` to `tests/requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df76afe51fe53a3a6111d1a5c4af53cdeeb546d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->