### PR TITLE
feat: AI-powered document data extraction on upload

### DIFF
--- a/migrations/versions/add_extraction_status.py
+++ b/migrations/versions/add_extraction_status.py
@@ -1,0 +1,30 @@
+"""Add extraction_status and extraction_error to transaction_documents
+
+Revision ID: add_extraction_status
+Revises: add_signed_original_filename
+Create Date: 2026-04-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'add_extraction_status'
+down_revision = 'add_signed_original_filename'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE transaction_documents
+        ADD COLUMN IF NOT EXISTS extraction_status VARCHAR(20)
+    """)
+    op.execute("""
+        ALTER TABLE transaction_documents
+        ADD COLUMN IF NOT EXISTS extraction_error TEXT
+    """)
+
+
+def downgrade():
+    op.execute("ALTER TABLE transaction_documents DROP COLUMN IF EXISTS extraction_status")
+    op.execute("ALTER TABLE transaction_documents DROP COLUMN IF EXISTS extraction_error")

--- a/models.py
+++ b/models.py
@@ -914,6 +914,10 @@ class TransactionDocument(db.Model):
     # (e.g., Special Tax District Notice, Referral Agreement when agent-provided)
     is_placeholder = db.Column(db.Boolean, default=False)
     
+    # AI extraction status for uploaded documents (null = not applicable)
+    extraction_status = db.Column(db.String(20))  # pending, processing, complete, failed
+    extraction_error = db.Column(db.Text)  # error details on failure
+    
     # Relationships
     signatures = db.relationship('DocumentSignature', backref='document',
                                 cascade='all, delete-orphan', lazy='dynamic')

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,9 @@ bleach==6.1.0
 # Image processing (for signature image resizing)
 Pillow==12.1.0
 
+# PDF rendering (for document extraction - renders pages to images)
+PyMuPDF==1.25.4
+
 # Server
 gunicorn==23.0.0
 

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -379,8 +379,6 @@ def create_transaction():
 @transactions_required
 def view_transaction(id):
     """View a single transaction."""
-    from datetime import datetime
-    
     # Load transaction with transaction_type - SCOPED TO ORGANIZATION
     transaction = Transaction.query.options(
         joinedload(Transaction.transaction_type)
@@ -410,61 +408,13 @@ def view_transaction(id):
     
     # For seller transactions, extract listing info from the listing agreement document
     listing_info = None
+    listing_extraction_status = None
     if transaction.transaction_type.name == 'seller':
-        # Find the listing agreement document (use Python filter on already-loaded documents)
+        from services.transaction_helpers import build_listing_info
+        listing_info = build_listing_info(documents)
         listing_doc = next((d for d in documents if d.template_slug == 'listing-agreement'), None)
-        if listing_doc and listing_doc.status != 'pending' and listing_doc.field_data:
-            field_data = listing_doc.field_data
-            # Build listing info from field data
-            # Format dates as "January 14, 2026"
-            def format_date(date_str):
-                if not date_str:
-                    return None
-                try:
-                    dt_obj = datetime.strptime(date_str, '%Y-%m-%d')
-                    return dt_obj.strftime('%B %d, %Y')
-                except (ValueError, TypeError):
-                    return date_str
-            
-            # Determine commission structure: Section 5A (with buyer agent) vs 5B (listing broker only)
-            # Detect by checking which fields are populated
-            listing_only_percent = field_data.get('listing_only_percent')
-            listing_only_flat = field_data.get('listing_only_flat')
-            is_listing_broker_only = bool(listing_only_percent or listing_only_flat)
-            
-            if is_listing_broker_only:
-                # Section 5B: Listing broker only
-                broker_fee = None
-                if listing_only_percent:
-                    broker_fee = f"{listing_only_percent}%"
-                elif listing_only_flat:
-                    broker_fee = f"${listing_only_flat}"
-                
-                listing_info = {
-                    'list_price': field_data.get('list_price'),
-                    'listing_start_date': format_date(field_data.get('listing_start_date')),
-                    'listing_end_date': format_date(field_data.get('listing_end_date')),
-                    'commission_type': '5b',
-                    'broker_fee': broker_fee,
-                }
-            else:
-                # Section 5A: With buyer agent compensation
-                buyer_commission = field_data.get('buyer_agent_percent')
-                if buyer_commission:
-                    buyer_commission = f"{buyer_commission}%"
-                else:
-                    buyer_flat = field_data.get('buyer_agent_flat')
-                    if buyer_flat:
-                        buyer_commission = f"${buyer_flat}"
-                
-                listing_info = {
-                    'list_price': field_data.get('list_price'),
-                    'listing_start_date': format_date(field_data.get('listing_start_date')),
-                    'listing_end_date': format_date(field_data.get('listing_end_date')),
-                    'commission_type': '5a',
-                    'total_commission': field_data.get('total_commission'),
-                    'buyer_commission': buyer_commission,
-                }
+        if listing_doc:
+            listing_extraction_status = listing_doc.extraction_status
     
     # Get lockbox combo from extra_data (always available for seller transactions)
     lockbox_combo = None
@@ -495,12 +445,50 @@ def view_transaction(id):
         documents=documents,
         contact_files=contact_files,
         listing_info=listing_info,
+        listing_extraction_status=listing_extraction_status,
         lockbox_combo=lockbox_combo,
         rentcast_data=rentcast_data,
         rentcast_fetched_at=rentcast_fetched_at,
         has_intake_schema=has_intake_schema,
         document_workflow_mode=document_workflow_mode
     )
