### PR TITLE
feat: Tax Protest tool for enterprise agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ node_modules/
 .vite/
 !static/dist/
 !static/dist/**
+
+# Tax data (large reference files, imported via scripts/import_tax_data.py)
+tax_data/

--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ from routes.platform_admin import platform_bp
 from routes.contact_us import contact_bp
 from routes.gmail_integration import gmail_bp
 from routes.reports import reports_bp
+from routes.tax_protest import tax_protest_bp
 
 def create_app():
     app = Flask(__name__)
@@ -156,6 +157,7 @@ def create_app():
     app.register_blueprint(contact_bp)
     app.register_blueprint(gmail_bp)
     app.register_blueprint(reports_bp)
+    app.register_blueprint(tax_protest_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/feature_flags.py
+++ b/feature_flags.py
@@ -30,6 +30,7 @@ TIER_FEATURES = {
         'TRANSACTIONS': False,
         'DOCUMENT_GENERATION': False,
         'MARKETING': False,
+        'TAX_PROTEST': False,
         
         # Fun features
         'SHOW_DASHBOARD_JOKE': False,
@@ -47,6 +48,7 @@ TIER_FEATURES = {
         'TRANSACTIONS': True,
         'DOCUMENT_GENERATION': True,
         'MARKETING': False,  # Still disabled for all
+        'TAX_PROTEST': False,
         'SHOW_DASHBOARD_JOKE': True,
     },
     'enterprise': {
@@ -61,7 +63,8 @@ TIER_FEATURES = {
         'AI_TASK_SUGGESTIONS': True,
         'TRANSACTIONS': True,
         'DOCUMENT_GENERATION': True,
-        'MARKETING': True,  # Only enterprise has marketing
+        'MARKETING': True,
+        'TAX_PROTEST': True,
         'SHOW_DASHBOARD_JOKE': True,
     }
 }

--- a/migrations/versions/add_tax_protest_tables.py
+++ b/migrations/versions/add_tax_protest_tables.py
@@ -1,0 +1,134 @@
+"""Add tax protest reference tables (chambers_properties, hcad_properties, hcad_buildings)
+
+Revision ID: add_tax_protest_tables
+Revises: add_extraction_status
+Create Date: 2026-04-10
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_tax_protest_tables'
+down_revision = 'add_extraction_status'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    op.create_table(
+        'chambers_properties',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('parcel_id', sa.String(50)),
+        sa.Column('account', sa.String(50)),
+        sa.Column('street', sa.String(200)),
+        sa.Column('street_overflow', sa.String(200)),
+        sa.Column('city', sa.String(100)),
+        sa.Column('zip5', sa.String(10)),
+        sa.Column('prop_street_number', sa.String(20)),
+        sa.Column('prop_street', sa.String(100)),
+        sa.Column('prop_street_dir', sa.String(10)),
+        sa.Column('prop_city', sa.String(100)),
+        sa.Column('prop_zip5', sa.String(10)),
+        sa.Column('legal1', sa.String(500)),
+        sa.Column('legal2', sa.String(500)),
+        sa.Column('legal3', sa.String(500)),
+        sa.Column('legal4', sa.String(500)),
+        sa.Column('acres', sa.Numeric(14, 4)),
+        sa.Column('market_value', sa.Integer()),
+        sa.Column('improvement_hs_val', sa.Integer()),
+        sa.Column('improvement_nhs_val', sa.Integer()),
+    )
+
+    op.create_index('ix_chambers_parcel_id', 'chambers_properties', ['parcel_id'])
+    op.create_index('ix_chambers_account', 'chambers_properties', ['account'])
+    op.create_index('ix_chambers_prop_street_number', 'chambers_properties', ['prop_street_number'])
+    op.create_index('ix_chambers_prop_street', 'chambers_properties', ['prop_street'])
+    op.create_index('ix_chambers_prop_zip5', 'chambers_properties', ['prop_zip5'])
+
+    op.create_table(
+        'hcad_properties',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('acct', sa.String(30)),
+        sa.Column('str_num', sa.String(30)),
+        sa.Column('str_num_sfx', sa.String(50)),
+        sa.Column('str', sa.String(200)),
+        sa.Column('str_sfx', sa.String(50)),
+        sa.Column('str_sfx_dir', sa.String(50)),
+        sa.Column('str_unit', sa.String(50)),
+        sa.Column('site_addr_1', sa.String(200)),
+        sa.Column('site_addr_2', sa.String(100)),
+        sa.Column('site_addr_3', sa.String(30)),
+        sa.Column('acreage', sa.Numeric(14, 4)),
+        sa.Column('assessed_val', sa.Integer()),
+        sa.Column('tot_appr_val', sa.Integer()),
+        sa.Column('tot_mkt_val', sa.Integer()),
+        sa.Column('lgl_1', sa.String(500)),
+        sa.Column('lgl_2', sa.String(500)),
+        sa.Column('lgl_3', sa.String(500)),
+        sa.Column('lgl_4', sa.String(500)),
+        sa.Column('neighborhood_code', sa.String(20)),
+        sa.UniqueConstraint('acct', name='uq_hcad_acct'),
+    )
+
+    op.create_index('ix_hcad_acct', 'hcad_properties', ['acct'])
+    op.create_index('ix_hcad_str_num', 'hcad_properties', ['str_num'])
+    op.create_index('ix_hcad_str', 'hcad_properties', ['str'])
+    op.create_index('ix_hcad_site_addr_3', 'hcad_properties', ['site_addr_3'])
+    op.create_index('ix_hcad_neighborhood_code', 'hcad_properties', ['neighborhood_code'])
+
+    op.create_table(
+        'hcad_neighborhood_codes',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('cd', sa.String(20)),
+        sa.Column('grp_cd', sa.String(20)),
+        sa.Column('dscr', sa.String(500)),
+        sa.UniqueConstraint('cd', name='uq_hcad_nc_cd'),
+    )
+
+    op.create_index('ix_hcad_nc_cd', 'hcad_neighborhood_codes', ['cd'])
+
+    op.create_table(
+        'hcad_buildings',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('acct', sa.String(30), sa.ForeignKey('hcad_properties.acct'), nullable=False),
+        sa.Column('im_sq_ft', sa.Integer()),
+    )
+
+    op.create_index('ix_hcad_bld_acct', 'hcad_buildings', ['acct'])
+
+    if is_postgres:
+        op.execute('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_chambers_legal1_trgm '
+            'ON chambers_properties USING gin (legal1 gin_trgm_ops)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_chambers_prop_street_trgm '
+            'ON chambers_properties USING gin (prop_street gin_trgm_ops)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_hcad_lgl1_trgm '
+            'ON hcad_properties USING gin (lgl_1 gin_trgm_ops)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_hcad_str_trgm '
+            'ON hcad_properties USING gin (str gin_trgm_ops)'
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    if is_postgres:
+        op.execute('DROP INDEX IF EXISTS ix_hcad_str_trgm')
+        op.execute('DROP INDEX IF EXISTS ix_hcad_lgl1_trgm')
+        op.execute('DROP INDEX IF EXISTS ix_chambers_prop_street_trgm')
+        op.execute('DROP INDEX IF EXISTS ix_chambers_legal1_trgm')
+
+    op.drop_table('hcad_buildings')
+    op.drop_table('hcad_neighborhood_codes')
+    op.drop_table('hcad_properties')
+    op.drop_table('chambers_properties')

--- a/models.py
+++ b/models.py
@@ -1484,3 +1484,90 @@ class ContactEmail(db.Model):
             'body_html': self.body_html,
             'created_at': self.created_at.isoformat() if self.created_at else None
         }
+
+
+# =============================================================================
+# TAX PROTEST REFERENCE DATA (shared, no org_id / no RLS)
+# =============================================================================
+
+class ChambersProperty(db.Model):
+    """Chambers County tax appraisal records."""
+    __tablename__ = 'chambers_properties'
+
+    id = db.Column(db.Integer, primary_key=True)
+    parcel_id = db.Column(db.String(50), index=True)
+    account = db.Column(db.String(50), index=True)
+    street = db.Column(db.String(200))
+    street_overflow = db.Column(db.String(200))
+    city = db.Column(db.String(100))
+    zip5 = db.Column(db.String(10))
+    prop_street_number = db.Column(db.String(20), index=True)
+    prop_street = db.Column(db.String(100), index=True)
+    prop_street_dir = db.Column(db.String(10))
+    prop_city = db.Column(db.String(100))
+    prop_zip5 = db.Column(db.String(10), index=True)
+    legal1 = db.Column(db.String(500))
+    legal2 = db.Column(db.String(500))
+    legal3 = db.Column(db.String(500))
+    legal4 = db.Column(db.String(500))
+    acres = db.Column(db.Numeric(14, 4))
+    market_value = db.Column(db.Integer)
+    improvement_hs_val = db.Column(db.Integer)
+    improvement_nhs_val = db.Column(db.Integer)
+
+    def __repr__(self):
+        return f'<ChambersProperty {self.prop_street_number} {self.prop_street}>'
+
+
+class HcadProperty(db.Model):
+    """Harris County (HCAD) tax appraisal records."""
+    __tablename__ = 'hcad_properties'
+
+    id = db.Column(db.Integer, primary_key=True)
+    acct = db.Column(db.String(30), unique=True, index=True)
+    str_num = db.Column(db.String(30), index=True)
+    str_num_sfx = db.Column(db.String(50))
+    str = db.Column(db.String(200), index=True)
+    str_sfx = db.Column(db.String(50))
+    str_sfx_dir = db.Column(db.String(50))
+    str_unit = db.Column(db.String(50))
+    site_addr_1 = db.Column(db.String(200))
+    site_addr_2 = db.Column(db.String(100))
+    site_addr_3 = db.Column(db.String(30), index=True)
+    acreage = db.Column(db.Numeric(14, 4))
+    assessed_val = db.Column(db.Integer)
+    tot_appr_val = db.Column(db.Integer)
+    tot_mkt_val = db.Column(db.Integer)
+    lgl_1 = db.Column(db.String(500))
+    lgl_2 = db.Column(db.String(500))
+    lgl_3 = db.Column(db.String(500))
+    lgl_4 = db.Column(db.String(500))
+
+    neighborhood_code = db.Column(db.String(20), index=True)
+
+    buildings = db.relationship('HcadBuilding', backref='property', lazy='dynamic')
+
+    def __repr__(self):
+        return f'<HcadProperty {self.site_addr_1}>'
+
+
+class HcadNeighborhoodCode(db.Model):
+    """HCAD neighborhood code lookup table."""
+    __tablename__ = 'hcad_neighborhood_codes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    cd = db.Column(db.String(20), unique=True, index=True)
+    grp_cd = db.Column(db.String(20))
+    dscr = db.Column(db.String(500))
+
+    def __repr__(self):
+        return f'<HcadNeighborhoodCode {self.cd} {self.dscr}>'
+
+
+class HcadBuilding(db.Model):
+    """Harris County building records (sq footage)."""
+    __tablename__ = 'hcad_buildings'
+
+    id = db.Column(db.Integer, primary_key=True)
+    acct = db.Column(db.String(30), db.ForeignKey('hcad_properties.acct'), nullable=False, index=True)
+    im_sq_ft = db.Column(db.Integer)

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -1,0 +1,234 @@
+"""
+Tax Protest blueprint.
+Lets agents search their CRM contacts, locate properties in county tax data,
+extract subdivisions via LLM, find lower-value comparables, and download CSV.
+"""
+import csv
+import re
+from io import StringIO
+
+from flask import Blueprint, render_template, request, jsonify, Response, abort, session
+from flask_login import login_required, current_user
+
+from models import db, Contact
+from feature_flags import feature_required
+from services.tenant_service import org_query, can_view_all_org_data
+from services.tax_protest_service import (
+    find_property_in_tax_data,
+    extract_subdivision_llm,
+    find_comparables,
+    get_neighborhood_name,
+    cache_search_result,
+    get_cached_search_result,
+    get_main_property_by_id,
+    _is_valid_subdivision,
+)
+
+tax_protest_bp = Blueprint('tax_protest', __name__, url_prefix='/tax-protest')
+
+
+def _authorized_contact(contact_id):
+    """Load a contact with org + ownership checks. Returns contact or aborts 403."""
+    contact = org_query(Contact).filter_by(id=contact_id).first()
+    if not contact:
+        abort(404, description="Contact not found")
+    if not can_view_all_org_data() and contact.user_id != current_user.id:
+        abort(403, description="You can only search your own contacts")
+    return contact
+
+
+@tax_protest_bp.route('/')
+@login_required
+@feature_required('TAX_PROTEST')
+def index():
+    """Main Tax Protest page."""
+    return render_template('tax_protest/index.html')
+
+
+@tax_protest_bp.route('/search-contacts')
+@login_required
+@feature_required('TAX_PROTEST')
+def search_contacts():
+    """AJAX endpoint: search CRM contacts by name or address."""
+    q = request.args.get('q', '').strip()
+    if len(q) < 2:
+        return jsonify([])
+
+    query = org_query(Contact)
+
+    if not can_view_all_org_data():
+        query = query.filter(Contact.user_id == current_user.id)
+
+    search_term = f'%{q}%'
+    query = query.filter(
+        db.or_(
+            Contact.first_name.ilike(search_term),
+            Contact.last_name.ilike(search_term),
+            db.func.concat(Contact.first_name, ' ', Contact.last_name).ilike(search_term),
+            Contact.street_address.ilike(search_term),
+            Contact.city.ilike(search_term),
+            Contact.zip_code.ilike(search_term),
+        )
+    ).limit(15)
+
+    results = []
+    for c in query.all():
+        addr_parts = [p for p in [c.street_address, c.city, c.state, c.zip_code] if p]
+        results.append({
+            'id': c.id,
+            'name': f"{c.first_name} {c.last_name}",
+            'address': ', '.join(addr_parts),
+            'street_address': c.street_address,
+            'city': c.city,
+            'state': c.state,
+            'zip_code': c.zip_code,
+        })
+
+    return jsonify(results)
+
+
+@tax_protest_bp.route('/search', methods=['POST'])
+@login_required
+@feature_required('TAX_PROTEST')
+def search_property():
+    """Search tax data for a contact's property and find comparables."""
+    data = request.get_json()
+    if not data or not data.get('contact_id'):
+        return jsonify({'error': 'contact_id required'}), 400
+
+    contact = _authorized_contact(data['contact_id'])
+
+    if not contact.street_address:
+        return jsonify({'error': 'Contact has no street address on file'}), 400
+
+    property_record, source = find_property_in_tax_data(
+        contact.street_address, contact.city, contact.zip_code
+    )
+
+    if not property_record:
+        return jsonify({
+            'error': f'No property found matching "{contact.street_address}" in Chambers or Harris County tax records'
+        }), 404
+
+    market_value = property_record.get('market_value')
+    zip_code = property_record.get('zip')
+    neighborhood_code = property_record.get('neighborhood_code')
+    main_sq_ft = property_record.get('sq_ft')
+    subdivision = None
+
+    if source == 'hcad':
+        lgl_2 = property_record.get('legal2') or ''
+        fuzzy = False
+        if _is_valid_subdivision(lgl_2):
+            subdivision = lgl_2.strip()
+        else:
+            subdivision = extract_subdivision_llm(property_record.get('legal1', ''))
+            fuzzy = True
+        if not subdivision:
+            return jsonify({
+                'error': 'Could not determine subdivision from property legal description',
+                'main_property': property_record,
+                'source': source,
+            }), 422
+        comparables = find_comparables(
+            subdivision, zip_code, market_value, source,
+            main_sq_ft=main_sq_ft,
+            fuzzy_subdivision=fuzzy,
+        )
+    else:
+        legal_desc = property_record.get('legal1', '')
+        subdivision = extract_subdivision_llm(legal_desc)
+        if not subdivision:
+            return jsonify({
+                'error': 'Could not extract subdivision from property legal description',
+                'main_property': property_record,
+                'source': source,
+            }), 422
+        comparables = find_comparables(subdivision, zip_code, market_value, source)
+
+    cache_search_result(
+        source=source,
+        subdivision=subdivision,
+        main_property_id=property_record['id'],
+        contact_id=contact.id,
+        zip_code=zip_code,
+        neighborhood_code=neighborhood_code,
+        main_sq_ft=main_sq_ft,
+        fuzzy_subdivision=fuzzy if source == 'hcad' else False,
+    )
+
+    return jsonify({
+        'source': source,
+        'subdivision': subdivision,
+        'main_property': property_record,
+        'comparables': comparables,
+        'total_comparables': len(comparables),
+    })
+
+
+@tax_protest_bp.route('/download-csv')
+@login_required
+@feature_required('TAX_PROTEST')
+def download_csv():
+    """Download CSV of comparables using cached search result (no LLM re-run)."""
+    cached = get_cached_search_result()
+    if not cached:
+        abort(400, description="No search results to download. Run a search first.")
+
+    contact = _authorized_contact(cached['contact_id'])
+
+    main_property = get_main_property_by_id(cached['main_property_id'], cached['source'])
+    if not main_property:
+        abort(404, description="Main property no longer found in tax data")
+
+    comparables = find_comparables(
+        cached['subdivision'],
+        cached['zip_code'],
+        main_property['market_value'],
+        cached['source'],
+        main_sq_ft=cached.get('main_sq_ft'),
+        fuzzy_subdivision=cached.get('fuzzy_subdivision', False),
+    )
+
+    output = StringIO()
+    writer = csv.writer(output)
+
+    headers = ['Type', 'Address', 'City', 'Zip', 'Market Value', 'Sq Ft',
+               'Acreage', 'Subdivision', 'Legal Description', 'Account', 'County']
+    writer.writerow(headers)
+
+    county = 'Chambers' if cached['source'] == 'chambers' else 'Harris'
+    subdivision = cached.get('subdivision', '')
+
+    def write_row(prop, row_type='Comparable'):
+        writer.writerow([
+            row_type,
+            prop.get('full_address', ''),
+            prop.get('city', ''),
+            prop.get('zip', ''),
+            prop.get('market_value', ''),
+            prop.get('sq_ft', ''),
+            prop.get('acreage', ''),
+            subdivision,
+            prop.get('legal1', ''),
+            prop.get('account', ''),
+            county,
+        ])
+
+    write_row(main_property, 'Subject Property')
+    for comp in comparables:
+        write_row(comp)
+
+    output.seek(0)
+
+    addr = contact.street_address or 'unknown'
+    filename = re.sub(r'[^a-zA-Z0-9]+', '_', addr).strip('_') + '.csv'
+
+    return Response(
+        output.getvalue(),
+        mimetype='text/csv',
+        headers={
+            'Content-Disposition': f'attachment; filename={filename}',
+            'Content-Type': 'text/csv',
+        }
+    )

--- a/scripts/import_tax_data.py
+++ b/scripts/import_tax_data.py
@@ -1,0 +1,349 @@
+"""
+Re-runnable import script for tax protest reference data.
+
+Usage:
+    .venv/bin/python3 scripts/import_tax_data.py                 # Import all
+    .venv/bin/python3 scripts/import_tax_data.py chambers         # Chambers only
+    .venv/bin/python3 scripts/import_tax_data.py hcad             # HCAD only
+
+Data files:
+    tax_data/chambers.csv           - Chambers County (CSV, ~43k rows)
+    tax_data/real_acct.txt          - Harris County main (TAB-separated, ~1.6M rows)
+    tax_data/building_res.txt       - Harris County buildings (TAB-separated, ~1.3M rows)
+"""
+import csv
+import sys
+import os
+import time
+
+sys.stdout.reconfigure(line_buffering=True)
+csv.field_size_limit(sys.maxsize)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import create_app
+from models import db
+
+BATCH_SIZE = 5000
+
+
+def clean(val):
+    if val is None:
+        return None
+    cleaned = val.strip().strip('\xa0').strip()
+    return cleaned if cleaned else None
+
+
+def safe_int(val):
+    cleaned = clean(val)
+    if not cleaned or cleaned in ('Pending',):
+        return None
+    try:
+        return int(float(cleaned.replace(',', '')))
+    except (ValueError, TypeError):
+        return None
+
+
+def safe_decimal(val):
+    cleaned = clean(val)
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned.replace(',', ''))
+    except (ValueError, TypeError):
+        return None
+
+
+def _get_raw_conn(app):
+    """Get a raw psycopg2 connection from the SQLAlchemy engine."""
+    with app.app_context():
+        engine = db.engine
+        return engine.raw_connection()
+
+
+def _bulk_insert(cursor, table, columns, rows):
+    """Fast bulk insert using psycopg2 execute_values."""
+    from psycopg2.extras import execute_values
+    cols = ', '.join(columns)
+    template = '(' + ', '.join(['%s'] * len(columns)) + ')'
+    sql = f"INSERT INTO {table} ({cols}) VALUES %s"
+    if table == 'hcad_properties':
+        sql += " ON CONFLICT (acct) DO NOTHING"
+    execute_values(cursor, sql, rows, template=template, page_size=BATCH_SIZE)
+
+
+def import_chambers(app):
+    filepath = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'tax_data', 'chambers.csv')
+    if not os.path.exists(filepath):
+        print(f"ERROR: {filepath} not found")
+        return
+
+    print("=== Importing Chambers County data ===")
+    start = time.time()
+
+    conn = _get_raw_conn(app)
+    cursor = conn.cursor()
+
+    print("Truncating chambers_properties...")
+    cursor.execute("DELETE FROM chambers_properties")
+    conn.commit()
+
+    columns = [
+        'parcel_id', 'account', 'street', 'street_overflow', 'city', 'zip5',
+        'prop_street_number', 'prop_street', 'prop_street_dir', 'prop_city', 'prop_zip5',
+        'legal1', 'legal2', 'legal3', 'legal4', 'acres', 'market_value',
+        'improvement_hs_val', 'improvement_nhs_val',
+    ]
+
+    batch = []
+    count = 0
+
+    with open(filepath, 'r', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            batch.append((
+                clean(row.get('Parcel_ID')),
+                clean(row.get('Account')),
+                clean(row.get('Street')),
+                clean(row.get('Street_Overflow')),
+                clean(row.get('City')),
+                clean(row.get('Zip5')),
+                clean(row.get('Prop_Street_Number')),
+                clean(row.get('Prop_Street')),
+                clean(row.get('Prop_Street_Dir')),
+                clean(row.get('Prop_City')),
+                clean(row.get('Prop_Zip5')),
+                clean(row.get('Legal1')),
+                clean(row.get('Legal2')),
+                clean(row.get('Legal3')),
+                clean(row.get('Legal4')),
+                safe_decimal(row.get('Acres')),
+                safe_int(row.get('Market_Value')),
+                safe_int(row.get('Improvement_Hs')),
+                safe_int(row.get('Improvement_Nhs')),
+            ))
+
+            if len(batch) >= BATCH_SIZE:
+                _bulk_insert(cursor, 'chambers_properties', columns, batch)
+                conn.commit()
+                count += len(batch)
+                print(f"  Chambers: {count:,} rows...")
+                batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'chambers_properties', columns, batch)
+        conn.commit()
+        count += len(batch)
+
+    cursor.close()
+    conn.close()
+
+    elapsed = time.time() - start
+    print(f"  Chambers complete: {count:,} rows in {elapsed:.1f}s")
+
+
+def import_hcad_neighborhoods(app):
+    """Import the HCAD neighborhood code lookup table."""
+    nc_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'tax_data', 'real_neighborhood_code.txt')
+    if not os.path.exists(nc_path):
+        print(f"ERROR: {nc_path} not found")
+        return
+
+    print("=== Importing HCAD neighborhood codes ===")
+    conn = _get_raw_conn(app)
+    cursor = conn.cursor()
+
+    cursor.execute("DELETE FROM hcad_neighborhood_codes")
+    conn.commit()
+
+    cols = ['cd', 'grp_cd', 'dscr']
+    batch = []
+    count = 0
+
+    with open(nc_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            cd = clean(row.get('cd'))
+            if not cd:
+                continue
+            batch.append((cd, clean(row.get('grp_cd')), clean(row.get('dscr'))))
+
+            if len(batch) >= BATCH_SIZE:
+                _bulk_insert(cursor, 'hcad_neighborhood_codes', cols, batch)
+                conn.commit()
+                count += len(batch)
+                batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'hcad_neighborhood_codes', cols, batch)
+        conn.commit()
+        count += len(batch)
+
+    cursor.close()
+    conn.close()
+    print(f"  Neighborhood codes complete: {count:,} rows")
+
+
+def import_hcad(app):
+    main_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'tax_data', 'real_acct.txt')
+    bld_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'tax_data', 'building_res.txt')
+
+    if not os.path.exists(main_path):
+        print(f"ERROR: {main_path} not found")
+        return
+    if not os.path.exists(bld_path):
+        print(f"ERROR: {bld_path} not found")
+        return
+
+    print("=== Importing Harris County (HCAD) data ===")
+    start = time.time()
+
+    conn = _get_raw_conn(app)
+    cursor = conn.cursor()
+
+    print("Truncating hcad_buildings and hcad_properties...")
+    cursor.execute("DELETE FROM hcad_buildings")
+    cursor.execute("DELETE FROM hcad_properties")
+    conn.commit()
+
+
+    # --- Main properties ---
+    print("Importing HCAD main properties (real_acct.txt)...")
+    main_cols = [
+        'acct', 'str_num', 'str_num_sfx', 'str', 'str_sfx', 'str_sfx_dir', 'str_unit',
+        'site_addr_1', 'site_addr_2', 'site_addr_3',
+        'acreage', 'assessed_val', 'tot_appr_val', 'tot_mkt_val',
+        'lgl_1', 'lgl_2', 'lgl_3', 'lgl_4',
+        'neighborhood_code',
+    ]
+
+    batch = []
+    count = 0
+
+    with open(main_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            acct = clean(row.get('acct'))
+            if not acct:
+                continue
+
+            batch.append((
+                acct,
+                clean(row.get('str_num')),
+                clean(row.get('str_num_sfx')),
+                clean(row.get('str')),
+                clean(row.get('str_sfx')),
+                clean(row.get('str_sfx_dir')),
+                clean(row.get('str_unit')),
+                clean(row.get('site_addr_1')),
+                clean(row.get('site_addr_2')),
+                clean(row.get('site_addr_3')),
+                safe_decimal(row.get('acreage')),
+                safe_int(row.get('assessed_val')),
+                safe_int(row.get('tot_appr_val')),
+                safe_int(row.get('tot_mkt_val')),
+                clean(row.get('lgl_1')),
+                clean(row.get('lgl_2')),
+                clean(row.get('lgl_3')),
+                clean(row.get('lgl_4')),
+                clean(row.get('Neighborhood_Code')),
+            ))
+
+            if len(batch) >= BATCH_SIZE:
+                _bulk_insert(cursor, 'hcad_properties', main_cols, batch)
+                conn.commit()
+                count += len(batch)
+                if count % 50000 < BATCH_SIZE:
+                    elapsed = time.time() - start
+                    print(f"  HCAD main: {count:,} rows... ({elapsed:.0f}s)")
+                batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'hcad_properties', main_cols, batch)
+        conn.commit()
+        count += len(batch)
+
+    main_elapsed = time.time() - start
+    print(f"  HCAD main complete: {count:,} rows in {main_elapsed:.1f}s")
+
+    # --- Buildings ---
+    print("Importing HCAD buildings (building_res.txt)...")
+    bld_start = time.time()
+    bld_cols = ['acct', 'im_sq_ft']
+    batch = []
+    bld_count = 0
+    bld_skipped = 0
+
+    with open(bld_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            acct = clean(row.get('acct'))
+            if not acct:
+                bld_skipped += 1
+                continue
+
+            batch.append((acct, safe_int(row.get('im_sq_ft'))))
+
+            if len(batch) >= BATCH_SIZE:
+                try:
+                    _bulk_insert(cursor, 'hcad_buildings', bld_cols, batch)
+                    conn.commit()
+                except Exception as e:
+                    conn.rollback()
+                    print(f"  Warning: batch insert failed ({e}), inserting individually...")
+                    for item in batch:
+                        try:
+                            cursor.execute(
+                                "INSERT INTO hcad_buildings (acct, im_sq_ft) VALUES (%s, %s)",
+                                item,
+                            )
+                            conn.commit()
+                        except Exception:
+                            conn.rollback()
+                            bld_skipped += 1
+                bld_count += len(batch)
+                if bld_count % 50000 < BATCH_SIZE:
+                    elapsed = time.time() - bld_start
+                    print(f"  HCAD buildings: {bld_count:,} rows... ({elapsed:.0f}s)")
+                batch = []
+
+    if batch:
+        try:
+            _bulk_insert(cursor, 'hcad_buildings', bld_cols, batch)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            for item in batch:
+                try:
+                    cursor.execute(
+                        "INSERT INTO hcad_buildings (acct, im_sq_ft) VALUES (%s, %s)",
+                        item,
+                    )
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    bld_skipped += 1
+        bld_count += len(batch)
+
+    bld_elapsed = time.time() - bld_start
+    print(f"  HCAD buildings complete: {bld_count:,} rows in {bld_elapsed:.1f}s (skipped {bld_skipped:,})")
+
+    cursor.close()
+    conn.close()
+
+    total_elapsed = time.time() - start
+    print(f"=== HCAD import complete: {count:,} properties + {bld_count:,} buildings in {total_elapsed:.1f}s ===")
+
+
+if __name__ == '__main__':
+    target = sys.argv[1] if len(sys.argv) > 1 else 'all'
+    app = create_app()
+
+    if target in ('all', 'chambers'):
+        import_chambers(app)
+    if target in ('all', 'hcad', 'neighborhoods'):
+        import_hcad_neighborhoods(app)
+    if target in ('all', 'hcad'):
+        import_hcad(app)
+
+    print("\nDone!")

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -1,0 +1,396 @@
+"""
+Tax Protest service layer.
+Handles address lookup in county tax data, LLM-based subdivision extraction,
+comparable property queries, and search result caching for CSV consistency.
+"""
+import re
+import logging
+from flask import session
+from models import db, ChambersProperty, HcadProperty, HcadBuilding, HcadNeighborhoodCode
+
+logger = logging.getLogger(__name__)
+
+SUBDIVISION_SYSTEM_PROMPT = (
+    "You are a Texas property legal description parser. "
+    "Extract ONLY the subdivision or neighborhood name from the given legal description. "
+    "Strip lot numbers, block numbers, section numbers, and any other identifiers. "
+    "Return ONLY the subdivision name in uppercase, nothing else. "
+    "If you cannot identify a subdivision name, return UNKNOWN."
+)
+
+SUBDIVISION_EXAMPLES = (
+    "Examples:\n"
+    "'LOT 21 PINEHURST SEC 2' -> 'PINEHURST'\n"
+    "'111 & 112 PINEHURST SEC 2' -> 'PINEHURST'\n"
+    "'TR 15 BLK 2 SHADY OAKS' -> 'SHADY OAKS'\n"
+    "'LTS 1-3 BLK 4 RIVER BEND SEC 1' -> 'RIVER BEND'\n"
+    "'ALL BLK 1 SSBB' -> 'SSBB'\n"
+)
+
+
+def normalize_address(address):
+    """Normalize a street address for matching."""
+    if not address:
+        return ''
+    addr = address.upper().strip()
+    replacements = {
+        ' STREET': ' ST', ' DRIVE': ' DR', ' AVENUE': ' AVE',
+        ' BOULEVARD': ' BLVD', ' LANE': ' LN', ' COURT': ' CT',
+        ' CIRCLE': ' CIR', ' PLACE': ' PL', ' ROAD': ' RD',
+        ' HIGHWAY': ' HWY', ' PARKWAY': ' PKWY',
+    }
+    for old, new in replacements.items():
+        addr = addr.replace(old, new)
+    addr = re.sub(r'\s*(APT|UNIT|STE|SUITE|#)\s*\S*$', '', addr)
+    addr = re.sub(r'\s+', ' ', addr).strip()
+    return addr
+
+
+def _parse_street_parts(address):
+    """Extract street number and street name from a full address."""
+    addr = normalize_address(address)
+    if not addr:
+        return None, None
+    match = re.match(r'^(\d+)\s+(.+)', addr)
+    if match:
+        return match.group(1), match.group(2)
+    return None, addr
+
+
+def find_property_in_tax_data(street_address, city, zip_code):
+    """
+    Search for a property in Chambers County first, then Harris County.
+    Returns (record_dict, source) or (None, None).
+    """
+    street_num, street_name = _parse_street_parts(street_address)
+    zip_clean = (zip_code or '').strip()[:5]
+
+    # --- Chambers County ---
+    chambers_result = _search_chambers(street_num, street_name, zip_clean)
+    if chambers_result:
+        return chambers_result, 'chambers'
+
+    # --- Harris County (HCAD) ---
+    hcad_result = _search_hcad(street_num, street_name, zip_clean)
+    if hcad_result:
+        return hcad_result, 'hcad'
+
+    return None, None
+
+
+def _search_chambers(street_num, street_name, zip_code):
+    """Search Chambers County by address components.
+    Tries with zip first, retries without if no match (handles data entry mismatches)."""
+    if not street_num or not street_name:
+        return None
+
+    first_word = street_name.split()[0]
+
+    if zip_code:
+        result = ChambersProperty.query.filter(
+            ChambersProperty.prop_zip5 == zip_code,
+            ChambersProperty.prop_street_number == street_num,
+            ChambersProperty.prop_street.ilike(f'%{first_word}%'),
+        ).first()
+        if result:
+            return _chambers_to_dict(result)
+
+    result = ChambersProperty.query.filter(
+        ChambersProperty.prop_street_number == street_num,
+        ChambersProperty.prop_street.ilike(f'%{first_word}%'),
+    ).first()
+    if result:
+        return _chambers_to_dict(result)
+
+    return None
+
+
+def _search_hcad(street_num, street_name, zip_code):
+    """Search Harris County by address components.
+    Uses site_addr_1 (full combined address) to avoid str/str_sfx column split issues.
+    Falls back to relaxed search without zip if initial search misses."""
+    if street_num and street_name:
+        first_word = street_name.split()[0]
+
+        # Try with zip first
+        if zip_code:
+            result = HcadProperty.query.filter(
+                HcadProperty.site_addr_3 == zip_code,
+                HcadProperty.str_num == street_num,
+                HcadProperty.str.ilike(f'%{first_word}%'),
+            ).first()
+            if result:
+                return _hcad_found(result)
+
+        # Retry without zip (contact may have wrong/missing zip)
+        result = HcadProperty.query.filter(
+            HcadProperty.str_num == street_num,
+            HcadProperty.str.ilike(f'%{first_word}%'),
+        ).first()
+        if result:
+            return _hcad_found(result)
+
+    # Last resort: fuzzy match on full site_addr_1
+    if street_num and street_name:
+        result = HcadProperty.query.filter(
+            HcadProperty.site_addr_1.ilike(f'%{street_num}%{street_name.split()[0]}%'),
+        ).first()
+        if result:
+            return _hcad_found(result)
+
+    return None
+
+
+def _is_valid_subdivision(lgl_2):
+    """Check if lgl_2 contains a real subdivision name vs. block/plat/utility labels."""
+    if not lgl_2 or not lgl_2.strip():
+        return False
+    val = lgl_2.strip().upper()
+    if val.startswith('('):
+        return False
+    if re.match(r'^BLK\s+\d', val):
+        return False
+    if re.match(r'^(LTS?\s|LOTS?\s|TRS?\s)', val):
+        return False
+    if len(val) < 3:
+        return False
+    return True
+
+
+def _hcad_found(result):
+    """Helper to load sq_ft and return dict for a matched HCAD property."""
+
+    sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
+        HcadBuilding.acct == result.acct
+    ).scalar()
+
+    return _hcad_to_dict(result, sq_ft)
+
+
+def extract_subdivision_llm(legal_description):
+    """
+    Use GPT-4.1-mini to extract a clean subdivision name from a legal description.
+    Falls back to regex if the LLM call fails.
+    """
+    if not legal_description:
+        return None
+
+    try:
+        from services.ai_service import generate_ai_response
+        prompt = f"{SUBDIVISION_EXAMPLES}\nLegal description: '{legal_description}'"
+        result = generate_ai_response(
+            system_prompt=SUBDIVISION_SYSTEM_PROMPT,
+            user_prompt=prompt,
+            temperature=0.0,
+            reasoning_effort="low",
+        )
+        cleaned = result.strip().strip("'\"").upper()
+        if cleaned and cleaned != 'UNKNOWN' and len(cleaned) > 1:
+            return cleaned
+    except Exception as e:
+        logger.warning(f"LLM subdivision extraction failed, falling back to regex: {e}")
+
+    return extract_subdivision_regex(legal_description)
+
+
+def extract_subdivision_regex(legal_description):
+    """
+    Basic regex extraction of subdivision name from legal descriptions.
+    Strips lot/tract numbers from the front and SEC/BLK info from the end.
+    """
+    if not legal_description:
+        return None
+
+    text = legal_description.upper().strip()
+    text = re.sub(r'^(LOTS?\s+)?[\d\s&,\.]+\s+', '', text)
+    text = re.sub(r'^(TRS?\s+)[\d\s&,\.]+\s*', '', text)
+    text = re.sub(r'^(ALL\s+)?BLK\s+\d+\s*', '', text)
+    text = re.sub(r'\s+SEC(TION)?\s+\d+.*$', '', text)
+    text = re.sub(r'\s+BLK\s+\d+.*$', '', text)
+    text = re.sub(r'\s+PH(ASE)?\s+\d+.*$', '', text)
+
+    text = text.strip()
+    if text and len(text) > 1 and not text.isdigit():
+        return text
+    return None
+
+
+def get_neighborhood_name(neighborhood_code):
+    """Resolve a neighborhood code to its description from the lookup table."""
+    if not neighborhood_code:
+        return None
+    nc = HcadNeighborhoodCode.query.filter_by(cd=neighborhood_code).first()
+    return nc.dscr if nc else None
+
+
+def find_comparables(subdivision, zip_code, market_value, source,
+                     main_sq_ft=None, fuzzy_subdivision=False):
+    """
+    Find properties in the same subdivision and zip with lower market value.
+    For HCAD: matches on lgl_2 (exact when from structured data, ILIKE when
+    from LLM extraction), requires a building, and filters to within 250 sq ft.
+    For Chambers: uses ILIKE on legal1.
+    Returns list of property dicts.
+    """
+    SQ_FT_RANGE = 250
+
+    if source == 'chambers':
+        if not subdivision:
+            return []
+
+        pattern = f'%{subdivision}%'
+        has_improvement = db.or_(
+            db.and_(ChambersProperty.improvement_hs_val.isnot(None), ChambersProperty.improvement_hs_val > 0),
+            db.and_(ChambersProperty.improvement_nhs_val.isnot(None), ChambersProperty.improvement_nhs_val > 0),
+        )
+        base_filters = [
+            ChambersProperty.legal1.ilike(pattern),
+            ChambersProperty.market_value.isnot(None),
+            ChambersProperty.market_value > 0,
+            ChambersProperty.market_value < market_value,
+            ChambersProperty.prop_street_number.isnot(None),
+            ChambersProperty.prop_street_number != '0',
+            ChambersProperty.prop_street.isnot(None),
+            has_improvement,
+        ]
+
+        if zip_code:
+            results = ChambersProperty.query.filter(
+                ChambersProperty.prop_zip5 == zip_code,
+                *base_filters,
+            ).order_by(ChambersProperty.market_value.asc()).all()
+            if results:
+                return [_chambers_to_dict(r) for r in results]
+
+        results = ChambersProperty.query.filter(
+            *base_filters,
+        ).order_by(ChambersProperty.market_value.asc()).all()
+        return [_chambers_to_dict(r) for r in results]
+
+    elif source == 'hcad':
+        if not subdivision:
+            return []
+
+        if fuzzy_subdivision:
+            sub_filter = HcadProperty.lgl_2.ilike(f'%{subdivision}%')
+        else:
+            sub_filter = (HcadProperty.lgl_2 == subdivision)
+
+        def _hcad_query(use_zip):
+            q = db.session.query(
+                HcadProperty,
+                db.func.max(HcadBuilding.im_sq_ft).label('max_sq_ft')
+            ).join(
+                HcadBuilding, HcadProperty.acct == HcadBuilding.acct
+            ).filter(
+                sub_filter,
+                HcadProperty.tot_mkt_val.isnot(None),
+                HcadProperty.tot_mkt_val > 0,
+                HcadProperty.tot_mkt_val < market_value,
+                HcadProperty.site_addr_1.isnot(None),
+                HcadProperty.site_addr_1 != '',
+                HcadProperty.str_num.isnot(None),
+                HcadProperty.str_num != '0',
+                HcadBuilding.im_sq_ft.isnot(None),
+                HcadBuilding.im_sq_ft > 0,
+            )
+            if use_zip and zip_code:
+                q = q.filter(HcadProperty.site_addr_3 == zip_code)
+            q = q.group_by(HcadProperty.id)
+            if main_sq_ft and main_sq_ft > 0:
+                q = q.having(
+                    db.func.max(HcadBuilding.im_sq_ft).between(
+                        main_sq_ft - SQ_FT_RANGE,
+                        main_sq_ft + SQ_FT_RANGE,
+                    )
+                )
+            return q.order_by(HcadProperty.tot_mkt_val.asc()).all()
+
+        results = _hcad_query(use_zip=True)
+        if not results:
+            results = _hcad_query(use_zip=False)
+
+        return [_hcad_to_dict(prop, sq_ft) for prop, sq_ft in results]
+
+    return []
+
+
+def _chambers_to_dict(record):
+    """Convert a ChambersProperty to a display dict."""
+    return {
+        'id': record.id,
+        'source': 'chambers',
+        'address': f"{record.prop_street_number or ''} {record.prop_street or ''}".strip(),
+        'full_address': f"{record.prop_street_number or ''} {record.prop_street or ''} {record.prop_street_dir or ''}".strip(),
+        'city': record.prop_city,
+        'zip': record.prop_zip5,
+        'market_value': record.market_value,
+        'legal1': record.legal1,
+        'legal2': record.legal2,
+        'legal3': record.legal3,
+        'legal4': record.legal4,
+        'sq_ft': None,
+        'acreage': float(record.acres) if record.acres else None,
+        'parcel_id': record.parcel_id,
+        'account': record.account,
+    }
+
+
+def _hcad_to_dict(record, sq_ft=None):
+    """Convert an HcadProperty to a display dict."""
+    return {
+        'id': record.id,
+        'source': 'hcad',
+        'address': record.site_addr_1 or f"{record.str_num or ''} {record.str or ''}".strip(),
+        'full_address': record.site_addr_1 or '',
+        'city': record.site_addr_2,
+        'zip': record.site_addr_3,
+        'market_value': record.tot_mkt_val,
+        'legal1': record.lgl_1,
+        'legal2': record.lgl_2,
+        'legal3': record.lgl_3,
+        'legal4': record.lgl_4,
+        'sq_ft': sq_ft,
+        'acreage': float(record.acreage) if record.acreage else None,
+        'parcel_id': None,
+        'account': record.acct,
+        'neighborhood_code': record.neighborhood_code,
+        'subdivision': record.lgl_2,
+    }
+
+
+def cache_search_result(source, subdivision, main_property_id, contact_id,
+                        zip_code, neighborhood_code=None, main_sq_ft=None,
+                        fuzzy_subdivision=False):
+    """Store search params in Flask session for CSV download consistency."""
+    session['tax_protest_result'] = {
+        'source': source,
+        'subdivision': subdivision,
+        'main_property_id': main_property_id,
+        'contact_id': contact_id,
+        'zip_code': zip_code,
+        'neighborhood_code': neighborhood_code,
+        'main_sq_ft': main_sq_ft,
+        'fuzzy_subdivision': fuzzy_subdivision,
+    }
+
+
+def get_cached_search_result():
+    """Retrieve cached search params from Flask session."""
+    return session.get('tax_protest_result')
+
+
+def get_main_property_by_id(property_id, source):
+    """Load a single property record by its ID and source."""
+    if source == 'chambers':
+        record = ChambersProperty.query.get(property_id)
+        return _chambers_to_dict(record) if record else None
+    elif source == 'hcad':
+        record = HcadProperty.query.get(property_id)
+        if not record:
+            return None
+        sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
+            HcadBuilding.acct == record.acct
+        ).scalar()
+        return _hcad_to_dict(record, sq_ft)
+    return None

--- a/templates/base.html
+++ b/templates/base.html
@@ -454,6 +454,13 @@
                     Marketing
                 </a>
                 {% endif %}
+                {% if org_has_feature('TAX_PROTEST') %}
+                <a href="{{ url_for('tax_protest.index') }}"
+                    class="flex items-center px-6 py-3 text-white hover:bg-slate-800 {% if request.endpoint and request.endpoint.startswith('tax_protest.') %}bg-slate-800 border-l-4 border-orange-500{% endif %}">
+                    <i class="fas fa-gavel w-6 mr-3"></i>
+                    Tax Protest
+                </a>
+                {% endif %}
                 {% if org_has_feature('AI_ACTION_PLAN') %}
                 <a href="{{ url_for('action_plan.action_plan') }}"
                     class="flex items-center px-6 py-3 text-white hover:bg-slate-800 {% if request.endpoint == 'action_plan.action_plan' %}bg-slate-800 border-l-4 border-orange-500{% endif %}">
@@ -644,6 +651,27 @@
                 <div
                     class="hidden opacity-0 transition-opacity duration-200 absolute left-full ml-2 top-2 bg-gray-800 text-white text-sm py-1 px-2 rounded whitespace-nowrap tooltip-label">
                     Marketing
+                </div>
+            </div>
+            {% endif %}
+
+            <!-- Tax Protest Icon with Tooltip (Feature Gated) -->
+            {% if org_has_feature('TAX_PROTEST') %}
+            <div class="relative group mb-8 w-full px-3">
+                <a href="{{ url_for('tax_protest.index') }}"
+                    class="sidebar-link flex items-center p-2.5 rounded-lg hover:bg-[#3d4d63] {% if request.endpoint and request.endpoint.startswith('tax_protest.') %}text-orange-500{% else %}text-white{% endif %}">
+                    <div class="w-full flex items-center">
+                        <div class="flex justify-center w-[24px]">
+                            <i class="fas fa-gavel"></i>
+                        </div>
+                        <span
+                            class="sidebar-text ml-3 opacity-0 w-0 transition-all duration-300 overflow-hidden whitespace-nowrap">Tax
+                            Protest</span>
+                    </div>
+                </a>
+                <div
+                    class="hidden opacity-0 transition-opacity duration-200 absolute left-full ml-2 top-2 bg-gray-800 text-white text-sm py-1 px-2 rounded whitespace-nowrap tooltip-label">
+                    Tax Protest
                 </div>
             </div>
             {% endif %}

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -1,0 +1,349 @@
+{% extends "base.html" %}
+{% from "components/ui.html" import page_header %}
+
+{% block mobile_title %}Tax Protest{% endblock %}
+
+{% block content %}
+<div class="crm-page">
+    <div class="crm-page__inner">
+        {% call page_header('Tax Protest', '', 'Property Tax Comparison Tool') %}
+        {% endcall %}
+
+        <!-- Contact Search -->
+        <div class="mb-6">
+            <div class="relative max-w-md" id="searchContainer">
+                <div class="relative">
+                    <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm"></i>
+                    <input type="text"
+                           id="contactSearch"
+                           placeholder="Search by client name or address..."
+                           class="w-full pl-9 pr-10 py-2 border border-slate-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-orange-500/40 focus:border-orange-500 shadow-sm"
+                           autocomplete="off">
+                    <button type="button" id="clearSearch"
+                            class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 hidden">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+                <!-- Dropdown results -->
+                <div id="searchDropdown"
+                     class="absolute z-50 w-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto hidden">
+                </div>
+            </div>
+        </div>
+
+        <!-- Loading Spinner -->
+        <div id="loadingState" class="hidden">
+            <div class="premium-card p-12 text-center">
+                <div class="inline-flex items-center gap-3 text-slate-500">
+                    <svg class="animate-spin h-6 w-6 text-orange-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                    </svg>
+                    <span class="text-sm font-medium">Searching tax records...</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Error State -->
+        <div id="errorState" class="hidden">
+            <div class="premium-card p-6 border-l-4 border-red-400">
+                <div class="flex items-start gap-3">
+                    <i class="fas fa-exclamation-circle text-red-500 mt-0.5"></i>
+                    <div>
+                        <p class="font-medium text-slate-800">Property Not Found</p>
+                        <p id="errorMessage" class="text-sm text-slate-600 mt-1"></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Results Section -->
+        <div id="resultsSection" class="hidden">
+            <!-- Main Property Card -->
+            <div class="premium-card p-5 mb-4 bg-amber-50/60 border border-amber-200/60">
+                <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+                    <div>
+                        <div class="flex items-center gap-2 mb-1">
+                            <span class="text-xs font-bold uppercase tracking-wider text-amber-700">Subject Property</span>
+                            <span id="countyBadge" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700"></span>
+                        </div>
+                        <h3 id="mainAddress" class="text-lg font-semibold text-slate-900"></h3>
+                        <p id="mainCityZip" class="text-sm text-slate-600 mt-0.5"></p>
+                    </div>
+                    <div class="flex flex-wrap gap-4 text-sm">
+                        <div>
+                            <span class="text-slate-500 block text-xs uppercase tracking-wide">Market Value</span>
+                            <span id="mainValue" class="font-semibold text-slate-900"></span>
+                        </div>
+                        <div id="mainSqFtWrap">
+                            <span class="text-slate-500 block text-xs uppercase tracking-wide">Sq Ft</span>
+                            <span id="mainSqFt" class="font-semibold text-slate-900"></span>
+                        </div>
+                        <div id="mainAcreageWrap">
+                            <span class="text-slate-500 block text-xs uppercase tracking-wide">Acreage</span>
+                            <span id="mainAcreage" class="font-semibold text-slate-900"></span>
+                        </div>
+                        <div>
+                            <span class="text-slate-500 block text-xs uppercase tracking-wide">Subdivision</span>
+                            <span id="mainSubdivision" class="font-semibold text-slate-900"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Results Count + Actions -->
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+                <p id="resultsCount" class="text-sm text-slate-600"></p>
+                <div class="flex items-center gap-2">
+                    <a id="downloadBtn" href="#"
+                       class="crm-btn crm-btn-primary text-sm">
+                        <i class="fas fa-download text-xs mr-1"></i> Download CSV
+                    </a>
+                    <button type="button" id="clearResults"
+                            class="crm-btn crm-btn-secondary text-sm">
+                        <i class="fas fa-times text-xs mr-1"></i> Clear
+                    </button>
+                </div>
+            </div>
+
+            <!-- Comparables Table -->
+            <div class="crm-table-wrap">
+                <table class="crm-table" id="comparablesTable">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Address</th>
+                            <th class="text-left">City</th>
+                            <th class="text-left">Zip</th>
+                            <th class="text-right cursor-pointer hover:text-orange-600" id="sortValue">
+                                Market Value <i class="fas fa-sort-amount-up text-xs ml-1"></i>
+                            </th>
+                            <th class="text-right">Sq Ft</th>
+                            <th class="text-right">Acreage</th>
+                            <th class="text-left">Subdivision</th>
+                            <th class="text-left">Legal Description</th>
+                        </tr>
+                    </thead>
+                    <tbody id="comparablesBody">
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Mobile Cards -->
+            <div id="mobileCards" class="md:hidden space-y-3 mt-4">
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function() {
+    const searchInput = document.getElementById('contactSearch');
+    const searchDropdown = document.getElementById('searchDropdown');
+    const clearSearchBtn = document.getElementById('clearSearch');
+    const loadingState = document.getElementById('loadingState');
+    const errorState = document.getElementById('errorState');
+    const resultsSection = document.getElementById('resultsSection');
+    let searchTimeout;
+    let sortAsc = true;
+    let currentComparables = [];
+    let currentMainProperty = null;
+
+    function fmt(val) {
+        if (val == null || val === '') return '—';
+        return '$' + Number(val).toLocaleString();
+    }
+
+    function fmtNum(val) {
+        if (val == null || val === '') return '—';
+        return Number(val).toLocaleString();
+    }
+
+    // Debounced contact search
+    searchInput.addEventListener('input', function() {
+        const q = this.value.trim();
+        clearSearchBtn.classList.toggle('hidden', !q);
+
+        clearTimeout(searchTimeout);
+        if (q.length < 2) {
+            searchDropdown.classList.add('hidden');
+            return;
+        }
+
+        searchTimeout = setTimeout(() => {
+            fetch(`/tax-protest/search-contacts?q=${encodeURIComponent(q)}`)
+                .then(r => r.json())
+                .then(contacts => {
+                    if (!contacts.length) {
+                        searchDropdown.innerHTML = '<div class="px-4 py-3 text-sm text-slate-500">No contacts found</div>';
+                    } else {
+                        searchDropdown.innerHTML = contacts.map(c => `
+                            <button type="button"
+                                    class="w-full text-left px-4 py-3 hover:bg-slate-50 border-b border-slate-100 last:border-0"
+                                    data-contact-id="${c.id}">
+                                <div class="font-medium text-slate-800 text-sm">${c.name}</div>
+                                <div class="text-xs text-slate-500 mt-0.5">${c.address || 'No address'}</div>
+                            </button>
+                        `).join('');
+
+                        searchDropdown.querySelectorAll('[data-contact-id]').forEach(btn => {
+                            btn.addEventListener('click', () => {
+                                searchDropdown.classList.add('hidden');
+                                searchInput.value = btn.querySelector('.font-medium').textContent;
+                                runPropertySearch(btn.dataset.contactId);
+                            });
+                        });
+                    }
+                    searchDropdown.classList.remove('hidden');
+                });
+        }, 300);
+    });
+
+    clearSearchBtn.addEventListener('click', () => {
+        searchInput.value = '';
+        clearSearchBtn.classList.add('hidden');
+        searchDropdown.classList.add('hidden');
+        hideAll();
+    });
+
+    document.getElementById('clearResults').addEventListener('click', () => {
+        searchInput.value = '';
+        clearSearchBtn.classList.add('hidden');
+        hideAll();
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!document.getElementById('searchContainer').contains(e.target)) {
+            searchDropdown.classList.add('hidden');
+        }
+    });
+
+    function hideAll() {
+        loadingState.classList.add('hidden');
+        errorState.classList.add('hidden');
+        resultsSection.classList.add('hidden');
+    }
+
+    function runPropertySearch(contactId) {
+        hideAll();
+        loadingState.classList.remove('hidden');
+
+        fetch('/tax-protest/search', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({contact_id: contactId}),
+        })
+        .then(r => r.json().then(data => ({status: r.status, data})))
+        .then(({status, data}) => {
+            loadingState.classList.add('hidden');
+
+            if (status >= 400 || data.error) {
+                errorState.classList.remove('hidden');
+                document.getElementById('errorMessage').textContent = data.error || 'An error occurred';
+                return;
+            }
+
+            displayResults(data);
+        })
+        .catch(err => {
+            loadingState.classList.add('hidden');
+            errorState.classList.remove('hidden');
+            document.getElementById('errorMessage').textContent = 'Network error. Please try again.';
+        });
+    }
+
+    function displayResults(data) {
+        currentMainProperty = data.main_property;
+        currentComparables = data.comparables || [];
+        const county = data.source === 'chambers' ? 'Chambers County' : 'Harris County';
+
+        document.getElementById('countyBadge').textContent = county;
+        document.getElementById('mainAddress').textContent = data.main_property.full_address || data.main_property.address;
+        document.getElementById('mainCityZip').textContent =
+            [data.main_property.city, data.main_property.zip].filter(Boolean).join(', ');
+        document.getElementById('mainValue').textContent = fmt(data.main_property.market_value);
+        document.getElementById('mainSubdivision').textContent = data.subdivision;
+
+        const sqFtWrap = document.getElementById('mainSqFtWrap');
+        if (data.main_property.sq_ft) {
+            document.getElementById('mainSqFt').textContent = fmtNum(data.main_property.sq_ft);
+            sqFtWrap.classList.remove('hidden');
+        } else {
+            sqFtWrap.classList.add('hidden');
+        }
+
+        const acreageWrap = document.getElementById('mainAcreageWrap');
+        if (data.main_property.acreage) {
+            document.getElementById('mainAcreage').textContent = data.main_property.acreage.toFixed(2);
+            acreageWrap.classList.remove('hidden');
+        } else {
+            acreageWrap.classList.add('hidden');
+        }
+
+        document.getElementById('resultsCount').textContent =
+            `Found ${data.total_comparables} propert${data.total_comparables === 1 ? 'y' : 'ies'} with lower market value in ${data.subdivision || 'neighborhood'} (${data.main_property.zip || ''})`;
+
+        document.getElementById('downloadBtn').href = '/tax-protest/download-csv';
+
+        sortAsc = true;
+        renderTable();
+        resultsSection.classList.remove('hidden');
+    }
+
+    document.getElementById('sortValue').addEventListener('click', () => {
+        sortAsc = !sortAsc;
+        const icon = document.querySelector('#sortValue i');
+        icon.className = sortAsc ? 'fas fa-sort-amount-up text-xs ml-1' : 'fas fa-sort-amount-down text-xs ml-1';
+        renderTable();
+    });
+
+    function renderTable() {
+        const sorted = [...currentComparables].sort((a, b) =>
+            sortAsc ? (a.market_value || 0) - (b.market_value || 0)
+                    : (b.market_value || 0) - (a.market_value || 0)
+        );
+
+        const allRows = [
+            {...currentMainProperty, _isMain: true},
+            ...sorted,
+        ];
+
+        // Desktop table
+        const tbody = document.getElementById('comparablesBody');
+        tbody.innerHTML = allRows.map(p => `
+            <tr class="${p._isMain ? 'bg-amber-50 font-medium' : 'hover:bg-slate-50'}">
+                <td class="text-sm">
+                    ${p._isMain ? '<i class="fas fa-star text-amber-500 text-xs mr-1"></i>' : ''}
+                    ${p.full_address || p.address || ''}
+                </td>
+                <td class="text-sm">${p.city || ''}</td>
+                <td class="text-sm">${p.zip || ''}</td>
+                <td class="text-sm text-right">${fmt(p.market_value)}</td>
+                <td class="text-sm text-right">${p.sq_ft ? fmtNum(p.sq_ft) : '—'}</td>
+                <td class="text-sm text-right">${p.acreage ? p.acreage.toFixed(2) : '—'}</td>
+                <td class="text-sm text-slate-500">${p.subdivision || p.legal2 || ''}</td>
+                <td class="text-sm text-slate-500 max-w-[200px] truncate" title="${p.legal1 || ''}">${p.legal1 || ''}</td>
+            </tr>
+        `).join('');
+
+        // Mobile cards
+        const mobileContainer = document.getElementById('mobileCards');
+        mobileContainer.innerHTML = allRows.map(p => `
+            <div class="premium-card p-4 ${p._isMain ? 'bg-amber-50/60 border-amber-200/60' : ''}">
+                <div class="flex items-start justify-between mb-2">
+                    <div>
+                        ${p._isMain ? '<span class="text-xs font-bold text-amber-700 uppercase">Subject Property</span>' : ''}
+                        <p class="font-medium text-slate-800 text-sm">${p.full_address || p.address || ''}</p>
+                        <p class="text-xs text-slate-500">${[p.city, p.zip].filter(Boolean).join(', ')}</p>
+                    </div>
+                    <span class="font-semibold text-sm text-slate-900">${fmt(p.market_value)}</span>
+                </div>
+                <div class="flex gap-4 text-xs text-slate-500">
+                    ${p.sq_ft ? `<span>Sq Ft: ${fmtNum(p.sq_ft)}</span>` : ''}
+                    ${p.acreage ? `<span>Acres: ${p.acreage.toFixed(2)}</span>` : ''}
+                </div>
+            </div>
+        `).join('');
+    }
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds a new **Tax Protest** tab (enterprise-tier only) where agents search their CRM contacts, locate properties in Chambers or Harris County tax data, and find lower-valued comparable properties in the same subdivision for tax protest filings
- Three new shared reference tables (`chambers_properties` ~43k rows, `hcad_properties` ~1.6M rows, `hcad_buildings` ~1.3M rows, `hcad_neighborhood_codes` ~12k rows) populated via `scripts/import_tax_data.py`
- Contact search respects org/user ownership (admin sees all org contacts, agents see only their own)
- **Chambers County**: LLM-based subdivision extraction from legal descriptions, filters out vacant lots using improvement values
- **Harris County (HCAD)**: Uses structured `lgl_2` subdivision field with LLM fallback for edge cases, requires building record with sq ft within 250 of subject property, neighborhood code lookup table for reference
- Zip code fallback on both property lookup and comparable search to handle data mismatches
- Session-cached search results ensure CSV download matches UI preview exactly
- Clean UI with subject property card, sortable comparables table with subdivision column, and CSV export

## New files
- `routes/tax_protest.py` — Blueprint with search, contact lookup, and CSV download endpoints
- `services/tax_protest_service.py` — Address matching, LLM subdivision extraction, comparable queries
- `templates/tax_protest/index.html` — UI with contact search, property card, comparables table
- `migrations/versions/add_tax_protest_tables.py` — Schema for 4 reference tables with indexes
- `scripts/import_tax_data.py` — Re-runnable annual bulk import for tax data files

## Modified files
- `app.py` — Register tax_protest blueprint
- `feature_flags.py` — Add `TAX_PROTEST` flag (enterprise only)
- `models.py` — 4 new models (ChambersProperty, HcadProperty, HcadBuilding, HcadNeighborhoodCode)
- `templates/base.html` — Tax Protest nav link in mobile + desktop sidebar
- `.gitignore` — Exclude `tax_data/` directory

## Post-merge deployment
- **No Vite rebuild needed** — all changes are server-rendered Jinja2 templates
- **No migration needed** — schema already applied to production DB
- Railway deploys automatically on merge

## Test plan
- [ ] Verify Tax Protest tab appears only for enterprise-tier orgs
- [ ] Search a Harris County contact → should show comparables in same subdivision within 250 sqft
- [ ] Search a Chambers County contact → should show comparables with improvements only (no vacant lots)
- [ ] Verify non-admin agent can only search their own contacts
- [ ] Download CSV and confirm it matches the UI preview
- [ ] Clear search and run a new one


Made with [Cursor](https://cursor.com)