### PR TITLE
[codex] add Liberty County tax protest comparables

### DIFF
--- a/migrations/versions/add_fort_bend_tax_tables.py
+++ b/migrations/versions/add_fort_bend_tax_tables.py
@@ -1,0 +1,110 @@
+"""Add Fort Bend County tax protest reference tables.
+
+Revision ID: add_fort_bend_tax_tables
+Revises: add_liberty_code_profiles
+Create Date: 2026-04-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_fort_bend_tax_tables'
+down_revision = 'add_liberty_code_profiles'
+branch_labels = None
+depends_on = None
+
+
+def _has_index(inspector, table_name, columns):
+    target = tuple(columns)
+    for idx in inspector.get_indexes(table_name):
+        if tuple(idx.get('column_names') or []) == target:
+            return True
+    return False
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    if not inspector.has_table('fort_bend_properties'):
+        op.create_table(
+            'fort_bend_properties',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('property_id', sa.String(20), nullable=False),
+            sa.Column('quick_ref_id', sa.String(20)),
+            sa.Column('property_number', sa.String(40)),
+            sa.Column('legal_desc', sa.String(1000)),
+            sa.Column('legal_location_code', sa.String(50)),
+            sa.Column('legal_location_desc', sa.String(500)),
+            sa.Column('legal_acres', sa.Numeric(16, 4)),
+            sa.Column('market_value', sa.Integer()),
+            sa.Column('assessed_value', sa.Integer()),
+            sa.Column('land_value', sa.Integer()),
+            sa.Column('improvement_value', sa.Integer()),
+            sa.Column('sq_ft', sa.Integer()),
+            sa.Column('nbhd_code', sa.String(20)),
+            sa.Column('nbhd_desc', sa.String(500)),
+            sa.Column('situs', sa.String(255)),
+            sa.Column('site_addr_1', sa.String(200)),
+            sa.Column('normalized_site_addr', sa.String(200)),
+            sa.Column('situs_pre_directional', sa.String(20)),
+            sa.Column('situs_street_number', sa.String(20)),
+            sa.Column('situs_street_name', sa.String(100)),
+            sa.Column('situs_street_suffix', sa.String(20)),
+            sa.Column('situs_post_directional', sa.String(20)),
+            sa.Column('situs_city', sa.String(100)),
+            sa.Column('situs_state', sa.String(10)),
+            sa.Column('situs_zip', sa.String(10)),
+            sa.Column('acreage', sa.Numeric(16, 4)),
+            sa.Column('is_residential_home', sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.UniqueConstraint('property_id', name='uq_fort_bend_property_id'),
+        )
+        inspector = sa.inspect(bind)
+
+    if not _has_index(inspector, 'fort_bend_properties', ['property_id']):
+        op.create_index('ix_fort_bend_property_id', 'fort_bend_properties', ['property_id'], unique=True)
+    if not _has_index(inspector, 'fort_bend_properties', ['quick_ref_id']):
+        op.create_index('ix_fort_bend_quick_ref_id', 'fort_bend_properties', ['quick_ref_id'])
+    if not _has_index(inspector, 'fort_bend_properties', ['property_number']):
+        op.create_index('ix_fort_bend_property_number', 'fort_bend_properties', ['property_number'])
+    if not _has_index(inspector, 'fort_bend_properties', ['normalized_site_addr']):
+        op.create_index('ix_fort_bend_normalized_site_addr', 'fort_bend_properties', ['normalized_site_addr'])
+    if not _has_index(inspector, 'fort_bend_properties', ['situs_street_number']):
+        op.create_index('ix_fort_bend_situs_street_number', 'fort_bend_properties', ['situs_street_number'])
+    if not _has_index(inspector, 'fort_bend_properties', ['situs_street_name']):
+        op.create_index('ix_fort_bend_situs_street_name', 'fort_bend_properties', ['situs_street_name'])
+    if not _has_index(inspector, 'fort_bend_properties', ['situs_zip']):
+        op.create_index('ix_fort_bend_situs_zip', 'fort_bend_properties', ['situs_zip'])
+    if not _has_index(inspector, 'fort_bend_properties', ['nbhd_code']):
+        op.create_index('ix_fort_bend_nbhd_code', 'fort_bend_properties', ['nbhd_code'])
+    if not _has_index(inspector, 'fort_bend_properties', ['nbhd_desc']):
+        op.create_index('ix_fort_bend_nbhd_desc', 'fort_bend_properties', ['nbhd_desc'])
+    if not _has_index(inspector, 'fort_bend_properties', ['is_residential_home']):
+        op.create_index('ix_fort_bend_is_residential_home', 'fort_bend_properties', ['is_residential_home'])
+    if not _has_index(inspector, 'fort_bend_properties', ['is_residential_home', 'nbhd_code', 'situs_zip', 'market_value']):
+        op.create_index(
+            'ix_fort_bend_comp_filters',
+            'fort_bend_properties',
+            ['is_residential_home', 'nbhd_code', 'situs_zip', 'market_value'],
+        )
+
+    if is_postgres:
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_fort_bend_site_addr_trgm '
+            'ON fort_bend_properties USING gin (site_addr_1 gin_trgm_ops)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_fort_bend_situs_street_trgm '
+            'ON fort_bend_properties USING gin (situs_street_name gin_trgm_ops)'
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    if is_postgres:
+        op.execute('DROP INDEX IF EXISTS ix_fort_bend_situs_street_trgm')
+        op.execute('DROP INDEX IF EXISTS ix_fort_bend_site_addr_trgm')
+
+    op.drop_table('fort_bend_properties')

--- a/migrations/versions/add_liberty_code_profiles.py
+++ b/migrations/versions/add_liberty_code_profiles.py
@@ -1,0 +1,66 @@
+"""Add Liberty code profiles table for strategy classification.
+
+Revision ID: add_liberty_code_profiles
+Revises: add_liberty_tax_tables
+Create Date: 2026-04-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_liberty_code_profiles'
+down_revision = 'add_liberty_tax_tables'
+branch_labels = None
+depends_on = None
+
+
+def _has_index(inspector, table_name, columns):
+    target = tuple(columns)
+    for idx in inspector.get_indexes(table_name):
+        if tuple(idx.get('column_names') or []) == target:
+            return True
+    return False
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table('liberty_code_profiles'):
+        op.create_table(
+            'liberty_code_profiles',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('abs_subdv_cd', sa.String(10), nullable=False),
+            sa.Column('abs_subdv_desc', sa.String(200)),
+            sa.Column('property_count', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('avg_acreage', sa.Numeric(14, 4)),
+            sa.Column('median_acreage', sa.Numeric(14, 4)),
+            sa.Column('pct_with_situs_num', sa.Numeric(8, 4)),
+            sa.Column('pct_with_sq_ft', sa.Numeric(8, 4)),
+            sa.Column('distinct_street_count', sa.Integer()),
+            sa.Column('distinct_zip_count', sa.Integer()),
+            sa.Column('sample_addresses', sa.JSON()),
+            sa.Column('sample_legal_descriptions', sa.JSON()),
+            sa.Column('bucket', sa.String(30)),
+            sa.Column('strategy', sa.String(20)),
+            sa.Column('confidence', sa.Numeric(5, 4)),
+            sa.Column('rationale', sa.Text()),
+            sa.Column('model_name', sa.String(50)),
+            sa.Column('prompt_version', sa.String(30)),
+            sa.Column('classified_at', sa.DateTime()),
+            sa.Column('updated_at', sa.DateTime()),
+            sa.UniqueConstraint('abs_subdv_cd', name='uq_liberty_code_profile_abs_subdv_cd'),
+        )
+        inspector = sa.inspect(bind)
+
+    if not _has_index(inspector, 'liberty_code_profiles', ['abs_subdv_cd']):
+        op.create_index('ix_liberty_code_profile_abs_subdv_cd', 'liberty_code_profiles', ['abs_subdv_cd'], unique=True)
+    if not _has_index(inspector, 'liberty_code_profiles', ['abs_subdv_desc']):
+        op.create_index('ix_liberty_code_profile_abs_subdv_desc', 'liberty_code_profiles', ['abs_subdv_desc'])
+    if not _has_index(inspector, 'liberty_code_profiles', ['bucket']):
+        op.create_index('ix_liberty_code_profile_bucket', 'liberty_code_profiles', ['bucket'])
+    if not _has_index(inspector, 'liberty_code_profiles', ['strategy']):
+        op.create_index('ix_liberty_code_profile_strategy', 'liberty_code_profiles', ['strategy'])
+
+
+def downgrade():
+    op.drop_table('liberty_code_profiles')

--- a/migrations/versions/add_liberty_tax_tables.py
+++ b/migrations/versions/add_liberty_tax_tables.py
@@ -1,0 +1,104 @@
+"""Add Liberty County tax protest reference tables.
+
+Revision ID: add_liberty_tax_tables
+Revises: add_chambers_sq_ft
+Create Date: 2026-04-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_liberty_tax_tables'
+down_revision = 'add_chambers_sq_ft'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    op.create_table(
+        'liberty_properties',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('prop_id', sa.String(20), nullable=False),
+        sa.Column('geo_id', sa.String(50)),
+        sa.Column('prop_type_cd', sa.String(10)),
+        sa.Column('situs_num', sa.String(20)),
+        sa.Column('situs_street_prefx', sa.String(20)),
+        sa.Column('situs_street', sa.String(100)),
+        sa.Column('situs_street_suffix', sa.String(20)),
+        sa.Column('situs_unit', sa.String(20)),
+        sa.Column('situs_city', sa.String(100)),
+        sa.Column('situs_zip', sa.String(10)),
+        sa.Column('site_addr_1', sa.String(200)),
+        sa.Column('normalized_site_addr', sa.String(200)),
+        sa.Column('legal_desc', sa.String(500)),
+        sa.Column('legal_desc2', sa.String(500)),
+        sa.Column('legal_acreage', sa.Numeric(16, 4)),
+        sa.Column('abs_subdv_cd', sa.String(10)),
+        sa.Column('abs_subdv_desc', sa.String(200)),
+        sa.Column('appraised_val', sa.Integer()),
+        sa.Column('assessed_val', sa.Integer()),
+        sa.Column('market_value', sa.Integer()),
+        sa.Column('imprv_hstd_val', sa.Integer()),
+        sa.Column('imprv_non_hstd_val', sa.Integer()),
+        sa.Column('sq_ft', sa.Integer()),
+        sa.Column('is_residential_home', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.UniqueConstraint('prop_id', name='uq_liberty_prop_id'),
+    )
+
+    op.create_index('ix_liberty_prop_id', 'liberty_properties', ['prop_id'])
+    op.create_index('ix_liberty_geo_id', 'liberty_properties', ['geo_id'])
+    op.create_index('ix_liberty_prop_type_cd', 'liberty_properties', ['prop_type_cd'])
+    op.create_index('ix_liberty_situs_num', 'liberty_properties', ['situs_num'])
+    op.create_index('ix_liberty_situs_street', 'liberty_properties', ['situs_street'])
+    op.create_index('ix_liberty_situs_zip', 'liberty_properties', ['situs_zip'])
+    op.create_index('ix_liberty_normalized_site_addr', 'liberty_properties', ['normalized_site_addr'])
+    op.create_index('ix_liberty_abs_subdv_cd', 'liberty_properties', ['abs_subdv_cd'])
+    op.create_index('ix_liberty_abs_subdv_desc', 'liberty_properties', ['abs_subdv_desc'])
+    op.create_index('ix_liberty_is_residential_home', 'liberty_properties', ['is_residential_home'])
+    op.create_index(
+        'ix_liberty_comp_filters',
+        'liberty_properties',
+        ['is_residential_home', 'abs_subdv_cd', 'situs_zip', 'market_value'],
+    )
+
+    op.create_table(
+        'liberty_improvements',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('prop_id', sa.String(20), sa.ForeignKey('liberty_properties.prop_id'), nullable=False),
+        sa.Column('imprv_id', sa.String(20), nullable=False),
+        sa.Column('imprv_type_cd', sa.String(10)),
+        sa.Column('imprv_type_desc', sa.String(50)),
+        sa.Column('imprv_homesite', sa.String(1)),
+        sa.Column('imprv_val', sa.Integer()),
+        sa.Column('residential_sq_ft', sa.Integer()),
+        sa.Column('is_residential', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.UniqueConstraint('prop_id', 'imprv_id', name='uq_liberty_improvement_prop_imprv'),
+    )
+
+    op.create_index('ix_liberty_impr_prop_id', 'liberty_improvements', ['prop_id'])
+    op.create_index('ix_liberty_impr_imprv_id', 'liberty_improvements', ['imprv_id'])
+    op.create_index('ix_liberty_impr_is_residential', 'liberty_improvements', ['is_residential'])
+
+    if is_postgres:
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_liberty_site_addr_trgm '
+            'ON liberty_properties USING gin (site_addr_1 gin_trgm_ops)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_liberty_situs_street_trgm '
+            'ON liberty_properties USING gin (situs_street gin_trgm_ops)'
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == 'postgresql'
+
+    if is_postgres:
+        op.execute('DROP INDEX IF EXISTS ix_liberty_situs_street_trgm')
+        op.execute('DROP INDEX IF EXISTS ix_liberty_site_addr_trgm')
+
+    op.drop_table('liberty_improvements')
+    op.drop_table('liberty_properties')

--- a/migrations/versions/add_tax_protest_indexes.py
+++ b/migrations/versions/add_tax_protest_indexes.py
@@ -1,0 +1,84 @@
+"""Add missing indexes for tax protest search performance.
+
+HCAD (1.6M rows):
+  - expression index on upper(site_addr_1) for address lookup
+  - btree index on lgl_2 for comparable subdivision filtering
+  - partial composite index for comparable queries
+  - trgm index on site_addr_1 for ILIKE fallback searches
+
+Fort Bend (291k rows):
+  - expression index on upper(situs_city) for city fallback searches
+
+Revision ID: add_tax_protest_indexes
+Revises: add_fort_bend_tax_tables
+Create Date: 2026-04-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_tax_protest_indexes"
+down_revision = "add_fort_bend_tax_tables"
+branch_labels = None
+depends_on = None
+
+
+def _has_index(inspector, table_name, index_name):
+    for idx in inspector.get_indexes(table_name):
+        if idx["name"] == index_name:
+            return True
+    return False
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # --- HCAD indexes ---
+    if is_postgres:
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_hcad_site_addr_1_upper "
+            "ON hcad_properties (upper(site_addr_1))"
+        )
+
+    if not _has_index(inspector, "hcad_properties", "ix_hcad_lgl_2"):
+        op.create_index("ix_hcad_lgl_2", "hcad_properties", ["lgl_2"])
+
+    if is_postgres:
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_hcad_comp_filters "
+            "ON hcad_properties (lgl_2, site_addr_3, tot_mkt_val) "
+            "WHERE site_addr_1 IS NOT NULL "
+            "AND site_addr_1 != '' "
+            "AND str_num IS NOT NULL "
+            "AND str_num != '0' "
+            "AND tot_mkt_val IS NOT NULL "
+            "AND tot_mkt_val > 0"
+        )
+
+    if is_postgres:
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_hcad_site_addr_1_trgm "
+            "ON hcad_properties USING gin (site_addr_1 gin_trgm_ops)"
+        )
+
+    # --- Fort Bend indexes ---
+    if is_postgres:
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_fort_bend_situs_city_upper "
+            "ON fort_bend_properties (upper(situs_city))"
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    if is_postgres:
+        op.execute("DROP INDEX IF EXISTS ix_fort_bend_situs_city_upper")
+        op.execute("DROP INDEX IF EXISTS ix_hcad_site_addr_1_trgm")
+        op.execute("DROP INDEX IF EXISTS ix_hcad_comp_filters")
+        op.execute("DROP INDEX IF EXISTS ix_hcad_site_addr_1_upper")
+
+    op.drop_index("ix_hcad_lgl_2", table_name="hcad_properties", if_exists=True)

--- a/models.py
+++ b/models.py
@@ -1572,3 +1572,90 @@ class HcadBuilding(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     acct = db.Column(db.String(30), db.ForeignKey('hcad_properties.acct'), nullable=False, index=True)
     im_sq_ft = db.Column(db.Integer)
+
+
+class LibertyProperty(db.Model):
+    """Liberty County home-focused tax appraisal records."""
+    __tablename__ = 'liberty_properties'
+
+    id = db.Column(db.Integer, primary_key=True)
+    prop_id = db.Column(db.String(20), unique=True, index=True)
+    geo_id = db.Column(db.String(50), index=True)
+    prop_type_cd = db.Column(db.String(10), index=True)
+    situs_num = db.Column(db.String(20), index=True)
+    situs_street_prefx = db.Column(db.String(20))
+    situs_street = db.Column(db.String(100), index=True)
+    situs_street_suffix = db.Column(db.String(20))
+    situs_unit = db.Column(db.String(20))
+    situs_city = db.Column(db.String(100))
+    situs_zip = db.Column(db.String(10), index=True)
+    site_addr_1 = db.Column(db.String(200))
+    normalized_site_addr = db.Column(db.String(200), index=True)
+    legal_desc = db.Column(db.String(500))
+    legal_desc2 = db.Column(db.String(500))
+    legal_acreage = db.Column(db.Numeric(16, 4))
+    abs_subdv_cd = db.Column(db.String(10), index=True)
+    abs_subdv_desc = db.Column(db.String(200), index=True)
+    appraised_val = db.Column(db.Integer)
+    assessed_val = db.Column(db.Integer)
+    market_value = db.Column(db.Integer)
+    imprv_hstd_val = db.Column(db.Integer)
+    imprv_non_hstd_val = db.Column(db.Integer)
+    sq_ft = db.Column(db.Integer)
+    is_residential_home = db.Column(db.Boolean, nullable=False, default=False, index=True)
+
+    improvements = db.relationship('LibertyImprovement', backref='property', lazy='dynamic')
+
+    def __repr__(self):
+        return f'<LibertyProperty {self.site_addr_1 or self.geo_id}>'
+
+
+class LibertyImprovement(db.Model):
+    """Liberty County residential/mobile-home improvements used to classify homes."""
+    __tablename__ = 'liberty_improvements'
+
+    id = db.Column(db.Integer, primary_key=True)
+    prop_id = db.Column(db.String(20), db.ForeignKey('liberty_properties.prop_id'), nullable=False, index=True)
+    imprv_id = db.Column(db.String(20), nullable=False, index=True)
+    imprv_type_cd = db.Column(db.String(10))
+    imprv_type_desc = db.Column(db.String(50))
+    imprv_homesite = db.Column(db.String(1))
+    imprv_val = db.Column(db.Integer)
+    residential_sq_ft = db.Column(db.Integer)
+    is_residential = db.Column(db.Boolean, nullable=False, default=False, index=True)
+
+    __table_args__ = (
+        db.UniqueConstraint('prop_id', 'imprv_id', name='uq_liberty_improvement_prop_imprv'),
+    )
+
+    def __repr__(self):
+        return f'<LibertyImprovement {self.prop_id}/{self.imprv_id}>'
+
+
+class LibertyCodeProfile(db.Model):
+    """Stored strategy metadata for Liberty subdivision/abstract codes."""
+    __tablename__ = 'liberty_code_profiles'
+
+    id = db.Column(db.Integer, primary_key=True)
+    abs_subdv_cd = db.Column(db.String(10), unique=True, index=True, nullable=False)
+    abs_subdv_desc = db.Column(db.String(200), index=True)
+    property_count = db.Column(db.Integer, nullable=False, default=0)
+    avg_acreage = db.Column(db.Numeric(14, 4))
+    median_acreage = db.Column(db.Numeric(14, 4))
+    pct_with_situs_num = db.Column(db.Numeric(8, 4))
+    pct_with_sq_ft = db.Column(db.Numeric(8, 4))
+    distinct_street_count = db.Column(db.Integer)
+    distinct_zip_count = db.Column(db.Integer)
+    sample_addresses = db.Column(db.JSON)
+    sample_legal_descriptions = db.Column(db.JSON)
+    bucket = db.Column(db.String(30), index=True)
+    strategy = db.Column(db.String(20), index=True)
+    confidence = db.Column(db.Numeric(5, 4))
+    rationale = db.Column(db.Text)
+    model_name = db.Column(db.String(50))
+    prompt_version = db.Column(db.String(30))
+    classified_at = db.Column(db.DateTime)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<LibertyCodeProfile {self.abs_subdv_cd} {self.strategy}>'

--- a/models.py
+++ b/models.py
@@ -1659,3 +1659,40 @@ class LibertyCodeProfile(db.Model):
 
     def __repr__(self):
         return f'<LibertyCodeProfile {self.abs_subdv_cd} {self.strategy}>'
+
+
+class FortBendProperty(db.Model):
+    """Fort Bend County home-focused tax appraisal records."""
+    __tablename__ = 'fort_bend_properties'
+
+    id = db.Column(db.Integer, primary_key=True)
+    property_id = db.Column(db.String(20), unique=True, index=True)
+    quick_ref_id = db.Column(db.String(20), index=True)
+    property_number = db.Column(db.String(40), index=True)
+    legal_desc = db.Column(db.String(1000))
+    legal_location_code = db.Column(db.String(50))
+    legal_location_desc = db.Column(db.String(500))
+    legal_acres = db.Column(db.Numeric(16, 4))
+    market_value = db.Column(db.Integer)
+    assessed_value = db.Column(db.Integer)
+    land_value = db.Column(db.Integer)
+    improvement_value = db.Column(db.Integer)
+    sq_ft = db.Column(db.Integer)
+    nbhd_code = db.Column(db.String(20), index=True)
+    nbhd_desc = db.Column(db.String(500), index=True)
+    situs = db.Column(db.String(255))
+    site_addr_1 = db.Column(db.String(200))
+    normalized_site_addr = db.Column(db.String(200), index=True)
+    situs_pre_directional = db.Column(db.String(20))
+    situs_street_number = db.Column(db.String(20), index=True)
+    situs_street_name = db.Column(db.String(100), index=True)
+    situs_street_suffix = db.Column(db.String(20))
+    situs_post_directional = db.Column(db.String(20))
+    situs_city = db.Column(db.String(100))
+    situs_state = db.Column(db.String(10))
+    situs_zip = db.Column(db.String(10), index=True)
+    acreage = db.Column(db.Numeric(16, 4))
+    is_residential_home = db.Column(db.Boolean, nullable=False, default=False, index=True)
+
+    def __repr__(self):
+        return f'<FortBendProperty {self.site_addr_1 or self.property_number}>'

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -107,18 +107,20 @@ def search_property():
 
     if not property_record:
         return jsonify({
-            'error': f'No property found matching "{contact.street_address}" in Chambers or Harris County tax records'
+            'error': f'No property found matching "{contact.street_address}" in Chambers, Harris, or Liberty County tax records'
         }), 404
 
     market_value = property_record.get('market_value')
     zip_code = property_record.get('zip')
     neighborhood_code = property_record.get('neighborhood_code')
+    subdivision_code = property_record.get('subdivision_code')
     main_sq_ft = property_record.get('sq_ft')
+    main_acreage = property_record.get('acreage')
     subdivision = None
+    fuzzy = False
 
     if source == 'hcad':
         lgl_2 = property_record.get('legal2') or ''
-        fuzzy = False
         if _is_valid_subdivision(lgl_2):
             subdivision = lgl_2.strip()
         else:
@@ -134,6 +136,24 @@ def search_property():
             subdivision, zip_code, market_value, source,
             main_sq_ft=main_sq_ft,
             fuzzy_subdivision=fuzzy,
+            main_acreage=main_acreage,
+        )
+    elif source == 'liberty':
+        subdivision = property_record.get('subdivision')
+        if not subdivision or not subdivision_code:
+            return jsonify({
+                'error': 'Could not determine Liberty subdivision from tax data',
+                'main_property': property_record,
+                'source': source,
+            }), 422
+        comparables = find_comparables(
+            subdivision,
+            zip_code,
+            market_value,
+            source,
+            main_sq_ft=main_sq_ft,
+            subdivision_code=subdivision_code,
+            main_acreage=main_acreage,
         )
     else:
         legal_desc = property_record.get('legal1', '')