+
+
+@transactions_bp.route('/<int:id>/extraction-status')
+@login_required
+@transactions_required
+def extraction_status(id):
+    """Check document extraction status and return listing info if ready."""
+    from flask import jsonify
+    from services.transaction_helpers import build_listing_info
+
+    transaction = Transaction.query.filter_by(
+        id=id, organization_id=current_user.organization_id
+    ).first_or_404()
+
+    if transaction.created_by_id != current_user.id and current_user.org_role not in ('admin', 'owner'):
+        abort(403)
+
+    documents = TransactionDocument.query.filter_by(
+        transaction_id=transaction.id
+    ).all()
+
+    listing_doc = next((d for d in documents if d.template_slug == 'listing-agreement'), None)
+
+    status = None
+    error = None
+    if listing_doc:
+        status = listing_doc.extraction_status
+        error = listing_doc.extraction_error
+
+    listing_info = build_listing_info(documents) if transaction.transaction_type.name == 'seller' else None
+
+    return jsonify({
+        'extraction_status': status,
+        'extraction_error': error,
+        'ready': status in ('complete', 'failed'),
+        'listing_info': listing_info,
+    })
 
 
 @transactions_bp.route('/<int:id>/edit')

--- a/routes/transactions/documents.py
+++ b/routes/transactions/documents.py
@@ -951,6 +951,12 @@ def fulfill_placeholder_document(id, doc_id):
         doc.is_placeholder = False
         doc.updated_at = datetime.utcnow()
 
