### PR TITLE
feat: move document extraction to RQ worker with Railway Redis

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,6 +42,9 @@ class Config:
     # SendGrid configuration
     SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
 
+    # Redis / RQ task queue
+    REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+
     # RentCast API configuration
     RENTCAST_API_KEY = os.getenv('RENTCAST_API_KEY')
     RENTCAST_REFRESH_HOURS = int(os.getenv('RENTCAST_REFRESH_HOURS', 48))  # Hours before allowing re-fetch

--- a/jobs/document_extraction.py
+++ b/jobs/document_extraction.py
@@ -1,0 +1,55 @@
+"""
+RQ job for AI document data extraction.
+
+Downloads the PDF from Supabase Storage and runs the extraction pipeline
+(PyMuPDF rendering + GPT vision) inside the worker process, keeping the
+web workers free from memory-heavy rendering.
+"""
+import logging
+
+from jobs.base import set_job_org_context
+
+logger = logging.getLogger(__name__)
+
+
+def extract_document_job(doc_id: int, org_id: int):
+    """
+    Fetch PDF from Supabase and extract structured field data via AI.
+
+    Only doc_id and org_id are passed through the queue -- the PDF bytes
+    are fetched directly from storage so nothing large transits Redis.
+    """
+    from models import db, TransactionDocument
+    from services.supabase_storage import download_document
+    from services.document_extractor import extract_document_data
+
+    try:
+        set_job_org_context(org_id)
+        doc = TransactionDocument.query.get(doc_id)
+        if not doc:
+            logger.error(f"Document {doc_id} not found for extraction")
+            return
+
+        file_path = doc.source_file_path or doc.signed_file_path
+        if not file_path:
+            raise ValueError(
+                f"Document {doc_id} has no source_file_path or signed_file_path "
+                "-- cannot download for extraction"
+            )
+
+        file_data = download_document(file_path)
+        extract_document_data(doc_id, org_id, file_data)
+
+    except Exception as e:
+        logger.error(f"Document extraction job failed for doc {doc_id}: {e}", exc_info=True)
+        try:
+            set_job_org_context(org_id)
+            doc = TransactionDocument.query.get(doc_id)
+            if doc:
+                doc.extraction_status = 'failed'
+                doc.extraction_error = str(e)[:500]
+                db.session.commit()
+        except Exception:
+            logger.error(f"Failed to mark doc {doc_id} as failed", exc_info=True)
+    finally:
+        db.session.remove()

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,10 @@ Pillow==12.1.0
 # PDF rendering (for document extraction - renders pages to images)
 PyMuPDF==1.25.4
 
+# Task queue (background document extraction)
+redis==7.4.0
+rq==2.7.0
+
 # Server
 gunicorn==23.0.0
 

--- a/routes/transactions/documents.py
+++ b/routes/transactions/documents.py
@@ -986,7 +986,7 @@ def fulfill_placeholder_document(id, doc_id):
 
         db.session.commit()
 
