### PR TITLE
feat: placeholder document upload workflow (replaces DocuSeal flow)

### DIFF
--- a/intake_schemas/seller_conventional.json
+++ b/intake_schemas/seller_conventional.json
@@ -2,6 +2,7 @@
   "schema_version": "1.0",
   "transaction_type": "seller",
   "ownership_status": "conventional",
+  "document_workflow": "placeholder_upload_only",
   "title": "Property Questionnaire",
   "description": "Answer these questions to determine which documents are required for this listing.",
   "sections": [

--- a/migrations/versions/add_signed_original_filename.py
+++ b/migrations/versions/add_signed_original_filename.py
@@ -1,0 +1,28 @@
+"""Add signed_original_filename to transaction_documents
+
+Revision ID: add_signed_original_filename
+Revises: add_chat_file_attachments
+Create Date: 2026-04-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'add_signed_original_filename'
+down_revision = 'add_chat_file_attachments'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE transaction_documents
+        ADD COLUMN IF NOT EXISTS signed_original_filename VARCHAR(255)
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE transaction_documents
+        DROP COLUMN IF EXISTS signed_original_filename
+    """)

--- a/models.py
+++ b/models.py
@@ -895,6 +895,7 @@ class TransactionDocument(db.Model):
     signed_file_path = db.Column(db.String(500))  # Path in Supabase storage
     signed_file_size = db.Column(db.Integer)  # Size in bytes
     signed_file_downloaded_at = db.Column(db.DateTime)  # When downloaded from DocuSeal
+    signed_original_filename = db.Column(db.String(255))  # Original filename from upload
     
     # Signing method: 'esign', 'physical', or null (not yet signed)
     signing_method = db.Column(db.String(20), nullable=True)

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -479,6 +479,15 @@ def view_transaction(id):
         rentcast_data = transaction.rentcast_data
         rentcast_fetched_at = transaction.rentcast_fetched_at
     
+    # Determine intake schema availability and document workflow mode
+    from services.intake_service import get_intake_schema
+    intake_schema = get_intake_schema(
+        transaction.transaction_type.name,
+        transaction.ownership_status
+    )
+    has_intake_schema = intake_schema is not None
+    document_workflow_mode = intake_schema.get('document_workflow', 'docuseal') if intake_schema else None
+    
     return render_template(
         'transactions/detail.html',
         transaction=transaction,
@@ -488,7 +497,9 @@ def view_transaction(id):
         listing_info=listing_info,
         lockbox_combo=lockbox_combo,
         rentcast_data=rentcast_data,
-        rentcast_fetched_at=rentcast_fetched_at
+        rentcast_fetched_at=rentcast_fetched_at,
+        has_intake_schema=has_intake_schema,
+        document_workflow_mode=document_workflow_mode
     )
 
 

--- a/routes/transactions/documents.py
+++ b/routes/transactions/documents.py
@@ -108,6 +108,66 @@ def add_document(id):
         return jsonify({'success': False, 'error': str(e)}), 500
 
 
+@transactions_bp.route('/<int:id>/documents/add-placeholder', methods=['POST'])
+@login_required
+@transactions_required
+def add_custom_placeholder(id):
+    """Add a custom placeholder document to a transaction.
+
+    Used in the placeholder_upload_only workflow to let agents add extra
+    documents beyond what the questionnaire generated.  Uses a 'custom-<uuid>'
+    slug so it falls outside the document_rules set and survives re-sync.
+    """
+    import uuid
+
+    transaction = Transaction.query.get_or_404(id)
+
+    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+
+    document_name = (request.form.get('document_name') or '').strip()
+    if not document_name:
+        data = request.get_json(silent=True) or {}
+        document_name = data.get('document_name', '').strip()
+
+    if not document_name:
+        return jsonify({'success': False, 'error': 'Document name is required'}), 400
+
+    try:
+        custom_slug = f"custom-{uuid.uuid4().hex[:12]}"
+
+        doc = TransactionDocument(
+            organization_id=current_user.organization_id,
+            transaction_id=transaction.id,
+            template_slug=custom_slug,
+            template_name=document_name,
+            included_reason='Manually added',
+            status='pending',
+            is_placeholder=True,
+            document_source='placeholder'
+        )
+        db.session.add(doc)
+        db.session.flush()
+
+        audit_service.log_document_added(doc, 'Manually added placeholder')
+
+        db.session.commit()
+
+        return jsonify({
+            'success': True,
+            'document': {
+                'id': doc.id,
+                'name': doc.template_name,
+                'status': doc.status,
+                'source': doc.document_source
+            }
+        })
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @transactions_bp.route('/<int:id>/documents/<int:doc_id>', methods=['DELETE'])
 @login_required
 @transactions_required
@@ -797,6 +857,143 @@ def upload_static_document(id, doc_id):
             }
         })
         
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+# =============================================================================
+# FULFILL PLACEHOLDER (upload completed/signed document to an existing placeholder)
+# =============================================================================
+
+@transactions_bp.route('/<int:id>/documents/<int:doc_id>/fulfill', methods=['POST'])
+@login_required
+@transactions_required
+def fulfill_placeholder_document(id, doc_id):
+    """
+    Upload a completed/signed PDF to fulfill an existing placeholder document.
+
+    Used in the placeholder_upload_only workflow where agents create and sign
+    documents externally (e.g. in ZipForms) then upload the finished PDF here.
+    Sets status='signed', document_source='completed' so the document counts
+    as terminal/complete in progress tracking.
+    """
+    from datetime import datetime
+    from services.supabase_storage import upload_external_document as upload_storage, delete_transaction_document as delete_storage
+    from services.intake_service import post_upload_processing
+
+    transaction = Transaction.query.get_or_404(id)
+
+    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+        return jsonify({'success': False, 'error': 'Unauthorized'}), 403
+
+    doc = TransactionDocument.query.get_or_404(doc_id)
+
+    if doc.transaction_id != transaction.id:
+        return jsonify({'success': False, 'error': 'Document not found'}), 404
+
+    # Allow upload for any doc that hasn't reached a terminal DocuSeal-signed
+    # state. This covers: pending placeholders (initial upload), completed docs
+    # (replace), and legacy template/external/hybrid docs in any pre-signed
+    # state that are now part of a placeholder-mode transaction.
+    docuseal_signed = doc.status == 'signed' and doc.document_source not in ('completed', 'placeholder')
+
+    if docuseal_signed:
+        return jsonify({
+            'success': False,
+            'error': 'This document was signed via DocuSeal and cannot be replaced through upload.'
+        }), 400
+
+    if 'file' not in request.files:
+        return jsonify({'success': False, 'error': 'No file uploaded'}), 400
+
+    file = request.files['file']
+
+    if file.filename == '':
+        return jsonify({'success': False, 'error': 'No file selected'}), 400
+
+    allowed_extensions = {'pdf'}
+    file_ext = file.filename.rsplit('.', 1)[1].lower() if '.' in file.filename else ''
+
+    if file_ext not in allowed_extensions:
+        return jsonify({
+            'success': False,
+            'error': 'Only PDF files are allowed'
+        }), 400
+
+    file_data = file.read()
+    file_size = len(file_data)
+
+    max_size = 25 * 1024 * 1024
+    if file_size > max_size:
+        return jsonify({
+            'success': False,
+            'error': 'File too large. Maximum size is 25MB.'
+        }), 400
+
+    try:
+        result = upload_storage(
+            transaction_id=transaction.id,
+            file_data=file_data,
+            original_filename=file.filename,
+            content_type='application/pdf'
+        )
+
+        is_replace = doc.status == 'signed' and doc.signed_file_path
+        old_path = doc.signed_file_path if is_replace else None
+
+        doc.signed_file_path = result['path']
+        doc.signed_file_size = file_size
+        doc.signed_original_filename = file.filename
+        doc.signed_at = datetime.utcnow()
+        doc.status = 'signed'
+        doc.document_source = 'completed'
+        doc.is_placeholder = False
+        doc.updated_at = datetime.utcnow()
+
+        if is_replace and old_path:
+            try:
+                delete_storage(old_path)
+            except Exception:
+                pass
+
+        event_data = {
+            'document_name': doc.template_name,
+            'document_slug': doc.template_slug,
+            'original_filename': file.filename,
+            'file_size': file_size,
+            'storage_path': result['path']
+        }
+        if is_replace and old_path:
+            event_data['replaced_file_path'] = old_path
+
+        event_desc = f"Document replaced: {doc.template_name}" if is_replace else f"Placeholder fulfilled with uploaded document: {doc.template_name}"
+        audit_service.log_event(
+            event_type='document_placeholder_fulfilled',
+            transaction_id=transaction.id,
+            document_id=doc.id,
+            description=event_desc,
+            event_data=event_data,
+            source='app',
+            actor_id=current_user.id
+        )
+
+        db.session.commit()
+
+        post_upload_processing(doc, file_data)
+
+        return jsonify({
+            'success': True,
+            'message': 'Document uploaded successfully',
+            'document': {
+                'id': doc.id,
+                'name': doc.template_name,
+                'status': doc.status,
+                'source': doc.document_source,
+                'signed_file_path': doc.signed_file_path
+            }
+        })
+
     except Exception as e:
         db.session.rollback()
         return jsonify({'success': False, 'error': str(e)}), 500