@@ -145,7 +165,8 @@ def search_property():
                 'source': source,
             }), 422
         comparables = find_comparables(subdivision, zip_code, market_value, source,
-                                       main_sq_ft=main_sq_ft)
+                                       main_sq_ft=main_sq_ft,
+                                       main_acreage=main_acreage)
 
     cache_search_result(
         source=source,
@@ -154,8 +175,10 @@ def search_property():
         contact_id=contact.id,
         zip_code=zip_code,
         neighborhood_code=neighborhood_code,
+        subdivision_code=subdivision_code,
         main_sq_ft=main_sq_ft,
-        fuzzy_subdivision=fuzzy if source == 'hcad' else False,
+        main_acreage=main_acreage,
+        fuzzy_subdivision=fuzzy,
     )
 
     return jsonify({
@@ -189,6 +212,8 @@ def download_csv():
         cached['source'],
         main_sq_ft=cached.get('main_sq_ft'),
         fuzzy_subdivision=cached.get('fuzzy_subdivision', False),
+        subdivision_code=cached.get('subdivision_code'),
+        main_acreage=cached.get('main_acreage'),
     )
 
     output = StringIO()
@@ -198,7 +223,11 @@ def download_csv():
                'Acreage', 'Subdivision', 'Legal Description', 'Account', 'County']
     writer.writerow(headers)
 
-    county = 'Chambers' if cached['source'] == 'chambers' else 'Harris'
+    county = {
+        'chambers': 'Chambers',
+        'hcad': 'Harris',
+        'liberty': 'Liberty',
+    }.get(cached['source'], cached['source'].title())
     subdivision = cached.get('subdivision', '')
 
     def write_row(prop, row_type='Comparable'):

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -107,7 +107,7 @@ def search_property():
 
     if not property_record:
         return jsonify({
-            'error': f'No property found matching "{contact.street_address}" in Chambers, Harris, or Liberty County tax records'
+            'error': f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
         }), 404
 
     market_value = property_record.get('market_value')
@@ -143,6 +143,23 @@ def search_property():
         if not subdivision or not subdivision_code:
             return jsonify({
                 'error': 'Could not determine Liberty subdivision from tax data',
+                'main_property': property_record,
+                'source': source,
+            }), 422
+        comparables = find_comparables(
+            subdivision,
+            zip_code,
+            market_value,
+            source,
+            main_sq_ft=main_sq_ft,
+            subdivision_code=subdivision_code,
+            main_acreage=main_acreage,
+        )
+    elif source == 'fort_bend':
+        subdivision = property_record.get('subdivision')
+        if not subdivision or not subdivision_code:
+            return jsonify({
+                'error': 'Could not determine Fort Bend neighborhood from tax data',
                 'main_property': property_record,
                 'source': source,
             }), 422
@@ -227,6 +244,7 @@ def download_csv():
         'chambers': 'Chambers',
         'hcad': 'Harris',
         'liberty': 'Liberty',
+        'fort_bend': 'Fort Bend',
     }.get(cached['source'], cached['source'].title())
     subdivision = cached.get('subdivision', '')
 

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -3,6 +3,7 @@ Tax Protest blueprint.
 Lets agents search their CRM contacts, locate properties in county tax data,
 extract subdivisions via LLM, find lower-value comparables, and download CSV.
 """
+
 import csv
 import re
 from io import StringIO
@@ -18,13 +19,14 @@ from services.tax_protest_service import (
     extract_subdivision_llm,
     find_comparables,
     get_neighborhood_name,
+    get_subdivision_stats,
     cache_search_result,
     get_cached_search_result,
     get_main_property_by_id,
     _is_valid_subdivision,
 )
 
-tax_protest_bp = Blueprint('tax_protest', __name__, url_prefix='/tax-protest')
+tax_protest_bp = Blueprint("tax_protest", __name__, url_prefix="/tax-protest")
 
 
 def _authorized_contact(contact_id):
@@ -37,20 +39,20 @@ def _authorized_contact(contact_id):
     return contact
 
 
-@tax_protest_bp.route('/')
+@tax_protest_bp.route("/")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def index():
     """Main Tax Protest page."""
-    return render_template('tax_protest/index.html')
+    return render_template("tax_protest/index.html")
 
 
-@tax_protest_bp.route('/search-contacts')
+@tax_protest_bp.route("/search-contacts")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def search_contacts():
     """AJAX endpoint: search CRM contacts by name or address."""
-    q = request.args.get('q', '').strip()
+    q = request.args.get("q", "").strip()
     if len(q) < 2:
         return jsonify([])
 
@@ -59,12 +61,14 @@ def search_contacts():
     if not can_view_all_org_data():
         query = query.filter(Contact.user_id == current_user.id)
 
-    search_term = f'%{q}%'
+    search_term = f"%{q}%"
     query = query.filter(
         db.or_(
             Contact.first_name.ilike(search_term),
             Contact.last_name.ilike(search_term),
-            db.func.concat(Contact.first_name, ' ', Contact.last_name).ilike(search_term),
+            db.func.concat(Contact.first_name, " ", Contact.last_name).ilike(
+                search_term
+            ),
             Contact.street_address.ilike(search_term),
             Contact.city.ilike(search_term),
             Contact.zip_code.ilike(search_term),
@@ -74,78 +78,89 @@ def search_contacts():
     results = []
     for c in query.all():
         addr_parts = [p for p in [c.street_address, c.city, c.state, c.zip_code] if p]
-        results.append({
-            'id': c.id,
-            'name': f"{c.first_name} {c.last_name}",
-            'address': ', '.join(addr_parts),
-            'street_address': c.street_address,
-            'city': c.city,
-            'state': c.state,
-            'zip_code': c.zip_code,
-        })
+        results.append(
+            {
+                "id": c.id,
+                "name": f"{c.first_name} {c.last_name}",
+                "address": ", ".join(addr_parts),
+                "street_address": c.street_address,
+                "city": c.city,
+                "state": c.state,
+                "zip_code": c.zip_code,
+            }
+        )
 
     return jsonify(results)
 
 
-@tax_protest_bp.route('/search', methods=['POST'])
+@tax_protest_bp.route("/search", methods=["POST"])
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def search_property():
     """Search tax data for a contact's property and find comparables."""
     data = request.get_json()
-    if not data or not data.get('contact_id'):
-        return jsonify({'error': 'contact_id required'}), 400
+    if not data or not data.get("contact_id"):
+        return jsonify({"error": "contact_id required"}), 400
 
-    contact = _authorized_contact(data['contact_id'])
+    contact = _authorized_contact(data["contact_id"])
 
     if not contact.street_address:
-        return jsonify({'error': 'Contact has no street address on file'}), 400
+        return jsonify({"error": "Contact has no street address on file"}), 400
 
     property_record, source = find_property_in_tax_data(
         contact.street_address, contact.city, contact.zip_code
     )
 
     if not property_record:
-        return jsonify({
-            'error': f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
-        }), 404
+        return jsonify(
+            {
+                "error": f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
+            }
+        ), 404
 
-    market_value = property_record.get('market_value')
-    zip_code = property_record.get('zip')
-    neighborhood_code = property_record.get('neighborhood_code')
-    subdivision_code = property_record.get('subdivision_code')
-    main_sq_ft = property_record.get('sq_ft')
-    main_acreage = property_record.get('acreage')
+    market_value = property_record.get("market_value")
+    zip_code = property_record.get("zip")
+    neighborhood_code = property_record.get("neighborhood_code")
+    subdivision_code = property_record.get("subdivision_code")
+    main_sq_ft = property_record.get("sq_ft")
+    main_acreage = property_record.get("acreage")
     subdivision = None
     fuzzy = False
 
-    if source == 'hcad':
-        lgl_2 = property_record.get('legal2') or ''
+    if source == "hcad":
+        lgl_2 = property_record.get("legal2") or ""
         if _is_valid_subdivision(lgl_2):
             subdivision = lgl_2.strip()
         else:
-            subdivision = extract_subdivision_llm(property_record.get('legal1', ''))
+            subdivision = extract_subdivision_llm(property_record.get("legal1", ""))
             fuzzy = True
         if not subdivision:
-            return jsonify({
-                'error': 'Could not determine subdivision from property legal description',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine subdivision from property legal description",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
-            subdivision, zip_code, market_value, source,
+            subdivision,
+            zip_code,
+            market_value,
+            source,
             main_sq_ft=main_sq_ft,
             fuzzy_subdivision=fuzzy,
             main_acreage=main_acreage,
         )
-    elif source == 'liberty':
-        subdivision = property_record.get('subdivision')
+    elif source == "liberty":
+        subdivision = property_record.get("subdivision")
         if not subdivision or not subdivision_code:
-            return jsonify({
-                'error': 'Could not determine Liberty subdivision from tax data',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine Liberty subdivision from tax data",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
             subdivision,
             zip_code,
@@ -155,14 +170,16 @@ def search_property():
             subdivision_code=subdivision_code,
             main_acreage=main_acreage,
         )
-    elif source == 'fort_bend':
-        subdivision = property_record.get('subdivision')
+    elif source == "fort_bend":
+        subdivision = property_record.get("subdivision")
         if not subdivision or not subdivision_code:
-            return jsonify({
-                'error': 'Could not determine Fort Bend neighborhood from tax data',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine Fort Bend neighborhood from tax data",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
             subdivision,
             zip_code,
@@ -173,22 +190,29 @@ def search_property():
             main_acreage=main_acreage,
         )
     else:
-        legal_desc = property_record.get('legal1', '')
+        legal_desc = property_record.get("legal1", "")
         subdivision = extract_subdivision_llm(legal_desc)
         if not subdivision:
-            return jsonify({
-                'error': 'Could not extract subdivision from property legal description',
-                'main_property': property_record,
-                'source': source,
-            }), 422
-        comparables = find_comparables(subdivision, zip_code, market_value, source,
-                                       main_sq_ft=main_sq_ft,
-                                       main_acreage=main_acreage)
+            return jsonify(
+                {
+                    "error": "Could not extract subdivision from property legal description",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
+        comparables = find_comparables(
+            subdivision,
+            zip_code,
+            market_value,
+            source,
+            main_sq_ft=main_sq_ft,
+            main_acreage=main_acreage,
+        )
 
     cache_search_result(
         source=source,
         subdivision=subdivision,
-        main_property_id=property_record['id'],
+        main_property_id=property_record["id"],
         contact_id=contact.id,
         zip_code=zip_code,
         neighborhood_code=neighborhood_code,
@@ -198,85 +222,112 @@ def search_property():
         fuzzy_subdivision=fuzzy,
     )
 
-    return jsonify({
-        'source': source,
-        'subdivision': subdivision,
-        'main_property': property_record,
-        'comparables': comparables,
-        'total_comparables': len(comparables),
-    })
+    subdivision_stats = get_subdivision_stats(
+        subdivision,
+        zip_code,
+        market_value,
+        source,
+        fuzzy_subdivision=fuzzy,
+        subdivision_code=subdivision_code,
+    )
+
+    return jsonify(
+        {
+            "source": source,
+            "subdivision": subdivision,
+            "main_property": property_record,
+            "comparables": comparables,
+            "total_comparables": len(comparables),
+            "subdivision_stats": subdivision_stats,
+        }
+    )
 
 
-@tax_protest_bp.route('/download-csv')
+@tax_protest_bp.route("/download-csv")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def download_csv():
     """Download CSV of comparables using cached search result (no LLM re-run)."""
     cached = get_cached_search_result()
     if not cached:
         abort(400, description="No search results to download. Run a search first.")
 
-    contact = _authorized_contact(cached['contact_id'])
+    contact = _authorized_contact(cached["contact_id"])
 
-    main_property = get_main_property_by_id(cached['main_property_id'], cached['source'])
+    main_property = get_main_property_by_id(
+        cached["main_property_id"], cached["source"]
+    )
     if not main_property:
         abort(404, description="Main property no longer found in tax data")
 
     comparables = find_comparables(
-        cached['subdivision'],
-        cached['zip_code'],
-        main_property['market_value'],
-        cached['source'],
-        main_sq_ft=cached.get('main_sq_ft'),
-        fuzzy_subdivision=cached.get('fuzzy_subdivision', False),
-        subdivision_code=cached.get('subdivision_code'),
-        main_acreage=cached.get('main_acreage'),
+        cached["subdivision"],
+        cached["zip_code"],
+        main_property["market_value"],
+        cached["source"],
+        main_sq_ft=cached.get("main_sq_ft"),
+        fuzzy_subdivision=cached.get("fuzzy_subdivision", False),
+        subdivision_code=cached.get("subdivision_code"),
+        main_acreage=cached.get("main_acreage"),
     )
 
     output = StringIO()
     writer = csv.writer(output)
 
-    headers = ['Type', 'Address', 'City', 'Zip', 'Market Value', 'Sq Ft',
-               'Acreage', 'Subdivision', 'Legal Description', 'Account', 'County']
+    headers = [
+        "Type",
+        "Address",
+        "City",
+        "Zip",
+        "Market Value",
+        "Sq Ft",
+        "Acreage",
+        "Subdivision",
+        "Legal Description",
+        "Account",
+        "County",
+    ]
     writer.writerow(headers)
 
     county = {
-        'chambers': 'Chambers',
-        'hcad': 'Harris',
-        'liberty': 'Liberty',
-        'fort_bend': 'Fort Bend',
-    }.get(cached['source'], cached['source'].title())
-    subdivision = cached.get('subdivision', '')
+        "chambers": "Chambers",
+        "hcad": "Harris",
+        "liberty": "Liberty",
+        "fort_bend": "Fort Bend",
+    }.get(cached["source"], cached["source"].title())
+    subdivision = cached.get("subdivision", "")
 
-    def write_row(prop, row_type='Comparable'):
-        writer.writerow([
-            row_type,
-            prop.get('full_address', ''),
-            prop.get('city', ''),
-            prop.get('zip', ''),
-            prop.get('market_value', ''),
-            prop.get('sq_ft', ''),
-            prop.get('acreage', ''),
-            subdivision,
-            prop.get('legal1', ''),
-            prop.get('account', ''),
-            county,
-        ])
+    def write_row(prop, row_type="Comparable"):
+        writer.writerow(
+            [
+                row_type,
+                prop.get("full_address", ""),
+                prop.get("city", ""),
+                prop.get("zip", ""),
+                prop.get("market_value", ""),
+                prop.get("sq_ft", ""),
+                prop.get("acreage", ""),
+                subdivision,
+                prop.get("legal1", ""),
+                prop.get("account", ""),
+                county,
+            ]
+        )
 
-    write_row(main_property, 'Subject Property')
+    write_row(main_property, "Subject Property")
     for comp in comparables:
         write_row(comp)
 
     output.seek(0)
 
-    addr = contact.street_address or 'unknown'
-    filename = re.sub(r'[^a-zA-Z0-9]+', '_', addr).strip('_') + '.csv'
+    addr = contact.street_address or "unknown"
+    filename = re.sub(r"[^a-zA-Z0-9]+", "_", addr).strip("_") + ".csv"
 
     return Response(
         output.getvalue(),
-        mimetype='text/csv',
+        mimetype="text/csv",
         headers={
-            'Content-Disposition': f'attachment; filename={filename}',
-            'Content-Type': 'text/csv',
-        }
+            "Content-Disposition": f"attachment; filename={filename}",
+            "Content-Type": "text/csv",
+        },
     )

--- a/scripts/classify_liberty_codes.py
+++ b/scripts/classify_liberty_codes.py
@@ -1,0 +1,342 @@
+"""
+Build and classify Liberty County code profiles for tax protest comparables.
+
+Usage:
+    .venv/bin/python3 scripts/classify_liberty_codes.py
+    .venv/bin/python3 scripts/classify_liberty_codes.py --min-properties 20
+    .venv/bin/python3 scripts/classify_liberty_codes.py --limit 25
+    .venv/bin/python3 scripts/classify_liberty_codes.py --refresh
+"""
+import argparse
+import json
+import logging
+import os
+import statistics
+import sys
+from collections import defaultdict, Counter
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import openai
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import create_app
+from config import Config
+from models import db, LibertyProperty, LibertyCodeProfile
+
+MODEL_CANDIDATES = ["gpt-5.4-mini", "gpt-4.1-mini"]
+PROMPT_VERSION = "liberty_code_profiles_v1"
+DEFAULT_MIN_PROPERTIES = 5
+DEFAULT_SAMPLE_COUNT = 5
+VALID_BUCKETS = {
+    "platted_subdivision",
+    "broad_area",
+    "city_bucket",
+    "mhp_bucket",
+    "unknown",
+}
+VALID_STRATEGIES = {"normal", "strict", "reject"}
+
+SYSTEM_PROMPT = (
+    "You classify Liberty County, Texas appraisal subdivision/abstract codes for a property tax protest tool. "
+    "The tool should only use same-code homes as comparable properties when that is reasonably reliable. "
+    "Return JSON only. "
+    "Pick one bucket from: platted_subdivision, broad_area, city_bucket, mhp_bucket, unknown. "
+    "Pick one strategy from: normal, strict, reject. "
+    "Use normal only when the code clearly behaves like a true subdivision/neighborhood where same-code homes are likely comparable. "
+    "Use strict when the code may still be useful but only with tighter sqft/acreage/zip filters. "
+    "Use reject when the code is not a reliable neighborhood comp bucket, such as broad survey/tract/city/special buckets or junk categories. "
+    "Return a confidence from 0.0 to 1.0 and a short rationale."
+)
+
+
+def _utcnow_naive():
+    """Return a UTC timestamp compatible with existing naive DateTime columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+def _as_float(value):
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    return float(value)
+
+
+def _dedupe_preserve(values):
+    seen = set()
+    result = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _extract_json(text):
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("Empty classification response")
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"No JSON object found in response: {text[:200]}")
+    return json.loads(text[start:end + 1])
+
+
+def _build_profiles(app):
+    rows = []
+    with app.app_context():
+        query = LibertyProperty.query.with_entities(
+            LibertyProperty.abs_subdv_cd,
+            LibertyProperty.abs_subdv_desc,
+            LibertyProperty.legal_acreage,
+            LibertyProperty.situs_num,
+            LibertyProperty.sq_ft,
+            LibertyProperty.site_addr_1,
+            LibertyProperty.legal_desc,
+            LibertyProperty.situs_zip,
+        )
+        rows = query.all()
+
+    grouped = defaultdict(lambda: {
+        "desc": None,
+        "property_count": 0,
+        "acreages": [],
+        "with_situs_num": 0,
+        "with_sq_ft": 0,
+        "zips": Counter(),
+        "addresses": [],
+        "legals": [],
+        "streets": set(),
+    })
+
+    for code, desc, acreage, situs_num, sq_ft, site_addr_1, legal_desc, situs_zip in rows:
+        if not code:
+            continue
+        item = grouped[code]
+        if not item["desc"] and desc:
+            item["desc"] = desc
+        item["property_count"] += 1
+        acreage_val = _as_float(acreage)
+        if acreage_val and acreage_val > 0:
+            item["acreages"].append(acreage_val)
+        if situs_num:
+            item["with_situs_num"] += 1
+        if sq_ft and sq_ft > 0:
+            item["with_sq_ft"] += 1
+        if situs_zip:
+            item["zips"][situs_zip] += 1
+        if site_addr_1:
+            item["addresses"].append(site_addr_1)
+            streetish = site_addr_1
+            parts = streetish.split()
+            if parts and parts[0].isdigit():
+                streetish = " ".join(parts[1:])
+            item["streets"].add(streetish)
+        if legal_desc:
+            item["legals"].append(legal_desc)
+
+    profiles = []
+    for code, item in grouped.items():
+        count = item["property_count"]
+        acreages = item["acreages"]
+        profiles.append({
+            "abs_subdv_cd": code,
+            "abs_subdv_desc": item["desc"],
+            "property_count": count,
+            "avg_acreage": (sum(acreages) / len(acreages)) if acreages else None,
+            "median_acreage": statistics.median(acreages) if acreages else None,
+            "pct_with_situs_num": (item["with_situs_num"] / count) if count else 0.0,
+            "pct_with_sq_ft": (item["with_sq_ft"] / count) if count else 0.0,
+            "distinct_street_count": len(item["streets"]),
+            "distinct_zip_count": len(item["zips"]),
+            "sample_addresses": _dedupe_preserve(item["addresses"])[:DEFAULT_SAMPLE_COUNT],
+            "sample_legal_descriptions": _dedupe_preserve(item["legals"])[:DEFAULT_SAMPLE_COUNT],
+            "top_zips": [zip_code for zip_code, _ in item["zips"].most_common(3)],
+        })
+
+    return profiles
+
+
+def _manual_profile_decision(profile):
+    code = profile["abs_subdv_cd"]
+    desc = (profile["abs_subdv_desc"] or "").strip().upper()
+    if not code:
+        return {
+            "bucket": "unknown",
+            "strategy": "reject",
+            "confidence": 1.0,
+            "rationale": "Blank Liberty code cannot support reliable same-code comparables.",
+            "model_name": "manual",
+        }
+    if code == "MHP000" or desc == "NO MHP":
+        return {
+            "bucket": "mhp_bucket",
+            "strategy": "reject",
+            "confidence": 1.0,
+            "rationale": "NO MHP is not a neighborhood/subdivision code for same-code home comparables.",
+            "model_name": "manual",
+        }
+    return None
+
+
+def _classify_with_llm(client, profile):
+    prompt = {
+        "code": profile["abs_subdv_cd"],
+        "description": profile["abs_subdv_desc"],
+        "property_count": profile["property_count"],
+        "avg_acreage": profile["avg_acreage"],
+        "median_acreage": profile["median_acreage"],
+        "pct_with_situs_num": round(profile["pct_with_situs_num"], 4),
+        "pct_with_sq_ft": round(profile["pct_with_sq_ft"], 4),
+        "distinct_street_count": profile["distinct_street_count"],
+        "distinct_zip_count": profile["distinct_zip_count"],
+        "top_zips": profile["top_zips"],
+        "sample_addresses": profile["sample_addresses"],
+        "sample_legal_descriptions": profile["sample_legal_descriptions"],
+    }
+
+    user_prompt = (
+        "Classify this Liberty County appraisal code for same-code home comparable reliability.\n"
+        "Return JSON with keys: bucket, strategy, confidence, rationale.\n\n"
+        f"{json.dumps(prompt, ensure_ascii=True)}"
+    )
+
+    last_error = None
+    for model_name in MODEL_CANDIDATES:
+        for _ in range(3):
+            try:
+                if model_name.startswith("gpt-5"):
+                    response = client.responses.create(
+                        model=model_name,
+                        instructions=SYSTEM_PROMPT,
+                        input=user_prompt,
+                        reasoning={"effort": "low"},
+                    )
+                    output_text = response.output_text
+                else:
+                    response = client.chat.completions.create(
+                        model=model_name,
+                        messages=[
+                            {"role": "system", "content": SYSTEM_PROMPT},
+                            {"role": "user", "content": user_prompt},
+                        ],
+                        temperature=0.0,
+                        response_format={"type": "json_object"},
+                    )
+                    output_text = response.choices[0].message.content
+
+                parsed = _extract_json(output_text)
+                bucket = parsed.get("bucket")
+                strategy = parsed.get("strategy")
+                confidence = float(parsed.get("confidence"))
+                rationale = (parsed.get("rationale") or "").strip()
+                if bucket not in VALID_BUCKETS:
+                    raise ValueError(f"Invalid bucket: {bucket}")
+                if strategy not in VALID_STRATEGIES:
+                    raise ValueError(f"Invalid strategy: {strategy}")
+                confidence = max(0.0, min(1.0, confidence))
+                if not rationale:
+                    raise ValueError("Missing rationale")
+                return {
+                    "bucket": bucket,
+                    "strategy": strategy,
+                    "confidence": confidence,
+                    "rationale": rationale,
+                    "model_name": model_name,
+                }
+            except Exception as exc:
+                last_error = exc
+                continue
+    raise last_error
+
+
+def _upsert_profile(profile, classification):
+    existing = LibertyCodeProfile.query.filter_by(abs_subdv_cd=profile["abs_subdv_cd"]).first()
+    if not existing:
+        existing = LibertyCodeProfile(abs_subdv_cd=profile["abs_subdv_cd"])
+        db.session.add(existing)
+
+    existing.abs_subdv_desc = profile["abs_subdv_desc"]
+    existing.property_count = profile["property_count"]
+    existing.avg_acreage = profile["avg_acreage"]
+    existing.median_acreage = profile["median_acreage"]
+    existing.pct_with_situs_num = profile["pct_with_situs_num"]
+    existing.pct_with_sq_ft = profile["pct_with_sq_ft"]
+    existing.distinct_street_count = profile["distinct_street_count"]
+    existing.distinct_zip_count = profile["distinct_zip_count"]
+    existing.sample_addresses = profile["sample_addresses"]
+    existing.sample_legal_descriptions = profile["sample_legal_descriptions"]
+    existing.bucket = classification["bucket"]
+    existing.strategy = classification["strategy"]
+    existing.confidence = classification["confidence"]
+    existing.rationale = classification["rationale"]
+    existing.model_name = classification["model_name"]
+    existing.prompt_version = PROMPT_VERSION
+    existing.classified_at = _utcnow_naive()
+    existing.updated_at = _utcnow_naive()
+
+
+def run(app, min_properties=DEFAULT_MIN_PROPERTIES, limit=None, refresh=False):
+    profiles = _build_profiles(app)
+    profiles = [p for p in profiles if p["property_count"] >= min_properties]
+    profiles.sort(key=lambda p: (-p["property_count"], p["abs_subdv_cd"]))
+
+    key = Config.OPENAI_API_KEY
+    if not key:
+        raise ValueError("OPENAI_API_KEY is not configured")
+    client = openai.OpenAI(api_key=key)
+
+    processed = 0
+    llm_calls = 0
+    skipped_existing = 0
+
+    with app.app_context():
+        for profile in profiles:
+            existing = LibertyCodeProfile.query.filter_by(abs_subdv_cd=profile["abs_subdv_cd"]).first()
+            if existing and not refresh and existing.prompt_version == PROMPT_VERSION and existing.strategy:
+                skipped_existing += 1
+                continue
+
+            classification = _manual_profile_decision(profile)
+            if not classification:
+                classification = _classify_with_llm(client, profile)
+                llm_calls += 1
+
+            _upsert_profile(profile, classification)
+            processed += 1
+
+            if processed % 25 == 0:
+                db.session.commit()
+                print(f"Processed {processed} profiles ({llm_calls} LLM calls, {skipped_existing} skipped)")
+
+            if limit and processed >= limit:
+                break
+
+        db.session.commit()
+
+    print(
+        f"Done. Processed {processed} profiles, made {llm_calls} LLM calls, "
+        f"skipped {skipped_existing} existing profiles."
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Classify Liberty County code profiles")
+    parser.add_argument("--min-properties", type=int, default=DEFAULT_MIN_PROPERTIES)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--refresh", action="store_true")
+    args = parser.parse_args()
+
+    app = create_app()
+    run(app, min_properties=args.min_properties, limit=args.limit, refresh=args.refresh)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/import_tax_data.py
+++ b/scripts/import_tax_data.py
@@ -6,18 +6,21 @@ Usage:
     .venv/bin/python3 scripts/import_tax_data.py chambers         # Chambers only
     .venv/bin/python3 scripts/import_tax_data.py hcad             # HCAD only
     .venv/bin/python3 scripts/import_tax_data.py liberty          # Liberty only
+    .venv/bin/python3 scripts/import_tax_data.py fort_bend        # Fort Bend only
 
 Data files:
     tax_data/chambers.csv           - Chambers County (CSV, ~43k rows)
     tax_data/real_acct.txt          - Harris County main (TAB-separated, ~1.6M rows)
     tax_data/building_res.txt       - Harris County buildings (TAB-separated, ~1.3M rows)
     tax_data/liberty_county.txt     - Liberty County property file (fixed-width)
+    tax_data/fort_bend_county_tax_data/... - Fort Bend County export bundle (CSV)
 """
 import csv
 import sys
 import os
 import re
 import time
+from collections import defaultdict
 
 sys.stdout.reconfigure(line_buffering=True)
 csv.field_size_limit(sys.maxsize)
@@ -234,6 +237,65 @@ def _load_liberty_home_improvements(info_path, detail_path):
         ))
 
     return home_prop_ids, property_sq_ft, improvement_rows
+
+
+def _load_fort_bend_home_property_ids(filepath):
+    home_prop_ids = set()
+    with open(filepath, 'r', newline='', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            prop_id = clean(row.get('PropertyID'))
+            if not prop_id:
+                continue
+            if clean(row.get('Type')) in {'R', 'M'}:
+                home_prop_ids.add(prop_id)
+    return home_prop_ids
+
+
+def _load_fort_bend_acreage(filepath):
+    homesite_acres = defaultdict(float)
+    total_acres = defaultdict(float)
+
+    with open(filepath, 'r', newline='', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            prop_id = clean(row.get('PropertyID'))
+            if not prop_id:
+                continue
+
+            acreage = safe_decimal(row.get('Acres'))
+            square_feet = safe_decimal(row.get('SquareFeet'))
+            area_acres = acreage if acreage and acreage > 0 else (
+                (square_feet / 43560.0) if square_feet and square_feet > 0 else None
+            )
+            if not area_acres or area_acres <= 0:
+                continue
+
+            total_acres[prop_id] += area_acres
+            homesite_flag = safe_decimal(row.get('HomesiteFlag'))
+            if homesite_flag and homesite_flag > 0:
+                homesite_acres[prop_id] += area_acres
+
+    acreage_by_prop = {}
+    prop_ids = set(total_acres) | set(homesite_acres)
+    for prop_id in prop_ids:
+        acreage_by_prop[prop_id] = homesite_acres.get(prop_id) or total_acres.get(prop_id)
+    return acreage_by_prop
+
+
+def _fort_bend_site_addr(row):
+    situs = clean(row.get('Situs'))
+    if situs:
+        first_part = clean(situs.split(',')[0])
+        if first_part:
+            return first_part
+
+    return build_site_address(
+        clean(row.get('SitusStreetNumber')),
+        clean(row.get('SitusPreDirectional')),
+        clean(row.get('SitusStreetName')),
+        clean(row.get('SitusStreetSuffix')),
+    )
 
 
 def import_chambers(app):
@@ -655,6 +717,129 @@ def import_liberty(app):
     )
 
 
+def import_fort_bend(app):
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    base_dir = os.path.join(repo_root, 'tax_data', 'fort_bend_county_tax_data')
+
+    property_path = os.path.join(base_dir, 'PropertyProperty-E', 'PropertyDataExport4558080.txt')
+    improvement_path = os.path.join(base_dir, 'PropertyImprovement-E', 'PropertyDataExport4558083.txt')
+    land_path = os.path.join(base_dir, 'PropertyLand-E', 'PropertyDataExport4558082.txt')
+
+    missing = [path for path in [property_path, improvement_path, land_path] if not os.path.exists(path)]
+    if missing:
+        print("ERROR: Fort Bend County source files not found")
+        return
+
+    print("=== Importing Fort Bend County home data ===")
+    start = time.time()
+
+    home_prop_ids = _load_fort_bend_home_property_ids(improvement_path)
+    acreage_by_prop = _load_fort_bend_acreage(land_path)
+
+    print(f"  Fort Bend home properties identified: {len(home_prop_ids):,}")
+    print(f"  Fort Bend properties with acreage: {len(acreage_by_prop):,}")
+
+    conn = _get_raw_conn(app)
+    cursor = conn.cursor()
+
+    print("Truncating fort_bend_properties...")
+    cursor.execute("DELETE FROM fort_bend_properties")
+    conn.commit()
+
+    prop_cols = [
+        'property_id', 'quick_ref_id', 'property_number',
+        'legal_desc', 'legal_location_code', 'legal_location_desc', 'legal_acres',
+        'market_value', 'assessed_value', 'land_value', 'improvement_value',
+        'sq_ft', 'nbhd_code', 'nbhd_desc',
+        'situs', 'site_addr_1', 'normalized_site_addr',
+        'situs_pre_directional', 'situs_street_number', 'situs_street_name',
+        'situs_street_suffix', 'situs_post_directional',
+        'situs_city', 'situs_state', 'situs_zip',
+        'acreage', 'is_residential_home',
+    ]
+
+    batch = []
+    count = 0
+
+    with open(property_path, 'r', newline='', encoding='utf-8-sig', errors='replace') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            property_id = clean(row.get('PropertyID'))
+            if not property_id or property_id not in home_prop_ids:
+                continue
+
+            site_addr_1 = _fort_bend_site_addr(row)
+            acreage = acreage_by_prop.get(property_id)
+            if acreage is None:
+                acreage = safe_decimal(row.get('LegalAcres'))
+
+            market_value = safe_int(row.get('CurrMarketValue'))
+            if market_value is None:
+                market_value = safe_int(row.get('MarketValue'))
+
+            assessed_value = safe_int(row.get('CurrAssessedValue'))
+            if assessed_value is None:
+                assessed_value = safe_int(row.get('AssessedValue'))
+
+            land_value = safe_int(row.get('CurrLandValue'))
+            if land_value is None:
+                land_value = safe_int(row.get('LandValue'))
+
+            improvement_value = safe_int(row.get('CurrImprovmentValue'))
+            if improvement_value is None:
+                improvement_value = safe_int(row.get('ImprovmentValue'))
+
+            batch.append((
+                property_id,
+                clean(row.get('QuickRefID')),
+                clean(row.get('PropertyNumber')),
+                clean(row.get('LegalDesc')),
+                clean(row.get('LegalLocationCode')),
+                clean(row.get('LegalLocationDesc')),
+                safe_decimal(row.get('LegalAcres')),
+                market_value,
+                assessed_value,
+                land_value,
+                improvement_value,
+                safe_int(row.get('SquareFootage')),
+                clean(row.get('NbhdCode')),
+                clean(row.get('NbhdDesc')),
+                clean(row.get('Situs')),
+                site_addr_1,
+                normalize_address_text(site_addr_1),
+                clean(row.get('SitusPreDirectional')),
+                clean(row.get('SitusStreetNumber')),
+                clean(row.get('SitusStreetName')),
+                clean(row.get('SitusStreetSuffix')),
+                clean(row.get('SitusPostDirectional')),
+                clean(row.get('SitusCity')),
+                clean(row.get('SitusState')),
+                clean(row.get('SitusZip')),
+                acreage,
+                True,
+            ))
+
+            if len(batch) >= BATCH_SIZE:
+                _bulk_insert(cursor, 'fort_bend_properties', prop_cols, batch)
+                conn.commit()
+                count += len(batch)
+                if count % 25000 < BATCH_SIZE:
+                    elapsed = time.time() - start
+                    print(f"  Fort Bend properties: {count:,} rows... ({elapsed:.0f}s)")
+                batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'fort_bend_properties', prop_cols, batch)
+        conn.commit()
+        count += len(batch)
+
+    cursor.close()
+    conn.close()
+
+    elapsed = time.time() - start
+    print(f"=== Fort Bend import complete: {count:,} properties in {elapsed:.1f}s ===")
+
+
 if __name__ == '__main__':
     target = sys.argv[1] if len(sys.argv) > 1 else 'all'
     app = create_app()
@@ -667,5 +852,7 @@ if __name__ == '__main__':
         import_hcad(app)
     if target in ('all', 'liberty'):
         import_liberty(app)
+    if target in ('all', 'fort_bend', 'fortbend'):
+        import_fort_bend(app)
 
     print("\nDone!")

--- a/scripts/import_tax_data.py
+++ b/scripts/import_tax_data.py
@@ -5,15 +5,18 @@ Usage:
     .venv/bin/python3 scripts/import_tax_data.py                 # Import all
     .venv/bin/python3 scripts/import_tax_data.py chambers         # Chambers only
     .venv/bin/python3 scripts/import_tax_data.py hcad             # HCAD only
+    .venv/bin/python3 scripts/import_tax_data.py liberty          # Liberty only
 
 Data files:
     tax_data/chambers.csv           - Chambers County (CSV, ~43k rows)
     tax_data/real_acct.txt          - Harris County main (TAB-separated, ~1.6M rows)
     tax_data/building_res.txt       - Harris County buildings (TAB-separated, ~1.3M rows)
+    tax_data/liberty_county.txt     - Liberty County property file (fixed-width)
 """
 import csv
 import sys
 import os
+import re
 import time
 
 sys.stdout.reconfigure(line_buffering=True)
@@ -54,6 +57,64 @@ def safe_decimal(val):
         return None
 
 
+def safe_decimal_implied(val, scale=4):
+    cleaned = clean(val)
+    if not cleaned:
+        return None
+    digits = ''.join(ch for ch in cleaned if ch.isdigit() or ch == '-')
+    if not digits:
+        return None
+    try:
+        return int(digits) / (10 ** scale)
+    except (ValueError, TypeError):
+        return None
+
+
+def fixed_text(line, start, end):
+    return clean(line[start - 1:end])
+
+
+def fixed_int(line, start, end):
+    return safe_int(line[start - 1:end])
+
+
+def fixed_decimal_implied(line, start, end, scale=4):
+    return safe_decimal_implied(line[start - 1:end], scale=scale)
+
+
+def normalize_address_text(address):
+    if not address:
+        return None
+    addr = address.upper().strip()
+    replacements = {
+        ' STREET': ' ST', ' DRIVE': ' DR', ' AVENUE': ' AVE',
+        ' BOULEVARD': ' BLVD', ' LANE': ' LN', ' COURT': ' CT',
+        ' CIRCLE': ' CIR', ' PLACE': ' PL', ' ROAD': ' RD',
+        ' HIGHWAY': ' HWY', ' PARKWAY': ' PKWY',
+    }
+    for old, new in replacements.items():
+        addr = addr.replace(old, new)
+    addr = addr.replace('FARM TO MARKET', 'FM')
+    addr = re.sub(r'\s*(APT|UNIT|STE|SUITE|#)\s*\S*$', '', addr)
+    addr = re.sub(r'\s+', ' ', addr).strip()
+    return addr or None
+
+
+def build_site_address(street_num, street_prefix, street_name, street_suffix, unit=None):
+    parts = [street_num, street_prefix, street_name, street_suffix]
+    address = ' '.join(part for part in parts if part).strip()
+    if unit:
+        address = f"{address} UNIT {unit}".strip()
+    return address or None
+
+
+def resolve_existing_path(*candidates):
+    for candidate in candidates:
+        if candidate and os.path.exists(candidate):
+            return candidate
+    return None
+
+
 def _get_raw_conn(app):
     """Get a raw psycopg2 connection from the SQLAlchemy engine."""
     with app.app_context():
@@ -70,6 +131,109 @@ def _bulk_insert(cursor, table, columns, rows):
     if table == 'hcad_properties':
         sql += " ON CONFLICT (acct) DO NOTHING"
     execute_values(cursor, sql, rows, template=template, page_size=BATCH_SIZE)
+
+
+def _load_liberty_subdivision_lookup(filepath):
+    lookup = {}
+    with open(filepath, 'r', encoding='utf-8-sig', errors='replace') as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\r\n')
+            code = fixed_text(line, 1, 10)
+            if not code:
+                continue
+            lookup[code] = fixed_text(line, 11, 50)
+    return lookup
+
+
+def _choose_liberty_sq_ft(area_parts):
+    main_area = area_parts.get('main_area', 0)
+    story_area = area_parts.get('story_area', 0)
+    mobile_area = area_parts.get('mobile_area', 0)
+    best = max(main_area, story_area, mobile_area)
+    return best or None
+
+
+def _load_liberty_home_improvements(info_path, detail_path):
+    improvements = {}
+
+    print("Parsing Liberty improvement info...")
+    with open(info_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\r\n')
+            prop_id = fixed_text(line, 1, 12)
+            imprv_id = fixed_text(line, 17, 28)
+            if not prop_id or not imprv_id:
+                continue
+
+            imprv_type_cd = fixed_text(line, 29, 38)
+            imprv_type_desc = fixed_text(line, 39, 63)
+            is_residential = imprv_type_cd in {'R', 'M'} or imprv_type_desc in {'RESIDENTIAL', 'MOBILE HOME'}
+            if not is_residential:
+                continue
+
+            key = (prop_id, imprv_id)
+            improvements[key] = {
+                'prop_id': prop_id,
+                'imprv_id': imprv_id,
+                'imprv_type_cd': imprv_type_cd,
+                'imprv_type_desc': imprv_type_desc,
+                'imprv_homesite': fixed_text(line, 69, 69),
+                'imprv_val': fixed_int(line, 70, 83),
+                'residential_sq_ft': None,
+                'is_residential': True,
+            }
+
+    print("Parsing Liberty improvement detail...")
+    detail_area_by_key = {}
+    with open(detail_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\r\n')
+            prop_id = fixed_text(line, 1, 12)
+            imprv_id = fixed_text(line, 17, 28)
+            key = (prop_id, imprv_id)
+            if key not in improvements:
+                continue
+
+            detail_type = fixed_text(line, 41, 50) or ''
+            detail_desc = fixed_text(line, 51, 75) or ''
+            area = fixed_int(line, 94, 108)
+            if not area or area <= 0:
+                continue
+
+            buckets = detail_area_by_key.setdefault(key, {
+                'main_area': 0,
+                'story_area': 0,
+                'mobile_area': 0,
+            })
+            if 'M HOME' in detail_desc:
+                buckets['mobile_area'] += area
+            elif detail_type == 'MA':
+                buckets['main_area'] += area
+            elif detail_type.startswith('MA'):
+                buckets['story_area'] += area
+
+    improvement_rows = []
+    property_sq_ft = {}
+    home_prop_ids = set()
+
+    for key, info in improvements.items():
+        home_prop_ids.add(info['prop_id'])
+        residential_sq_ft = _choose_liberty_sq_ft(detail_area_by_key.get(key, {}))
+        info['residential_sq_ft'] = residential_sq_ft
+        if residential_sq_ft:
+            property_sq_ft[info['prop_id']] = max(property_sq_ft.get(info['prop_id']) or 0, residential_sq_ft)
+        improvement_rows.append((
+            info['prop_id'],
+            info['imprv_id'],
+            info['imprv_type_cd'],
+            info['imprv_type_desc'],
+            info['imprv_homesite'],
+            info['imprv_val'],
+            residential_sq_ft,
+            True,
+        ))
+
+    return home_prop_ids, property_sq_ft, improvement_rows
 
 
 def import_chambers(app):
@@ -335,6 +499,162 @@ def import_hcad(app):
     print(f"=== HCAD import complete: {count:,} properties + {bld_count:,} buildings in {total_elapsed:.1f}s ===")
 
 
+def import_liberty(app):
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    downloads_dir = os.path.join(os.path.expanduser('~'), 'Downloads', '2026 PRELIMARY APPRAISAL ROLL')
+
+    property_path = resolve_existing_path(
+        os.path.join(repo_root, 'tax_data', 'liberty_county.txt'),
+        os.path.join(downloads_dir, '2026-03-31_002100_APPRAISAL_ENTITY_INFO.TXT'),
+    )
+    subdv_path = resolve_existing_path(
+        os.path.join(repo_root, 'tax_data', '2026-03-31_002100_APPRAISAL_ABSTRACT_SUBDV.TXT'),
+        os.path.join(downloads_dir, '2026-03-31_002100_APPRAISAL_ABSTRACT_SUBDV.TXT'),
+    )
+    imprv_info_path = resolve_existing_path(
+        os.path.join(repo_root, 'tax_data', '2026-03-31_002100_APPRAISAL_IMPROVEMENT_INFO.TXT'),
+        os.path.join(downloads_dir, '2026-03-31_002100_APPRAISAL_IMPROVEMENT_INFO.TXT'),
+    )
+    imprv_detail_path = resolve_existing_path(
+        os.path.join(repo_root, 'tax_data', '2026-03-31_002100_APPRAISAL_IMPROVEMENT_DETAIL.TXT'),
+        os.path.join(downloads_dir, '2026-03-31_002100_APPRAISAL_IMPROVEMENT_DETAIL.TXT'),
+    )
+
+    missing = [
+        path for path in [property_path, subdv_path, imprv_info_path, imprv_detail_path]
+        if not path
+    ]
+    if missing:
+        print("ERROR: Liberty County source files not found")
+        return
+
+    print("=== Importing Liberty County home data ===")
+    start = time.time()
+
+    subdv_lookup = _load_liberty_subdivision_lookup(subdv_path)
+    home_prop_ids, property_sq_ft, improvement_rows = _load_liberty_home_improvements(
+        imprv_info_path, imprv_detail_path
+    )
+
+    print(f"  Liberty home properties identified: {len(home_prop_ids):,}")
+    print(f"  Liberty residential/mobile improvements: {len(improvement_rows):,}")
+
+    conn = _get_raw_conn(app)
+    cursor = conn.cursor()
+
+    print("Truncating liberty_improvements and liberty_properties...")
+    cursor.execute("DELETE FROM liberty_improvements")
+    cursor.execute("DELETE FROM liberty_properties")
+    conn.commit()
+
+    prop_cols = [
+        'prop_id', 'geo_id', 'prop_type_cd',
+        'situs_num', 'situs_street_prefx', 'situs_street', 'situs_street_suffix', 'situs_unit',
+        'situs_city', 'situs_zip', 'site_addr_1', 'normalized_site_addr',
+        'legal_desc', 'legal_desc2', 'legal_acreage',
+        'abs_subdv_cd', 'abs_subdv_desc',
+        'appraised_val', 'assessed_val', 'market_value',
+        'imprv_hstd_val', 'imprv_non_hstd_val',
+        'sq_ft', 'is_residential_home',
+    ]
+
+    batch = []
+    count = 0
+    imported_prop_ids = set()
+    with open(property_path, 'r', encoding='utf-8-sig', errors='replace') as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\r\n')
+            prop_id = fixed_text(line, 1, 12)
+            if not prop_id or prop_id not in home_prop_ids:
+                continue
+            imported_prop_ids.add(prop_id)
+
+            situs_num = fixed_text(line, 4460, 4474)
+            situs_prefx = fixed_text(line, 1040, 1049)
+            situs_street = fixed_text(line, 1050, 1099)
+            situs_suffix = fixed_text(line, 1100, 1109)
+            situs_unit = fixed_text(line, 4475, 4479)
+            site_addr_1 = build_site_address(situs_num, situs_prefx, situs_street, situs_suffix, situs_unit)
+
+            abs_subdv_cd = fixed_text(line, 1676, 1685)
+            abs_subdv_desc = subdv_lookup.get(abs_subdv_cd) if abs_subdv_cd else None
+
+            batch.append((
+                prop_id,
+                fixed_text(line, 547, 596),
+                fixed_text(line, 13, 17),
+                situs_num,
+                situs_prefx,
+                situs_street,
+                situs_suffix,
+                situs_unit,
+                fixed_text(line, 1110, 1139),
+                fixed_text(line, 1140, 1149),
+                site_addr_1,
+                normalize_address_text(site_addr_1),
+                fixed_text(line, 1150, 1404),
+                fixed_text(line, 1405, 1659),
+                fixed_decimal_implied(line, 1660, 1675, scale=4),
+                abs_subdv_cd,
+                abs_subdv_desc,
+                fixed_int(line, 1916, 1930),
+                fixed_int(line, 1946, 1960),
+                fixed_int(line, 4214, 4227),
+                fixed_int(line, 1826, 1840),
+                fixed_int(line, 1841, 1855),
+                property_sq_ft.get(prop_id),
+                True,
+            ))
+
+            if len(batch) >= BATCH_SIZE:
+                _bulk_insert(cursor, 'liberty_properties', prop_cols, batch)
+                conn.commit()
+                count += len(batch)
+                if count % 25000 < BATCH_SIZE:
+                    elapsed = time.time() - start
+                    print(f"  Liberty properties: {count:,} rows... ({elapsed:.0f}s)")
+                batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'liberty_properties', prop_cols, batch)
+        conn.commit()
+        count += len(batch)
+
+    print(f"  Liberty properties complete: {count:,} rows")
+
+    imprv_cols = [
+        'prop_id', 'imprv_id', 'imprv_type_cd', 'imprv_type_desc',
+        'imprv_homesite', 'imprv_val', 'residential_sq_ft', 'is_residential',
+    ]
+    batch = []
+    imprv_count = 0
+    skipped_improvements = 0
+    for row in improvement_rows:
+        if row[0] not in imported_prop_ids:
+            skipped_improvements += 1
+            continue
+        batch.append(row)
+        if len(batch) >= BATCH_SIZE:
+            _bulk_insert(cursor, 'liberty_improvements', imprv_cols, batch)
+            conn.commit()
+            imprv_count += len(batch)
+            batch = []
+
+    if batch:
+        _bulk_insert(cursor, 'liberty_improvements', imprv_cols, batch)
+        conn.commit()
+        imprv_count += len(batch)
+
+    cursor.close()
+    conn.close()
+
+    elapsed = time.time() - start
+    print(
+        f"=== Liberty import complete: {count:,} properties + {imprv_count:,} improvements "
+        f"in {elapsed:.1f}s (skipped {skipped_improvements:,} orphan improvements) ==="
+    )
+
+
 if __name__ == '__main__':
     target = sys.argv[1] if len(sys.argv) > 1 else 'all'
     app = create_app()
@@ -345,5 +665,7 @@ if __name__ == '__main__':
         import_hcad_neighborhoods(app)
     if target in ('all', 'hcad'):
         import_hcad(app)
+    if target in ('all', 'liberty'):
+        import_liberty(app)
 
     print("\nDone!")

--- a/scripts/scrape_chambers_sqft.py
+++ b/scripts/scrape_chambers_sqft.py
@@ -2,17 +2,16 @@
 Scrape square footage from chamberscad.org for Chambers County properties.
 
 Navigates directly to each property's detail page via URL, finds the
-Improvement Building table, and sums residential sqft (RES MAS rows).
+Improvement Building table, and sums sq ft for MLS-style Gross Living Area (GLA):
+main structure (RES MAS / RES FRM), upper/second story, half-story, additions,
+converted garage, finished attic. Excludes garages, porches, patios, unfinished
+attic, etc.
 
 Usage:
-    # Test mode: visible browser, first 3 properties
     python3 scripts/scrape_chambers_sqft.py --limit 3 --visible
-
-    # Full run: headless, all un-scraped properties with improvements
     python3 scripts/scrape_chambers_sqft.py
-
-    # Resume after interruption (only processes sq_ft IS NULL)
-    python3 scripts/scrape_chambers_sqft.py
+    # Recompute all improved properties (overwrites existing sq_ft)
+    python3 scripts/scrape_chambers_sqft.py --rescan
 
 Requires: playwright (pip install playwright && playwright install chromium)
 This is a standalone script -- playwright is NOT an app runtime dependency.
@@ -46,24 +45,29 @@ DELAY_MIN = 0.8
 DELAY_MAX = 1.2
 
 
-def get_properties_to_scrape(app, limit=None):
-    """Return list of (id, parcel_id) for Chambers properties needing sqft."""
+def get_properties_to_scrape(app, limit=None, rescan=False):
+    """Return list of (id, parcel_id) for Chambers properties to scrape.
+
+    By default only rows with sq_ft IS NULL. With rescan=True, all properties
+    with improvements (overwrites prior sq_ft).
+    """
     from models import db, ChambersProperty
 
     with app.app_context():
-        query = ChambersProperty.query.filter(
-            ChambersProperty.sq_ft.is_(None),
-            db.or_(
-                db.and_(
-                    ChambersProperty.improvement_hs_val.isnot(None),
-                    ChambersProperty.improvement_hs_val > 0,
-                ),
-                db.and_(
-                    ChambersProperty.improvement_nhs_val.isnot(None),
-                    ChambersProperty.improvement_nhs_val > 0,
-                ),
+        has_imp = db.or_(
+            db.and_(
+                ChambersProperty.improvement_hs_val.isnot(None),
+                ChambersProperty.improvement_hs_val > 0,
             ),
-        ).order_by(ChambersProperty.id)
+            db.and_(
+                ChambersProperty.improvement_nhs_val.isnot(None),
+                ChambersProperty.improvement_nhs_val > 0,
+            ),
+        )
+        query = ChambersProperty.query.filter(has_imp)
+        if not rescan:
+            query = query.filter(ChambersProperty.sq_ft.is_(None))
+        query = query.order_by(ChambersProperty.id)
 
         if limit:
             query = query.limit(limit)
@@ -88,7 +92,7 @@ def scrape_property(page, parcel_id):
     """
     Navigate directly to a property detail page and extract sqft.
 
-    Returns total residential sqft (int), or 0 if no RES MAS rows found.
+    Returns total GLA sqft (int), or 0 if no matching improvement rows.
     Raises on navigation/scraping failure.
     """
     url = DETAIL_URL.format(parcel_id=parcel_id)
@@ -109,14 +113,50 @@ def scrape_property(page, parcel_id):
 
 def extract_residential_sqft(page):
     """
-    Parse the Improvement Building table on the detail page.
-    Sum the Sqft column for rows where Type starts with "RES MAS".
-    Returns int (0 if no residential rows found).
+    Sum Improvement Building sq ft for MLS-style GLA (finished living area).
+
+    Includes: RES MAS / RES FRM, UPPER / 2ND FLR, 1/2 STRY, ADD / ADDN,
+    CONV GAR, FIN ATTIC. Excludes garages (non-converted), porches, patios,
+    unfinished attic, storage, etc.
     """
     total = 0
 
     # The page uses JavaScript to render tables; extract via JS for reliability
     sqft_data = page.evaluate('''() => {
+        function norm(s) {
+            return s.replace(/\\s+/g, ' ').trim().toUpperCase();
+        }
+        /** CAD "Type" cell → counts toward gross living area (MLS-style). */
+        function isGlaType(typeRaw) {
+            const t = norm(typeRaw);
+            if (!t) return false;
+
+            // Converted garage counts as living area; check before generic GAR exclude
+            if (t.includes('CONV') && t.includes('GAR')) return true;
+
+            // Main structure
+            if (t.startsWith('RES MAS') || t.startsWith('RES FRM')) return true;
+
+            // Additional finished stories / levels
+            if (t === 'UPPER' || t.startsWith('UPPER ')) return true;
+            if (t.includes('2ND') && (t.includes('FLR') || t.includes('FLOOR'))) return true;
+            if ((t.includes('1/2') || t.includes('HALF')) && t.includes('STRY')) return true;
+
+            // Finished additions (whole-word ADD / ADDN)
+            if (/\\bADDN?\\b/.test(t)) return true;
+
+            // Finished attic
+            if ((t.includes('FIN') && t.includes('ATTIC')) || t.startsWith('FIN ATT')) return true;
+
+            // Non-GLA — do not count
+            if (t.includes('UNF') && t.includes('ATTIC')) return false;
+            if (/GARAGE|ATT\\s*GAR|DET\\s*GAR|\\bGAR\\b/i.test(t)) return false;
+            if (/POR\\s*CH|PORCH|OPEN\\s*PORCH|CVRD\\s*PCH|CVRD\\s*PORCH/i.test(t)) return false;
+            if (/\\bPATIO\\b|\\bDECK\\b|STORAGE|SHED|OUTBLDG|OUT\\s*BLDG/i.test(t)) return false;
+
+            return false;
+        }
+
         const results = [];
         const tables = document.querySelectorAll('table');
         for (const table of tables) {
@@ -130,10 +170,10 @@ def extract_residential_sqft(page):
             for (const row of rows) {
                 const cells = row.querySelectorAll('td');
                 if (cells.length <= Math.max(typeIdx, sqftIdx)) continue;
-                const type = cells[typeIdx].textContent.trim().toUpperCase();
+                const type = cells[typeIdx].textContent.trim();
                 const sqft = cells[sqftIdx].textContent.trim().replace(/,/g, '');
-                if (type.startsWith('RES MAS')) {
-                    results.push({type, sqft: parseInt(sqft) || 0});
+                if (isGlaType(type)) {
+                    results.push({type: norm(type), sqft: parseInt(sqft, 10) || 0});
                 }
             }
         }
@@ -152,14 +192,19 @@ def main():
                         help='Max properties to scrape (default: all)')
     parser.add_argument('--visible', action='store_true',
                         help='Run browser in visible (non-headless) mode')
+    parser.add_argument('--rescan', action='store_true',
+                        help='Re-scrape all improved properties (overwrite existing sq_ft)')
     args = parser.parse_args()
 
     from app import create_app
     app = create_app()
 
-    properties = get_properties_to_scrape(app, limit=args.limit)
+    properties = get_properties_to_scrape(
+        app, limit=args.limit, rescan=args.rescan)
     total = len(properties)
     log.info(f'Found {total} properties to scrape')
+    if args.rescan:
+        log.info('Rescan mode: existing sq_ft values will be overwritten')
 
     if total == 0:
         log.info('Nothing to do')
@@ -187,7 +232,7 @@ def main():
                 if sqft > 0:
                     log.info(f'[{idx+1}/{total}] Parcel {parcel_id}: {sqft} sqft')
                 else:
-                    log.info(f'[{idx+1}/{total}] Parcel {parcel_id}: no RES MAS rows (sq_ft=0)')
+                    log.info(f'[{idx+1}/{total}] Parcel {parcel_id}: no GLA rows matched (sq_ft=0)')
 
             except (PlaywrightTimeout, Exception) as e:
                 failed += 1

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -3,6 +3,7 @@ Tax Protest service layer.
 Handles address lookup in county tax data, LLM-based subdivision extraction,
 comparable property queries, and search result caching for CSV consistency.
 """
+
 import re
 import logging
 from flask import session
@@ -18,6 +19,9 @@ from models import (
 )
 
 logger = logging.getLogger(__name__)
+
+SQ_FT_RANGE = 250
+MIN_COMPARABLES = 5
 
 SUBDIVISION_SYSTEM_PROMPT = (
     "You are a Texas property legal description parser. "
@@ -40,24 +44,43 @@ SUBDIVISION_EXAMPLES = (
 def normalize_address(address):
     """Normalize a street address for matching."""
     if not address:
-        return ''
+        return ""
     addr = address.upper().strip()
     replacements = {
-        ' STREET': ' ST', ' DRIVE': ' DR', ' AVENUE': ' AVE',
-        ' BOULEVARD': ' BLVD', ' LANE': ' LN', ' COURT': ' CT',
-        ' CIRCLE': ' CIR', ' PLACE': ' PL', ' ROAD': ' RD',
-        ' HIGHWAY': ' HWY', ' PARKWAY': ' PKWY',
+        " STREET": " ST",
+        " DRIVE": " DR",
+        " AVENUE": " AVE",
+        " BOULEVARD": " BLVD",
+        " LANE": " LN",
+        " COURT": " CT",
+        " CIRCLE": " CIR",
+        " PLACE": " PL",
+        " ROAD": " RD",
+        " HIGHWAY": " HWY",
+        " PARKWAY": " PKWY",
     }
     for old, new in replacements.items():
         addr = addr.replace(old, new)
-    addr = addr.replace('FARM TO MARKET', 'FM')
-    addr = re.sub(r'\s*(APT|UNIT|STE|SUITE|#)\s*\S*$', '', addr)
-    addr = re.sub(r'\s+', ' ', addr).strip()
+    addr = addr.replace("FARM TO MARKET", "FM")
+    addr = re.sub(r"\s*(APT|UNIT|STE|SUITE|#)\s*\S*$", "", addr)
+    addr = re.sub(r"\s+", " ", addr).strip()
     return addr
 
 
-DIRECTIONAL_PREFIXES = {'N', 'S', 'E', 'W', 'NE', 'NW', 'SE', 'SW',
-                         'NORTH', 'SOUTH', 'EAST', 'WEST'}
+DIRECTIONAL_PREFIXES = {
+    "N",
+    "S",
+    "E",
+    "W",
+    "NE",
+    "NW",
+    "SE",
+    "SW",
+    "NORTH",
+    "SOUTH",
+    "EAST",
+    "WEST",
+}
 
 
 def _parse_street_parts(address):
@@ -67,7 +90,7 @@ def _parse_street_parts(address):
     addr = normalize_address(address)
     if not addr:
         return None, None, None
-    match = re.match(r'^(\d+)\s+(.+)', addr)
+    match = re.match(r"^(\d+)\s+(.+)", addr)
     if not match:
         return None, None, addr
     street_num = match.group(1)
@@ -75,7 +98,7 @@ def _parse_street_parts(address):
     parts = remainder.split()
     if parts and parts[0] in DIRECTIONAL_PREFIXES:
         direction = parts[0]
-        street_name = ' '.join(parts[1:]) if len(parts) > 1 else ''
+        street_name = " ".join(parts[1:]) if len(parts) > 1 else ""
         return street_num, direction, street_name
     return street_num, None, remainder
 
@@ -88,32 +111,34 @@ def find_property_in_tax_data(street_address, city, zip_code):
     """
     normalized_address = normalize_address(street_address)
     street_num, direction, street_name = _parse_street_parts(street_address)
-    zip_clean = (zip_code or '').strip()[:5]
-    city_clean = (city or '').strip().upper()
+    zip_clean = (zip_code or "").strip()[:5]
+    city_clean = (city or "").strip().upper()
 
     # --- Chambers County ---
     chambers_result = _search_chambers(street_num, direction, street_name, zip_clean)
     if chambers_result:
-        return chambers_result, 'chambers'
+        return chambers_result, "chambers"
 
     # --- Harris County (HCAD) ---
-    hcad_result = _search_hcad(normalized_address, street_num, direction, street_name, zip_clean)
+    hcad_result = _search_hcad(
+        normalized_address, street_num, direction, street_name, zip_clean
+    )
     if hcad_result:
-        return hcad_result, 'hcad'
+        return hcad_result, "hcad"
 
     # --- Liberty County ---
     liberty_result = _search_liberty(
         normalized_address, street_num, street_name, city_clean, zip_clean
     )
     if liberty_result:
-        return liberty_result, 'liberty'
+        return liberty_result, "liberty"
 
     # --- Fort Bend County ---
     fort_bend_result = _search_fort_bend(
         normalized_address, street_num, street_name, city_clean, zip_clean
     )
     if fort_bend_result:
-        return fort_bend_result, 'fort_bend'
+        return fort_bend_result, "fort_bend"
 
     return None, None
 
@@ -128,7 +153,7 @@ def _search_chambers(street_num, direction, street_name, zip_code):
     first_word = street_name.split()[0]
     base_filters = [
         ChambersProperty.prop_street_number == street_num,
-        ChambersProperty.prop_street.ilike(f'{first_word}%'),
+        ChambersProperty.prop_street.ilike(f"{first_word}%"),
     ]
     if direction:
         base_filters.append(ChambersProperty.prop_street_dir == direction)
@@ -173,7 +198,7 @@ def _search_hcad(normalized_address, street_num, direction, street_name, zip_cod
         first_word = street_name.split()[0]
         base_filters = [
             HcadProperty.str_num == street_num,
-            HcadProperty.str.ilike(f'{first_word}%'),
+            HcadProperty.str.ilike(f"{first_word}%"),
         ]
         if direction:
             base_filters.append(HcadProperty.str_sfx_dir == direction)
@@ -197,7 +222,7 @@ def _search_hcad(normalized_address, street_num, direction, street_name, zip_cod
     # Last resort: fuzzy match on full site_addr_1
     if street_num and street_name:
         result = HcadProperty.query.filter(
-            HcadProperty.site_addr_1.ilike(f'{street_num} {street_name}%'),
+            HcadProperty.site_addr_1.ilike(f"{street_num} {street_name}%"),
         ).first()
         if result:
             return _hcad_found(result)
@@ -229,7 +254,7 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
     if street_name:
         first_word = street_name.split()[0]
         street_filters = [
-            LibertyProperty.situs_street.ilike(f'{first_word}%'),
+            LibertyProperty.situs_street.ilike(f"{first_word}%"),
             *base_filter,
         ]
         if street_num:
@@ -259,7 +284,7 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
 
         if street_num:
             result = LibertyProperty.query.filter(
-                LibertyProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
+                LibertyProperty.site_addr_1.ilike(f"{street_num} {first_word}%"),
                 *base_filter,
             ).first()
             if result:
@@ -292,7 +317,7 @@ def _search_fort_bend(normalized_address, street_num, street_name, city, zip_cod
     if street_name:
         first_word = street_name.split()[0]
         street_filters = [
-            FortBendProperty.situs_street_name.ilike(f'{first_word}%'),
+            FortBendProperty.situs_street_name.ilike(f"{first_word}%"),
             *base_filter,
         ]
         if street_num:
@@ -322,7 +347,7 @@ def _search_fort_bend(normalized_address, street_num, street_name, city, zip_cod
 
         if street_num:
             result = FortBendProperty.query.filter(
-                FortBendProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
+                FortBendProperty.site_addr_1.ilike(f"{street_num} {first_word}%"),
                 *base_filter,
             ).first()
             if result:
@@ -336,11 +361,11 @@ def _is_valid_subdivision(lgl_2):
     if not lgl_2 or not lgl_2.strip():
         return False
     val = lgl_2.strip().upper()
-    if val.startswith('('):
+    if val.startswith("("):
         return False
-    if re.match(r'^BLK\s+\d', val):
+    if re.match(r"^BLK\s+\d", val):
         return False
-    if re.match(r'^(LTS?\s|LOTS?\s|TRS?\s)', val):
+    if re.match(r"^(LTS?\s|LOTS?\s|TRS?\s)", val):
         return False
     if len(val) < 3:
         return False
@@ -350,9 +375,11 @@ def _is_valid_subdivision(lgl_2):
 def _hcad_found(result):
     """Helper to load sq_ft and return dict for a matched HCAD property."""
 
-    sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
-        HcadBuilding.acct == result.acct
-    ).scalar()
+    sq_ft = (
+        db.session.query(db.func.max(HcadBuilding.im_sq_ft))
+        .filter(HcadBuilding.acct == result.acct)
+        .scalar()
+    )
 
     return _hcad_to_dict(result, sq_ft)
 
@@ -367,6 +394,7 @@ def extract_subdivision_llm(legal_description):
 
     try:
         from services.ai_service import generate_ai_response
+
         prompt = f"{SUBDIVISION_EXAMPLES}\nLegal description: '{legal_description}'"
         result = generate_ai_response(
             system_prompt=SUBDIVISION_SYSTEM_PROMPT,
@@ -375,7 +403,7 @@ def extract_subdivision_llm(legal_description):
             reasoning_effort="low",
         )
         cleaned = result.strip().strip("'\"").upper()
-        if cleaned and cleaned != 'UNKNOWN' and len(cleaned) > 1:
+        if cleaned and cleaned != "UNKNOWN" and len(cleaned) > 1:
             return cleaned
     except Exception as e:
         logger.warning(f"LLM subdivision extraction failed, falling back to regex: {e}")
@@ -392,12 +420,12 @@ def extract_subdivision_regex(legal_description):
         return None
 
     text = legal_description.upper().strip()
-    text = re.sub(r'^(LOTS?\s+)?[\d\s&,\.]+\s+', '', text)
-    text = re.sub(r'^(TRS?\s+)[\d\s&,\.]+\s*', '', text)
-    text = re.sub(r'^(ALL\s+)?BLK\s+\d+\s*', '', text)
-    text = re.sub(r'\s+SEC(TION)?\s+\d+.*$', '', text)
-    text = re.sub(r'\s+BLK\s+\d+.*$', '', text)
-    text = re.sub(r'\s+PH(ASE)?\s+\d+.*$', '', text)
+    text = re.sub(r"^(LOTS?\s+)?[\d\s&,\.]+\s+", "", text)
+    text = re.sub(r"^(TRS?\s+)[\d\s&,\.]+\s*", "", text)
+    text = re.sub(r"^(ALL\s+)?BLK\s+\d+\s*", "", text)
+    text = re.sub(r"\s+SEC(TION)?\s+\d+.*$", "", text)
+    text = re.sub(r"\s+BLK\s+\d+.*$", "", text)
+    text = re.sub(r"\s+PH(ASE)?\s+\d+.*$", "", text)
 
     text = text.strip()
     if text and len(text) > 1 and not text.isdigit():
@@ -413,9 +441,16 @@ def get_neighborhood_name(neighborhood_code):
     return nc.dscr if nc else None
 
 
-def find_comparables(subdivision, zip_code, market_value, source,
-                     main_sq_ft=None, fuzzy_subdivision=False,
-                     subdivision_code=None, main_acreage=None):
+def find_comparables(
+    subdivision,
+    zip_code,
+    market_value,
+    source,
+    main_sq_ft=None,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    main_acreage=None,
+):
     """
     Find properties in the same subdivision and zip with lower market value.
     For HCAD: matches on lgl_2 (exact when from structured data, ILIKE when
@@ -423,16 +458,21 @@ def find_comparables(subdivision, zip_code, market_value, source,
     For Chambers: uses ILIKE on legal1 (no sq ft band; HCAD still uses ±250).
     Returns list of property dicts.
     """
-    SQ_FT_RANGE = 250
 
-    if source == 'chambers':
+    if source == "chambers":
         if not subdivision:
             return []
 
-        pattern = f'%{subdivision}%'
+        pattern = f"%{subdivision}%"
         has_improvement = db.or_(
-            db.and_(ChambersProperty.improvement_hs_val.isnot(None), ChambersProperty.improvement_hs_val > 0),
-            db.and_(ChambersProperty.improvement_nhs_val.isnot(None), ChambersProperty.improvement_nhs_val > 0),
+            db.and_(
+                ChambersProperty.improvement_hs_val.isnot(None),
+                ChambersProperty.improvement_hs_val > 0,
+            ),
+            db.and_(
+                ChambersProperty.improvement_nhs_val.isnot(None),
+                ChambersProperty.improvement_nhs_val > 0,
+            ),
         )
         base_filters = [
             ChambersProperty.legal1.ilike(pattern),
@@ -440,50 +480,59 @@ def find_comparables(subdivision, zip_code, market_value, source,
             ChambersProperty.market_value > 0,
             ChambersProperty.market_value < market_value,
             ChambersProperty.prop_street_number.isnot(None),
-            ChambersProperty.prop_street_number != '0',
+            ChambersProperty.prop_street_number != "0",
             ChambersProperty.prop_street.isnot(None),
             has_improvement,
         ]
 
         if zip_code:
-            results = ChambersProperty.query.filter(
-                ChambersProperty.prop_zip5 == zip_code,
-                *base_filters,
-            ).order_by(ChambersProperty.market_value.asc()).all()
+            results = (
+                ChambersProperty.query.filter(
+                    ChambersProperty.prop_zip5 == zip_code,
+                    *base_filters,
+                )
+                .order_by(ChambersProperty.market_value.asc())
+                .all()
+            )
             if results:
                 return [_chambers_to_dict(r) for r in results]
 
-        results = ChambersProperty.query.filter(
-            *base_filters,
-        ).order_by(ChambersProperty.market_value.asc()).all()
+        results = (
+            ChambersProperty.query.filter(
+                *base_filters,
+            )
+            .order_by(ChambersProperty.market_value.asc())
+            .all()
+        )
         return [_chambers_to_dict(r) for r in results]
 
-    elif source == 'hcad':
+    elif source == "hcad":
         if not subdivision:
             return []
 
         if fuzzy_subdivision:
-            sub_filter = HcadProperty.lgl_2.ilike(f'%{subdivision}%')
+            sub_filter = HcadProperty.lgl_2.ilike(f"%{subdivision}%")
         else:
-            sub_filter = (HcadProperty.lgl_2 == subdivision)
+            sub_filter = HcadProperty.lgl_2 == subdivision
 
         def _hcad_query(use_zip):
-            q = db.session.query(
-                HcadProperty,
-                db.func.max(HcadBuilding.im_sq_ft).label('max_sq_ft')
-            ).join(
-                HcadBuilding, HcadProperty.acct == HcadBuilding.acct
-            ).filter(
-                sub_filter,
-                HcadProperty.tot_mkt_val.isnot(None),
-                HcadProperty.tot_mkt_val > 0,
-                HcadProperty.tot_mkt_val < market_value,
-                HcadProperty.site_addr_1.isnot(None),
-                HcadProperty.site_addr_1 != '',
-                HcadProperty.str_num.isnot(None),
-                HcadProperty.str_num != '0',
-                HcadBuilding.im_sq_ft.isnot(None),
-                HcadBuilding.im_sq_ft > 0,
+            q = (
+                db.session.query(
+                    HcadProperty, db.func.max(HcadBuilding.im_sq_ft).label("max_sq_ft")
+                )
+                .join(HcadBuilding, HcadProperty.acct == HcadBuilding.acct)
+                .filter(
+                    sub_filter,
+                    HcadProperty.tot_mkt_val.isnot(None),
+                    HcadProperty.tot_mkt_val > 0,
+                    HcadProperty.tot_mkt_val < market_value,
+                    HcadProperty.site_addr_1.isnot(None),
+                    HcadProperty.site_addr_1 != "",
+                    HcadProperty.str_num.isnot(None),
+                    HcadProperty.str_num != "0",
+                    HcadBuilding.im_sq_ft.isnot(None),
+                    HcadBuilding.im_sq_ft > 0,
+                )
             )
             if use_zip and zip_code:
                 q = q.filter(HcadProperty.site_addr_3 == zip_code)
@@ -503,232 +552,431 @@ def find_comparables(subdivision, zip_code, market_value, source,
 
         return [_hcad_to_dict(prop, sq_ft) for prop, sq_ft in results]
 
-    elif source == 'liberty':
+    elif source == "liberty":
         if not subdivision_code:
             return []
 
-        profile = LibertyCodeProfile.query.filter_by(abs_subdv_cd=subdivision_code).first()
-        strategy = profile.strategy if profile and profile.strategy else 'strict'
-        if strategy == 'reject':
+        profile = LibertyCodeProfile.query.filter_by(
+            abs_subdv_cd=subdivision_code
+        ).first()
+        strategy = profile.strategy if profile and profile.strategy else "strict"
+        if strategy == "reject":
             return []
 
-        base_filters = [
-            LibertyProperty.is_residential_home.is_(True),
-            LibertyProperty.abs_subdv_cd == subdivision_code,
-            LibertyProperty.market_value.isnot(None),
-            LibertyProperty.market_value > 0,
-            LibertyProperty.market_value < market_value,
-            LibertyProperty.site_addr_1.isnot(None),
-            LibertyProperty.site_addr_1 != '',
-        ]
+        results = _liberty_comparable_query(
+            subdivision_code,
+            market_value,
+            strategy,
+            zip_code,
+            main_acreage,
+            use_zip=True,
+        )
+        if not results:
+            results = _liberty_comparable_query(
+                subdivision_code,
+                market_value,
+                strategy,
+                zip_code,
+                main_acreage,
+                use_zip=False,
+            )
 
-        def _liberty_query(use_zip):
-            q = LibertyProperty.query.filter(*base_filters)
-            if use_zip and zip_code:
-                q = q.filter(LibertyProperty.situs_zip == zip_code)
-
-            if strategy == 'strict':
-                if main_sq_ft and main_sq_ft > 0:
-                    q = q.filter(
-                        LibertyProperty.sq_ft.isnot(None),
-                        LibertyProperty.sq_ft.between(
-                            max(0, main_sq_ft - 300),
-                            main_sq_ft + 300,
-                        )
+        if len(results) < MIN_COMPARABLES:
+            sibling_codes = _find_liberty_sibling_codes(subdivision_code)
+            if sibling_codes:
+                logger.info(
+                    "Liberty %s returned %d comparables, expanding to siblings: %s",
+                    subdivision_code,
+                    len(results),
+                    sibling_codes,
+                )
+                for sibling_cd in sibling_codes:
+                    sibling_profile = LibertyCodeProfile.query.filter_by(
+                        abs_subdv_cd=sibling_cd
+                    ).first()
+                    sibling_strategy = (
+                        sibling_profile.strategy
+                        if sibling_profile and sibling_profile.strategy
+                        else "strict"
                     )
-                if main_acreage and main_acreage > 0:
-                    tol = min(5.0, max(0.25, main_acreage * 0.5))
-                    q = q.filter(
-                        LibertyProperty.legal_acreage.isnot(None),
-                        LibertyProperty.legal_acreage.between(
-                            max(0, main_acreage - tol),
-                            main_acreage + tol,
-                        )
+                    if sibling_strategy == "reject":
+                        continue
+                    sibling_results = _liberty_comparable_query(
+                        sibling_cd,
+                        market_value,
+                        sibling_strategy,
+                        zip_code,
+                        main_acreage,
+                        use_zip=True,
                     )
+                    if not sibling_results:
+                        sibling_results = _liberty_comparable_query(
+                            sibling_cd,
+                            market_value,
+                            sibling_strategy,
+                            zip_code,
+                            main_acreage,
+                            use_zip=False,
+                        )
+                    results.extend(sibling_results)
+                    if len(results) >= MIN_COMPARABLES:
+                        break
 
-            return q.order_by(LibertyProperty.market_value.asc()).all()
-
-        results = _liberty_query(use_zip=True)
-        if results:
-            return [_liberty_to_dict(r) for r in results]
-
-        results = _liberty_query(use_zip=False)
         return [_liberty_to_dict(r) for r in results]
 
-    elif source == 'fort_bend':
+    elif source == "fort_bend":
         if not subdivision_code:
             return []
 
-        base_filters = [
-            FortBendProperty.is_residential_home.is_(True),
-            FortBendProperty.nbhd_code == subdivision_code,
-            FortBendProperty.market_value.isnot(None),
-            FortBendProperty.market_value > 0,
-            FortBendProperty.market_value < market_value,
-            FortBendProperty.site_addr_1.isnot(None),
-            FortBendProperty.site_addr_1 != '',
-        ]
+        results = _fort_bend_comparable_query(
+            subdivision_code,
+            market_value,
+            main_sq_ft,
+            zip_code,
+            use_zip=True,
+        )
+        if not results:
+            results = _fort_bend_comparable_query(
+                subdivision_code,
+                market_value,
+                main_sq_ft,
+                zip_code,
+                use_zip=False,
+            )
 
-        def _fort_bend_query(use_zip):
-            q = FortBendProperty.query.filter(*base_filters)
-            if use_zip and zip_code:
-                q = q.filter(FortBendProperty.situs_zip == zip_code)
-            if main_sq_ft and main_sq_ft > 0:
-                q = q.filter(
-                    FortBendProperty.sq_ft.isnot(None),
-                    FortBendProperty.sq_ft.between(
-                        max(0, main_sq_ft - SQ_FT_RANGE),
-                        main_sq_ft + SQ_FT_RANGE,
-                    )
+        if len(results) < MIN_COMPARABLES:
+            sibling_codes = _find_fort_bend_sibling_codes(subdivision_code)
+            if sibling_codes:
+                logger.info(
+                    "Fort Bend %s returned %d comparables, expanding to siblings: %s",
+                    subdivision_code,
+                    len(results),
+                    sibling_codes,
                 )
-            return q.order_by(FortBendProperty.market_value.asc()).all()
+                for sibling_cd in sibling_codes:
+                    sibling_results = _fort_bend_comparable_query(
+                        sibling_cd,
+                        market_value,
+                        main_sq_ft,
+                        zip_code,
+                        use_zip=True,
+                    )
+                    if not sibling_results:
+                        sibling_results = _fort_bend_comparable_query(
+                            sibling_cd,
+                            market_value,
+                            main_sq_ft,
+                            zip_code,
+                            use_zip=False,
+                        )
+                    results.extend(sibling_results)
+                    if len(results) >= MIN_COMPARABLES:
+                        break
 
-        results = _fort_bend_query(use_zip=True)
-        if results:
-            return [_fort_bend_to_dict(r) for r in results]
-
-        results = _fort_bend_query(use_zip=False)
         return [_fort_bend_to_dict(r) for r in results]
 
     return []
 
 
+_SUBDIVISION_SECTION_RE = re.compile(
+    r",\s*SEC(?:TION)?\s*\d+"
+    r"|,\s*SEC\s*\d+"
+    r"|\s+SEC(?:TION)?\s+\d+"
+    r"$",
+    re.IGNORECASE,
+)
+
+
+def _extract_base_subdivision_name(desc):
+    """Strip section suffixes like ', SEC 4' or ' SECTION 2' from a subdivision name."""
+    if not desc:
+        return ""
+    return _SUBDIVISION_SECTION_RE.sub("", desc).strip()
+
+
+def _find_liberty_sibling_codes(subdivision_code):
+    """Find other subdivision codes that share the same base subdivision name.
+
+    Liberty County splits one subdivision into multiple codes by section (e.g.,
+    'RAVEN HILL RANCH' vs 'RAVEN HILL RANCH, SEC 4'). When a code has very few
+    homes and returns 0 comparables, expand the search to sibling sections.
+    """
+    main_record = LibertyProperty.query.filter(
+        LibertyProperty.abs_subdv_cd == subdivision_code,
+        LibertyProperty.is_residential_home.is_(True),
+    ).first()
+    if not main_record or not main_record.abs_subdv_desc:
+        return []
+
+    base_name = _extract_base_subdivision_name(main_record.abs_subdv_desc)
+    if not base_name:
+        return []
+
+    pattern = f"{base_name}%"
+    sibling_rows = (
+        db.session.query(
+            LibertyProperty.abs_subdv_cd,
+        )
+        .filter(
+            LibertyProperty.abs_subdv_desc.ilike(pattern),
+            LibertyProperty.abs_subdv_cd != subdivision_code,
+            LibertyProperty.is_residential_home.is_(True),
+        )
+        .distinct()
+        .all()
+    )
+
+    return [row[0] for row in sibling_rows]
+
+
+def _liberty_comparable_query(
+    subdivision_code, market_value, strategy, zip_code, main_acreage, use_zip
+):
+    """Execute a Liberty County comparable property query."""
+    base_filters = [
+        LibertyProperty.is_residential_home.is_(True),
+        LibertyProperty.abs_subdv_cd == subdivision_code,
+        LibertyProperty.market_value.isnot(None),
+        LibertyProperty.market_value > 0,
+        LibertyProperty.market_value < market_value,
+        LibertyProperty.site_addr_1.isnot(None),
+        LibertyProperty.site_addr_1 != "",
+    ]
+
+    q = LibertyProperty.query.filter(*base_filters)
+    if use_zip and zip_code:
+        q = q.filter(LibertyProperty.situs_zip == zip_code)
+
+    if strategy == "strict":
+        if main_acreage and main_acreage > 0:
+            tol = min(5.0, max(0.25, main_acreage * 0.5))
+            q = q.filter(
+                LibertyProperty.legal_acreage.isnot(None),
+                LibertyProperty.legal_acreage.between(
+                    max(0, main_acreage - tol),
+                    main_acreage + tol,
+                ),
+            )
+
+    return q.order_by(LibertyProperty.market_value.asc()).all()
+
+
+def _find_fort_bend_sibling_codes(subdivision_code):
+    """Find other neighborhood codes sharing the same base neighborhood name.
+
+    Uses nbhd_desc to find sibling sections (e.g. 'SIENNA PLANTATION SEC 1'
+    and 'SIENNA PLANTATION SEC 2').
+    """
+    main_record = FortBendProperty.query.filter(
+        FortBendProperty.nbhd_code == subdivision_code,
+        FortBendProperty.is_residential_home.is_(True),
+    ).first()
+    if not main_record or not main_record.nbhd_desc:
+        return []
+
+    base_name = _extract_base_subdivision_name(main_record.nbhd_desc)
+    if not base_name:
+        return []
+
+    pattern = f"{base_name}%"
+    sibling_rows = (
+        db.session.query(
+            FortBendProperty.nbhd_code,
+        )
+        .filter(
+            FortBendProperty.nbhd_desc.ilike(pattern),
+            FortBendProperty.nbhd_code != subdivision_code,
+            FortBendProperty.is_residential_home.is_(True),
+        )
+        .distinct()
+        .all()
+    )
+
+    return [row[0] for row in sibling_rows]
+
+
+def _fort_bend_comparable_query(
+    subdivision_code, market_value, main_sq_ft, zip_code, use_zip
+):
+    """Execute a Fort Bend County comparable property query."""
+    base_filters = [
+        FortBendProperty.is_residential_home.is_(True),
+        FortBendProperty.nbhd_code == subdivision_code,
+        FortBendProperty.market_value.isnot(None),
+        FortBendProperty.market_value > 0,
+        FortBendProperty.market_value < market_value,
+        FortBendProperty.site_addr_1.isnot(None),
+        FortBendProperty.site_addr_1 != "",
+    ]
+
+    q = FortBendProperty.query.filter(*base_filters)
+    if use_zip and zip_code:
+        q = q.filter(FortBendProperty.situs_zip == zip_code)
+    if main_sq_ft and main_sq_ft > 0:
+        q = q.filter(
+            FortBendProperty.sq_ft.isnot(None),
+            FortBendProperty.sq_ft.between(
+                max(0, main_sq_ft - SQ_FT_RANGE),
+                main_sq_ft + SQ_FT_RANGE,
+            ),
+        )
+    return q.order_by(FortBendProperty.market_value.asc()).all()
+
+
 def _chambers_to_dict(record):
     """Convert a ChambersProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'chambers',
-        'address': f"{record.prop_street_number or ''} {record.prop_street or ''}".strip(),
-        'full_address': f"{record.prop_street_number or ''} {record.prop_street or ''} {record.prop_street_dir or ''}".strip(),
-        'city': record.prop_city,
-        'zip': record.prop_zip5,
-        'market_value': record.market_value,
-        'legal1': record.legal1,
-        'legal2': record.legal2,
-        'legal3': record.legal3,
-        'legal4': record.legal4,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.acres) if record.acres else None,
-        'parcel_id': record.parcel_id,
-        'account': record.account,
+        "id": record.id,
+        "source": "chambers",
+        "address": f"{record.prop_street_number or ''} {record.prop_street or ''}".strip(),
+        "full_address": f"{record.prop_street_number or ''} {record.prop_street or ''} {record.prop_street_dir or ''}".strip(),
+        "city": record.prop_city,
+        "zip": record.prop_zip5,
+        "market_value": record.market_value,
+        "legal1": record.legal1,
+        "legal2": record.legal2,
+        "legal3": record.legal3,
+        "legal4": record.legal4,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.acres) if record.acres else None,
+        "parcel_id": record.parcel_id,
+        "account": record.account,
     }
 
 
 def _hcad_to_dict(record, sq_ft=None):
     """Convert an HcadProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'hcad',
-        'address': record.site_addr_1 or f"{record.str_num or ''} {record.str or ''}".strip(),
-        'full_address': record.site_addr_1 or '',
-        'city': record.site_addr_2,
-        'zip': record.site_addr_3,
-        'market_value': record.tot_mkt_val,
-        'legal1': record.lgl_1,
-        'legal2': record.lgl_2,
-        'legal3': record.lgl_3,
-        'legal4': record.lgl_4,
-        'sq_ft': sq_ft,
-        'acreage': float(record.acreage) if record.acreage else None,
-        'parcel_id': None,
-        'account': record.acct,
-        'neighborhood_code': record.neighborhood_code,
-        'subdivision': record.lgl_2,
+        "id": record.id,
+        "source": "hcad",
+        "address": record.site_addr_1
+        or f"{record.str_num or ''} {record.str or ''}".strip(),
+        "full_address": record.site_addr_1 or "",
+        "city": record.site_addr_2,
+        "zip": record.site_addr_3,
+        "market_value": record.tot_mkt_val,
+        "legal1": record.lgl_1,
+        "legal2": record.lgl_2,
+        "legal3": record.lgl_3,
+        "legal4": record.lgl_4,
+        "sq_ft": sq_ft,
+        "acreage": float(record.acreage) if record.acreage else None,
+        "parcel_id": None,
+        "account": record.acct,
+        "neighborhood_code": record.neighborhood_code,
+        "subdivision": record.lgl_2,
     }
 
 
 def _liberty_to_dict(record):
     """Convert a LibertyProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'liberty',
-        'address': record.site_addr_1 or ' '.join(
-            part for part in [record.situs_num, record.situs_street_prefx, record.situs_street, record.situs_street_suffix]
+        "id": record.id,
+        "source": "liberty",
+        "address": record.site_addr_1
+        or " ".join(
+            part
+            for part in [
+                record.situs_num,
+                record.situs_street_prefx,
+                record.situs_street,
+                record.situs_street_suffix,
+            ]
             if part
         ).strip(),
-        'full_address': record.site_addr_1 or '',
-        'city': record.situs_city,
-        'zip': record.situs_zip,
-        'market_value': record.market_value,
-        'legal1': record.legal_desc,
-        'legal2': record.abs_subdv_desc,
-        'legal3': record.legal_desc2,
-        'legal4': None,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.legal_acreage) if record.legal_acreage else None,
-        'parcel_id': record.prop_id,
-        'account': record.geo_id,
-        'subdivision': record.abs_subdv_desc,
-        'subdivision_code': record.abs_subdv_cd,
+        "full_address": record.site_addr_1 or "",
+        "city": record.situs_city,
+        "zip": record.situs_zip,
+        "market_value": record.market_value,
+        "legal1": record.legal_desc,
+        "legal2": record.abs_subdv_desc,
+        "legal3": record.legal_desc2,
+        "legal4": None,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.legal_acreage) if record.legal_acreage else None,
+        "parcel_id": record.prop_id,
+        "account": record.geo_id,
+        "subdivision": record.abs_subdv_desc,
+        "subdivision_code": record.abs_subdv_cd,
     }
 
 
 def _fort_bend_to_dict(record):
     """Convert a FortBendProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'fort_bend',
-        'address': record.site_addr_1 or record.situs or '',
-        'full_address': record.site_addr_1 or record.situs or '',
-        'city': record.situs_city,
-        'zip': record.situs_zip,
-        'market_value': record.market_value,
-        'legal1': record.legal_desc,
-        'legal2': record.nbhd_desc,
-        'legal3': record.legal_location_desc,
-        'legal4': None,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.acreage) if record.acreage else (
-            float(record.legal_acres) if record.legal_acres else None
-        ),
-        'parcel_id': record.property_id,
-        'account': record.property_number,
-        'subdivision': record.nbhd_desc,
-        'subdivision_code': record.nbhd_code,
+        "id": record.id,
+        "source": "fort_bend",
+        "address": record.site_addr_1 or record.situs or "",
+        "full_address": record.site_addr_1 or record.situs or "",
+        "city": record.situs_city,
+        "zip": record.situs_zip,
+        "market_value": record.market_value,
+        "legal1": record.legal_desc,
+        "legal2": record.nbhd_desc,
+        "legal3": record.legal_location_desc,
+        "legal4": None,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.acreage)
+        if record.acreage
+        else (float(record.legal_acres) if record.legal_acres else None),
+        "parcel_id": record.property_id,
+        "account": record.property_number,
+        "subdivision": record.nbhd_desc,
+        "subdivision_code": record.nbhd_code,
     }
 
 
-def cache_search_result(source, subdivision, main_property_id, contact_id,
-                        zip_code, neighborhood_code=None, main_sq_ft=None,
-                        fuzzy_subdivision=False, subdivision_code=None,
-                        main_acreage=None):
+def cache_search_result(
+    source,
+    subdivision,
+    main_property_id,
+    contact_id,
+    zip_code,
+    neighborhood_code=None,
+    main_sq_ft=None,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    main_acreage=None,
+):
     """Store search params in Flask session for CSV download consistency."""
-    session['tax_protest_result'] = {
-        'source': source,
-        'subdivision': subdivision,
-        'main_property_id': main_property_id,
-        'contact_id': contact_id,
-        'zip_code': zip_code,
-        'neighborhood_code': neighborhood_code,
-        'subdivision_code': subdivision_code,
-        'main_sq_ft': main_sq_ft,
-        'main_acreage': main_acreage,
-        'fuzzy_subdivision': fuzzy_subdivision,
+    session["tax_protest_result"] = {
+        "source": source,
+        "subdivision": subdivision,
+        "main_property_id": main_property_id,
+        "contact_id": contact_id,
+        "zip_code": zip_code,
+        "neighborhood_code": neighborhood_code,
+        "subdivision_code": subdivision_code,
+        "main_sq_ft": main_sq_ft,
+        "main_acreage": main_acreage,
+        "fuzzy_subdivision": fuzzy_subdivision,
     }
 
 
 def get_cached_search_result():
     """Retrieve cached search params from Flask session."""
-    return session.get('tax_protest_result')
+    return session.get("tax_protest_result")
 
 
 def get_main_property_by_id(property_id, source):
     """Load a single property record by its ID and source."""
-    if source == 'chambers':
+    if source == "chambers":
         record = ChambersProperty.query.get(property_id)
         return _chambers_to_dict(record) if record else None
-    elif source == 'hcad':
+    elif source == "hcad":
         record = HcadProperty.query.get(property_id)
         if not record:
             return None
-        sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
-            HcadBuilding.acct == record.acct
-        ).scalar()
+        sq_ft = (
+            db.session.query(db.func.max(HcadBuilding.im_sq_ft))
+            .filter(HcadBuilding.acct == record.acct)
+            .scalar()
+        )
         return _hcad_to_dict(record, sq_ft)
-    elif source == 'liberty':
+    elif source == "liberty":
         record = LibertyProperty.query.get(property_id)
         return _liberty_to_dict(record) if record else None
-    elif source == 'fort_bend':
+    elif source == "fort_bend":
         record = FortBendProperty.query.get(property_id)
         return _fort_bend_to_dict(record) if record else None
     return None

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -6,7 +6,15 @@ comparable property queries, and search result caching for CSV consistency.
 import re
 import logging
 from flask import session
-from models import db, ChambersProperty, HcadProperty, HcadBuilding, HcadNeighborhoodCode
+from models import (
+    db,
+    ChambersProperty,
+    HcadProperty,
+    HcadBuilding,
+    HcadNeighborhoodCode,
+    LibertyProperty,
+    LibertyCodeProfile,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +49,7 @@ def normalize_address(address):
     }
     for old, new in replacements.items():
         addr = addr.replace(old, new)
+    addr = addr.replace('FARM TO MARKET', 'FM')
     addr = re.sub(r'\s*(APT|UNIT|STE|SUITE|#)\s*\S*$', '', addr)
     addr = re.sub(r'\s+', ' ', addr).strip()
     return addr
@@ -72,11 +81,13 @@ def _parse_street_parts(address):
 
 def find_property_in_tax_data(street_address, city, zip_code):
     """