-        post_upload_processing(doc, file_data)
+        post_upload_processing(doc)
 
         return jsonify({
             'success': True,

--- a/services/document_extractor.py
+++ b/services/document_extractor.py
@@ -47,7 +47,7 @@ def _render_pdf_to_images(file_data: bytes) -> list:
     doc = fitz.open(stream=file_data, filetype="pdf")
     try:
         for page in doc:
-            pix = page.get_pixmap(dpi=200)
+            pix = page.get_pixmap(dpi=150)
             png_bytes = pix.tobytes("png")
             images.append(base64.b64encode(png_bytes).decode('ascii'))
     finally:

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -172,38 +172,42 @@ def compute_document_diff(schema: dict, intake_data: dict, existing_docs: dict) 
     }
 
 
-def post_upload_processing(doc, file_data: bytes):
+def post_upload_processing(doc):
     """
-    Hook for post-upload processing on fulfilled placeholder documents.
-    Spawns a background thread to extract structured data from the uploaded
-    PDF via AI vision, then stores results in doc.field_data.
-    """
-    import threading
-    import logging
+    Enqueue background AI extraction for fulfilled placeholder documents.
 
+    Non-fatal: if Redis/RQ is unavailable the upload still succeeds and
+    extraction_status stays 'pending' for later retry.
+    """
+    import logging
     from services.document_extractor import EXTRACTION_SCHEMAS
 
     if doc.template_slug not in EXTRACTION_SCHEMAS:
         return
 
-    doc_id = doc.id
-    org_id = doc.organization_id
-
-    from flask import current_app
-    app = current_app._get_current_object()
     logger = logging.getLogger(__name__)
 
-    def _run():
-        with app.app_context():
-            try:
-                from models import db
-                from services.document_extractor import extract_document_data
-                extract_document_data(doc_id, org_id, file_data)
-            except Exception as e:
-                logger.error(f"Document extraction failed for doc {doc_id}: {e}", exc_info=True)
-            finally:
-                db.session.remove()
+    try:
+        from redis import Redis
+        from rq import Queue
+        from config import Config
 
-    thread = threading.Thread(target=_run, daemon=True)
-    thread.start()
+        conn = Redis.from_url(
+            Config.REDIS_URL,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        q = Queue('doc_extraction', connection=conn)
+        q.enqueue(
+            'jobs.document_extraction.extract_document_job',
+            doc_id=doc.id,
+            org_id=doc.organization_id,
+            job_timeout=300,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to enqueue extraction for doc {doc.id}: {e}. "
+            "extraction_status remains 'pending' for manual retry.",
+            exc_info=True,
+        )
 

--- a/tests/test_document_extraction_job.py
+++ b/tests/test_document_extraction_job.py
@@ -1,0 +1,123 @@
+"""
+Tests for the RQ document extraction pipeline.
+
+Covers:
+- post_upload_processing() enqueue failure is non-fatal (upload still succeeds)
+- extract_document_job() fails fast when document has no storage path
+- extract_document_job() marks extraction as 'failed' on download error
+"""
+import io
+from unittest.mock import patch, MagicMock
+
+
+class TestPostUploadEnqueue:
+    """Verify that enqueue failure does not break the upload response."""
+
+    def test_fulfill_succeeds_when_redis_unavailable(self, owner_a_client, seed):
+        """
+        Upload should return 200 even if Redis is down and enqueue raises.
+        The document gets committed; extraction_status stays 'pending'.
+        """
+        pdf_bytes = b'%PDF-1.4 fake content'
+        data = {
+            'file': (io.BytesIO(pdf_bytes), 'listing.pdf'),
+        }
+
+        with patch('redis.Redis.from_url', side_effect=ConnectionError("Redis unavailable")), \
+             patch('services.supabase_storage.get_supabase_client') as mock_sb:
+            mock_client = MagicMock()
+            mock_client.storage.from_.return_value.upload.return_value = None
+            mock_sb.return_value = mock_client
+
+            resp = owner_a_client.post(
+                f'/transactions/{seed["tx_a"]}/documents/{seed["doc_a"]}/fulfill',
+                data=data,
+                content_type='multipart/form-data',
+            )
+
+        assert resp.status_code == 200
+        result = resp.get_json()
+        assert result['success'] is True
+
+    def test_fulfill_enqueues_when_redis_available(self, owner_a_client, seed):
+        """When Redis is available, enqueue is called with correct args."""
+        pdf_bytes = b'%PDF-1.4 fake content'
+        data = {
+            'file': (io.BytesIO(pdf_bytes), 'listing.pdf'),
+        }
+
+        mock_queue_instance = MagicMock()
+
+        with patch('rq.Queue', return_value=mock_queue_instance), \
+             patch('redis.Redis.from_url', return_value=MagicMock()), \
+             patch('services.supabase_storage.get_supabase_client') as mock_sb:
+            mock_client = MagicMock()
+            mock_client.storage.from_.return_value.upload.return_value = None
+            mock_sb.return_value = mock_client
+
+            resp = owner_a_client.post(
+                f'/transactions/{seed["tx_a"]}/documents/{seed["doc_a"]}/fulfill',
+                data=data,
+                content_type='multipart/form-data',
+            )
+
+        assert resp.status_code == 200
+        mock_queue_instance.enqueue.assert_called_once()
+        call_kwargs = mock_queue_instance.enqueue.call_args
+        assert call_kwargs.kwargs['doc_id'] == seed['doc_a']
+
+
+class TestExtractDocumentJob:
+    """Unit tests for the RQ job function itself."""
+
+    def test_missing_storage_path_marks_failed(self, app, db, seed):
+        """Document with no source_file_path or signed_file_path fails fast."""
+        from models import TransactionDocument
+        from jobs.document_extraction import extract_document_job
+
+        doc = db.session.get(TransactionDocument, seed['doc_a'])
+        doc.source_file_path = None
+        doc.signed_file_path = None
+        doc.extraction_status = 'pending'
+        doc.extraction_error = None
+        db.session.flush()
+
+        with patch('jobs.document_extraction.set_job_org_context'), \
+             patch('models.db.session.remove'):
+            extract_document_job(doc_id=seed['doc_a'], org_id=seed['org_a'])
+
+        db.session.expire_all()
+        doc = db.session.get(TransactionDocument, seed['doc_a'])
+        assert doc.extraction_status == 'failed'
+        assert 'cannot download for extraction' in (doc.extraction_error or '').lower()
+
+    def test_download_failure_marks_failed(self, app, db, seed):
+        """If Supabase download raises, extraction is marked failed."""
+        from models import TransactionDocument
+        from jobs.document_extraction import extract_document_job
+
+        doc = db.session.get(TransactionDocument, seed['doc_a'])
+        doc.source_file_path = 'documents/test/fake.pdf'
+        doc.signed_file_path = None
+        doc.extraction_status = 'pending'
+        doc.extraction_error = None
+        db.session.flush()
+
+        with patch('jobs.document_extraction.set_job_org_context'), \
+             patch('models.db.session.remove'), \
+             patch('services.supabase_storage.download_document',
+                   side_effect=Exception("Storage unavailable")):
+            extract_document_job(doc_id=seed['doc_a'], org_id=seed['org_a'])
+
+        db.session.expire_all()
+        doc = db.session.get(TransactionDocument, seed['doc_a'])
+        assert doc.extraction_status == 'failed'
+        assert 'storage unavailable' in (doc.extraction_error or '').lower()
+
+    def test_nonexistent_doc_does_not_raise(self, app, seed):
+        """Job with a bad doc_id logs an error but does not raise."""
+        from jobs.document_extraction import extract_document_job
+
+        with patch('jobs.document_extraction.set_job_org_context'), \
+             patch('models.db.session.remove'):
+            extract_document_job(doc_id=999999, org_id=seed['org_a'])

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,29 @@
+"""
+RQ worker entry point for background document extraction.
+
+Boots the Flask app (reuses the module-level instance from app.py) so that
+SQLAlchemy, config, and all services are available inside jobs.
+
+Usage (local):
+    python worker.py
+
+Railway: set as the custom start command for the worker service.
+"""
+from dotenv import load_dotenv
+load_dotenv()
+
+from redis import Redis
+from rq import Worker, Queue
+from app import app
+from config import Config
+
+def main():
+    with app.app_context():
+        conn = Redis.from_url(Config.REDIS_URL)
+        queues = [Queue('doc_extraction', connection=conn)]
+        worker = Worker(queues, connection=conn)
+        worker.work()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Replaces in-process daemon threads with an RQ background job for AI document extraction, isolating memory-heavy PDF rendering from gunicorn web workers
- Enqueue is non-fatal: if Redis is down, the upload still succeeds and `extraction_status` stays `pending` for later retry
- PDF bytes never transit Redis -- the worker fetches directly from Supabase storage using the existing `download_document()` helper
- Lowers PyMuPDF DPI from 200 to 150 (~44% memory reduction per rendered page)

## Railway deployment steps

After merging, the following manual steps are needed:

1. **Add Redis**: Project canvas > "+ New" > Database > Redis
2. **Add `REDIS_URL` to web service**: Variables > Add Reference to Redis service's `REDIS_URL`
3. **Create worker service**: "+ New" > GitHub Repo > same CRM repo > Settings > Custom Start Command: `python worker.py` > copy all env vars from web service (use Raw Editor bulk copy)
4. **Verify**: Worker logs should show `Worker rq:worker-xxx started`. Upload a test document and confirm extraction runs in the worker logs, not the web logs.

## Test plan

- [x] `pytest tests/test_document_extraction_job.py` -- 5 tests passing (enqueue failure resilience, missing storage path, download failure, nonexistent doc)
- [ ] Deploy to Railway with Redis + worker service
- [ ] Upload a listing agreement PDF and verify extraction completes via worker
- [ ] Confirm web service memory stays flat (~650MB) during uploads


Made with [Cursor](https://cursor.com)