--- a/routes/transactions/intake.py
+++ b/routes/transactions/intake.py
@@ -116,15 +116,19 @@ def preview_document_changes(id):
     """
     Preview what documents will be added/removed/kept based on intake answers.
     Returns a diff with clear explanations of WHY each change is happening.
+    Uses the shared compute_document_diff helper so preview and generate
+    stay in sync.
     """
-    from services.intake_service import get_intake_schema, evaluate_document_rules, validate_intake_data
+    from services.intake_service import (
+        get_intake_schema, validate_intake_data, compute_document_diff,
+        get_question_labels
+    )
     
     transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         return jsonify({'success': False, 'error': 'Unauthorized'}), 403
     
-    # Get the schema
     schema = get_intake_schema(
         transaction.transaction_type.name,
         transaction.ownership_status
@@ -133,11 +137,7 @@ def preview_document_changes(id):
     if not schema:
         return jsonify({'success': False, 'error': 'Schema not found'}), 404
     
-    # Build question labels lookup
-    question_labels = {}
-    for section in schema.get('sections', []):
-        for question in section.get('questions', []):
-            question_labels[question['id']] = question['label']
+    question_labels = get_question_labels(schema)
     
     # Parse incoming intake data from request
     data = request.get_json() if request.is_json else None
@@ -154,10 +154,8 @@ def preview_document_changes(id):
     else:
         new_intake_data = data.get('intake_data', {})
     
-    # Get old intake data for comparison
     old_intake_data = transaction.intake_data or {}
     
-    # Validate
     is_valid, missing = validate_intake_data(schema, new_intake_data)
     if not is_valid:
         return jsonify({
@@ -172,7 +170,6 @@ def preview_document_changes(id):
         old_val = old_intake_data.get(field_id)
         new_val = new_intake_data.get(field_id)
         if old_val != new_val:
-            # Format values for display
             def format_val(v):
                 if v is True:
                     return 'Yes'
@@ -188,7 +185,7 @@ def preview_document_changes(id):
                 'new_value': format_val(new_val)
             }
     
-    # Build a map of document slug -> triggering rule condition
+    # Build a map of document slug -> triggering rule condition for explanations
     doc_rules = {}
     for rule in schema.get('document_rules', []):
         slug = rule['slug']
@@ -202,74 +199,41 @@ def preview_document_changes(id):
                 'condition': cond
             }
     
-    # Evaluate document rules with new answers
-    required_docs = evaluate_document_rules(schema, new_intake_data)
-    
-    # Get existing documents
+    # Use shared diff helper
     existing_docs = {doc.template_slug: doc for doc in transaction.documents.all()}
-    existing_slugs = set(existing_docs.keys())
+    diff = compute_document_diff(schema, new_intake_data, existing_docs)
     
-    # Get required slugs
-    required_slugs = {doc['slug'] for doc in required_docs}
-    required_docs_by_slug = {doc['slug']: doc for doc in required_docs}
-    
-    # Compute diff
-    to_keep = existing_slugs & required_slugs
-    to_remove = existing_slugs - required_slugs
-    to_add = required_slugs - existing_slugs
-    
-    # Helper to build explanation for a document change
     def get_change_explanation(slug, is_addition):
         rule = doc_rules.get(slug, {})
         if rule.get('always'):
-            return None  # Always-included docs don't need explanation
-        
+            return None
         field = rule.get('field')
         if field and field in changed_questions:
             change = changed_questions[field]
-            if is_addition:
-                return f"You changed \"{change['label']}\" from {change['old_value']} to {change['new_value']}"
-            else:
-                return f"You changed \"{change['label']}\" from {change['old_value']} to {change['new_value']}"
+            return f"You changed \"{change['label']}\" from {change['old_value']} to {change['new_value']}"
         return None
     
-    # Check for blocked removals (sent/signed docs)
-    blocked_removals = []
-    safe_removals = []
-    for slug in to_remove:
-        doc = existing_docs[slug]
-        explanation = get_change_explanation(slug, False)
-        
-        if doc.status in ('sent', 'signed'):
-            blocked_removals.append({
-                'slug': slug,
-                'name': doc.template_name,
-                'status': doc.status,
-                'explanation': explanation,
-                'blocked_reason': f'This document is already {doc.status} and cannot be automatically removed. Void it first if you need to remove it.'
-            })
-        else:
-            safe_removals.append({
-                'slug': slug,
-                'name': doc.template_name,
-                'status': doc.status,
-                'explanation': explanation
-            })
+    # Enrich removals with explanations
+    for removal in diff['safe_removals']:
+        removal['explanation'] = get_change_explanation(removal['slug'], False)
     
-    # Build additions list with explanations
+    blocked_with_detail = []
+    for blocked in diff['blocked_removals']:
+        blocked['explanation'] = get_change_explanation(blocked['slug'], False)
+        blocked['blocked_reason'] = f"This document is already {blocked['status']} and cannot be automatically removed. Void it first if you need to remove it."
+        blocked_with_detail.append(blocked)
+    
     additions = []
-    for slug in to_add:
-        doc_info = required_docs_by_slug[slug]
-        explanation = get_change_explanation(slug, True)
+    for slug in diff['to_add']:
+        doc_info = diff['required_docs_by_slug'][slug]
         additions.append({
             'slug': slug,
             'name': doc_info['name'],
-            'explanation': explanation
+            'explanation': get_change_explanation(slug, True)
         })
     
-    # Build keep list
     kept = []
-    for slug in to_keep:
+    for slug in diff['to_keep']:
         doc = existing_docs[slug]
         kept.append({
             'slug': slug,
@@ -277,25 +241,28 @@ def preview_document_changes(id):
             'status': doc.status
         })
     
-    # Determine if this is initial generation or update
-    is_initial = len(existing_slugs) == 0
-    has_changes = len(to_add) > 0 or len(safe_removals) > 0
+    managed_existing = {s for s in existing_docs if not s.startswith('custom-')}
+    is_initial = len(managed_existing) == 0
+    has_changes = len(diff['to_add']) > 0 or len(diff['safe_removals']) > 0
+    
+    document_workflow = schema.get('document_workflow', 'docuseal')
     
     return jsonify({
         'success': True,
         'is_initial': is_initial,
         'has_changes': has_changes,
+        'document_workflow': document_workflow,
         'summary': {
-            'total_docs': len(required_docs),
+            'total_docs': len(diff['required_docs']),
             'adding': len(additions),
-            'removing': len(safe_removals),
+            'removing': len(diff['safe_removals']),
             'keeping': len(kept),
-            'blocked': len(blocked_removals)
+            'blocked': len(blocked_with_detail)
         },
         'additions': additions,
-        'removals': safe_removals,
+        'removals': diff['safe_removals'],
         'kept': kept,
-        'blocked': blocked_removals,
+        'blocked': blocked_with_detail,
         'changed_questions': list(changed_questions.values())
     })
 
@@ -304,16 +271,23 @@ def preview_document_changes(id):
 @login_required
 @transactions_required
 def generate_document_package(id):
-    """Generate the document package based on intake answers."""
-    from services.intake_service import get_intake_schema, evaluate_document_rules, validate_intake_data
-    from services.documents import DocumentLoader, FieldResolver
+    """Generate the document package based on intake answers.
+
+    Branches on schema.document_workflow:
+      - 'placeholder_upload_only': all docs become placeholders for external
+        creation/signing (e.g. ZipForms).
+      - default / 'docuseal': legacy template-based flow with DocuSeal
+        integration (form-driven, pdf-preview, etc.).
+    """
+    from services.intake_service import (
+        get_intake_schema, validate_intake_data, compute_document_diff
+    )
     
     transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
     if transaction.created_by_id != current_user.id and current_user.role != 'admin':
         abort(403)
     
-    # Get the schema
     schema = get_intake_schema(
         transaction.transaction_type.name,
         transaction.ownership_status
@@ -323,162 +297,138 @@ def generate_document_package(id):
         flash('Schema not found for this transaction type.', 'error')
         return redirect(url_for('transactions.view_transaction', id=id))
     
-    # Validate that all required questions are answered
     is_valid, missing = validate_intake_data(schema, transaction.intake_data or {})
     
     if not is_valid:
-        flash(f'Please answer all required questions before generating the document package.', 'error')
+        flash('Please answer all required questions before generating the document package.', 'error')
         return redirect(url_for('transactions.intake_questionnaire', id=id))
     
-    # Evaluate document rules
-    required_docs = evaluate_document_rules(schema, transaction.intake_data)
+    document_workflow = schema.get('document_workflow', 'docuseal')
     
     try:
-        # =================================================================
-        # SMART DIFF-BASED SYNC
-        # Instead of deleting all docs, compare old vs new and only
-        # add/remove what changed. Preserves filled data and signatures.
-        # =================================================================
-        
-        # Get existing documents indexed by slug
         existing_docs = {doc.template_slug: doc for doc in transaction.documents.all()}
-        existing_slugs = set(existing_docs.keys())
-        
-        # Get required slugs from new rules
-        required_slugs = {doc['slug'] for doc in required_docs}
-        required_docs_by_slug = {doc['slug']: doc for doc in required_docs}
-        
-        # Compute diff
-        to_keep = existing_slugs & required_slugs
-        to_remove = existing_slugs - required_slugs
-        to_add = required_slugs - existing_slugs
-        
-        # Track results for user feedback
+        diff = compute_document_diff(schema, transaction.intake_data, existing_docs)
+
+        managed_existing = {s for s in existing_docs if not s.startswith('custom-')}
+
         added_count = 0
         removed_count = 0
-        blocked_removals = []
-        
-        # =================================================================
-        # HANDLE REMOVALS (with safety check for sent/signed docs)
-        # =================================================================
-        for slug in to_remove:
-            doc = existing_docs[slug]
-            
-            # Safety check: don't auto-remove docs that are sent or signed
-            if doc.status in ('sent', 'signed'):
-                blocked_removals.append(doc.template_name)
-                continue
-            
-            # Log removal before deleting
+        blocked_names = [b['name'] for b in diff['blocked_removals']]
+
+        # ---- REMOVALS (same for both workflows) ----
+        for removal in diff['safe_removals']:
+            doc = existing_docs[removal['slug']]
             audit_service.log_document_removed(
                 transaction_id=transaction.id,
                 document_id=doc.id,
                 template_name=doc.template_name
             )
-            
-            # Delete the document (cascade handles signatures)
             db.session.delete(doc)
             removed_count += 1
-        
-        # =================================================================
-        # HANDLE ADDITIONS (create new TransactionDocument records)
-        # =================================================================
-        for slug in to_add:
-            doc_info = required_docs_by_slug[slug]
-            
-            # Check if this is a placeholder document (agent will upload content later)
-            is_placeholder = doc_info.get('is_placeholder', False)
-            
-            # Check if this is a preview-only document
-            definition = DocumentLoader.get(slug)
-            is_preview = definition and definition.is_pdf_preview
-            
-            # Determine document_source and status based on document type
-            if is_placeholder:
-                # Placeholder documents: agent needs to upload content later
-                document_source = 'placeholder'
-                status = 'pending'
-            elif is_preview:
-                # Preview-only documents are auto-filled
-                document_source = 'template'
-                status = 'filled'
-            else:
-                # Regular template documents
-                document_source = 'template'
-                status = 'pending'
-            
-            tx_doc = TransactionDocument(
-                organization_id=current_user.organization_id,
-                transaction_id=transaction.id,
-                template_slug=slug,
-                template_name=doc_info['name'],
-                included_reason=doc_info['reason'] if not doc_info.get('always') else None,
-                status=status,
-                is_placeholder=is_placeholder,
-                document_source=document_source
-            )
-            
-            # Auto-populate field_data for preview-only documents (not placeholders)
-            if is_preview and definition and not is_placeholder:
-                context = {
-                    'user': current_user,
-                    'transaction': transaction,
-                    'form': {},
-                    'organization': current_user.organization
-                }
-                resolved_fields = FieldResolver.resolve(definition, context)
-                field_data = {}
-                for field in resolved_fields:
-                    if field.value:
-                        field_data[field.field_key] = field.value
-                tx_doc.field_data = field_data
-            
-            db.session.add(tx_doc)
-            db.session.flush()  # Get the ID for audit log
-            
-            # Log addition
-            audit_service.log_document_added(tx_doc, tx_doc.included_reason)
-            added_count += 1
-        
-        # =================================================================
-        # LOG PACKAGE SYNC EVENT (if this is a regeneration)
-        # =================================================================
-        if existing_slugs:
-            # This is a re-sync, not initial generation
-            # Calculate actually removed (excluding blocked)
-            actually_removed = [s for s in to_remove if existing_docs[s].status not in ('sent', 'signed')]
-            
+
+        # ---- ADDITIONS ----
+        if document_workflow == 'placeholder_upload_only':
+            # All documents are placeholders — no YAML templates, no DocuSeal
+            for slug in diff['to_add']:
+                doc_info = diff['required_docs_by_slug'][slug]
+                tx_doc = TransactionDocument(
+                    organization_id=current_user.organization_id,
+                    transaction_id=transaction.id,
+                    template_slug=slug,
+                    template_name=doc_info['name'],
+                    included_reason=doc_info['reason'] if not doc_info.get('always') else None,
+                    status='pending',
+                    is_placeholder=True,
+                    document_source='placeholder'
+                )
+                db.session.add(tx_doc)
+                db.session.flush()
+                audit_service.log_document_added(tx_doc, tx_doc.included_reason)
+                added_count += 1
+        else:
+            # Legacy DocuSeal template flow
+            from services.documents import DocumentLoader, FieldResolver
+
+            for slug in diff['to_add']:
+                doc_info = diff['required_docs_by_slug'][slug]
+                is_placeholder = doc_info.get('is_placeholder', False)
+                definition = DocumentLoader.get(slug)
+                is_preview = definition and definition.is_pdf_preview
+
+                if is_placeholder:
+                    document_source = 'placeholder'
+                    status = 'pending'
+                elif is_preview:
+                    document_source = 'template'
+                    status = 'filled'
+                else:
+                    document_source = 'template'
+                    status = 'pending'
+
+                tx_doc = TransactionDocument(
+                    organization_id=current_user.organization_id,
+                    transaction_id=transaction.id,
+                    template_slug=slug,
+                    template_name=doc_info['name'],
+                    included_reason=doc_info['reason'] if not doc_info.get('always') else None,
+                    status=status,
+                    is_placeholder=is_placeholder,
+                    document_source=document_source
+                )
+
+                if is_preview and definition and not is_placeholder:
+                    context = {
+                        'user': current_user,
+                        'transaction': transaction,
+                        'form': {},
+                        'organization': current_user.organization
+                    }
+                    resolved_fields = FieldResolver.resolve(definition, context)
+                    field_data = {}
+                    for field in resolved_fields:
+                        if field.value:
+                            field_data[field.field_key] = field.value
+                    tx_doc.field_data = field_data
+
+                db.session.add(tx_doc)
+                db.session.flush()
+                audit_service.log_document_added(tx_doc, tx_doc.included_reason)
+                added_count += 1
+
+        # ---- AUDIT ----
+        if managed_existing:
+            actually_removed = [r['slug'] for r in diff['safe_removals']]
             audit_service.log_event(
                 event_type=AuditEvent.DOCUMENT_PACKAGE_SYNCED,
                 transaction_id=transaction.id,
                 event_data={
-                    'added': list(to_add),
+                    'added': list(diff['to_add']),
                     'removed': actually_removed,
-                    'kept': list(to_keep),
-                    'blocked': blocked_removals
+                    'kept': list(diff['to_keep']),
+                    'blocked': blocked_names,
+                    'workflow': document_workflow
                 }
             )
         else:
-            # Initial generation
             all_docs = transaction.documents.all()
             audit_service.log_document_package_generated(transaction, all_docs)
 
         db.session.commit()
-        
-        # Build user feedback message
+
+        # ---- USER FEEDBACK ----
         messages = []
         if added_count:
             messages.append(f'{added_count} document(s) added')
         if removed_count:
             messages.append(f'{removed_count} document(s) removed')
-        if to_keep and not added_count and not removed_count:
+        if diff['to_keep'] and not added_count and not removed_count:
             messages.append('No changes needed')
-        if not existing_slugs:
-            messages = [f'{len(required_docs)} document(s) generated']
-        
-        if blocked_removals:
-            flash(f'Warning: Could not remove {", ".join(blocked_removals)} because they are already sent/signed. Void them first if needed.', 'warning')
-        
+        if not managed_existing:
+            messages = [f'{len(diff["required_docs"])} document(s) generated']
+
+        if blocked_names:
+            flash(f'Warning: Could not remove {", ".join(blocked_names)} because they are already sent/signed. Void them first if needed.', 'warning')
+
         flash(f'Document package updated: {", ".join(messages)}!', 'success')
         return redirect(url_for('transactions.view_transaction', id=id))
         

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -115,3 +115,68 @@ def get_question_labels(schema: dict) -> dict:
             labels[question['id']] = question['label']
     return labels
 
+
+def compute_document_diff(schema: dict, intake_data: dict, existing_docs: dict) -> dict:
+    """
+    Evaluate document rules and compute add/remove/keep diff against existing docs.
+
+    Manually added placeholder docs (slugs starting with 'custom-') are excluded
+    from the diff so they survive questionnaire re-sync.
+
+    Args:
+        schema: The intake schema with document_rules
+        intake_data: The user's questionnaire answers
+        existing_docs: Dict of {template_slug: TransactionDocument} for the transaction
+
+    Returns:
+        Dict with keys:
+            required_docs_by_slug, to_add, to_remove, to_keep,
+            blocked_removals, safe_removals
+    """
+    required_docs = evaluate_document_rules(schema, intake_data)
+    required_docs_by_slug = {doc['slug']: doc for doc in required_docs}
+    required_slugs = set(required_docs_by_slug.keys())
+
+    # Exclude manually-added custom placeholders from diffing
+    managed_slugs = {slug for slug in existing_docs if not slug.startswith('custom-')}
+
+    to_keep = managed_slugs & required_slugs
+    to_remove = managed_slugs - required_slugs
+    to_add = required_slugs - managed_slugs
+
+    blocked_removals = []
+    safe_removals = []
+    for slug in to_remove:
+        doc = existing_docs[slug]
+        if doc.status in ('sent', 'signed'):
+            blocked_removals.append({
+                'slug': slug,
+                'name': doc.template_name,
+                'status': doc.status,
+            })
+        else:
+            safe_removals.append({
+                'slug': slug,
+                'name': doc.template_name,
+                'status': doc.status,
+            })
+
+    return {
+        'required_docs': required_docs,
+        'required_docs_by_slug': required_docs_by_slug,
+        'to_add': to_add,
+        'to_remove': to_remove,
+        'to_keep': to_keep,
+        'blocked_removals': blocked_removals,
+        'safe_removals': safe_removals,
+    }
+
+
+def post_upload_processing(doc, file_data: bytes):
+    """
+    Hook for post-upload processing on fulfilled placeholder documents.
+    Currently a no-op. Will be extended with OCR to extract property
+    information from uploaded PDFs and populate transaction fields.
+    """
+    pass
+

--- a/static/js/transaction_uploads.js
+++ b/static/js/transaction_uploads.js
@@ -4,6 +4,29 @@
  */
 
 // =============================================================================
+// SCROLL POSITION PERSISTENCE
+// =============================================================================
+
+const DOCUMENTS_SECTION_ID = 'transaction-documents-card';
+
+function reloadPreservingScroll(targetId) {
+    // Set the hash on the current URL, then reload.
+    // The browser reloads the full page from the server and then scrolls
+    // to the hash element natively — no JS timing issues.
+    const target = targetId || DOCUMENTS_SECTION_ID;
+    history.replaceState(null, '', '#' + target);
+    window.location.reload();
+}
+
+// After the reload, clean the hash from the URL so it doesn't persist.
+window.addEventListener('load', function () {
+    const hash = window.location.hash;
+    if (hash === '#' + DOCUMENTS_SECTION_ID || hash.startsWith('#transaction-document-')) {
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+});
+
+// =============================================================================
 // SHARED HELPER
 // =============================================================================
 
@@ -135,7 +158,7 @@ if (uploadForm) {
                 if (data.success) {
                     showToast('Scanned document uploaded successfully!', 'success');
                     closeUploadScanModal();
-                    location.reload();
+                    reloadPreservingScroll(`transaction-document-${currentUploadDocId}`);
                 } else {
                     showUploadError(data.error || 'Upload failed');
                     document.getElementById('uploadProgress').classList.add('hidden');
@@ -296,7 +319,7 @@ if (esignForm) {
                     if (data.redirect_url) {
                         window.location.href = data.redirect_url;
                     } else {
-                        location.reload();
+                        reloadPreservingScroll(`transaction-document-${currentSignatureDocId}`);
                     }
                 } else {
                     showEsignError(data.error || 'Upload failed');
@@ -454,7 +477,7 @@ if (completedForm) {
                 if (data.success) {
                     showToast('Document uploaded successfully!', 'success');
                     closeAddDocumentModal();
-                    location.reload();
+                    reloadPreservingScroll();
                 } else {
                     showCompletedError(data.error || 'Upload failed');
                     document.getElementById('completedProgress').classList.add('hidden');
@@ -605,7 +628,7 @@ if (staticForm) {
                 if (data.success) {
                     showToast('Document uploaded successfully!', 'success');
                     closeUploadStaticModal();
-                    location.reload();
+                    reloadPreservingScroll(`transaction-document-${currentStaticDocId}`);
                 } else {
                     showStaticError(data.error || 'Upload failed');
                     document.getElementById('staticProgress').classList.add('hidden');
@@ -760,7 +783,7 @@ if (signatureForm) {
                     if (data.redirect_url) {
                         window.location.href = data.redirect_url;
                     } else {
-                        location.reload();
+                        reloadPreservingScroll();
                     }
                 } else {
                     showSignatureError(data.error || 'Upload failed');
@@ -787,5 +810,212 @@ if (signatureForm) {
 
         xhr.open('POST', `/transactions/${transactionId}/documents/${currentSignatureDocId}/upload-for-signature`);
         xhr.send(formData);
+    });
+}
+
+
+// =============================================================================
+// FULFILL PLACEHOLDER MODAL (placeholder_upload_only workflow)
+// =============================================================================
+
+let currentFulfillDocId = null;
+
+function showFulfillPlaceholderModal(docId, docName, isReplace) {
+    currentFulfillDocId = docId;
+    document.getElementById('fulfillDocId').value = docId;
+    document.getElementById('fulfillDocName').textContent = docName;
+
+    document.getElementById('fulfillFileInput').value = '';
+    document.getElementById('fulfillDropContent').classList.remove('hidden');
+    document.getElementById('fulfillFileInfo').classList.add('hidden');
+    document.getElementById('fulfillProgress').classList.add('hidden');
+    document.getElementById('fulfillError').classList.add('hidden');
+    document.getElementById('fulfillUploadBtn').disabled = true;
+
+    const infoBanner = document.getElementById('fulfillInfoBanner');
+    const replaceBanner = document.getElementById('fulfillReplaceBanner');
+    const uploadBtn = document.getElementById('fulfillUploadBtn');
+
+    if (isReplace) {
+        infoBanner.classList.add('hidden');
+        replaceBanner.classList.remove('hidden');
+        uploadBtn.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Replace & Delete Old';
+    } else {
+        infoBanner.classList.remove('hidden');
+        replaceBanner.classList.add('hidden');
+        uploadBtn.innerHTML = '<i class="fas fa-upload mr-2"></i>Upload';
+    }
+
+    document.getElementById('fulfillPlaceholderModal').classList.remove('hidden');
+}
+
+function closeFulfillPlaceholderModal() {
+    document.getElementById('fulfillPlaceholderModal').classList.add('hidden');
+    currentFulfillDocId = null;
+}
+
+function handleFulfillFileSelect(input) {
+    const file = input.files[0];
+    if (!file) return;
+
+    if (!file.name.toLowerCase().endsWith('.pdf')) {
+        showFulfillError('Please select a PDF file.');
+        return;
+    }
+
+    const maxSize = 25 * 1024 * 1024;
+    if (file.size > maxSize) {
+        showFulfillError('File too large. Maximum size is 25MB.');
+        return;
+    }
+
+    document.getElementById('fulfillDropContent').classList.add('hidden');
+    document.getElementById('fulfillFileInfo').classList.remove('hidden');
+    document.getElementById('fulfillFileName').textContent = file.name;
+    document.getElementById('fulfillFileSize').textContent = formatFileSize(file.size);
+    document.getElementById('fulfillError').classList.add('hidden');
+    document.getElementById('fulfillUploadBtn').disabled = false;
+}
+
+function showFulfillError(message) {
+    document.getElementById('fulfillError').classList.remove('hidden');
+    document.getElementById('fulfillErrorText').textContent = message;
+    document.getElementById('fulfillUploadBtn').disabled = true;
+}
+
+// Drag and drop for fulfill placeholder
+const fulfillDropZone = document.getElementById('fulfillDropZone');
+if (fulfillDropZone) {
+    fulfillDropZone.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        this.classList.add('border-teal-400', 'bg-teal-50/30');
+    });
+
+    fulfillDropZone.addEventListener('dragleave', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-teal-400', 'bg-teal-50/30');
+    });
+
+    fulfillDropZone.addEventListener('drop', function(e) {
+        e.preventDefault();
+        this.classList.remove('border-teal-400', 'bg-teal-50/30');
+
+        const files = e.dataTransfer.files;
+        if (files.length > 0) {
+            const fileInput = document.getElementById('fulfillFileInput');
+            fileInput.files = files;
+            handleFulfillFileSelect(fileInput);
+        }
+    });
+}
+
+// Fulfill placeholder form submission
+const fulfillForm = document.getElementById('fulfillPlaceholderForm');
+if (fulfillForm) {
+    fulfillForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+
+        const fileInput = document.getElementById('fulfillFileInput');
+        const file = fileInput.files[0];
+        if (!file) {
+            showFulfillError('Please select a file first.');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        document.getElementById('fulfillProgress').classList.remove('hidden');
+        document.getElementById('fulfillUploadBtn').disabled = true;
+
+        const xhr = new XMLHttpRequest();
+        const transactionId = TX_CONFIG.transactionId;
+
+        xhr.upload.addEventListener('progress', function(e) {
+            if (e.lengthComputable) {
+                const percent = Math.round((e.loaded / e.total) * 100);
+                document.getElementById('fulfillPercent').textContent = percent + '%';
+                document.getElementById('fulfillProgressBar').style.width = percent + '%';
+            }
+        });
+
+        xhr.addEventListener('load', function() {
+            if (xhr.status === 200) {
+                const data = JSON.parse(xhr.responseText);
+                if (data.success) {
+                    showToast('Document uploaded successfully!', 'success');
+                    closeFulfillPlaceholderModal();
+                    reloadPreservingScroll(`transaction-document-${currentFulfillDocId}`);
+                } else {
+                    showFulfillError(data.error || 'Upload failed');
+                    document.getElementById('fulfillProgress').classList.add('hidden');
+                    document.getElementById('fulfillUploadBtn').disabled = false;
+                }
+            } else {
+                try {
+                    const data = JSON.parse(xhr.responseText);
+                    showFulfillError(data.error || 'Upload failed');
+                } catch (err) {
+                    showFulfillError('Upload failed. Please try again.');
+                }
+                document.getElementById('fulfillProgress').classList.add('hidden');
+                document.getElementById('fulfillUploadBtn').disabled = false;
+            }
+        });
+
+        xhr.addEventListener('error', function() {
+            showFulfillError('Network error. Please try again.');
+            document.getElementById('fulfillProgress').classList.add('hidden');
+            document.getElementById('fulfillUploadBtn').disabled = false;
+        });
+
+        xhr.open('POST', `/transactions/${transactionId}/documents/${currentFulfillDocId}/fulfill`);
+        xhr.send(formData);
+    });
+}
+
+
+// =============================================================================
+// ADD CUSTOM PLACEHOLDER MODAL (placeholder_upload_only workflow)
+// =============================================================================
+
+function showAddPlaceholderModal() {
+    document.getElementById('placeholderDocName').value = '';
+    document.getElementById('addPlaceholderModal').classList.remove('hidden');
+}
+
+function closeAddPlaceholderModal() {
+    document.getElementById('addPlaceholderModal').classList.add('hidden');
+}
+
+const addPlaceholderForm = document.getElementById('addPlaceholderForm');
+if (addPlaceholderForm) {
+    addPlaceholderForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+
+        const docName = document.getElementById('placeholderDocName').value.trim();
+        if (!docName) return;
+
+        const transactionId = TX_CONFIG.transactionId;
+        const formData = new FormData();
+        formData.append('document_name', docName);
+
+        fetch(`/transactions/${transactionId}/documents/add-placeholder`, {
+            method: 'POST',
+            body: formData
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                showToast('Placeholder added successfully!', 'success');
+                closeAddPlaceholderModal();
+                reloadPreservingScroll();
+            } else {
+                showToast(data.error || 'Failed to add placeholder', 'error');
+            }
+        })
+        .catch(() => {
+            showToast('Network error. Please try again.', 'error');
+        });
     });
 }

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -100,7 +100,7 @@
         transition: background-color 0.15s ease;
     }
     .doc-row:hover {
-        background: #fafafa;
+        background: #f8fafc;
     }
 
     /* Participant card */
@@ -598,7 +598,7 @@
                 <div id="content-details" class="tab-content active space-y-6">
                 {% endif %}
                 <!-- Property Details Card -->
-                <div class="premium-card p-6">
+                <div id="transaction-documents-card" class="premium-card p-6">
                     <h2 class="section-title">PROPERTY DETAILS</h2>
 
                     <div class="detail-grid">
@@ -657,8 +657,8 @@
                     </div>
                 </div>
 
-                <!-- Property Questionnaire Card (for Seller Conventional) -->
-                {% if transaction.transaction_type.name == 'seller' and transaction.ownership_status == 'conventional' %}
+                <!-- Property Questionnaire Card -->
+                {% if has_intake_schema %}
                 <div class="premium-card p-6">
                     <div class="flex justify-between items-center mb-4">
                         <h2 class="section-title mb-0 pb-0">PROPERTY QUESTIONNAIRE</h2>
@@ -713,106 +713,62 @@
                     <div class="flex justify-between items-center mb-4">
                         <div>
                             <h2 class="section-title mb-0 pb-0">DOCUMENTS</h2>
-                            <p class="text-xs text-slate-500 mt-1">{{ documents|length if documents else 0 }} document{% if documents|length != 1 %}s{% endif %}</p>
+                            {% if document_workflow_mode == 'placeholder_upload_only' and documents %}
+                            {% set uploaded_count = documents|selectattr('status', 'equalto', 'signed')|list|length %}
+                            <p class="text-xs text-slate-400 mt-1">{{ uploaded_count }}/{{ documents|length }} uploaded</p>
+                            {% else %}
+                            <p class="text-xs text-slate-400 mt-1">{{ documents|length if documents else 0 }} document{% if documents|length != 1 %}s{% endif %}</p>
+                            {% endif %}
                         </div>
+                        {% if document_workflow_mode == 'placeholder_upload_only' %}
+                        <button onclick="showAddPlaceholderModal()"
+                                class="text-sm px-3 py-1.5 bg-slate-100 text-slate-600 rounded-md hover:bg-slate-200 transition-colors font-medium border border-slate-200">
+                            <i class="fas fa-plus mr-1.5"></i>Add
+                        </button>
+                        {% else %}
                         <button onclick="showAddDocumentPicker()"
                                 class="text-sm px-3 py-1.5 bg-slate-100 text-slate-600 rounded-md hover:bg-slate-200 transition-colors font-medium border border-slate-200">
                             <i class="fas fa-plus mr-1.5"></i>Add
                         </button>
+                        {% endif %}
                     </div>
                     
                     {% if documents %}
-                    <div class="space-y-2">
+                    <div class="divide-y divide-slate-100">
                         {% for doc in documents %}
-                        <div class="doc-row flex items-center justify-between p-4 rounded-xl border 
-                            {% if doc.is_placeholder and doc.status == 'pending' %}border-amber-300 bg-amber-50
-                            {% else %}border-slate-100{% endif %}">
-                            <div class="flex items-center gap-4">
-                                <div class="w-12 h-12 rounded-xl flex items-center justify-center
-                                    {% if doc.is_placeholder and doc.status == 'pending' %}bg-amber-100
-                                    {% elif doc.status == 'signed' and doc.document_source == 'completed' %}bg-teal-100
-                                    {% elif doc.status == 'signed' %}bg-green-100
-                                    {% elif doc.status == 'sent' %}bg-blue-100
-                                    {% elif doc.status == 'filled' %}bg-purple-100
-                                    {% else %}bg-slate-100{% endif %}">
-                                    {% if doc.is_placeholder and doc.status == 'pending' %}
-                                    <i class="fas fa-exclamation-circle text-amber-600 text-lg"></i>
-                                    {% elif doc.status == 'signed' and doc.document_source == 'completed' %}
-                                    <i class="fas fa-file-upload text-teal-600 text-lg"></i>
-                                    {% elif doc.status == 'signed' and doc.signing_method == 'physical' %}
-                                    <i class="fas fa-pen-nib text-green-600 text-lg"></i>
-                                    {% elif doc.status == 'signed' %}
-                                    <i class="fas fa-file-signature text-green-600 text-lg"></i>
-                                    {% elif doc.status == 'sent' %}
-                                    <i class="fas fa-paper-plane text-blue-600 text-lg"></i>
-                                    {% elif doc.status == 'filled' %}
-                                    <i class="fas fa-file-check text-purple-600 text-lg"></i>
-                                    {% else %}
-                                    <i class="fas fa-file-alt text-slate-400 text-lg"></i>
-                                    {% endif %}
-                                </div>
-                                <div>
-                                    <div class="flex items-center gap-2">
-                                        <span class="font-medium text-slate-800">{{ doc.template_name }}</span>
-                                        {% if doc.is_placeholder and doc.status == 'pending' %}
-                                        <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-amber-100 text-amber-700">
-                                            <i class="fas fa-exclamation-triangle mr-1"></i>Needs Content
-                                        </span>
-                                        {% elif doc.document_source == 'completed' %}
-                                        <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-teal-100 text-teal-700">Uploaded</span>
-                                        {% elif doc.document_source == 'static' %}
-                                        <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-teal-100 text-teal-700">Static PDF</span>
-                                        {% elif doc.document_source == 'external' %}
-                                        <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-purple-100 text-purple-700">External</span>
-                                        {% elif doc.document_source == 'hybrid' %}
-                                        <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-orange-100 text-orange-700">Hybrid</span>
-                                        {% endif %}
-                                    </div>
-                                    {% if doc.included_reason %}
-                                    <div class="text-xs text-slate-500 mt-0.5">
-                                        <i class="fas fa-info-circle mr-1 text-slate-400"></i>{{ doc.included_reason }}
-                                    </div>
+                        {% set awaiting_upload = (document_workflow_mode == 'placeholder_upload_only' and doc.status != 'signed') or (doc.is_placeholder and doc.status == 'pending') %}
+                        <div id="transaction-document-{{ doc.id }}" class="doc-row flex items-center justify-between py-3 px-1 group scroll-mt-28">
+                            <div class="flex items-center gap-3 min-w-0">
+                                <i class="fas {% if doc.status == 'signed' %}fa-file-contract text-emerald-500{% elif awaiting_upload %}fa-file-upload text-slate-400{% elif doc.status == 'sent' %}fa-file-export text-blue-500{% elif doc.status == 'filled' %}fa-file-alt text-purple-500{% else %}fa-file text-slate-300{% endif %} text-lg flex-shrink-0"></i>
+                                <div class="min-w-0">
+                                    <span class="text-sm font-medium text-slate-800 block truncate">{{ doc.template_name }}</span>
+                                    {% if doc.status == 'signed' and doc.signed_original_filename %}
+                                    <span class="text-xs text-slate-400 block truncate" title="{{ doc.signed_original_filename }}"><i class="fas fa-paperclip mr-0.5 text-slate-300"></i>{{ doc.signed_original_filename }}</span>
+                                    {% elif doc.included_reason %}
+                                    <span class="text-xs text-slate-400 block truncate">{{ doc.included_reason }}</span>
                                     {% endif %}
                                 </div>
                             </div>
-                            <div class="flex items-center gap-3">
+                            <div class="flex items-center gap-2 flex-shrink-0 ml-3">
                                 {% if doc.status == 'signed' and doc.signed_file_path %}
-                                <!-- Signed with local copy stored -->
-                                <div class="flex items-center gap-2">
-                                    <span class="px-3 py-1 rounded-md text-xs font-semibold flex items-center gap-1
-                                        {% if doc.document_source == 'completed' %}bg-teal-100 text-teal-700{% else %}bg-green-100 text-green-700{% endif %}">
-                                        {% if doc.document_source == 'completed' %}
-                                        <i class="fas fa-file-upload"></i>Uploaded
-                                        {% elif doc.signing_method == 'physical' %}
-                                        <i class="fas fa-pen-nib"></i>Wet Signed
-                                        {% else %}
-                                        <i class="fas fa-signature"></i>E-Signed
-                                        {% endif %}
-                                    </span>
-                                    <span class="px-2 py-1 rounded-md text-xs font-medium bg-emerald-50 text-emerald-600 flex items-center gap-1" 
-                                          title="Local copy stored in Supabase{% if doc.signed_file_size %} ({{ (doc.signed_file_size / 1024)|round(1) }} KB){% endif %}">
-                                        <i class="fas fa-cloud-download-alt text-xs"></i>
-                                        Stored
-                                    </span>
-                                </div>
-                                {% elif doc.status == 'signed' %}
-                                <!-- Signed but not yet stored locally -->
-                                <span class="px-3 py-1 rounded-md text-xs font-semibold flex items-center gap-1
-                                    {% if doc.document_source == 'completed' %}bg-teal-100 text-teal-700{% else %}bg-green-100 text-green-700{% endif %}">
-                                    {% if doc.document_source == 'completed' %}
-                                    <i class="fas fa-file-upload"></i>Uploaded
-                                    {% elif doc.signing_method == 'physical' %}
-                                    <i class="fas fa-pen-nib"></i>Wet Signed
-                                    {% else %}
-                                    <i class="fas fa-signature"></i>E-Signed
-                                    {% endif %}
+                                <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200">
+                                    <i class="fas fa-check text-[10px]"></i>
+                                    {% if doc.document_source == 'completed' %}Uploaded{% elif doc.signing_method == 'physical' %}Wet Signed{% else %}E-Signed{% endif %}
                                 </span>
+                                {% elif doc.status == 'signed' %}
+                                <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200">
+                                    <i class="fas fa-check text-[10px]"></i>Signed
+                                </span>
+                                {% elif awaiting_upload %}
+                                <button onclick='showFulfillPlaceholderModal({{ doc.id }}, {{ doc.template_name|tojson }})' 
+                                        class="inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium text-slate-500 bg-white border border-slate-200 hover:border-slate-300 hover:text-slate-700 hover:bg-slate-50 transition-colors cursor-pointer">
+                                    <i class="fas fa-upload text-[10px]"></i>Upload
+                                </button>
                                 {% else %}
-                                <span class="px-3 py-1 rounded-md text-xs font-semibold
-                                    {% if doc.status == 'sent' %}bg-blue-100 text-blue-700
-                                    {% elif doc.status == 'filled' %}bg-purple-100 text-purple-700
-                                    {% elif doc.status == 'generated' %}bg-indigo-100 text-indigo-700
-                                    {% else %}bg-slate-100 text-slate-600{% endif %}">
+                                <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium
+                                    {% if doc.status == 'sent' %}bg-blue-50 text-blue-600 border border-blue-200
+                                    {% elif doc.status == 'filled' %}bg-purple-50 text-purple-600 border border-purple-200
+                                    {% else %}bg-slate-50 text-slate-500 border border-slate-200{% endif %}">
                                     {{ doc.status|title }}
                                 </span>
                                 {% endif %}
@@ -820,13 +776,58 @@
                                 <!-- Actions Dropdown Menu -->
                                 <div class="relative doc-actions-dropdown">
                                     <button onclick="toggleDocActionsMenu({{ doc.id }})" 
-                                            class="p-2 rounded-lg text-slate-400 hover:text-orange-600 hover:bg-orange-50 transition-all">
-                                        <i class="fas fa-ellipsis-v"></i>
+                                            class="p-1.5 rounded-md text-slate-300 hover:text-slate-600 hover:bg-slate-100 transition-colors">
+                                        <i class="fas fa-ellipsis-v text-sm"></i>
                                     </button>
                                     <div id="docActionsMenu-{{ doc.id }}" 
                                          class="hidden absolute right-0 top-full mt-1 w-56 bg-white rounded-lg shadow-lg border border-slate-200 z-50 py-2">
                                         
-                                        <!-- EXTERNAL/HYBRID DOCUMENTS: Edit Fields -->
+                                        {% if document_workflow_mode == 'placeholder_upload_only' %}
+                                        {# ============================================================ #}
+                                        {# PLACEHOLDER UPLOAD ONLY WORKFLOW                             #}
+                                        {# Handles: pending placeholders, legacy template docs that     #}
+                                        {# haven't been signed, and already-uploaded completed docs.    #}
+                                        {# ============================================================ #}
+                                        
+                                        {% if doc.status != 'signed' %}
+                                        <button onclick='showFulfillPlaceholderModal({{ doc.id }}, {{ doc.template_name|tojson }})'
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
+                                            <i class="fas fa-upload w-5 text-slate-400"></i>
+                                            <span class="ml-2">Upload Document</span>
+                                        </button>
+                                        {% endif %}
+                                        
+                                        {% if doc.status == 'signed' and doc.signed_file_path %}
+                                        <button onclick="viewStoredDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
+                                            <i class="fas fa-eye w-5 text-slate-400"></i>
+                                            <span class="ml-2">View Document</span>
+                                        </button>
+                                        <button onclick="downloadDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
+                                            <i class="fas fa-download w-5 text-slate-400"></i>
+                                            <span class="ml-2">Download</span>
+                                        </button>
+                                        <div class="border-t border-slate-100 my-1"></div>
+                                        <button onclick='showFulfillPlaceholderModal({{ doc.id }}, {{ doc.template_name|tojson }}, true)'
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
+                                            <i class="fas fa-sync-alt w-5 text-slate-400"></i>
+                                            <span class="ml-2">Replace Document</span>
+                                        </button>
+                                        {% endif %}
+                                        
+                                        <div class="border-t border-slate-100 my-1"></div>
+                                        <button onclick="removeDocument({{ doc.id }})" 
+                                                class="w-full flex items-center px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 transition-colors">
+                                            <i class="fas fa-trash-alt w-5 text-red-400"></i>
+                                            <span class="ml-2">Remove</span>
+                                        </button>
+                                        
+                                        {% else %}
+                                        {# ============================================================ #}
+                                        {# LEGACY DOCUSEAL WORKFLOW (preserved for future reactivation) #}
+                                        {# ============================================================ #}
+                                        
                                         {% if doc.document_source in ['external', 'hybrid'] %}
                                         <a href="{{ url_for('transactions.document_field_editor', id=transaction.id, doc_id=doc.id) }}" 
                                            class="flex items-center px-4 py-2.5 text-sm text-purple-600 hover:bg-purple-50 transition-colors">
@@ -843,7 +844,6 @@
                                         <div class="border-t border-slate-100 my-2"></div>
                                         {% endif %}
                                         
-                                        <!-- PLACEHOLDER DOCUMENTS: Upload options -->
                                         {% if doc.is_placeholder and doc.status == 'pending' %}
                                         <div class="px-4 py-1.5 text-xs font-semibold text-amber-600 uppercase tracking-wider">
                                             Placeholder - Add Content
@@ -861,7 +861,6 @@
                                         <div class="border-t border-slate-100 my-2"></div>
                                         {% endif %}
                                         
-                                        <!-- STATIC DOCUMENTS: View options -->
                                         {% if doc.document_source == 'static' and doc.status == 'filled' %}
                                         <button onclick="viewStaticDocument({{ doc.id }})" 
                                                 class="w-full flex items-center px-4 py-2.5 text-sm text-teal-600 hover:bg-teal-50 transition-colors">
@@ -876,7 +875,6 @@
                                         <div class="border-t border-slate-100 my-2"></div>
                                         {% endif %}
                                         
-                                        <!-- PENDING: Fill Form (Template docs only, not placeholders) -->
                                         {% if doc.status == 'pending' and doc.document_source != 'external' and not doc.is_placeholder %}
                                         <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=doc.id) }}" 
                                            class="flex items-center px-4 py-2.5 text-sm text-blue-600 hover:bg-blue-50 transition-colors">
@@ -885,7 +883,6 @@
                                         </a>
                                         {% endif %}
                                         
-                                        <!-- FILLED/GENERATED: Edit, Preview, Signing Options (not for static or external docs) -->
                                         {% if doc.status in ['filled', 'generated'] and doc.document_source not in ['static', 'external'] %}
                                         <a href="{{ url_for('transactions.document_form', id=transaction.id, doc_id=doc.id) }}" 
                                            class="flex items-center px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 transition-colors">
@@ -914,7 +911,6 @@
                                         </button>
                                         {% endif %}
                                         
-                                        <!-- SENT: Awaiting Signatures -->
                                         {% if doc.status == 'sent' %}
                                         <div class="px-4 py-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
                                             Awaiting Signatures
@@ -937,7 +933,6 @@
                                         </button>
                                         {% endif %}
                                         
-                                        <!-- SIGNED: View/Download -->
                                         {% if doc.status == 'signed' %}
                                         <div class="px-4 py-1.5 text-xs font-semibold text-slate-400 uppercase tracking-wider">
                                             {% if doc.document_source == 'completed' %}Uploaded{% elif doc.signing_method == 'physical' %}Wet Signed{% else %}E-Signed{% endif %}
@@ -983,13 +978,13 @@
                                         {% endif %}
                                         {% endif %}
                                         
-                                        <!-- Remove Document -->
                                         <div class="border-t border-slate-100 my-2"></div>
                                         <button onclick="removeDocument({{ doc.id }})" 
                                                 class="w-full flex items-center px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 transition-colors">
                                             <i class="fas fa-trash-alt w-5"></i>
                                             <span class="ml-2">Remove Document</span>
                                         </button>
+                                        {% endif %}{# end workflow mode branch #}
                                     </div>
                                 </div>
                             </div>
@@ -997,21 +992,21 @@
                         {% endfor %}
                     </div>
                     
-                    <!-- Bulk Actions -->
+                    <!-- Bulk Actions (hidden in placeholder-only workflow) -->
+                    {% if document_workflow_mode != 'placeholder_upload_only' %}
                     <div class="mt-5 pt-5 border-t border-slate-100">
                         <button onclick="fillAllForms()" class="btn-primary w-full px-4 py-3 text-sm">
                             <i class="fas fa-edit mr-2"></i>Fill All Forms
                         </button>
                     </div>
+                    {% endif %}
                     {% else %}
-                    <div class="text-center py-12">
-                        <div class="w-16 h-16 bg-slate-100 rounded-xl flex items-center justify-center mx-auto mb-4">
-                            <i class="fas fa-folder-open text-2xl text-slate-400"></i>
-                        </div>
-                        <h3 class="text-slate-800 font-medium mb-1">No documents yet</h3>
-                        <p class="text-slate-500 text-sm mb-4">
-                            {% if transaction.transaction_type.name == 'seller' and transaction.ownership_status == 'conventional' %}
-                            Complete the questionnaire to generate the document package.
+                    <div class="text-center py-10">
+                        <i class="fas fa-folder-open text-3xl text-slate-200 mb-3"></i>
+                        <h3 class="text-slate-600 font-medium text-sm mb-1">No documents yet</h3>
+                        <p class="text-slate-400 text-xs">
+                            {% if has_intake_schema %}
+                            Complete the questionnaire to generate documents.
                             {% else %}
                             Click "Add" to start building your document package.
                             {% endif %}
@@ -2204,6 +2199,133 @@
     </div>
 </div>
 
+<!-- Fulfill Placeholder Modal (placeholder_upload_only workflow) -->
+<div id="fulfillPlaceholderModal" class="fixed inset-0 z-50 hidden">
+    <div class="modal-overlay absolute inset-0" onclick="closeFulfillPlaceholderModal()"></div>
+    <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-xl shadow-lg max-w-lg w-full p-6 relative z-10">
+            <div class="flex items-center gap-3 mb-5">
+                <div class="w-10 h-10 bg-teal-100 rounded-xl flex items-center justify-center">
+                    <i class="fas fa-cloud-upload-alt text-teal-600"></i>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-slate-800">Upload Completed Document</h3>
+                    <p id="fulfillDocName" class="text-sm text-slate-500"></p>
+                </div>
+            </div>
+            
+            <div id="fulfillInfoBanner" class="mb-4 p-3 bg-teal-50 border border-teal-200 rounded-lg">
+                <p class="text-sm text-teal-700">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    Upload the signed document from ZipForms. It will be stored and marked as complete.
+                </p>
+            </div>
+
+            <div id="fulfillReplaceBanner" class="hidden mb-4 p-3 bg-amber-50 border border-amber-300 rounded-lg">
+                <p class="text-sm text-amber-800 font-medium">
+                    <i class="fas fa-exclamation-triangle mr-1"></i>
+                    This document already has an uploaded file.
+                </p>
+                <p class="text-sm text-amber-700 mt-1">
+                    Uploading a new file will <strong>permanently delete</strong> the existing document and replace it with the new one. This cannot be undone.
+                </p>
+            </div>
+            
+            <form id="fulfillPlaceholderForm" enctype="multipart/form-data">
+                <input type="hidden" id="fulfillDocId" name="doc_id" value="">
+                
+                <div id="fulfillDropZone" 
+                     class="border-2 border-dashed border-slate-200 rounded-xl p-8 text-center cursor-pointer hover:border-teal-400 hover:bg-teal-50/30 transition-colors mb-4"
+                     onclick="document.getElementById('fulfillFileInput').click()">
+                    <div id="fulfillDropContent">
+                        <i class="fas fa-cloud-upload-alt text-4xl text-slate-300 mb-3"></i>
+                        <p class="text-sm font-medium text-slate-600">Drop your PDF here</p>
+                        <p class="text-xs text-slate-400 mt-1">or click to browse</p>
+                    </div>
+                    <div id="fulfillFileInfo" class="hidden">
+                        <i class="fas fa-file-pdf text-4xl text-red-500 mb-3"></i>
+                        <p id="fulfillFileName" class="text-sm font-medium text-slate-700"></p>
+                        <p id="fulfillFileSize" class="text-xs text-slate-400 mt-1"></p>
+                    </div>
+                </div>
+                <input type="file" id="fulfillFileInput" name="file" accept=".pdf" class="hidden" onchange="handleFulfillFileSelect(this)">
+                
+                <div id="fulfillProgress" class="hidden mb-4">
+                    <div class="flex items-center justify-between text-sm mb-2">
+                        <span class="text-slate-600">Uploading...</span>
+                        <span id="fulfillPercent" class="font-medium text-teal-600">0%</span>
+                    </div>
+                    <div class="h-2 bg-slate-100 rounded-full overflow-hidden">
+                        <div id="fulfillProgressBar" class="h-full bg-teal-500 rounded-full transition-all duration-300" style="width: 0%"></div>
+                    </div>
+                </div>
+                
+                <div id="fulfillError" class="hidden mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <p id="fulfillErrorText" class="text-sm text-red-600"></p>
+                </div>
+                
+                <p class="text-xs text-slate-400 mb-4">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    Only PDF files are accepted. Maximum file size: 25MB.
+                </p>
+                
+                <div class="flex gap-3">
+                    <button type="button" onclick="closeFulfillPlaceholderModal()" 
+                            class="flex-1 px-4 py-3 bg-slate-100 text-slate-700 rounded-xl font-medium hover:bg-slate-200 transition-colors">
+                        Cancel
+                    </button>
+                    <button type="submit" id="fulfillUploadBtn" disabled
+                            class="flex-1 px-4 py-3 bg-teal-500 text-white rounded-lg font-medium hover:bg-teal-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                        <i class="fas fa-upload mr-2"></i>Upload
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Add Custom Placeholder Modal (placeholder_upload_only workflow) -->
+<div id="addPlaceholderModal" class="fixed inset-0 z-50 hidden">
+    <div class="modal-overlay absolute inset-0" onclick="closeAddPlaceholderModal()"></div>
+    <div class="absolute inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-xl shadow-lg max-w-lg w-full p-6 relative z-10">
+            <div class="flex items-center justify-between mb-6">
+                <h3 class="text-xl font-bold text-slate-800">Add Document Placeholder</h3>
+                <button onclick="closeAddPlaceholderModal()" class="text-slate-400 hover:text-slate-600 transition-colors">
+                    <i class="fas fa-times text-lg"></i>
+                </button>
+            </div>
+            
+            <div class="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p class="text-sm text-amber-700">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    This creates a placeholder for a document you will prepare and upload later.
+                </p>
+            </div>
+            
+            <form id="addPlaceholderForm">
+                <div class="mb-4">
+                    <label class="block text-sm font-medium text-slate-700 mb-1.5">Document Name *</label>
+                    <input type="text" id="placeholderDocName" name="document_name" required
+                           class="w-full px-4 py-2.5 bg-slate-50 border-2 border-slate-200 rounded-xl text-sm focus:border-orange-500 focus:ring-0 transition-colors" 
+                           placeholder="e.g., Amendment to Contract">
+                </div>
+                
+                <div class="flex gap-3">
+                    <button type="button" onclick="closeAddPlaceholderModal()" 
+                            class="flex-1 px-4 py-3 bg-slate-100 text-slate-700 rounded-xl font-medium hover:bg-slate-200 transition-colors">
+                        Cancel
+                    </button>
+                    <button type="submit" 
+                            class="btn-primary flex-1 px-4 py-3">
+                        Add Placeholder
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <!-- Toast Notification -->
 <div id="toast" class="fixed top-6 left-1/2 transform -translate-x-1/2 z-50 hidden">
     <div id="toastContent" class="flex items-center gap-3 px-5 py-4 bg-white rounded-xl shadow-lg border border-slate-200">
@@ -2217,7 +2339,8 @@
     window.TX_CONFIG = {
         transactionId: {{ transaction.id }},
         rentcastData: {{ rentcast_data|tojson if rentcast_data else 'null' }},
-        fillAllFormsUrl: '{{ url_for("transactions.fill_all_documents", id=transaction.id) }}'
+        fillAllFormsUrl: '{{ url_for("transactions.fill_all_documents", id=transaction.id) }}',
+        documentWorkflowMode: {{ (document_workflow_mode or '')|tojson }}
     };
 </script>
 <script src="{{ url_for('static', filename='js/transaction_detail.js') }}"></script>

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -424,16 +424,18 @@ function showPreviewModal(data) {
     
     let html = '';
     
+    const isPlaceholderWorkflow = data.document_workflow === 'placeholder_upload_only';
+
     if (data.is_initial) {
         // Initial generation - show what will be created
-        confirmBtnText.textContent = 'Generate Documents';
+        confirmBtnText.textContent = isPlaceholderWorkflow ? 'Create Document List' : 'Generate Documents';
         html = `
             <div class="text-center mb-6">
                 <div class="w-20 h-20 mx-auto mb-5 rounded-3xl bg-gradient-to-br from-orange-400 to-orange-600 flex items-center justify-center shadow-xl shadow-orange-500/30">
                     <i class="fas fa-layer-group text-white text-3xl"></i>
                 </div>
-                <h4 class="text-xl font-bold text-slate-800">Create Document Package</h4>
-                <p class="text-slate-500 mt-2">${data.summary.total_docs} documents based on your answers</p>
+                <h4 class="text-xl font-bold text-slate-800">${isPlaceholderWorkflow ? 'Documents to Prepare' : 'Create Document Package'}</h4>
+                <p class="text-slate-500 mt-2">${data.summary.total_docs} document${data.summary.total_docs !== 1 ? 's' : ''} based on your answers${isPlaceholderWorkflow ? ' — create in ZipForms and upload when ready' : ''}</p>
             </div>
             <div class="space-y-2 max-h-60 overflow-y-auto">
                 ${data.additions.map((doc, i) => `
@@ -447,7 +449,6 @@ function showPreviewModal(data) {
             </div>
         `;
     } else if (!data.has_changes) {
-        // No changes needed
         confirmBtnText.textContent = 'Done';
         html = `
             <div class="text-center py-6">


### PR DESCRIPTION
## Summary

- Replaces the DocuSeal document generation/signing flow with a placeholder-based upload workflow for Seller/Conventional transactions. Agents now create and sign documents externally (e.g. ZipForms) and upload the completed PDFs to placeholder slots generated from the questionnaire.
- All existing DocuSeal integration code is preserved and conditionally hidden for future reactivation when Texas Realtors approval is obtained.
- Redesigned documents section UI for a clean, professional look with inline upload buttons, single status badges, uploaded filename display, and scroll position preservation across uploads.

### Backend
- `intake_schemas/seller_conventional.json`: added `document_workflow: "placeholder_upload_only"` flag
- `services/intake_service.py`: extracted shared `compute_document_diff()` helper; added `post_upload_processing()` hook for future OCR
- `routes/transactions/documents.py`: new `fulfill_placeholder_document` route (upload, replace with old file cleanup) and `add_custom_placeholder` route
- `routes/transactions/intake.py`: refactored preview/generate to branch on workflow mode using shared diff helper
- `routes/transactions/crud.py`: passes `document_workflow_mode` and `has_intake_schema` to detail template
- `models.py` + migration: added `signed_original_filename` column to `TransactionDocument`

### Frontend
- `templates/transactions/detail.html`: redesigned documents card — flat rows with dividers, inline upload buttons for pending docs, uploaded filename subtitle, single pill-style status badges, conditional rendering by workflow mode
- `templates/transactions/intake.html`: updated preview modal labels for placeholder workflow
- `static/js/transaction_uploads.js`: fulfill/replace modal with confirmation warning, add-placeholder modal, scroll preservation via URL hash on reload

## Test plan
- [ ] Create a new Seller/Conventional transaction, complete questionnaire, verify placeholder documents are generated (not DocuSeal)
- [ ] Upload a PDF to a pending placeholder — verify it shows as "Uploaded" with filename
- [ ] Replace an already-uploaded document — verify confirmation warning appears and old file is deleted from Supabase
- [ ] Add a custom placeholder via "+ Add" button — verify it persists across questionnaire re-syncs
- [ ] Verify scroll position stays at documents section after upload reload
- [ ] Verify legacy DocuSeal transactions (other types) still show fill/send actions
- [ ] Verify no DocuSeal actions appear for placeholder-mode transactions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a new document workflow mode, new upload/replace endpoints, and a schema-driven branching path that changes document lifecycle/status semantics and storage cleanup behavior for affected transactions.
> 
> **Overview**
> Adds a schema-driven `placeholder_upload_only` document workflow for seller/conventional intake, where questionnaire “generation” creates placeholder `TransactionDocument`s instead of DocuSeal-backed templates.
> 
> Introduces new document APIs to (1) add custom placeholders with `custom-` slugs that persist across re-sync, and (2) fulfill/replace placeholders by uploading signed PDFs to Supabase (including old-file deletion, audit events, and tracking `signed_original_filename`).
> 
> Refactors intake preview/generate to use a shared `compute_document_diff()` helper (excluding `custom-` docs) and updates the transaction detail UI/JS to support the placeholder workflow (inline upload + replace modals, uploaded filename display, hidden DocuSeal actions, and scroll-preserving reloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757342fd29582c9848a8c49efe2812bc5f9ad8ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->