-    Search for a property in Chambers County first, then Harris County.
+    Search for a property in Chambers County first, then Harris County, then Liberty County.
     Returns (record_dict, source) or (None, None).
     """
+    normalized_address = normalize_address(street_address)
     street_num, direction, street_name = _parse_street_parts(street_address)
     zip_clean = (zip_code or '').strip()[:5]
+    city_clean = (city or '').strip().upper()
 
     # --- Chambers County ---
     chambers_result = _search_chambers(street_num, direction, street_name, zip_clean)
@@ -87,6 +98,13 @@ def find_property_in_tax_data(street_address, city, zip_code):
     hcad_result = _search_hcad(street_num, direction, street_name, zip_clean)
     if hcad_result:
         return hcad_result, 'hcad'
+
+    # --- Liberty County ---
+    liberty_result = _search_liberty(
+        normalized_address, street_num, street_name, city_clean, zip_clean
+    )
+    if liberty_result:
+        return liberty_result, 'liberty'
 
     return None, None
 
@@ -159,6 +177,69 @@ def _search_hcad(street_num, direction, street_name, zip_code):
         ).first()
         if result:
             return _hcad_found(result)
+
+    return None
+
+
+def _search_liberty(normalized_address, street_num, street_name, city, zip_code):
+    """Search Liberty County home records using normalized address, then relaxed fallbacks."""
+    base_filter = [LibertyProperty.is_residential_home.is_(True)]
+
+    if normalized_address:
+        if zip_code:
+            result = LibertyProperty.query.filter(
+                LibertyProperty.normalized_site_addr == normalized_address,
+                LibertyProperty.situs_zip == zip_code,
+                *base_filter,
+            ).first()
+            if result:
+                return _liberty_to_dict(result)
+
+        result = LibertyProperty.query.filter(
+            LibertyProperty.normalized_site_addr == normalized_address,
+            *base_filter,
+        ).first()
+        if result:
+            return _liberty_to_dict(result)
+
+    if street_name:
+        first_word = street_name.split()[0]
+        street_filters = [
+            LibertyProperty.situs_street.ilike(f'%{first_word}%'),
+            *base_filter,
+        ]
+        if street_num:
+            street_filters.append(LibertyProperty.situs_num == street_num)
+
+        if zip_code:
+            result = LibertyProperty.query.filter(
+                LibertyProperty.situs_zip == zip_code,
+                *street_filters,
+            ).first()
+            if result:
+                return _liberty_to_dict(result)
+
+        if city:
+            result = LibertyProperty.query.filter(
+                db.func.upper(LibertyProperty.situs_city) == city,
+                *street_filters,
+            ).first()
+            if result:
+                return _liberty_to_dict(result)
+
+        result = LibertyProperty.query.filter(
+            *street_filters,
+        ).first()
+        if result:
+            return _liberty_to_dict(result)
+
+        if street_num:
+            result = LibertyProperty.query.filter(
+                LibertyProperty.site_addr_1.ilike(f'%{street_num}%{first_word}%'),
+                *base_filter,
+            ).first()
+            if result:
+                return _liberty_to_dict(result)
 
     return None
 
@@ -246,7 +327,8 @@ def get_neighborhood_name(neighborhood_code):
 
 
 def find_comparables(subdivision, zip_code, market_value, source,
-                     main_sq_ft=None, fuzzy_subdivision=False):
+                     main_sq_ft=None, fuzzy_subdivision=False,
+                     subdivision_code=None, main_acreage=None):
     """
     Find properties in the same subdivision and zip with lower market value.
     For HCAD: matches on lgl_2 (exact when from structured data, ILIKE when
@@ -334,6 +416,58 @@ def find_comparables(subdivision, zip_code, market_value, source,
 
         return [_hcad_to_dict(prop, sq_ft) for prop, sq_ft in results]
 
+    elif source == 'liberty':
+        if not subdivision_code:
+            return []
+
+        profile = LibertyCodeProfile.query.filter_by(abs_subdv_cd=subdivision_code).first()
+        strategy = profile.strategy if profile and profile.strategy else 'strict'
+        if strategy == 'reject':
+            return []
+
+        base_filters = [
+            LibertyProperty.is_residential_home.is_(True),
+            LibertyProperty.abs_subdv_cd == subdivision_code,
+            LibertyProperty.market_value.isnot(None),
+            LibertyProperty.market_value > 0,
+            LibertyProperty.market_value < market_value,
+            LibertyProperty.site_addr_1.isnot(None),
+            LibertyProperty.site_addr_1 != '',
+        ]
+
+        def _liberty_query(use_zip):
+            q = LibertyProperty.query.filter(*base_filters)
+            if use_zip and zip_code:
+                q = q.filter(LibertyProperty.situs_zip == zip_code)
+
+            if strategy == 'strict':
+                if main_sq_ft and main_sq_ft > 0:
+                    q = q.filter(
+                        LibertyProperty.sq_ft.isnot(None),
+                        LibertyProperty.sq_ft.between(
+                            max(0, main_sq_ft - 300),
+                            main_sq_ft + 300,
+                        )
+                    )
+                if main_acreage and main_acreage > 0:
+                    tol = min(5.0, max(0.25, main_acreage * 0.5))
+                    q = q.filter(
+                        LibertyProperty.legal_acreage.isnot(None),
+                        LibertyProperty.legal_acreage.between(
+                            max(0, main_acreage - tol),
+                            main_acreage + tol,
+                        )
+                    )
+
+            return q.order_by(LibertyProperty.market_value.asc()).all()
+
+        results = _liberty_query(use_zip=True)
+        if results:
+            return [_liberty_to_dict(r) for r in results]
+
+        results = _liberty_query(use_zip=False)
+        return [_liberty_to_dict(r) for r in results]
+
     return []
 
 
@@ -381,9 +515,36 @@ def _hcad_to_dict(record, sq_ft=None):
     }
 
 
+def _liberty_to_dict(record):
+    """Convert a LibertyProperty to a display dict."""
+    return {
+        'id': record.id,
+        'source': 'liberty',
+        'address': record.site_addr_1 or ' '.join(
+            part for part in [record.situs_num, record.situs_street_prefx, record.situs_street, record.situs_street_suffix]
+            if part
+        ).strip(),
+        'full_address': record.site_addr_1 or '',
+        'city': record.situs_city,
+        'zip': record.situs_zip,
+        'market_value': record.market_value,
+        'legal1': record.legal_desc,
+        'legal2': record.abs_subdv_desc,
+        'legal3': record.legal_desc2,
+        'legal4': None,
+        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        'acreage': float(record.legal_acreage) if record.legal_acreage else None,
+        'parcel_id': record.prop_id,
+        'account': record.geo_id,
+        'subdivision': record.abs_subdv_desc,
+        'subdivision_code': record.abs_subdv_cd,
+    }
+
+
 def cache_search_result(source, subdivision, main_property_id, contact_id,
                         zip_code, neighborhood_code=None, main_sq_ft=None,
-                        fuzzy_subdivision=False):
+                        fuzzy_subdivision=False, subdivision_code=None,
+                        main_acreage=None):
     """Store search params in Flask session for CSV download consistency."""
     session['tax_protest_result'] = {
         'source': source,
@@ -392,7 +553,9 @@ def cache_search_result(source, subdivision, main_property_id, contact_id,
         'contact_id': contact_id,
         'zip_code': zip_code,
         'neighborhood_code': neighborhood_code,
+        'subdivision_code': subdivision_code,
         'main_sq_ft': main_sq_ft,
+        'main_acreage': main_acreage,
         'fuzzy_subdivision': fuzzy_subdivision,
     }
 
@@ -415,4 +578,7 @@ def get_main_property_by_id(property_id, source):
             HcadBuilding.acct == record.acct
         ).scalar()
         return _hcad_to_dict(record, sq_ft)