+        from services.document_extractor import EXTRACTION_SCHEMAS
+        if doc.template_slug in EXTRACTION_SCHEMAS:
+            doc.extraction_status = 'pending'
+            doc.extraction_error = None
+            doc.field_data = None
+
         if is_replace and old_path:
             try:
                 delete_storage(old_path)

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -18,6 +18,7 @@ Usage:
     )
 """
 
+import json
 import openai
 import logging
 from config import Config
@@ -390,3 +391,60 @@ def generate_vision_response(
     except Exception as legacy_error:
         logger.error(f"FATAL: All vision models failed. Error: {str(legacy_error)}")
         raise
+
+
+# =============================================================================
+# DOCUMENT EXTRACTION (structured data from document images)
+# =============================================================================
+
+EXTRACTION_MODEL = "gpt-4.1-mini"
+
+
+def generate_document_extraction(
+    system_prompt: str,
+    user_prompt: str,
+    images: list = None,
+    api_key: str = None
+) -> dict:
+    """
+    Extract structured data from document images using GPT-4.1-mini.
+    Returns parsed JSON dict. Uses json_object response format for
+    guaranteed valid JSON output.
+
+    Args:
+        system_prompt: Instructions for the extraction task
+        user_prompt: Field definitions and format instructions
+        images: List of base64-encoded PNG image strings (one per page)
+        api_key: Optional API key override
+
+    Returns:
+        dict with extracted field values
+    """
+    key = api_key or Config.OPENAI_API_KEY
+    if not key:
+        raise ValueError("OpenAI API key is not configured")
+
+    client = openai.OpenAI(api_key=key)
+
+    user_content = [{"type": "text", "text": user_prompt}]
+    for img_b64 in images or []:
+        user_content.append({
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{img_b64}", "detail": "high"}
+        })
+
+    logger.info(f"Document extraction: sending {len(images or [])} page images to {EXTRACTION_MODEL}")
+
+    response = client.chat.completions.create(
+        model=EXTRACTION_MODEL,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content}
+        ],
+        response_format={"type": "json_object"},
+        temperature=0.1
+    )
+
+    result = json.loads(response.choices[0].message.content)
+    logger.info(f"Document extraction: received {len(result)} fields from {EXTRACTION_MODEL}")
+    return result

--- a/services/document_extractor.py
+++ b/services/document_extractor.py
@@ -1,0 +1,151 @@
+"""
+Document data extraction service.
+
+Uses GPT-4.1-mini vision to extract structured field data from uploaded
+PDF documents. Each document type has a registered extraction schema
+that defines which fields to extract and how to prompt the AI.
+
+The extracted data is stored in TransactionDocument.field_data and used
+to populate UI sections (e.g., LISTING INFO) without manual form entry.
+"""
+
+import base64
+import logging
+
+import fitz  # PyMuPDF
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_SCHEMAS = {
+    'listing-agreement': {
+        'fields': {
+            'list_price': 'The listing/sales price of the property (digits only, no $ or commas)',
+            'listing_start_date': 'The listing agreement start/beginning date (YYYY-MM-DD)',
+            'listing_end_date': 'The listing agreement end/expiration date (YYYY-MM-DD)',
+            'total_commission': 'Total commission percentage from Section 5A(1) (number only, no %)',
+            'buyer_agent_percent': 'Buyer agent/other broker percentage share from Section 5A(2) (number only, no %)',
+            'buyer_agent_flat': 'Buyer agent/other broker flat fee from Section 5A(2) (digits only, no $ or commas)',
+            'listing_only_percent': 'Listing broker only fee percentage from Section 5B(1) (number only, no %)',
+            'listing_only_flat': 'Listing broker only flat fee from Section 5B(1) (digits only, no $ or commas)',
+            'protection_period_days': 'Number of days for the protection period from Section 5F (number only)',
+            'financing_types': 'Comma-separated list of accepted financing types checked in Section 11C (e.g. "Conventional, VA, FHA, Cash"). Only include types that are explicitly checked/marked on the document.',
+            'has_hoa': 'Whether the property is subject to a mandatory HOA from Section 2E. Return "yes" if "is" is checked, "no" if "is not" is checked, or null if neither is marked.',
+            'special_provisions': 'The full text of any special provisions from Section 15. Return the exact text as written, or null if blank.',
+        },
+        'system_prompt': (
+            "You are a precise document data extractor for Texas residential listing agreements. "
+            "Extract ONLY the values explicitly written on the document. "
+            "Do NOT invent or guess values. If a field is not filled in, blank, or not found, use null."
+        ),
+    },
+}
+
+
+def _render_pdf_to_images(file_data: bytes) -> list:
+    """Render all PDF pages to base64-encoded PNG images."""
+    images = []
+    doc = fitz.open(stream=file_data, filetype="pdf")
+    try:
+        for page in doc:
+            pix = page.get_pixmap(dpi=200)
+            png_bytes = pix.tobytes("png")
+            images.append(base64.b64encode(png_bytes).decode('ascii'))
+    finally:
+        doc.close()
+    return images
+
+
+def _build_extraction_prompt(schema: dict) -> str:
+    """Build the user prompt with field definitions and format instructions."""
+    lines = [
+        "Extract the following fields from this document.",
+        "Return ONLY a JSON object with these exact keys.",
+        "If a field is not found or is blank, use null. Do NOT invent values.",
+        "",
+        "Fields to extract:",
+    ]
+    for key, description in schema['fields'].items():
+        lines.append(f'  - "{key}": {description}')
+
+    lines.extend([
+        "",
+        "Format rules:",
+        "- Dates MUST be YYYY-MM-DD format",
+        "- Currency/price values: digits only, no $ sign or commas (e.g. 450000)",
+        "- Percentage values: number only, no % sign (e.g. 6)",
+        "- Flat fee values: digits only, no $ sign or commas",
+        "",
+        "Return the JSON object now.",
+    ])
+    return "\n".join(lines)
+
+
+def _set_rls(org_id: int):
+    """Re-set RLS context. Must be called after every commit since SET LOCAL is transaction-scoped."""
+    from jobs.base import set_job_org_context
+    set_job_org_context(org_id)
+
+
+def extract_document_data(doc_id: int, org_id: int, file_data: bytes):
+    """
+    Extract structured data from a document PDF and store in field_data.
+
+    Runs inside a background thread with its own DB session and RLS context.
+    The caller is responsible for setting up app context before calling.
+    org_id is required to re-set RLS after each commit.
+    """
+    from models import db, TransactionDocument
+
+    _set_rls(org_id)
+    doc = TransactionDocument.query.get(doc_id)
+    if not doc:
+        logger.error(f"Document {doc_id} not found for extraction")
+        return
+
+    schema = EXTRACTION_SCHEMAS.get(doc.template_slug)
+    if not schema:
+        logger.warning(f"No extraction schema for template_slug={doc.template_slug}")
+        return
+
+    doc.extraction_status = 'processing'
+    db.session.commit()
+
+    try:
+        _set_rls(org_id)
+
+        images = _render_pdf_to_images(file_data)
+        logger.info(f"Rendered {len(images)} pages for doc {doc_id}")
+
+        from services.ai_service import generate_document_extraction
+
+        result = generate_document_extraction(
+            system_prompt=schema['system_prompt'],
+            user_prompt=_build_extraction_prompt(schema),
+            images=images,
+        )
+
+        logger.info(f"Raw extraction result for doc {doc_id}: {result}")
+
+        doc.field_data = {key: result.get(key) for key in schema['fields'] if result.get(key) is not None}
+
+        from sqlalchemy.orm.attributes import flag_modified
+        flag_modified(doc, 'field_data')
+
+        doc.extraction_status = 'complete'
+        doc.extraction_error = None
+        db.session.commit()
+        logger.info(f"Extraction complete for doc {doc_id}: {len(doc.field_data)} fields populated")
+
+    except Exception as e:
+        db.session.rollback()
+        try:
+            _set_rls(org_id)
+            doc = TransactionDocument.query.get(doc_id)
+            if doc:
+                doc.extraction_status = 'failed'
+                doc.extraction_error = str(e)[:500]
+                db.session.commit()
+        except Exception:
+            logger.error(f"Failed to update extraction_status for doc {doc_id}", exc_info=True)
+
+        logger.error(f"Document extraction failed for doc {doc_id}: {e}", exc_info=True)

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -175,8 +175,35 @@ def compute_document_diff(schema: dict, intake_data: dict, existing_docs: dict) 
 def post_upload_processing(doc, file_data: bytes):
     """
     Hook for post-upload processing on fulfilled placeholder documents.
-    Currently a no-op. Will be extended with OCR to extract property
-    information from uploaded PDFs and populate transaction fields.
+    Spawns a background thread to extract structured data from the uploaded
+    PDF via AI vision, then stores results in doc.field_data.
     """
-    pass
+    import threading
+    import logging
+
+    from services.document_extractor import EXTRACTION_SCHEMAS
+
+    if doc.template_slug not in EXTRACTION_SCHEMAS:
+        return
+
+    doc_id = doc.id
+    org_id = doc.organization_id
+
+    from flask import current_app
+    app = current_app._get_current_object()
+    logger = logging.getLogger(__name__)
+
+    def _run():
+        with app.app_context():
+            try:
+                from models import db
+                from services.document_extractor import extract_document_data
+                extract_document_data(doc_id, org_id, file_data)
+            except Exception as e:
+                logger.error(f"Document extraction failed for doc {doc_id}: {e}", exc_info=True)
+            finally:
+                db.session.remove()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
 

--- a/services/transaction_helpers.py
+++ b/services/transaction_helpers.py
@@ -1,0 +1,92 @@
+"""
+Shared helpers for transaction views and API endpoints.
+"""
+
+from datetime import datetime
+
+
+def _format_date(date_str):
+    if not date_str:
+        return None
+    try:
+        dt_obj = datetime.strptime(str(date_str), '%Y-%m-%d')
+        return dt_obj.strftime('%B %d, %Y')
+    except (ValueError, TypeError):
+        return str(date_str)
+
+
+def _format_currency(value):
+    """Format a numeric value as $X,XXX,XXX."""
+    if value is None:
+        return None
+    try:
+        num = int(float(str(value).replace(',', '').replace('$', '')))
+        return f"${num:,}"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def _format_percent(value):
+    """Format a numeric value as X% (strips trailing zeros)."""
+    if value is None:
+        return None
+    try:
+        num = float(str(value).replace('%', ''))
+        formatted = f"{num:g}"
+        return f"{formatted}%"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def build_listing_info(documents):
+    """
+    Build listing info dict from the listing agreement document's field_data.
+    Returns None if no listing agreement exists or has no data.
+
+    Used by both the transaction detail view and the extraction-status API.
+    """
+    listing_doc = next((d for d in documents if d.template_slug == 'listing-agreement'), None)
+    if not listing_doc or listing_doc.status == 'pending' or not listing_doc.field_data:
+        return None
+
+    field_data = listing_doc.field_data
+
+    listing_only_percent = field_data.get('listing_only_percent')
+    listing_only_flat = field_data.get('listing_only_flat')
+    is_listing_broker_only = bool(listing_only_percent or listing_only_flat)
+
+    hoa_raw = field_data.get('has_hoa')
+    if hoa_raw == 'yes':
+        hoa_display = 'Yes'
+    elif hoa_raw == 'no':
+        hoa_display = 'No'
+    else:
+        hoa_display = None
+
+    common = {
+        'list_price': _format_currency(field_data.get('list_price')),
+        'listing_start_date': _format_date(field_data.get('listing_start_date')),
+        'listing_end_date': _format_date(field_data.get('listing_end_date')),
+        'protection_period_days': field_data.get('protection_period_days'),
+        'financing_types': field_data.get('financing_types'),
+        'has_hoa': hoa_display,
+        'special_provisions': field_data.get('special_provisions'),
+    }
+
+    if is_listing_broker_only:
+        broker_fee = _format_percent(listing_only_percent) or _format_currency(listing_only_flat)
+        common.update({
+            'commission_type': '5b',
+            'broker_fee': broker_fee,
+        })
+    else:
+        buyer_commission = _format_percent(field_data.get('buyer_agent_percent'))
+        if not buyer_commission:
+            buyer_commission = _format_currency(field_data.get('buyer_agent_flat'))
+        common.update({
+            'commission_type': '5a',
+            'total_commission': _format_percent(field_data.get('total_commission')),
+            'buyer_commission': buyer_commission,
+        })
+
+    return common

--- a/static/js/transaction_uploads.js
+++ b/static/js/transaction_uploads.js
@@ -1019,3 +1019,121 @@ if (addPlaceholderForm) {
         });
     });
 }
+
+
+// =============================================================================
+// EXTRACTION STATUS POLLING (listing info auto-populate)
+// =============================================================================
+
+(function() {
+    const card = document.getElementById('listing-info-card');
+    if (!card) return;
+
+    const status = card.dataset.extractionStatus;
+    if (status !== 'pending' && status !== 'processing') return;
+
+    const txId = card.dataset.transactionId;
+    const contentEl = document.getElementById('listing-info-content');
+    if (!txId || !contentEl) return;
+
+    const POLL_INTERVAL = 4000;
+    const MAX_POLLS = 8;
+    let polls = 0;
+
+    const timer = setInterval(function() {
+        polls++;
+
+        fetch(`/transactions/${txId}/extraction-status`)
+            .then(r => r.json())
+            .then(data => {
+                if (data.ready) {
+                    clearInterval(timer);
+                    if (data.listing_info) {
+                        renderListingInfo(contentEl, data.listing_info);
+                    } else if (data.extraction_status === 'failed') {
+                        renderStatusMessage(contentEl, 'bg-red-50', 'fas fa-exclamation-triangle text-red-400', 'Data extraction failed. Try re-uploading the document.');
+                    } else {
+                        renderStatusMessage(contentEl, 'bg-amber-50', 'fas fa-exclamation-triangle text-amber-400', 'Could not extract listing data from this document. Try re-uploading a clearer copy.');
+                    }
+                } else if (polls >= MAX_POLLS) {
+                    clearInterval(timer);
+                    renderStatusMessage(contentEl, 'bg-amber-50', 'fas fa-clock text-amber-400', 'Extraction is taking longer than expected.');
+                }
+            })
+            .catch(function() {
+                if (polls >= MAX_POLLS) clearInterval(timer);
+            });
+    }, POLL_INTERVAL);
+
+    function renderStatusMessage(el, bgClass, iconClass, message) {
+        el.textContent = '';
+        var outer = document.createElement('div');
+        outer.className = 'text-center py-6 mb-4';
+        var iconWrap = document.createElement('div');
+        iconWrap.className = 'w-12 h-12 ' + bgClass + ' rounded-xl flex items-center justify-center mx-auto mb-3';
+        var icon = document.createElement('i');
+        icon.className = iconClass;
+        iconWrap.appendChild(icon);
+        outer.appendChild(iconWrap);
+        var msg = document.createElement('p');
+        msg.className = 'text-sm text-slate-500';
+        msg.textContent = message;
+        outer.appendChild(msg);
+        el.appendChild(outer);
+    }
+
+    function renderListingInfo(el, info) {
+        el.textContent = '';
+
+        function makeRow(label, value, extraClasses) {
+            var row = document.createElement('div');
+            row.className = 'info-row';
+            var labelEl = document.createElement('span');
+            labelEl.className = 'info-label';
+            labelEl.textContent = label;
+            var valueEl = document.createElement('span');
+            valueEl.className = 'info-value' + (extraClasses ? ' ' + extraClasses : '');
+            valueEl.textContent = value || '\u2014';
+            row.appendChild(labelEl);
+            row.appendChild(valueEl);
+            return row;
+        }
+
+        var wrapper = document.createElement('div');
+        wrapper.className = 'space-y-0';
+
+        var price = info.list_price || '\u2014';
+        wrapper.appendChild(makeRow('List Price', price, 'text-emerald-600 font-semibold'));
+        wrapper.appendChild(makeRow('Listing Start Date', info.listing_start_date));
+        wrapper.appendChild(makeRow('Listing Expiration Date', info.listing_end_date));
+
+        if (info.commission_type === '5b') {
+            wrapper.appendChild(makeRow("Broker's Fee (Origen Realty)", info.broker_fee));
+            wrapper.appendChild(makeRow('Buyer Side Commission', 'N/A \u2014 Listing Broker Only (Section 5B)', 'text-slate-400 italic'));
+        } else {
+            wrapper.appendChild(makeRow('Total Commission', info.total_commission));
+            wrapper.appendChild(makeRow('Buyer Side Commission', info.buyer_commission));
+        }
+
+        var protectionVal = info.protection_period_days ? info.protection_period_days + ' days' : null;
+        wrapper.appendChild(makeRow('Protection Period', protectionVal));
+        wrapper.appendChild(makeRow('Accepted Financing', info.financing_types));
+        wrapper.appendChild(makeRow('HOA Required', info.has_hoa));
+
+        if (info.special_provisions) {
+            var divider = document.createElement('div');
+            divider.className = 'pt-3 mt-3 border-t border-slate-100';
+            var spLabel = document.createElement('span');
+            spLabel.className = 'info-label block mb-1';
+            spLabel.textContent = 'Special Provisions';
+            var spText = document.createElement('p');
+            spText.className = 'text-sm text-slate-700 leading-relaxed';
+            spText.textContent = info.special_provisions;
+            divider.appendChild(spLabel);
+            divider.appendChild(spText);
+            wrapper.appendChild(divider);
+        }
+
+        el.appendChild(wrapper);
+    }
+})();

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1304,15 +1304,24 @@
 
                 {% if transaction.transaction_type.name == 'seller' %}
                 <!-- Listing Info Card (Seller Transactions Only) -->
-                <div class="premium-card p-6">
+                <div class="premium-card p-6" id="listing-info-card" data-transaction-id="{{ transaction.id }}" data-extraction-status="{{ listing_extraction_status or '' }}">
                     <h2 class="section-title">LISTING INFO</h2>
                     
-                    {% if listing_info %}
+                    <div id="listing-info-content">
+                    {% if listing_extraction_status in ('pending', 'processing') %}
+                    <div class="text-center py-6 mb-4" id="extraction-loading">
+                        <div class="w-12 h-12 bg-blue-50 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <i class="fas fa-spinner fa-spin text-blue-500"></i>
+                        </div>
+                        <p class="text-sm text-slate-600 font-medium">Extracting listing data...</p>
+                        <p class="text-xs text-slate-400 mt-1">This usually takes 10–20 seconds</p>
+                    </div>
+                    {% elif listing_info %}
                     <div class="space-y-0">
                         <div class="info-row">
                             <span class="info-label">List Price</span>
                             <span class="info-value text-emerald-600 font-semibold">
-                                {% if listing_info.list_price %}${{ listing_info.list_price }}{% else %}—{% endif %}
+                                {{ listing_info.list_price or '—' }}
                             </span>
                         </div>
                         <div class="info-row">
@@ -1342,15 +1351,41 @@
                             <span class="info-value">{{ listing_info.buyer_commission or '—' }}</span>
                         </div>
                         {% endif %}
+                        <div class="info-row">
+                            <span class="info-label">Protection Period</span>
+                            <span class="info-value">{% if listing_info.protection_period_days %}{{ listing_info.protection_period_days }} days{% else %}—{% endif %}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Accepted Financing</span>
+                            <span class="info-value">{{ listing_info.financing_types or '—' }}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">HOA Required</span>
+                            <span class="info-value">{{ listing_info.has_hoa or '—' }}</span>
+                        </div>
+                        {% if listing_info.special_provisions %}
+                        <div class="pt-3 mt-3 border-t border-slate-100">
+                            <span class="info-label block mb-1">Special Provisions</span>
+                            <p class="text-sm text-slate-700 leading-relaxed">{{ listing_info.special_provisions }}</p>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% elif listing_extraction_status == 'failed' %}
+                    <div class="text-center py-6 mb-4">
+                        <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <i class="fas fa-exclamation-triangle text-red-400"></i>
+                        </div>
+                        <p class="text-sm text-slate-500">Data extraction failed. Try re-uploading the document.</p>
                     </div>
                     {% else %}
                     <div class="text-center py-6 mb-4">
                         <div class="w-12 h-12 bg-slate-100 rounded-xl flex items-center justify-center mx-auto mb-3">
                             <i class="fas fa-file-alt text-slate-400"></i>
                         </div>
-                        <p class="text-sm text-slate-500">Complete the Listing Agreement to populate this section</p>
+                        <p class="text-sm text-slate-500">Upload the Listing Agreement to populate this section</p>
                     </div>
                     {% endif %}
+                    </div>
                     
                     <!-- Lockbox Combo (always editable) -->
                     <div class="{% if listing_info %}pt-4 mt-4 border-t border-slate-100{% endif %}">


### PR DESCRIPTION
## Summary

- Extracts structured data from uploaded listing agreement PDFs using GPT-4.1-mini vision, automatically populating the LISTING INFO section without manual form entry
- Runs extraction asynchronously in a background thread so agents can continue uploading documents without waiting
- UI polls for extraction status and dynamically renders results when ready, with proper timeout and error handling

## What's extracted (12 fields)

**Financial:** List price, total commission, buyer agent commission (% or flat), listing-only broker fee (% or flat)
**Dates:** Listing start date, listing end date
**Terms:** Protection period days, accepted financing types, HOA status, special provisions

## Key implementation details

- `services/document_extractor.py`: Schema registry + vision extraction pipeline (PDF → PNG via PyMuPDF → GPT-4.1-mini)
- `services/transaction_helpers.py`: Shared `build_listing_info()` helper with currency/percent/date formatting
- Background thread re-sets PostgreSQL RLS context after each commit (SET LOCAL is transaction-scoped)
- Polling endpoint mirrors the same ownership check as the transaction detail view
- JS renderer uses `textContent` (not innerHTML) for all AI-extracted values to prevent XSS
- Replace uploads clear `field_data` before re-extraction to prevent stale values

## Test plan

- [x] Upload a filled listing agreement PDF → LISTING INFO populates within ~15s
- [x] Upload a blank listing agreement → graceful "no data" message
- [x] Replace an uploaded document → old data cleared, new extraction runs
- [ ] Verify extraction works on Railway (PyMuPDF in requirements.txt)
- [ ] Verify polling stops cleanly on timeout, failure, and success states


Made with [Cursor](https://cursor.com)