+    elif source == 'liberty':
+        record = LibertyProperty.query.get(property_id)
+        return _liberty_to_dict(record) if record else None
     return None

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -441,6 +441,139 @@ def get_neighborhood_name(neighborhood_code):
     return nc.dscr if nc else None
 
 
+def get_subdivision_stats(
+    subdivision,
+    zip_code,
+    market_value,
+    source,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    sibling_codes=None,
+):
+    """Compute subdivision-level statistics for the subject property.
+
+    Returns dict with:
+      total_homes: total residential homes in the subdivision
+      lower_values: how many have a lower market value
+      higher_values: how many have a higher market value
+      percentile: where the subject falls (e.g. 90 means 90% of homes are cheaper)
+      value_distribution: list of {label, count} buckets for charting
+    """
+    if source == "liberty" and subdivision_code:
+        codes = [subdivision_code]
+        if not sibling_codes:
+            sibling_codes = _find_liberty_sibling_codes(subdivision_code)
+        if sibling_codes:
+            codes.extend(sibling_codes)
+        rows = (
+            LibertyProperty.query.filter(
+                LibertyProperty.is_residential_home.is_(True),
+                LibertyProperty.market_value.isnot(None),
+                LibertyProperty.market_value > 0,
+                LibertyProperty.abs_subdv_cd.in_(codes),
+            )
+            .with_entities(
+                LibertyProperty.market_value,
+            )
+            .order_by(LibertyProperty.market_value.asc())
+            .all()
+        )
+    elif source == "fort_bend" and subdivision_code:
+        codes = [subdivision_code]
+        if not sibling_codes:
+            sibling_codes = _find_fort_bend_sibling_codes(subdivision_code)
+        if sibling_codes:
+            codes.extend(sibling_codes)
+        rows = (
+            FortBendProperty.query.filter(
+                FortBendProperty.is_residential_home.is_(True),
+                FortBendProperty.market_value.isnot(None),
+                FortBendProperty.market_value > 0,
+                FortBendProperty.nbhd_code.in_(codes),
+            )
+            .with_entities(
+                FortBendProperty.market_value,
+            )
+            .order_by(FortBendProperty.market_value.asc())
+            .all()
+        )
+    elif source == "hcad" and subdivision:
+        if fuzzy_subdivision:
+            sub_filter = HcadProperty.lgl_2.ilike(f"%{subdivision}%")
+        else:
+            sub_filter = HcadProperty.lgl_2 == subdivision
+        rows = (
+            HcadProperty.query.filter(
+                sub_filter,
+                HcadProperty.tot_mkt_val.isnot(None),
+                HcadProperty.tot_mkt_val > 0,
+            )
+            .with_entities(
+                HcadProperty.tot_mkt_val,
+            )
+            .order_by(HcadProperty.tot_mkt_val.asc())
+            .all()
+        )
+    elif source == "chambers" and subdivision:
+        rows = (
+            ChambersProperty.query.filter(
+                ChambersProperty.legal1.ilike(f"%{subdivision}%"),
+                ChambersProperty.market_value.isnot(None),
+                ChambersProperty.market_value > 0,
+            )
+            .with_entities(
+                ChambersProperty.market_value,
+            )
+            .order_by(ChambersProperty.market_value.asc())
+            .all()
+        )
+    else:
+        return None
+
+    values = [int(r[0]) for r in rows if r[0] is not None]
+    sorted_values = sorted(values)
+    total_homes = len(sorted_values)
+    lower_values = sum(1 for v in sorted_values if v < market_value)
+    higher_values = sum(1 for v in sorted_values if v > market_value)
+    percentile = (
+        round((lower_values / total_homes) * 100, 1) if total_homes > 0 else None
+    )
+
+    return {
+        "total_homes": total_homes,
+        "lower_values": lower_values,
+        "higher_values": higher_values,
+        "percentile": percentile,
+        "value_distribution": _bucket_values(sorted_values),
+        "min_value": sorted_values[0] if sorted_values else None,
+        "max_value": sorted_values[-1] if sorted_values else None,
+        "median_value": (
+            sorted_values[len(sorted_values) // 2] if sorted_values else None
+        ),
+    }
+
+
+def _bucket_values(values, num_buckets=8):
+    """Return evenly sized buckets across the full observed value range."""
+    if not values:
+        return []
+    min_val = min(values)
+    max_val = max(values)
+    if min_val == max_val:
+        return [{"label": f"${min_val / 1000:.0f}k", "count": len(values)}]
+    bucket_size = (max_val - min_val) / num_buckets
+    buckets = []
+    for i in range(num_buckets):
+        lo = min_val + i * bucket_size
+        hi = lo + bucket_size
+        if i == num_buckets - 1:
+            count = sum(1 for v in values if lo <= v <= hi)
+        else:
+            count = sum(1 for v in values if lo <= v < hi)
+        buckets.append({"label": f"${lo / 1000:.0f}k", "count": count})
+    return buckets
+
+
 def find_comparables(
     subdivision,
     zip_code,

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -14,6 +14,7 @@ from models import (
     HcadNeighborhoodCode,
     LibertyProperty,
     LibertyCodeProfile,
+    FortBendProperty,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,8 @@ def _parse_street_parts(address):
 
 def find_property_in_tax_data(street_address, city, zip_code):
     """
-    Search for a property in Chambers County first, then Harris County, then Liberty County.
+    Search for a property in Chambers County first, then Harris County,
+    then Liberty County, then Fort Bend County.
     Returns (record_dict, source) or (None, None).
     """
     normalized_address = normalize_address(street_address)
@@ -95,7 +97,7 @@ def find_property_in_tax_data(street_address, city, zip_code):
         return chambers_result, 'chambers'
 
     # --- Harris County (HCAD) ---
-    hcad_result = _search_hcad(street_num, direction, street_name, zip_clean)
+    hcad_result = _search_hcad(normalized_address, street_num, direction, street_name, zip_clean)
     if hcad_result:
         return hcad_result, 'hcad'
 
@@ -105,6 +107,13 @@ def find_property_in_tax_data(street_address, city, zip_code):
     )
     if liberty_result:
         return liberty_result, 'liberty'
+
+    # --- Fort Bend County ---
+    fort_bend_result = _search_fort_bend(
+        normalized_address, street_num, street_name, city_clean, zip_clean
+    )
+    if fort_bend_result:
+        return fort_bend_result, 'fort_bend'
 
     return None, None
 
@@ -119,7 +128,7 @@ def _search_chambers(street_num, direction, street_name, zip_code):
     first_word = street_name.split()[0]
     base_filters = [
         ChambersProperty.prop_street_number == street_num,
-        ChambersProperty.prop_street.ilike(f'%{first_word}%'),
+        ChambersProperty.prop_street.ilike(f'{first_word}%'),
     ]
     if direction:
         base_filters.append(ChambersProperty.prop_street_dir == direction)
@@ -141,15 +150,30 @@ def _search_chambers(street_num, direction, street_name, zip_code):
     return None
 
 
-def _search_hcad(street_num, direction, street_name, zip_code):
+def _search_hcad(normalized_address, street_num, direction, street_name, zip_code):
     """Search Harris County by address components.
     Matches street number, direction (via str_sfx_dir), and first word of street name.
     Falls back to relaxed search without zip if initial search misses."""
+    if normalized_address:
+        if zip_code:
+            result = HcadProperty.query.filter(
+                HcadProperty.site_addr_3 == zip_code,
+                db.func.upper(HcadProperty.site_addr_1) == normalized_address,
+            ).first()
+            if result:
+                return _hcad_found(result)
+
+        result = HcadProperty.query.filter(
+            db.func.upper(HcadProperty.site_addr_1) == normalized_address,
+        ).first()
+        if result:
+            return _hcad_found(result)
+
     if street_num and street_name:
         first_word = street_name.split()[0]
         base_filters = [
             HcadProperty.str_num == street_num,
-            HcadProperty.str.ilike(f'%{first_word}%'),
+            HcadProperty.str.ilike(f'{first_word}%'),
         ]
         if direction:
             base_filters.append(HcadProperty.str_sfx_dir == direction)
@@ -173,7 +197,7 @@ def _search_hcad(street_num, direction, street_name, zip_code):
     # Last resort: fuzzy match on full site_addr_1
     if street_num and street_name:
         result = HcadProperty.query.filter(
-            HcadProperty.site_addr_1.ilike(f'%{street_num}%{street_name.split()[0]}%'),
+            HcadProperty.site_addr_1.ilike(f'{street_num} {street_name}%'),
         ).first()
         if result:
             return _hcad_found(result)
@@ -205,7 +229,7 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
     if street_name:
         first_word = street_name.split()[0]
         street_filters = [
-            LibertyProperty.situs_street.ilike(f'%{first_word}%'),
+            LibertyProperty.situs_street.ilike(f'{first_word}%'),
             *base_filter,
         ]
         if street_num:
@@ -235,11 +259,74 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
 
         if street_num:
             result = LibertyProperty.query.filter(
-                LibertyProperty.site_addr_1.ilike(f'%{street_num}%{first_word}%'),
+                LibertyProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
                 *base_filter,
             ).first()
             if result:
                 return _liberty_to_dict(result)
+
+    return None
+
+
+def _search_fort_bend(normalized_address, street_num, street_name, city, zip_code):
+    """Search Fort Bend County home records using normalized address, then relaxed fallbacks."""
+    base_filter = [FortBendProperty.is_residential_home.is_(True)]
+
+    if normalized_address:
+        if zip_code:
+            result = FortBendProperty.query.filter(
+                FortBendProperty.normalized_site_addr == normalized_address,
+                FortBendProperty.situs_zip == zip_code,
+                *base_filter,
+            ).first()
+            if result:
+                return _fort_bend_to_dict(result)
+
+        result = FortBendProperty.query.filter(
+            FortBendProperty.normalized_site_addr == normalized_address,
+            *base_filter,
+        ).first()
+        if result:
+            return _fort_bend_to_dict(result)
+
+    if street_name:
+        first_word = street_name.split()[0]
+        street_filters = [
+            FortBendProperty.situs_street_name.ilike(f'{first_word}%'),
+            *base_filter,
+        ]
+        if street_num:
+            street_filters.append(FortBendProperty.situs_street_number == street_num)
+
+        if zip_code:
+            result = FortBendProperty.query.filter(
+                FortBendProperty.situs_zip == zip_code,
+                *street_filters,
+            ).first()
+            if result:
+                return _fort_bend_to_dict(result)
+
+        if city:
+            result = FortBendProperty.query.filter(
+                db.func.upper(FortBendProperty.situs_city) == city,
+                *street_filters,
+            ).first()
+            if result:
+                return _fort_bend_to_dict(result)
+
+        result = FortBendProperty.query.filter(
+            *street_filters,
+        ).first()
+        if result:
+            return _fort_bend_to_dict(result)
+
+        if street_num:
+            result = FortBendProperty.query.filter(
+                FortBendProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
+                *base_filter,
+            ).first()
+            if result:
+                return _fort_bend_to_dict(result)
 
     return None
 
@@ -468,6 +555,41 @@ def find_comparables(subdivision, zip_code, market_value, source,
         results = _liberty_query(use_zip=False)
         return [_liberty_to_dict(r) for r in results]
 
+    elif source == 'fort_bend':
+        if not subdivision_code:
+            return []
+
+        base_filters = [
+            FortBendProperty.is_residential_home.is_(True),
+            FortBendProperty.nbhd_code == subdivision_code,
+            FortBendProperty.market_value.isnot(None),
+            FortBendProperty.market_value > 0,
+            FortBendProperty.market_value < market_value,
+            FortBendProperty.site_addr_1.isnot(None),
+            FortBendProperty.site_addr_1 != '',
+        ]
+
+        def _fort_bend_query(use_zip):
+            q = FortBendProperty.query.filter(*base_filters)
+            if use_zip and zip_code:
+                q = q.filter(FortBendProperty.situs_zip == zip_code)
+            if main_sq_ft and main_sq_ft > 0:
+                q = q.filter(
+                    FortBendProperty.sq_ft.isnot(None),
+                    FortBendProperty.sq_ft.between(
+                        max(0, main_sq_ft - SQ_FT_RANGE),
+                        main_sq_ft + SQ_FT_RANGE,
+                    )
+                )
+            return q.order_by(FortBendProperty.market_value.asc()).all()
+
+        results = _fort_bend_query(use_zip=True)
+        if results:
+            return [_fort_bend_to_dict(r) for r in results]
+
+        results = _fort_bend_query(use_zip=False)
+        return [_fort_bend_to_dict(r) for r in results]
+
     return []
 
 
@@ -541,6 +663,31 @@ def _liberty_to_dict(record):
     }
 
 
+def _fort_bend_to_dict(record):
+    """Convert a FortBendProperty to a display dict."""
+    return {
+        'id': record.id,
+        'source': 'fort_bend',
+        'address': record.site_addr_1 or record.situs or '',
+        'full_address': record.site_addr_1 or record.situs or '',
+        'city': record.situs_city,
+        'zip': record.situs_zip,
+        'market_value': record.market_value,
+        'legal1': record.legal_desc,
+        'legal2': record.nbhd_desc,
+        'legal3': record.legal_location_desc,
+        'legal4': None,
+        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        'acreage': float(record.acreage) if record.acreage else (
+            float(record.legal_acres) if record.legal_acres else None
+        ),
+        'parcel_id': record.property_id,
+        'account': record.property_number,
+        'subdivision': record.nbhd_desc,
+        'subdivision_code': record.nbhd_code,
+    }
+
+
 def cache_search_result(source, subdivision, main_property_id, contact_id,
                         zip_code, neighborhood_code=None, main_sq_ft=None,
                         fuzzy_subdivision=False, subdivision_code=None,
@@ -581,4 +728,7 @@ def get_main_property_by_id(property_id, source):
     elif source == 'liberty':
         record = LibertyProperty.query.get(property_id)
         return _liberty_to_dict(record) if record else None
+    elif source == 'fort_bend':
+        record = FortBendProperty.query.get(property_id)
+        return _fort_bend_to_dict(record) if record else None
     return None

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -268,6 +268,7 @@
             chambers: 'Chambers County',
             hcad: 'Harris County',
             liberty: 'Liberty County',
+            fort_bend: 'Fort Bend County',
         }[data.source] || 'County Tax Data';
 
         document.getElementById('countyBadge').textContent = county;

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -24,14 +24,13 @@
                         <i class="fas fa-times"></i>
                     </button>
                 </div>
-                <!-- Dropdown results -->
                 <div id="searchDropdown"
                      class="absolute z-50 w-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto hidden">
                 </div>
             </div>
         </div>
 
-        <!-- Loading Spinner -->
+        <!-- Loading -->
         <div id="loadingState" class="hidden">
             <div class="premium-card p-12 text-center">
                 <div class="inline-flex items-center gap-3 text-slate-500">
@@ -44,7 +43,7 @@
             </div>
         </div>
 
-        <!-- Error State -->
+        <!-- Error -->
         <div id="errorState" class="hidden">
             <div class="premium-card p-6 border-l-4 border-red-400">
                 <div class="flex items-start gap-3">
@@ -57,9 +56,10 @@
             </div>
         </div>
 
-        <!-- Results Section -->
+        <!-- Results -->
         <div id="resultsSection" class="hidden">
-            <!-- Main Property Card -->
+
+            <!-- Subject Property -->
             <div class="premium-card p-5 mb-4 bg-amber-50/60 border border-amber-200/60">
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
                     <div>
@@ -91,16 +91,51 @@
                 </div>
             </div>
 
-            <!-- Results Count + Actions -->
+            <!-- Neighborhood Position Chart -->
+            <div id="statsCard" class="hidden premium-card mb-4 overflow-hidden">
+                <div class="flex items-center justify-between px-5 py-3 border-b border-slate-100">
+                    <div class="flex items-center gap-2.5">
+                        <i class="fas fa-chart-bar text-orange-500 text-sm"></i>
+                        <span class="text-sm font-semibold text-slate-700">Neighborhood Position</span>
+                        <span id="statsPctBadge" class="hidden rounded-full px-2.5 py-0.5 text-xs font-semibold"></span>
+                    </div>
+                    <span id="statsSubdivisionLabel" class="text-xs text-slate-400 truncate max-w-xs text-right"></span>
+                </div>
+                <div class="px-5 pt-4 pb-5">
+                    <!-- Summary row: ring + legend -->
+                    <div class="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-5 mb-5">
+                        <!-- Animated percentile ring -->
+                        <div class="flex-none flex flex-col items-center">
+                            <div class="relative w-16 h-16">
+                                <svg viewBox="0 0 100 100" width="64" height="64" class="-rotate-90">
+                                    <circle cx="50" cy="50" r="40" fill="none" stroke="#f1f5f9" stroke-width="14"/>
+                                    <circle id="statsRingFg" cx="50" cy="50" r="40" fill="none"
+                                            stroke="#10b981" stroke-width="14" stroke-linecap="round"
+                                            stroke-dasharray="251.33" stroke-dashoffset="251.33"
+                                            style="transition:stroke-dashoffset 0.9s ease,stroke 0.4s ease"/>
+                                </svg>
+                                <div class="absolute inset-0 flex flex-col items-center justify-center">
+                                    <span id="statsPercentilePct" class="text-base font-bold text-slate-900 leading-none tabular-nums"></span>
+                                    <span class="text-[8px] text-slate-400 font-medium mt-0.5">pctile</span>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Legend chips -->
+                        <div id="statsLine" class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm"></div>
+                    </div>
+                    <!-- Chart -->
+                    <div id="statsChartWrap" class="w-full"></div>
+                </div>
+            </div>
+
+            <!-- Count + Actions -->
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
                 <p id="resultsCount" class="text-sm text-slate-600"></p>
                 <div class="flex items-center gap-2">
-                    <a id="downloadBtn" href="#"
-                       class="crm-btn crm-btn-primary text-sm">
+                    <a id="downloadBtn" href="#" class="crm-btn crm-btn-primary text-sm">
                         <i class="fas fa-download text-xs mr-1"></i> Download CSV
                     </a>
-                    <button type="button" id="clearResults"
-                            class="crm-btn crm-btn-secondary text-sm">
+                    <button type="button" id="clearResults" class="crm-btn crm-btn-secondary text-sm">
                         <i class="fas fa-times text-xs mr-1"></i> Clear
                     </button>
                 </div>
@@ -133,70 +168,246 @@
                             <th>Legal Description</th>
                         </tr>
                     </thead>
-                    <tbody id="comparablesBody">
-                    </tbody>
+                    <tbody id="comparablesBody"></tbody>
                 </table>
             </div>
 
             <!-- Mobile Cards -->
-            <div id="mobileCards" class="md:hidden space-y-3 mt-4">
-            </div>
+            <div id="mobileCards" class="md:hidden space-y-3 mt-4"></div>
         </div>
     </div>
 </div>
 
 <script>
-(function() {
-    const searchInput = document.getElementById('contactSearch');
-    const searchDropdown = document.getElementById('searchDropdown');
-    const clearSearchBtn = document.getElementById('clearSearch');
-    const loadingState = document.getElementById('loadingState');
-    const errorState = document.getElementById('errorState');
-    const resultsSection = document.getElementById('resultsSection');
+(function () {
+    // ─── State ───────────────────────────────────────────────────────────
     let searchTimeout;
     let sortAsc = true;
     let currentComparables = [];
     let currentMainProperty = null;
 
-    function fmt(val) {
-        if (val == null || val === '') return '—';
-        return '$' + Number(val).toLocaleString();
+    const searchInput    = document.getElementById('contactSearch');
+    const searchDropdown = document.getElementById('searchDropdown');
+    const clearSearchBtn = document.getElementById('clearSearch');
+    const loadingState   = document.getElementById('loadingState');
+    const errorState     = document.getElementById('errorState');
+    const resultsSection = document.getElementById('resultsSection');
+
+    // ─── Formatters ──────────────────────────────────────────────────────
+    function fmt(v) {
+        if (v == null || v === '') return '—';
+        return '$' + Number(v).toLocaleString();
+    }
+    function fmtNum(v) {
+        if (v == null || v === '') return '—';
+        return Number(v).toLocaleString();
+    }
+    function fmtK(v) {
+        if (v == null) return '';
+        if (Math.abs(v) >= 1000000) return '$' + (v / 1000000).toFixed(1) + 'M';
+        return '$' + Math.round(v / 1000) + 'k';
+    }
+    function ordinalSuffix(v) {
+        var abs = Math.abs(Number(v));
+        var mod100 = abs % 100;
+        if (mod100 >= 11 && mod100 <= 13) return 'th';
+        switch (abs % 10) {
+            case 1: return 'st';
+            case 2: return 'nd';
+            case 3: return 'rd';
+            default: return 'th';
+        }
     }
 
-    function fmtNum(val) {
-        if (val == null || val === '') return '—';
-        return Number(val).toLocaleString();
-    }
+    // ─── Chart ───────────────────────────────────────────────────────────
+    function buildChart(dist, subjectValue, minVal, maxVal) {
+        if (!dist || dist.length === 0 || minVal == null || maxVal == null) return '';
 
-    // Debounced contact search
-    searchInput.addEventListener('input', function() {
-        const q = this.value.trim();
-        clearSearchBtn.classList.toggle('hidden', !q);
+        // SVG coordinate space
+        const W = 600, H = 170;
+        const PAD = { t: 28, r: 10, b: 28, l: 10 };
+        const cW = W - PAD.l - PAD.r;
+        const cH = H - PAD.t - PAD.b;
+        const n = dist.length;
+        const maxCnt = Math.max.apply(null, dist.map(function (b) { return b.count; })) || 1;
+        const range = maxVal > minVal ? maxVal - minVal : 1;
+        const bW = cW / n;
+        const bucketSize = range / n;
+        const barBottom = PAD.t + cH;
 
-        clearTimeout(searchTimeout);
-        if (q.length < 2) {
-            searchDropdown.classList.add('hidden');
-            return;
+        // Which bucket holds the subject?
+        var subjectIdx = Math.floor((subjectValue - minVal) / bucketSize);
+        subjectIdx = Math.max(0, Math.min(n - 1, subjectIdx));
+
+        // Subject vertical line X (exact value position)
+        var rawX = PAD.l + cW * (subjectValue - minVal) / range;
+        var mX = Math.max(PAD.l + 4, Math.min(W - PAD.r - 4, rawX));
+        var anchor = mX > W * 0.72 ? 'end' : mX < W * 0.28 ? 'start' : 'middle';
+
+        // ── Bars ─────────────────────────────────────────────────────────
+        var bars = '';
+        for (var i = 0; i < n; i++) {
+            var b = dist[i];
+            var x = PAD.l + i * bW;
+            var gap = Math.max(2, bW * 0.1);
+            var bH = b.count > 0 ? Math.max(8, cH * b.count / maxCnt) : 0;
+            var y = barBottom - bH;
+
+            // Color: green (cheaper), amber (subject bucket), slate (pricier)
+            var fill = i < subjectIdx  ? '#34d399'
+                     : i === subjectIdx ? '#fbbf24'
+                     :                   '#cbd5e1';
+
+            bars += '<rect'
+                + ' x="' + (x + gap).toFixed(1) + '"'
+                + ' y="' + y.toFixed(1) + '"'
+                + ' width="' + Math.max(2, bW - 2 * gap).toFixed(1) + '"'
+                + ' height="' + bH.toFixed(1) + '"'
+                + ' rx="4" fill="' + fill + '"/>';
+
+            // Count label — above bar, vertically clamped so it doesn't go off top
+            if (b.count > 0) {
+                var countY = Math.max(14, y - 6);
+                bars += '<text'
+                    + ' x="' + (x + bW / 2).toFixed(1) + '"'
+                    + ' y="' + countY.toFixed(1) + '"'
+                    + ' text-anchor="middle" font-size="12" fill="#475569" font-weight="600">'
+                    + b.count + '</text>';
+            }
         }
 
-        searchTimeout = setTimeout(() => {
-            fetch(`/tax-protest/search-contacts?q=${encodeURIComponent(q)}`)
-                .then(r => r.json())
-                .then(contacts => {
+        // ── Axis labels (first, last, + one mid if space) ────────────────
+        var axis = '';
+        // First bucket
+        axis += '<text x="' + (PAD.l + bW / 2).toFixed(1) + '" y="' + (H - 4)
+              + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + dist[0].label + '</text>';
+        // Last bucket
+        axis += '<text x="' + (PAD.l + (n - 0.5) * bW).toFixed(1) + '" y="' + (H - 4)
+              + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + fmtK(maxVal) + '</text>';
+        // Middle bucket (skip if too close to subject label)
+        var midI = Math.floor(n / 2);
+        if (Math.abs(midI - subjectIdx) > 1 && Math.abs(n - midI) > 1 && midI !== 0) {
+            var midX = PAD.l + (midI + 0.5) * bW;
+            if (Math.abs(midX - mX) > 50) {
+                axis += '<text x="' + midX.toFixed(1) + '" y="' + (H - 4)
+                      + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + dist[midI].label + '</text>';
+            }
+        }
+
+        // ── Subject marker line + value label ────────────────────────────
+        var marker =
+            // Dashed vertical line
+            '<line'
+            + ' x1="' + mX.toFixed(1) + '" y1="' + PAD.t
+            + '" x2="' + mX.toFixed(1) + '" y2="' + (barBottom + 4).toFixed(1) + '"'
+            + ' stroke="#f59e0b" stroke-width="2" stroke-dasharray="5,3" opacity="0.85"/>'
+            // Small circle at line bottom
+            + '<circle cx="' + mX.toFixed(1) + '" cy="' + (barBottom + 4).toFixed(1)
+            + '" r="3.5" fill="#f59e0b"/>'
+            // Value label just below the circle, above the axis labels
+            + '<text'
+            + ' x="' + mX.toFixed(1) + '"'
+            + ' y="' + (barBottom + 18).toFixed(1) + '"'
+            + ' text-anchor="' + anchor + '"'
+            + ' font-size="10" fill="#b45309" font-weight="700">'
+            + fmtK(subjectValue) + ' \u2191 you'
+            + '</text>';
+
+        return '<svg viewBox="0 0 ' + W + ' ' + H + '" width="100%" height="' + H + '"'
+             + ' style="display:block;overflow:visible">'
+             + bars + axis + marker
+             + '</svg>';
+    }
+
+    // ─── Stats card renderer ──────────────────────────────────────────────
+    function renderStats(stats, subdivision, subjectValue) {
+        var card = document.getElementById('statsCard');
+        if (!stats || !stats.total_homes) { card.classList.add('hidden'); return; }
+
+        var lower  = stats.lower_values  || 0;
+        var higher = stats.higher_values || 0;
+        var total  = stats.total_homes   || 0;
+        var pct    = Math.round(stats.percentile || 0);
+
+        // Subdivision label
+        document.getElementById('statsSubdivisionLabel').textContent =
+            (subdivision || '') + ' \u00B7 ' + total + ' home' + (total === 1 ? '' : 's');
+
+        // Percentile pill in header
+        var pillCls = pct >= 75 ? 'bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200'
+                    : pct >= 50 ? 'bg-amber-100 text-amber-700 ring-1 ring-amber-200'
+                    : pct >= 25 ? 'bg-orange-100 text-orange-700 ring-1 ring-orange-200'
+                    :             'bg-slate-100 text-slate-500 ring-1 ring-slate-200';
+        var pill = document.getElementById('statsPctBadge');
+        pill.className = 'rounded-full px-2.5 py-0.5 text-xs font-semibold ' + pillCls;
+        pill.textContent = pct + ordinalSuffix(pct) + ' percentile';
+        pill.classList.remove('hidden');
+
+        // Animated ring  (r=40, circumference = 2π×40 ≈ 251.33)
+        var CIRC = 251.33;
+        var ringColor = pct >= 75 ? '#10b981' : pct >= 50 ? '#f59e0b' : pct >= 25 ? '#f97316' : '#94a3b8';
+        document.getElementById('statsPercentilePct').textContent = pct + '%';
+        var ring = document.getElementById('statsRingFg');
+        ring.style.stroke = ringColor;
+        ring.style.transition = 'none';
+        ring.style.strokeDashoffset = CIRC.toFixed(2);
+        ring.getBoundingClientRect();
+        ring.style.transition = 'stroke-dashoffset 0.9s ease,stroke 0.4s ease';
+        requestAnimationFrame(function () {
+            ring.style.strokeDashoffset = (CIRC * (1 - pct / 100)).toFixed(2);
+        });
+
+        // Summary legend row
+        document.getElementById('statsLine').innerHTML =
+            '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-emerald-400 flex-none"></span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + lower + '</span>'
+            + '<span class="text-slate-500">cheaper in subdivision</span>'
+            + '</span>'
+            + '<span class="text-slate-300 select-none">\u00B7</span>'
+            + '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-amber-400 flex-none"></span>'
+            + '<span class="text-slate-500">Subject</span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + fmt(subjectValue) + '</span>'
+            + '</span>'
+            + '<span class="text-slate-300 select-none">\u00B7</span>'
+            + '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-slate-300 flex-none"></span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + higher + '</span>'
+            + '<span class="text-slate-500">more expensive</span>'
+            + '</span>';
+
+        // Chart
+        document.getElementById('statsChartWrap').innerHTML =
+            buildChart(stats.value_distribution, subjectValue, stats.min_value, stats.max_value);
+
+        card.classList.remove('hidden');
+    }
+
+    // ─── Contact search ───────────────────────────────────────────────────
+    searchInput.addEventListener('input', function () {
+        var q = this.value.trim();
+        clearSearchBtn.classList.toggle('hidden', !q);
+        clearTimeout(searchTimeout);
+        if (q.length < 2) { searchDropdown.classList.add('hidden'); return; }
+
+        searchTimeout = setTimeout(function () {
+            fetch('/tax-protest/search-contacts?q=' + encodeURIComponent(q))
+                .then(function (r) { return r.json(); })
+                .then(function (contacts) {
                     if (!contacts.length) {
                         searchDropdown.innerHTML = '<div class="px-4 py-3 text-sm text-slate-500">No contacts found</div>';
                     } else {
-                        searchDropdown.innerHTML = contacts.map(c => `
-                            <button type="button"
-                                    class="w-full text-left px-4 py-3 hover:bg-slate-50 border-b border-slate-100 last:border-0"
-                                    data-contact-id="${c.id}">
-                                <div class="font-medium text-slate-800 text-sm">${c.name}</div>
-                                <div class="text-xs text-slate-500 mt-0.5">${c.address || 'No address'}</div>
-                            </button>
-                        `).join('');
-
-                        searchDropdown.querySelectorAll('[data-contact-id]').forEach(btn => {
-                            btn.addEventListener('click', () => {
+                        searchDropdown.innerHTML = contacts.map(function (c) {
+                            return '<button type="button"'
+                                + ' class="w-full text-left px-4 py-3 hover:bg-slate-50 border-b border-slate-100 last:border-0"'
+                                + ' data-contact-id="' + c.id + '">'
+                                + '<div class="font-medium text-slate-800 text-sm">' + c.name + '</div>'
+                                + '<div class="text-xs text-slate-500 mt-0.5">' + (c.address || 'No address') + '</div>'
+                                + '</button>';
+                        }).join('');
+                        searchDropdown.querySelectorAll('[data-contact-id]').forEach(function (btn) {
+                            btn.addEventListener('click', function () {
                                 searchDropdown.classList.add('hidden');
                                 searchInput.value = btn.querySelector('.font-medium').textContent;
                                 runPropertySearch(btn.dataset.contactId);
@@ -208,23 +419,22 @@
         }, 300);
     });
 
-    clearSearchBtn.addEventListener('click', () => {
+    clearSearchBtn.addEventListener('click', function () {
         searchInput.value = '';
         clearSearchBtn.classList.add('hidden');
         searchDropdown.classList.add('hidden');
         hideAll();
     });
 
-    document.getElementById('clearResults').addEventListener('click', () => {
+    document.getElementById('clearResults').addEventListener('click', function () {
         searchInput.value = '';
         clearSearchBtn.classList.add('hidden');
         hideAll();
     });
 
-    document.addEventListener('click', (e) => {
-        if (!document.getElementById('searchContainer').contains(e.target)) {
+    document.addEventListener('click', function (e) {
+        if (!document.getElementById('searchContainer').contains(e.target))
             searchDropdown.classList.add('hidden');
-        }
     });
 
     function hideAll() {
@@ -233,28 +443,27 @@
         resultsSection.classList.add('hidden');
     }
 
+    // ─── Property search ─────────────────────────────────────────────────
     function runPropertySearch(contactId) {
         hideAll();
         loadingState.classList.remove('hidden');
 
         fetch('/tax-protest/search', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({contact_id: contactId}),
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ contact_id: contactId }),
         })
-        .then(r => r.json().then(data => ({status: r.status, data})))
-        .then(({status, data}) => {
+        .then(function (r) { return r.json().then(function (d) { return { status: r.status, data: d }; }); })
+        .then(function (res) {
             loadingState.classList.add('hidden');
-
-            if (status >= 400 || data.error) {
+            if (res.status >= 400 || res.data.error) {
                 errorState.classList.remove('hidden');
-                document.getElementById('errorMessage').textContent = data.error || 'An error occurred';
+                document.getElementById('errorMessage').textContent = res.data.error || 'An error occurred';
                 return;
             }
-
-            displayResults(data);
+            displayResults(res.data);
         })
-        .catch(err => {
+        .catch(function () {
             loadingState.classList.add('hidden');
             errorState.classList.remove('hidden');
             document.getElementById('errorMessage').textContent = 'Network error. Please try again.';
@@ -263,103 +472,91 @@
 
     function displayResults(data) {
         currentMainProperty = data.main_property;
-        currentComparables = data.comparables || [];
-        const county = {
-            chambers: 'Chambers County',
-            hcad: 'Harris County',
-            liberty: 'Liberty County',
-            fort_bend: 'Fort Bend County',
-        }[data.source] || 'County Tax Data';
+        currentComparables  = data.comparables || [];
 
-        document.getElementById('countyBadge').textContent = county;
-        document.getElementById('mainAddress').textContent = data.main_property.full_address || data.main_property.address;
-        document.getElementById('mainCityZip').textContent =
-            [data.main_property.city, data.main_property.zip].filter(Boolean).join(', ');
-        document.getElementById('mainValue').textContent = fmt(data.main_property.market_value);
+        var county = { chambers: 'Chambers County', hcad: 'Harris County',
+                       liberty: 'Liberty County', fort_bend: 'Fort Bend County' }[data.source]
+                   || 'County Tax Data';
+
+        document.getElementById('countyBadge').textContent    = county;
+        document.getElementById('mainAddress').textContent     = data.main_property.full_address || data.main_property.address;
+        document.getElementById('mainCityZip').textContent     = [data.main_property.city, data.main_property.zip].filter(Boolean).join(', ');
+        document.getElementById('mainValue').textContent       = fmt(data.main_property.market_value);
         document.getElementById('mainSubdivision').textContent = data.subdivision;
 
-        const sqFtWrap = document.getElementById('mainSqFtWrap');
+        var sqFtWrap = document.getElementById('mainSqFtWrap');
         if (data.main_property.sq_ft) {
             document.getElementById('mainSqFt').textContent = fmtNum(data.main_property.sq_ft);
             sqFtWrap.classList.remove('hidden');
-        } else {
-            sqFtWrap.classList.add('hidden');
-        }
+        } else { sqFtWrap.classList.add('hidden'); }
 
-        const acreageWrap = document.getElementById('mainAcreageWrap');
+        var acreageWrap = document.getElementById('mainAcreageWrap');
         if (data.main_property.acreage) {
             document.getElementById('mainAcreage').textContent = data.main_property.acreage.toFixed(2);
             acreageWrap.classList.remove('hidden');
-        } else {
-            acreageWrap.classList.add('hidden');
-        }
+        } else { acreageWrap.classList.add('hidden'); }
 
-        const zipSuffix = data.main_property.zip ? ` (${data.main_property.zip})` : '';
+        var zipSuffix = data.main_property.zip ? ' (' + data.main_property.zip + ')' : '';
         document.getElementById('resultsCount').textContent =
-            `Found ${data.total_comparables} propert${data.total_comparables === 1 ? 'y' : 'ies'} with lower market value in ${data.subdivision || 'neighborhood'}${zipSuffix}`;
+            'Found ' + data.total_comparables
+            + ' propert' + (data.total_comparables === 1 ? 'y' : 'ies')
+            + ' with lower market value in ' + (data.subdivision || 'neighborhood') + zipSuffix;
 
         document.getElementById('downloadBtn').href = '/tax-protest/download-csv';
+
+        renderStats(data.subdivision_stats, data.subdivision, data.main_property.market_value);
 
         sortAsc = true;
         renderTable();
         resultsSection.classList.remove('hidden');
     }
 
-    document.getElementById('sortValue').addEventListener('click', () => {
+    document.getElementById('sortValue').addEventListener('click', function () {
         sortAsc = !sortAsc;
-        const icon = document.querySelector('#sortValue i');
-        icon.className = sortAsc ? 'fas fa-sort-amount-up text-xs ml-1' : 'fas fa-sort-amount-down text-xs ml-1';
+        document.querySelector('#sortValue i').className =
+            sortAsc ? 'fas fa-sort-amount-up text-xs ml-1' : 'fas fa-sort-amount-down text-xs ml-1';
         renderTable();
     });
 
     function renderTable() {
-        const sorted = [...currentComparables].sort((a, b) =>
-            sortAsc ? (a.market_value || 0) - (b.market_value || 0)
-                    : (b.market_value || 0) - (a.market_value || 0)
-        );
+        var sorted = currentComparables.slice().sort(function (a, b) {
+            return sortAsc ? (a.market_value || 0) - (b.market_value || 0)
+                           : (b.market_value || 0) - (a.market_value || 0);
+        });
+        var allRows = [Object.assign({}, currentMainProperty, { _isMain: true })].concat(sorted);
 
-        const allRows = [
-            {...currentMainProperty, _isMain: true},
-            ...sorted,
-        ];
+        document.getElementById('comparablesBody').innerHTML = allRows.map(function (p) {
+            return '<tr class="' + (p._isMain ? 'bg-amber-50 font-medium' : 'hover:bg-slate-50') + '">'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.full_address || p.address || '') + '">'
+                + (p._isMain ? '<i class="fas fa-star text-amber-500 text-xs mr-1"></i>' : '')
+                + (p.full_address || p.address || '') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis">' + (p.city || '') + '</td>'
+                + '<td>' + (p.zip || '') + '</td>'
+                + '<td style="text-align:right">' + fmt(p.market_value) + '</td>'
+                + '<td style="text-align:right">' + (p.sq_ft ? fmtNum(p.sq_ft) : '—') + '</td>'
+                + '<td style="text-align:right">' + (p.acreage ? p.acreage.toFixed(2) : '—') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.subdivision || p.legal2 || '') + '">' + (p.subdivision || p.legal2 || '') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.legal1 || '') + '">' + (p.legal1 || '') + '</td>'
+                + '</tr>';
+        }).join('');
 
-        // Desktop table
-        const tbody = document.getElementById('comparablesBody');
-        tbody.innerHTML = allRows.map(p => `
-            <tr class="${p._isMain ? 'bg-amber-50 font-medium' : 'hover:bg-slate-50'}">
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.full_address || p.address || ''}">
-                    ${p._isMain ? '<i class="fas fa-star text-amber-500 text-xs mr-1"></i>' : ''}
-                    ${p.full_address || p.address || ''}
-                </td>
-                <td style="overflow:hidden;text-overflow:ellipsis">${p.city || ''}</td>
-                <td>${p.zip || ''}</td>
-                <td style="text-align:right">${fmt(p.market_value)}</td>
-                <td style="text-align:right">${p.sq_ft ? fmtNum(p.sq_ft) : '—'}</td>
-                <td style="text-align:right">${p.acreage ? p.acreage.toFixed(2) : '—'}</td>
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.subdivision || p.legal2 || ''}">${p.subdivision || p.legal2 || ''}</td>
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.legal1 || ''}">${p.legal1 || ''}</td>
-            </tr>
-        `).join('');
-
-        // Mobile cards
-        const mobileContainer = document.getElementById('mobileCards');
-        mobileContainer.innerHTML = allRows.map(p => `
-            <div class="premium-card p-4 ${p._isMain ? 'bg-amber-50/60 border-amber-200/60' : ''}">
-                <div class="flex items-start justify-between mb-2">
-                    <div>
-                        ${p._isMain ? '<span class="text-xs font-bold text-amber-700 uppercase">Subject Property</span>' : ''}
-                        <p class="font-medium text-slate-800 text-sm">${p.full_address || p.address || ''}</p>
-                        <p class="text-xs text-slate-500">${[p.city, p.zip].filter(Boolean).join(', ')}</p>
-                    </div>
-                    <span class="font-semibold text-sm text-slate-900">${fmt(p.market_value)}</span>
-                </div>
-                <div class="flex gap-4 text-xs text-slate-500">
-                    ${p.sq_ft ? `<span>Sq Ft: ${fmtNum(p.sq_ft)}</span>` : ''}
-                    ${p.acreage ? `<span>Acres: ${p.acreage.toFixed(2)}</span>` : ''}
-                </div>
-            </div>
-        `).join('');
+        document.getElementById('mobileCards').innerHTML = allRows.map(function (p) {
+            return '<div class="premium-card p-4 ' + (p._isMain ? 'bg-amber-50/60 border-amber-200/60' : '') + '">'
+                + '<div class="flex items-start justify-between mb-2">'
+                + '<div>'
+                + (p._isMain ? '<span class="text-xs font-bold text-amber-700 uppercase">Subject Property</span>' : '')
+                + '<p class="font-medium text-slate-800 text-sm">' + (p.full_address || p.address || '') + '</p>'
+                + '<p class="text-xs text-slate-500">' + [p.city, p.zip].filter(Boolean).join(', ') + '</p>'
+                + '</div>'
+                + '<span class="font-semibold text-sm text-slate-900">' + fmt(p.market_value) + '</span>'
+                + '</div>'
+                + '<div class="flex gap-4 text-xs text-slate-500">'
+                + (p.sq_ft ? '<span>Sq Ft: ' + fmtNum(p.sq_ft) + '</span>' : '')
+                + (p.acreage ? '<span>Acres: ' + p.acreage.toFixed(2) + '</span>' : '')
+                + '</div>'
+                + '</div>';
+        }).join('');
     }
-})();
+}());
 </script>
 {% endblock %}

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -264,7 +264,11 @@
     function displayResults(data) {
         currentMainProperty = data.main_property;
         currentComparables = data.comparables || [];
-        const county = data.source === 'chambers' ? 'Chambers County' : 'Harris County';
+        const county = {
+            chambers: 'Chambers County',
+            hcad: 'Harris County',
+            liberty: 'Liberty County',
+        }[data.source] || 'County Tax Data';
 
         document.getElementById('countyBadge').textContent = county;
         document.getElementById('mainAddress').textContent = data.main_property.full_address || data.main_property.address;
@@ -289,8 +293,9 @@
             acreageWrap.classList.add('hidden');
         }
 
+        const zipSuffix = data.main_property.zip ? ` (${data.main_property.zip})` : '';
         document.getElementById('resultsCount').textContent =
-            `Found ${data.total_comparables} propert${data.total_comparables === 1 ? 'y' : 'ies'} with lower market value in ${data.subdivision || 'neighborhood'} (${data.main_property.zip || ''})`;
+            `Found ${data.total_comparables} propert${data.total_comparables === 1 ? 'y' : 'ies'} with lower market value in ${data.subdivision || 'neighborhood'}${zipSuffix}`;
 
         document.getElementById('downloadBtn').href = '/tax-protest/download-csv';
 

--- a/tests/test_tax_protest.py
+++ b/tests/test_tax_protest.py
@@ -1,0 +1,134 @@
+"""
+Regression tests for the tax protest stats flow.
+"""
+
+from types import SimpleNamespace
+
+import feature_flags as feature_flags_module
+import routes.tax_protest as tax_protest_route
+import services.tax_protest_service as tax_protest_service
+
+
+class _QueryStub:
+    def __init__(self, values):
+        self._rows = [(value,) for value in values]
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def with_entities(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+def test_get_subdivision_stats_returns_list_distribution(monkeypatch):
+    values = [390000, 420000, 450000, 610000, 615000, 700000, 820000]
+    monkeypatch.setattr(
+        tax_protest_service.LibertyProperty,
+        "query",
+        _QueryStub(values),
+    )
+    monkeypatch.setattr(
+        tax_protest_service,
+        "_find_liberty_sibling_codes",
+        lambda subdivision_code: [],
+    )
+
+    stats = tax_protest_service.get_subdivision_stats(
+        subdivision="LIBERTY OAKS",
+        zip_code="77327",
+        market_value=590000,
+        source="liberty",
+        subdivision_code="007206",
+    )
+
+    assert stats["total_homes"] == len(values)
+    assert stats["min_value"] == min(values)
+    assert stats["max_value"] == max(values)
+    assert isinstance(stats["value_distribution"], list)
+    assert sum(bucket["count"] for bucket in stats["value_distribution"]) == len(values)
+
+
+def test_search_property_returns_subdivision_stats(owner_a_client, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+
+    fake_contact = SimpleNamespace(
+        id=999,
+        street_address="156 Maryville Lane",
+        city="Cleveland",
+        zip_code="77327",
+    )
+    fake_property = {
+        "id": "liberty-1",
+        "address": "156 Maryville Lane",
+        "full_address": "156 Maryville Lane, Cleveland, TX 77327",
+        "city": "Cleveland",
+        "zip": "77327",
+        "market_value": 591000,
+        "sq_ft": 2184,
+        "acreage": 0.23,
+        "subdivision": "MARYVILLE",
+        "subdivision_code": "007206",
+        "neighborhood_code": None,
+    }
+    fake_stats = {
+        "total_homes": 21,
+        "lower_values": 2,
+        "higher_values": 18,
+        "percentile": 9.5,
+        "value_distribution": [
+            {"label": "$362k", "count": 7},
+            {"label": "$462k", "count": 7},
+            {"label": "$562k", "count": 2},
+            {"label": "$662k", "count": 1},
+            {"label": "$762k", "count": 0},
+            {"label": "$862k", "count": 2},
+            {"label": "$962k", "count": 0},
+            {"label": "$1062k", "count": 2},
+        ],
+        "min_value": 362000,
+        "max_value": 1162000,
+        "median_value": 505000,
+    }
+
+    monkeypatch.setattr(
+        tax_protest_route,
+        "_authorized_contact",
+        lambda contact_id: fake_contact,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_property_in_tax_data",
+        lambda street_address, city, zip_code: (fake_property, "liberty"),
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_comparables",
+        lambda *args, **kwargs: [{"id": "comp-1", "market_value": 420000}],
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "cache_search_result",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_subdivision_stats",
+        lambda *args, **kwargs: fake_stats,
+    )
+
+    response = owner_a_client.post(
+        "/tax-protest/search",
+        json={"contact_id": fake_contact.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["subdivision"] == "MARYVILLE"
+    assert payload["main_property"]["market_value"] == 591000
+    assert payload["subdivision_stats"] == fake_stats


### PR DESCRIPTION
## What changed

This adds Liberty County as a new tax-protest county data source and layers in stored Liberty code profiles so comparable selection is smarter and more reliable.

Key changes:
- add `liberty_properties`, `liberty_improvements`, and `liberty_code_profiles`
- extend the tax data import flow to parse and load Liberty county data
- update tax protest search to fall back `chambers -> hcad -> liberty`
- use exact Liberty subdivision/abstract codes for matching instead of fuzzy text parsing
- add a one-time classifier script that stores a per-code Liberty strategy (`normal`, `strict`, `reject`)
- apply the stored Liberty strategy at runtime so broad-area buckets are rejected and ambiguous buckets use tighter sqft/acreage filtering
- update the tax protest UI/CSV flow to display Liberty county results correctly

## Why it changed

The Liberty county PACS export has useful subdivision/abstract codes, but not every code is a reliable neighborhood comp bucket. Some codes are true subdivisions, some are broad rural areas, and some are junk buckets like `NO MHP`.

The stored code-profile layer keeps the runtime search deterministic while using one-time LLM classification to decide how safe each Liberty code is for same-code home comparables.

## User impact

Agents can now search Liberty county homes in the tax protest tool when a property is not found in Chambers or Harris.

Liberty comparables should now behave in three modes:
- `normal`: same-code subdivision comps
- `strict`: same-code comps with tighter sqft and acreage filters
- `reject`: no Liberty comps for unreliable codes

## Validation

Ran live verification against the current environment:
- `.venv/bin/python3 scripts/classify_liberty_codes.py` -> `Processed 0 profiles, made 0 LLM calls, skipped 827 existing profiles.`
- Liberty comparable smoke test:
  - `007312 normal` -> `493` comps
  - `006320 strict` -> `3` comps
  - `003700 reject` -> `0` comps

## Notes

This PR is intentionally based on `feat/tax-protest-tool` so the review scope stays limited to the Liberty county additions and does not reopen the full tax-protest feature stack.