### PR TITLE
[codex] Complete tax protest neighborhood stats rollout

### DIFF
--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -3,6 +3,7 @@ Tax Protest blueprint.
 Lets agents search their CRM contacts, locate properties in county tax data,
 extract subdivisions via LLM, find lower-value comparables, and download CSV.
 """
+
 import csv
 import re
 from io import StringIO
@@ -18,13 +19,14 @@ from services.tax_protest_service import (
     extract_subdivision_llm,
     find_comparables,
     get_neighborhood_name,
+    get_subdivision_stats,
     cache_search_result,
     get_cached_search_result,
     get_main_property_by_id,
     _is_valid_subdivision,
 )
 
-tax_protest_bp = Blueprint('tax_protest', __name__, url_prefix='/tax-protest')
+tax_protest_bp = Blueprint("tax_protest", __name__, url_prefix="/tax-protest")
 
 
 def _authorized_contact(contact_id):
@@ -37,20 +39,20 @@ def _authorized_contact(contact_id):
     return contact
 
 
-@tax_protest_bp.route('/')
+@tax_protest_bp.route("/")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def index():
     """Main Tax Protest page."""
-    return render_template('tax_protest/index.html')
+    return render_template("tax_protest/index.html")
 
 
-@tax_protest_bp.route('/search-contacts')
+@tax_protest_bp.route("/search-contacts")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def search_contacts():
     """AJAX endpoint: search CRM contacts by name or address."""
-    q = request.args.get('q', '').strip()
+    q = request.args.get("q", "").strip()
     if len(q) < 2:
         return jsonify([])
 
@@ -59,12 +61,14 @@ def search_contacts():
     if not can_view_all_org_data():
         query = query.filter(Contact.user_id == current_user.id)
 
-    search_term = f'%{q}%'
+    search_term = f"%{q}%"
     query = query.filter(
         db.or_(
             Contact.first_name.ilike(search_term),
             Contact.last_name.ilike(search_term),
-            db.func.concat(Contact.first_name, ' ', Contact.last_name).ilike(search_term),
+            db.func.concat(Contact.first_name, " ", Contact.last_name).ilike(
+                search_term
+            ),
             Contact.street_address.ilike(search_term),
             Contact.city.ilike(search_term),
             Contact.zip_code.ilike(search_term),
@@ -74,78 +78,89 @@ def search_contacts():
     results = []
     for c in query.all():
         addr_parts = [p for p in [c.street_address, c.city, c.state, c.zip_code] if p]
-        results.append({
-            'id': c.id,
-            'name': f"{c.first_name} {c.last_name}",
-            'address': ', '.join(addr_parts),
-            'street_address': c.street_address,
-            'city': c.city,
-            'state': c.state,
-            'zip_code': c.zip_code,
-        })
+        results.append(
+            {
+                "id": c.id,
+                "name": f"{c.first_name} {c.last_name}",
+                "address": ", ".join(addr_parts),
+                "street_address": c.street_address,
+                "city": c.city,
+                "state": c.state,
+                "zip_code": c.zip_code,
+            }
+        )
 
     return jsonify(results)
 
 
-@tax_protest_bp.route('/search', methods=['POST'])
+@tax_protest_bp.route("/search", methods=["POST"])
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def search_property():
     """Search tax data for a contact's property and find comparables."""
     data = request.get_json()
-    if not data or not data.get('contact_id'):
-        return jsonify({'error': 'contact_id required'}), 400
+    if not data or not data.get("contact_id"):
+        return jsonify({"error": "contact_id required"}), 400
 
-    contact = _authorized_contact(data['contact_id'])
+    contact = _authorized_contact(data["contact_id"])
 
     if not contact.street_address:
-        return jsonify({'error': 'Contact has no street address on file'}), 400
+        return jsonify({"error": "Contact has no street address on file"}), 400
 
     property_record, source = find_property_in_tax_data(
         contact.street_address, contact.city, contact.zip_code
     )
 
     if not property_record:
-        return jsonify({
-            'error': f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
-        }), 404
+        return jsonify(
+            {
+                "error": f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
+            }
+        ), 404
 
-    market_value = property_record.get('market_value')
-    zip_code = property_record.get('zip')
-    neighborhood_code = property_record.get('neighborhood_code')
-    subdivision_code = property_record.get('subdivision_code')
-    main_sq_ft = property_record.get('sq_ft')
-    main_acreage = property_record.get('acreage')
+    market_value = property_record.get("market_value")
+    zip_code = property_record.get("zip")
+    neighborhood_code = property_record.get("neighborhood_code")
+    subdivision_code = property_record.get("subdivision_code")
+    main_sq_ft = property_record.get("sq_ft")
+    main_acreage = property_record.get("acreage")
     subdivision = None
     fuzzy = False
 
-    if source == 'hcad':
-        lgl_2 = property_record.get('legal2') or ''
+    if source == "hcad":
+        lgl_2 = property_record.get("legal2") or ""
         if _is_valid_subdivision(lgl_2):
             subdivision = lgl_2.strip()
         else:
-            subdivision = extract_subdivision_llm(property_record.get('legal1', ''))
+            subdivision = extract_subdivision_llm(property_record.get("legal1", ""))
             fuzzy = True
         if not subdivision:
-            return jsonify({
-                'error': 'Could not determine subdivision from property legal description',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine subdivision from property legal description",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
-            subdivision, zip_code, market_value, source,
+            subdivision,
+            zip_code,
+            market_value,
+            source,
             main_sq_ft=main_sq_ft,
             fuzzy_subdivision=fuzzy,
             main_acreage=main_acreage,
         )
-    elif source == 'liberty':
-        subdivision = property_record.get('subdivision')
+    elif source == "liberty":
+        subdivision = property_record.get("subdivision")
         if not subdivision or not subdivision_code:
-            return jsonify({
-                'error': 'Could not determine Liberty subdivision from tax data',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine Liberty subdivision from tax data",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
             subdivision,
             zip_code,
@@ -155,14 +170,16 @@ def search_property():
             subdivision_code=subdivision_code,
             main_acreage=main_acreage,
         )
-    elif source == 'fort_bend':
-        subdivision = property_record.get('subdivision')
+    elif source == "fort_bend":
+        subdivision = property_record.get("subdivision")
         if not subdivision or not subdivision_code:
-            return jsonify({
-                'error': 'Could not determine Fort Bend neighborhood from tax data',
-                'main_property': property_record,
-                'source': source,
-            }), 422
+            return jsonify(
+                {
+                    "error": "Could not determine Fort Bend neighborhood from tax data",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
         comparables = find_comparables(
             subdivision,
             zip_code,
@@ -173,22 +190,29 @@ def search_property():
             main_acreage=main_acreage,
         )
     else:
-        legal_desc = property_record.get('legal1', '')
+        legal_desc = property_record.get("legal1", "")
         subdivision = extract_subdivision_llm(legal_desc)
         if not subdivision:
-            return jsonify({
-                'error': 'Could not extract subdivision from property legal description',
-                'main_property': property_record,
-                'source': source,
-            }), 422
-        comparables = find_comparables(subdivision, zip_code, market_value, source,
-                                       main_sq_ft=main_sq_ft,
-                                       main_acreage=main_acreage)
+            return jsonify(
+                {
+                    "error": "Could not extract subdivision from property legal description",
+                    "main_property": property_record,
+                    "source": source,
+                }
+            ), 422
+        comparables = find_comparables(
+            subdivision,
+            zip_code,
+            market_value,
+            source,
+            main_sq_ft=main_sq_ft,
+            main_acreage=main_acreage,
+        )
 
     cache_search_result(
         source=source,
         subdivision=subdivision,
-        main_property_id=property_record['id'],
+        main_property_id=property_record["id"],
         contact_id=contact.id,
         zip_code=zip_code,
         neighborhood_code=neighborhood_code,
@@ -198,85 +222,112 @@ def search_property():
         fuzzy_subdivision=fuzzy,
     )
 
-    return jsonify({
-        'source': source,
-        'subdivision': subdivision,
-        'main_property': property_record,
-        'comparables': comparables,
-        'total_comparables': len(comparables),
-    })
+    subdivision_stats = get_subdivision_stats(
+        subdivision,
+        zip_code,
+        market_value,
+        source,
+        fuzzy_subdivision=fuzzy,
+        subdivision_code=subdivision_code,
+    )
+
+    return jsonify(
+        {
+            "source": source,
+            "subdivision": subdivision,
+            "main_property": property_record,
+            "comparables": comparables,
+            "total_comparables": len(comparables),
+            "subdivision_stats": subdivision_stats,
+        }
+    )
 
 
-@tax_protest_bp.route('/download-csv')
+@tax_protest_bp.route("/download-csv")
 @login_required
-@feature_required('TAX_PROTEST')
+@feature_required("TAX_PROTEST")
 def download_csv():
     """Download CSV of comparables using cached search result (no LLM re-run)."""
     cached = get_cached_search_result()
     if not cached:
         abort(400, description="No search results to download. Run a search first.")
 
-    contact = _authorized_contact(cached['contact_id'])
+    contact = _authorized_contact(cached["contact_id"])
 
-    main_property = get_main_property_by_id(cached['main_property_id'], cached['source'])
+    main_property = get_main_property_by_id(
+        cached["main_property_id"], cached["source"]
+    )
     if not main_property:
         abort(404, description="Main property no longer found in tax data")
 
     comparables = find_comparables(
-        cached['subdivision'],
-        cached['zip_code'],
-        main_property['market_value'],
-        cached['source'],
-        main_sq_ft=cached.get('main_sq_ft'),
-        fuzzy_subdivision=cached.get('fuzzy_subdivision', False),
-        subdivision_code=cached.get('subdivision_code'),
-        main_acreage=cached.get('main_acreage'),
+        cached["subdivision"],
+        cached["zip_code"],
+        main_property["market_value"],
+        cached["source"],
+        main_sq_ft=cached.get("main_sq_ft"),
+        fuzzy_subdivision=cached.get("fuzzy_subdivision", False),
+        subdivision_code=cached.get("subdivision_code"),
+        main_acreage=cached.get("main_acreage"),
     )
 
     output = StringIO()
     writer = csv.writer(output)
 
-    headers = ['Type', 'Address', 'City', 'Zip', 'Market Value', 'Sq Ft',
-               'Acreage', 'Subdivision', 'Legal Description', 'Account', 'County']
+    headers = [
+        "Type",
+        "Address",
+        "City",
+        "Zip",
+        "Market Value",
+        "Sq Ft",
+        "Acreage",
+        "Subdivision",
+        "Legal Description",
+        "Account",
+        "County",
+    ]
     writer.writerow(headers)
 
     county = {
-        'chambers': 'Chambers',
-        'hcad': 'Harris',
-        'liberty': 'Liberty',
-        'fort_bend': 'Fort Bend',
-    }.get(cached['source'], cached['source'].title())
-    subdivision = cached.get('subdivision', '')
+        "chambers": "Chambers",
+        "hcad": "Harris",
+        "liberty": "Liberty",
+        "fort_bend": "Fort Bend",
+    }.get(cached["source"], cached["source"].title())
+    subdivision = cached.get("subdivision", "")
 
-    def write_row(prop, row_type='Comparable'):
-        writer.writerow([
-            row_type,
-            prop.get('full_address', ''),
-            prop.get('city', ''),
-            prop.get('zip', ''),
-            prop.get('market_value', ''),
-            prop.get('sq_ft', ''),
-            prop.get('acreage', ''),
-            subdivision,
-            prop.get('legal1', ''),
-            prop.get('account', ''),
-            county,
-        ])
+    def write_row(prop, row_type="Comparable"):
+        writer.writerow(
+            [
+                row_type,
+                prop.get("full_address", ""),
+                prop.get("city", ""),
+                prop.get("zip", ""),
+                prop.get("market_value", ""),
+                prop.get("sq_ft", ""),
+                prop.get("acreage", ""),
+                subdivision,
+                prop.get("legal1", ""),
+                prop.get("account", ""),
+                county,
+            ]
+        )
 
-    write_row(main_property, 'Subject Property')
+    write_row(main_property, "Subject Property")
     for comp in comparables:
         write_row(comp)
 
     output.seek(0)
 
-    addr = contact.street_address or 'unknown'
-    filename = re.sub(r'[^a-zA-Z0-9]+', '_', addr).strip('_') + '.csv'
+    addr = contact.street_address or "unknown"
+    filename = re.sub(r"[^a-zA-Z0-9]+", "_", addr).strip("_") + ".csv"
 
     return Response(
         output.getvalue(),
-        mimetype='text/csv',
+        mimetype="text/csv",
         headers={
-            'Content-Disposition': f'attachment; filename={filename}',
-            'Content-Type': 'text/csv',
-        }
+            "Content-Disposition": f"attachment; filename={filename}",
+            "Content-Type": "text/csv",
+        },
     )

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -3,6 +3,7 @@ Tax Protest service layer.
 Handles address lookup in county tax data, LLM-based subdivision extraction,
 comparable property queries, and search result caching for CSV consistency.
 """
+
 import re
 import logging
 from flask import session
@@ -18,6 +19,9 @@ from models import (
 )
 
 logger = logging.getLogger(__name__)
+
+SQ_FT_RANGE = 250
+MIN_COMPARABLES = 5
 
 SUBDIVISION_SYSTEM_PROMPT = (
     "You are a Texas property legal description parser. "
@@ -40,24 +44,43 @@ SUBDIVISION_EXAMPLES = (
 def normalize_address(address):
     """Normalize a street address for matching."""
     if not address:
-        return ''
+        return ""
     addr = address.upper().strip()
     replacements = {
-        ' STREET': ' ST', ' DRIVE': ' DR', ' AVENUE': ' AVE',
-        ' BOULEVARD': ' BLVD', ' LANE': ' LN', ' COURT': ' CT',
-        ' CIRCLE': ' CIR', ' PLACE': ' PL', ' ROAD': ' RD',
-        ' HIGHWAY': ' HWY', ' PARKWAY': ' PKWY',
+        " STREET": " ST",
+        " DRIVE": " DR",
+        " AVENUE": " AVE",
+        " BOULEVARD": " BLVD",
+        " LANE": " LN",
+        " COURT": " CT",
+        " CIRCLE": " CIR",
+        " PLACE": " PL",
+        " ROAD": " RD",
+        " HIGHWAY": " HWY",
+        " PARKWAY": " PKWY",
     }
     for old, new in replacements.items():
         addr = addr.replace(old, new)
-    addr = addr.replace('FARM TO MARKET', 'FM')
-    addr = re.sub(r'\s*(APT|UNIT|STE|SUITE|#)\s*\S*$', '', addr)
-    addr = re.sub(r'\s+', ' ', addr).strip()
+    addr = addr.replace("FARM TO MARKET", "FM")
+    addr = re.sub(r"\s*(APT|UNIT|STE|SUITE|#)\s*\S*$", "", addr)
+    addr = re.sub(r"\s+", " ", addr).strip()
     return addr
 
 
-DIRECTIONAL_PREFIXES = {'N', 'S', 'E', 'W', 'NE', 'NW', 'SE', 'SW',
-                         'NORTH', 'SOUTH', 'EAST', 'WEST'}
+DIRECTIONAL_PREFIXES = {
+    "N",
+    "S",
+    "E",
+    "W",
+    "NE",
+    "NW",
+    "SE",
+    "SW",
+    "NORTH",
+    "SOUTH",
+    "EAST",
+    "WEST",
+}
 
 
 def _parse_street_parts(address):
@@ -67,7 +90,7 @@ def _parse_street_parts(address):
     addr = normalize_address(address)
     if not addr:
         return None, None, None
-    match = re.match(r'^(\d+)\s+(.+)', addr)
+    match = re.match(r"^(\d+)\s+(.+)", addr)
     if not match:
         return None, None, addr
     street_num = match.group(1)
@@ -75,7 +98,7 @@ def _parse_street_parts(address):
     parts = remainder.split()
     if parts and parts[0] in DIRECTIONAL_PREFIXES:
         direction = parts[0]
-        street_name = ' '.join(parts[1:]) if len(parts) > 1 else ''
+        street_name = " ".join(parts[1:]) if len(parts) > 1 else ""
         return street_num, direction, street_name
     return street_num, None, remainder
 
@@ -88,32 +111,34 @@ def find_property_in_tax_data(street_address, city, zip_code):
     """
     normalized_address = normalize_address(street_address)
     street_num, direction, street_name = _parse_street_parts(street_address)
-    zip_clean = (zip_code or '').strip()[:5]
-    city_clean = (city or '').strip().upper()
+    zip_clean = (zip_code or "").strip()[:5]
+    city_clean = (city or "").strip().upper()
 
     # --- Chambers County ---
     chambers_result = _search_chambers(street_num, direction, street_name, zip_clean)
     if chambers_result:
-        return chambers_result, 'chambers'
+        return chambers_result, "chambers"
 
     # --- Harris County (HCAD) ---
-    hcad_result = _search_hcad(normalized_address, street_num, direction, street_name, zip_clean)
+    hcad_result = _search_hcad(
+        normalized_address, street_num, direction, street_name, zip_clean
+    )
     if hcad_result:
-        return hcad_result, 'hcad'
+        return hcad_result, "hcad"
 
     # --- Liberty County ---
     liberty_result = _search_liberty(
         normalized_address, street_num, street_name, city_clean, zip_clean
     )
     if liberty_result:
-        return liberty_result, 'liberty'
+        return liberty_result, "liberty"
 
     # --- Fort Bend County ---
     fort_bend_result = _search_fort_bend(
         normalized_address, street_num, street_name, city_clean, zip_clean
     )
     if fort_bend_result:
-        return fort_bend_result, 'fort_bend'
+        return fort_bend_result, "fort_bend"
 
     return None, None
 
@@ -128,7 +153,7 @@ def _search_chambers(street_num, direction, street_name, zip_code):
     first_word = street_name.split()[0]
     base_filters = [
         ChambersProperty.prop_street_number == street_num,
-        ChambersProperty.prop_street.ilike(f'{first_word}%'),
+        ChambersProperty.prop_street.ilike(f"{first_word}%"),
     ]
     if direction:
         base_filters.append(ChambersProperty.prop_street_dir == direction)
@@ -173,7 +198,7 @@ def _search_hcad(normalized_address, street_num, direction, street_name, zip_cod
         first_word = street_name.split()[0]
         base_filters = [
             HcadProperty.str_num == street_num,
-            HcadProperty.str.ilike(f'{first_word}%'),
+            HcadProperty.str.ilike(f"{first_word}%"),
         ]
         if direction:
             base_filters.append(HcadProperty.str_sfx_dir == direction)
@@ -197,7 +222,7 @@ def _search_hcad(normalized_address, street_num, direction, street_name, zip_cod
     # Last resort: fuzzy match on full site_addr_1
     if street_num and street_name:
         result = HcadProperty.query.filter(
-            HcadProperty.site_addr_1.ilike(f'{street_num} {street_name}%'),
+            HcadProperty.site_addr_1.ilike(f"{street_num} {street_name}%"),
         ).first()
         if result:
             return _hcad_found(result)
@@ -229,7 +254,7 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
     if street_name:
         first_word = street_name.split()[0]
         street_filters = [
-            LibertyProperty.situs_street.ilike(f'{first_word}%'),
+            LibertyProperty.situs_street.ilike(f"{first_word}%"),
             *base_filter,
         ]
         if street_num:
@@ -259,7 +284,7 @@ def _search_liberty(normalized_address, street_num, street_name, city, zip_code)
 
         if street_num:
             result = LibertyProperty.query.filter(
-                LibertyProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
+                LibertyProperty.site_addr_1.ilike(f"{street_num} {first_word}%"),
                 *base_filter,
             ).first()
             if result:
@@ -292,7 +317,7 @@ def _search_fort_bend(normalized_address, street_num, street_name, city, zip_cod
     if street_name:
         first_word = street_name.split()[0]
         street_filters = [
-            FortBendProperty.situs_street_name.ilike(f'{first_word}%'),
+            FortBendProperty.situs_street_name.ilike(f"{first_word}%"),
             *base_filter,
         ]
         if street_num:
@@ -322,7 +347,7 @@ def _search_fort_bend(normalized_address, street_num, street_name, city, zip_cod
 
         if street_num:
             result = FortBendProperty.query.filter(
-                FortBendProperty.site_addr_1.ilike(f'{street_num} {first_word}%'),
+                FortBendProperty.site_addr_1.ilike(f"{street_num} {first_word}%"),
                 *base_filter,
             ).first()
             if result:
@@ -336,11 +361,11 @@ def _is_valid_subdivision(lgl_2):
     if not lgl_2 or not lgl_2.strip():
         return False
     val = lgl_2.strip().upper()
-    if val.startswith('('):
+    if val.startswith("("):
         return False
-    if re.match(r'^BLK\s+\d', val):
+    if re.match(r"^BLK\s+\d", val):
         return False
-    if re.match(r'^(LTS?\s|LOTS?\s|TRS?\s)', val):
+    if re.match(r"^(LTS?\s|LOTS?\s|TRS?\s)", val):
         return False
     if len(val) < 3:
         return False
@@ -350,9 +375,11 @@ def _is_valid_subdivision(lgl_2):
 def _hcad_found(result):
     """Helper to load sq_ft and return dict for a matched HCAD property."""
 
-    sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
-        HcadBuilding.acct == result.acct
-    ).scalar()
+    sq_ft = (
+        db.session.query(db.func.max(HcadBuilding.im_sq_ft))
+        .filter(HcadBuilding.acct == result.acct)
+        .scalar()
+    )
 
     return _hcad_to_dict(result, sq_ft)
 
@@ -367,6 +394,7 @@ def extract_subdivision_llm(legal_description):
 
     try:
         from services.ai_service import generate_ai_response
+
         prompt = f"{SUBDIVISION_EXAMPLES}\nLegal description: '{legal_description}'"
         result = generate_ai_response(
             system_prompt=SUBDIVISION_SYSTEM_PROMPT,
@@ -375,7 +403,7 @@ def extract_subdivision_llm(legal_description):
             reasoning_effort="low",
         )
         cleaned = result.strip().strip("'\"").upper()
-        if cleaned and cleaned != 'UNKNOWN' and len(cleaned) > 1:
+        if cleaned and cleaned != "UNKNOWN" and len(cleaned) > 1:
             return cleaned
     except Exception as e:
         logger.warning(f"LLM subdivision extraction failed, falling back to regex: {e}")
@@ -392,12 +420,12 @@ def extract_subdivision_regex(legal_description):
         return None
 
     text = legal_description.upper().strip()
-    text = re.sub(r'^(LOTS?\s+)?[\d\s&,\.]+\s+', '', text)
-    text = re.sub(r'^(TRS?\s+)[\d\s&,\.]+\s*', '', text)
-    text = re.sub(r'^(ALL\s+)?BLK\s+\d+\s*', '', text)
-    text = re.sub(r'\s+SEC(TION)?\s+\d+.*$', '', text)
-    text = re.sub(r'\s+BLK\s+\d+.*$', '', text)
-    text = re.sub(r'\s+PH(ASE)?\s+\d+.*$', '', text)
+    text = re.sub(r"^(LOTS?\s+)?[\d\s&,\.]+\s+", "", text)
+    text = re.sub(r"^(TRS?\s+)[\d\s&,\.]+\s*", "", text)
+    text = re.sub(r"^(ALL\s+)?BLK\s+\d+\s*", "", text)
+    text = re.sub(r"\s+SEC(TION)?\s+\d+.*$", "", text)
+    text = re.sub(r"\s+BLK\s+\d+.*$", "", text)
+    text = re.sub(r"\s+PH(ASE)?\s+\d+.*$", "", text)
 
     text = text.strip()
     if text and len(text) > 1 and not text.isdigit():
@@ -413,9 +441,16 @@ def get_neighborhood_name(neighborhood_code):
     return nc.dscr if nc else None
 
 
-def find_comparables(subdivision, zip_code, market_value, source,
-                     main_sq_ft=None, fuzzy_subdivision=False,
-                     subdivision_code=None, main_acreage=None):
+def find_comparables(
+    subdivision,
+    zip_code,
+    market_value,
+    source,
+    main_sq_ft=None,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    main_acreage=None,
+):
     """
     Find properties in the same subdivision and zip with lower market value.
     For HCAD: matches on lgl_2 (exact when from structured data, ILIKE when
@@ -423,16 +458,21 @@ def find_comparables(subdivision, zip_code, market_value, source,
     For Chambers: uses ILIKE on legal1 (no sq ft band; HCAD still uses ±250).
     Returns list of property dicts.
     """
-    SQ_FT_RANGE = 250
 
-    if source == 'chambers':
+    if source == "chambers":
         if not subdivision:
             return []
 
-        pattern = f'%{subdivision}%'
+        pattern = f"%{subdivision}%"
         has_improvement = db.or_(
-            db.and_(ChambersProperty.improvement_hs_val.isnot(None), ChambersProperty.improvement_hs_val > 0),
-            db.and_(ChambersProperty.improvement_nhs_val.isnot(None), ChambersProperty.improvement_nhs_val > 0),
+            db.and_(
+                ChambersProperty.improvement_hs_val.isnot(None),
+                ChambersProperty.improvement_hs_val > 0,
+            ),
+            db.and_(
+                ChambersProperty.improvement_nhs_val.isnot(None),
+                ChambersProperty.improvement_nhs_val > 0,
+            ),
         )
         base_filters = [
             ChambersProperty.legal1.ilike(pattern),
@@ -440,50 +480,59 @@ def find_comparables(subdivision, zip_code, market_value, source,
             ChambersProperty.market_value > 0,
             ChambersProperty.market_value < market_value,
             ChambersProperty.prop_street_number.isnot(None),
-            ChambersProperty.prop_street_number != '0',
+            ChambersProperty.prop_street_number != "0",
             ChambersProperty.prop_street.isnot(None),
             has_improvement,
         ]
 
         if zip_code:
-            results = ChambersProperty.query.filter(
-                ChambersProperty.prop_zip5 == zip_code,
-                *base_filters,
-            ).order_by(ChambersProperty.market_value.asc()).all()
+            results = (
+                ChambersProperty.query.filter(
+                    ChambersProperty.prop_zip5 == zip_code,
+                    *base_filters,
+                )
+                .order_by(ChambersProperty.market_value.asc())
+                .all()
+            )
             if results:
                 return [_chambers_to_dict(r) for r in results]
 
-        results = ChambersProperty.query.filter(
-            *base_filters,
-        ).order_by(ChambersProperty.market_value.asc()).all()
+        results = (
+            ChambersProperty.query.filter(
+                *base_filters,
+            )
+            .order_by(ChambersProperty.market_value.asc())
+            .all()
+        )
         return [_chambers_to_dict(r) for r in results]
 
-    elif source == 'hcad':
+    elif source == "hcad":
         if not subdivision:
             return []
 
         if fuzzy_subdivision:
-            sub_filter = HcadProperty.lgl_2.ilike(f'%{subdivision}%')
+            sub_filter = HcadProperty.lgl_2.ilike(f"%{subdivision}%")
         else:
-            sub_filter = (HcadProperty.lgl_2 == subdivision)
+            sub_filter = HcadProperty.lgl_2 == subdivision
 
         def _hcad_query(use_zip):
-            q = db.session.query(
-                HcadProperty,
-                db.func.max(HcadBuilding.im_sq_ft).label('max_sq_ft')
-            ).join(
-                HcadBuilding, HcadProperty.acct == HcadBuilding.acct
-            ).filter(
-                sub_filter,
-                HcadProperty.tot_mkt_val.isnot(None),
-                HcadProperty.tot_mkt_val > 0,
-                HcadProperty.tot_mkt_val < market_value,
-                HcadProperty.site_addr_1.isnot(None),
-                HcadProperty.site_addr_1 != '',
-                HcadProperty.str_num.isnot(None),
-                HcadProperty.str_num != '0',
-                HcadBuilding.im_sq_ft.isnot(None),
-                HcadBuilding.im_sq_ft > 0,
+            q = (
+                db.session.query(
+                    HcadProperty, db.func.max(HcadBuilding.im_sq_ft).label("max_sq_ft")
+                )
+                .join(HcadBuilding, HcadProperty.acct == HcadBuilding.acct)
+                .filter(
+                    sub_filter,
+                    HcadProperty.tot_mkt_val.isnot(None),
+                    HcadProperty.tot_mkt_val > 0,
+                    HcadProperty.tot_mkt_val < market_value,
+                    HcadProperty.site_addr_1.isnot(None),
+                    HcadProperty.site_addr_1 != "",
+                    HcadProperty.str_num.isnot(None),
+                    HcadProperty.str_num != "0",
+                    HcadBuilding.im_sq_ft.isnot(None),
+                    HcadBuilding.im_sq_ft > 0,
+                )
             )
             if use_zip and zip_code:
                 q = q.filter(HcadProperty.site_addr_3 == zip_code)
@@ -503,232 +552,431 @@ def find_comparables(subdivision, zip_code, market_value, source,
 
         return [_hcad_to_dict(prop, sq_ft) for prop, sq_ft in results]
 
-    elif source == 'liberty':
+    elif source == "liberty":
         if not subdivision_code:
             return []
 
-        profile = LibertyCodeProfile.query.filter_by(abs_subdv_cd=subdivision_code).first()
-        strategy = profile.strategy if profile and profile.strategy else 'strict'
-        if strategy == 'reject':
+        profile = LibertyCodeProfile.query.filter_by(
+            abs_subdv_cd=subdivision_code
+        ).first()
+        strategy = profile.strategy if profile and profile.strategy else "strict"
+        if strategy == "reject":
             return []
 
-        base_filters = [
-            LibertyProperty.is_residential_home.is_(True),
-            LibertyProperty.abs_subdv_cd == subdivision_code,
-            LibertyProperty.market_value.isnot(None),
-            LibertyProperty.market_value > 0,
-            LibertyProperty.market_value < market_value,
-            LibertyProperty.site_addr_1.isnot(None),
-            LibertyProperty.site_addr_1 != '',
-        ]
+        results = _liberty_comparable_query(
+            subdivision_code,
+            market_value,
+            strategy,
+            zip_code,
+            main_acreage,
+            use_zip=True,
+        )
+        if not results:
+            results = _liberty_comparable_query(
+                subdivision_code,
+                market_value,
+                strategy,
+                zip_code,
+                main_acreage,
+                use_zip=False,
+            )
 
-        def _liberty_query(use_zip):
-            q = LibertyProperty.query.filter(*base_filters)
-            if use_zip and zip_code:
-                q = q.filter(LibertyProperty.situs_zip == zip_code)
-
-            if strategy == 'strict':
-                if main_sq_ft and main_sq_ft > 0:
-                    q = q.filter(
-                        LibertyProperty.sq_ft.isnot(None),
-                        LibertyProperty.sq_ft.between(
-                            max(0, main_sq_ft - 300),
-                            main_sq_ft + 300,
-                        )
+        if len(results) < MIN_COMPARABLES:
+            sibling_codes = _find_liberty_sibling_codes(subdivision_code)
+            if sibling_codes:
+                logger.info(
+                    "Liberty %s returned %d comparables, expanding to siblings: %s",
+                    subdivision_code,
+                    len(results),
+                    sibling_codes,
+                )
+                for sibling_cd in sibling_codes:
+                    sibling_profile = LibertyCodeProfile.query.filter_by(
+                        abs_subdv_cd=sibling_cd
+                    ).first()
+                    sibling_strategy = (
+                        sibling_profile.strategy
+                        if sibling_profile and sibling_profile.strategy
+                        else "strict"
                     )
-                if main_acreage and main_acreage > 0:
-                    tol = min(5.0, max(0.25, main_acreage * 0.5))
-                    q = q.filter(
-                        LibertyProperty.legal_acreage.isnot(None),
-                        LibertyProperty.legal_acreage.between(
-                            max(0, main_acreage - tol),
-                            main_acreage + tol,
-                        )
+                    if sibling_strategy == "reject":
+                        continue
+                    sibling_results = _liberty_comparable_query(
+                        sibling_cd,
+                        market_value,
+                        sibling_strategy,
+                        zip_code,
+                        main_acreage,
+                        use_zip=True,
                     )
+                    if not sibling_results:
+                        sibling_results = _liberty_comparable_query(
+                            sibling_cd,
+                            market_value,
+                            sibling_strategy,
+                            zip_code,
+                            main_acreage,
+                            use_zip=False,
+                        )
+                    results.extend(sibling_results)
+                    if len(results) >= MIN_COMPARABLES:
+                        break
 
-            return q.order_by(LibertyProperty.market_value.asc()).all()
-
-        results = _liberty_query(use_zip=True)
-        if results:
-            return [_liberty_to_dict(r) for r in results]
-
-        results = _liberty_query(use_zip=False)
         return [_liberty_to_dict(r) for r in results]
 
-    elif source == 'fort_bend':
+    elif source == "fort_bend":
         if not subdivision_code:
             return []
 
-        base_filters = [
-            FortBendProperty.is_residential_home.is_(True),
-            FortBendProperty.nbhd_code == subdivision_code,
-            FortBendProperty.market_value.isnot(None),
-            FortBendProperty.market_value > 0,
-            FortBendProperty.market_value < market_value,
-            FortBendProperty.site_addr_1.isnot(None),
-            FortBendProperty.site_addr_1 != '',
-        ]
+        results = _fort_bend_comparable_query(
+            subdivision_code,
+            market_value,
+            main_sq_ft,
+            zip_code,
+            use_zip=True,
+        )
+        if not results:
+            results = _fort_bend_comparable_query(
+                subdivision_code,
+                market_value,
+                main_sq_ft,
+                zip_code,
+                use_zip=False,
+            )
 
-        def _fort_bend_query(use_zip):
-            q = FortBendProperty.query.filter(*base_filters)
-            if use_zip and zip_code:
-                q = q.filter(FortBendProperty.situs_zip == zip_code)
-            if main_sq_ft and main_sq_ft > 0:
-                q = q.filter(
-                    FortBendProperty.sq_ft.isnot(None),
-                    FortBendProperty.sq_ft.between(
-                        max(0, main_sq_ft - SQ_FT_RANGE),
-                        main_sq_ft + SQ_FT_RANGE,
-                    )
+        if len(results) < MIN_COMPARABLES:
+            sibling_codes = _find_fort_bend_sibling_codes(subdivision_code)
+            if sibling_codes:
+                logger.info(
+                    "Fort Bend %s returned %d comparables, expanding to siblings: %s",
+                    subdivision_code,
+                    len(results),
+                    sibling_codes,
                 )
-            return q.order_by(FortBendProperty.market_value.asc()).all()
+                for sibling_cd in sibling_codes:
+                    sibling_results = _fort_bend_comparable_query(
+                        sibling_cd,
+                        market_value,
+                        main_sq_ft,
+                        zip_code,
+                        use_zip=True,
+                    )
+                    if not sibling_results:
+                        sibling_results = _fort_bend_comparable_query(
+                            sibling_cd,
+                            market_value,
+                            main_sq_ft,
+                            zip_code,
+                            use_zip=False,
+                        )
+                    results.extend(sibling_results)
+                    if len(results) >= MIN_COMPARABLES:
+                        break
 
-        results = _fort_bend_query(use_zip=True)
-        if results:
-            return [_fort_bend_to_dict(r) for r in results]
-
-        results = _fort_bend_query(use_zip=False)
         return [_fort_bend_to_dict(r) for r in results]
 
     return []
 
 
+_SUBDIVISION_SECTION_RE = re.compile(
+    r",\s*SEC(?:TION)?\s*\d+"
+    r"|,\s*SEC\s*\d+"
+    r"|\s+SEC(?:TION)?\s+\d+"
+    r"$",
+    re.IGNORECASE,
+)
+
+
+def _extract_base_subdivision_name(desc):
+    """Strip section suffixes like ', SEC 4' or ' SECTION 2' from a subdivision name."""
+    if not desc:
+        return ""
+    return _SUBDIVISION_SECTION_RE.sub("", desc).strip()
+
+
+def _find_liberty_sibling_codes(subdivision_code):
+    """Find other subdivision codes that share the same base subdivision name.
+
+    Liberty County splits one subdivision into multiple codes by section (e.g.,
+    'RAVEN HILL RANCH' vs 'RAVEN HILL RANCH, SEC 4'). When a code has very few
+    homes and returns 0 comparables, expand the search to sibling sections.
+    """
+    main_record = LibertyProperty.query.filter(
+        LibertyProperty.abs_subdv_cd == subdivision_code,
+        LibertyProperty.is_residential_home.is_(True),
+    ).first()
+    if not main_record or not main_record.abs_subdv_desc:
+        return []
+
+    base_name = _extract_base_subdivision_name(main_record.abs_subdv_desc)
+    if not base_name:
+        return []
+
+    pattern = f"{base_name}%"
+    sibling_rows = (
+        db.session.query(
+            LibertyProperty.abs_subdv_cd,
+        )
+        .filter(
+            LibertyProperty.abs_subdv_desc.ilike(pattern),
+            LibertyProperty.abs_subdv_cd != subdivision_code,
+            LibertyProperty.is_residential_home.is_(True),
+        )
+        .distinct()
+        .all()
+    )
+
+    return [row[0] for row in sibling_rows]
+
+
+def _liberty_comparable_query(
+    subdivision_code, market_value, strategy, zip_code, main_acreage, use_zip
+):
+    """Execute a Liberty County comparable property query."""
+    base_filters = [
+        LibertyProperty.is_residential_home.is_(True),
+        LibertyProperty.abs_subdv_cd == subdivision_code,
+        LibertyProperty.market_value.isnot(None),
+        LibertyProperty.market_value > 0,
+        LibertyProperty.market_value < market_value,
+        LibertyProperty.site_addr_1.isnot(None),
+        LibertyProperty.site_addr_1 != "",
+    ]
+
+    q = LibertyProperty.query.filter(*base_filters)
+    if use_zip and zip_code:
+        q = q.filter(LibertyProperty.situs_zip == zip_code)
+
+    if strategy == "strict":
+        if main_acreage and main_acreage > 0:
+            tol = min(5.0, max(0.25, main_acreage * 0.5))
+            q = q.filter(
+                LibertyProperty.legal_acreage.isnot(None),
+                LibertyProperty.legal_acreage.between(
+                    max(0, main_acreage - tol),
+                    main_acreage + tol,
+                ),
+            )
+
+    return q.order_by(LibertyProperty.market_value.asc()).all()
+
+
+def _find_fort_bend_sibling_codes(subdivision_code):
+    """Find other neighborhood codes sharing the same base neighborhood name.
+
+    Uses nbhd_desc to find sibling sections (e.g. 'SIENNA PLANTATION SEC 1'
+    and 'SIENNA PLANTATION SEC 2').
+    """
+    main_record = FortBendProperty.query.filter(
+        FortBendProperty.nbhd_code == subdivision_code,
+        FortBendProperty.is_residential_home.is_(True),
+    ).first()
+    if not main_record or not main_record.nbhd_desc:
+        return []
+
+    base_name = _extract_base_subdivision_name(main_record.nbhd_desc)
+    if not base_name:
+        return []
+
+    pattern = f"{base_name}%"
+    sibling_rows = (
+        db.session.query(
+            FortBendProperty.nbhd_code,
+        )
+        .filter(
+            FortBendProperty.nbhd_desc.ilike(pattern),
+            FortBendProperty.nbhd_code != subdivision_code,
+            FortBendProperty.is_residential_home.is_(True),
+        )
+        .distinct()
+        .all()
+    )
+
+    return [row[0] for row in sibling_rows]
+
+
+def _fort_bend_comparable_query(
+    subdivision_code, market_value, main_sq_ft, zip_code, use_zip
+):
+    """Execute a Fort Bend County comparable property query."""
+    base_filters = [
+        FortBendProperty.is_residential_home.is_(True),
+        FortBendProperty.nbhd_code == subdivision_code,
+        FortBendProperty.market_value.isnot(None),
+        FortBendProperty.market_value > 0,
+        FortBendProperty.market_value < market_value,
+        FortBendProperty.site_addr_1.isnot(None),
+        FortBendProperty.site_addr_1 != "",
+    ]
+
+    q = FortBendProperty.query.filter(*base_filters)
+    if use_zip and zip_code:
+        q = q.filter(FortBendProperty.situs_zip == zip_code)
+    if main_sq_ft and main_sq_ft > 0:
+        q = q.filter(
+            FortBendProperty.sq_ft.isnot(None),
+            FortBendProperty.sq_ft.between(
+                max(0, main_sq_ft - SQ_FT_RANGE),
+                main_sq_ft + SQ_FT_RANGE,
+            ),
+        )
+    return q.order_by(FortBendProperty.market_value.asc()).all()
+
+
 def _chambers_to_dict(record):
     """Convert a ChambersProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'chambers',
-        'address': f"{record.prop_street_number or ''} {record.prop_street or ''}".strip(),
-        'full_address': f"{record.prop_street_number or ''} {record.prop_street or ''} {record.prop_street_dir or ''}".strip(),
-        'city': record.prop_city,
-        'zip': record.prop_zip5,
-        'market_value': record.market_value,
-        'legal1': record.legal1,
-        'legal2': record.legal2,
-        'legal3': record.legal3,
-        'legal4': record.legal4,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.acres) if record.acres else None,
-        'parcel_id': record.parcel_id,
-        'account': record.account,
+        "id": record.id,
+        "source": "chambers",
+        "address": f"{record.prop_street_number or ''} {record.prop_street or ''}".strip(),
+        "full_address": f"{record.prop_street_number or ''} {record.prop_street or ''} {record.prop_street_dir or ''}".strip(),
+        "city": record.prop_city,
+        "zip": record.prop_zip5,
+        "market_value": record.market_value,
+        "legal1": record.legal1,
+        "legal2": record.legal2,
+        "legal3": record.legal3,
+        "legal4": record.legal4,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.acres) if record.acres else None,
+        "parcel_id": record.parcel_id,
+        "account": record.account,
     }
 
 
 def _hcad_to_dict(record, sq_ft=None):
     """Convert an HcadProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'hcad',
-        'address': record.site_addr_1 or f"{record.str_num or ''} {record.str or ''}".strip(),
-        'full_address': record.site_addr_1 or '',
-        'city': record.site_addr_2,
-        'zip': record.site_addr_3,
-        'market_value': record.tot_mkt_val,
-        'legal1': record.lgl_1,
-        'legal2': record.lgl_2,
-        'legal3': record.lgl_3,
-        'legal4': record.lgl_4,
-        'sq_ft': sq_ft,
-        'acreage': float(record.acreage) if record.acreage else None,
-        'parcel_id': None,
-        'account': record.acct,
-        'neighborhood_code': record.neighborhood_code,
-        'subdivision': record.lgl_2,
+        "id": record.id,
+        "source": "hcad",
+        "address": record.site_addr_1
+        or f"{record.str_num or ''} {record.str or ''}".strip(),
+        "full_address": record.site_addr_1 or "",
+        "city": record.site_addr_2,
+        "zip": record.site_addr_3,
+        "market_value": record.tot_mkt_val,
+        "legal1": record.lgl_1,
+        "legal2": record.lgl_2,
+        "legal3": record.lgl_3,
+        "legal4": record.lgl_4,
+        "sq_ft": sq_ft,
+        "acreage": float(record.acreage) if record.acreage else None,
+        "parcel_id": None,
+        "account": record.acct,
+        "neighborhood_code": record.neighborhood_code,
+        "subdivision": record.lgl_2,
     }
 
 
 def _liberty_to_dict(record):
     """Convert a LibertyProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'liberty',
-        'address': record.site_addr_1 or ' '.join(
-            part for part in [record.situs_num, record.situs_street_prefx, record.situs_street, record.situs_street_suffix]
+        "id": record.id,
+        "source": "liberty",
+        "address": record.site_addr_1
+        or " ".join(
+            part
+            for part in [
+                record.situs_num,
+                record.situs_street_prefx,
+                record.situs_street,
+                record.situs_street_suffix,
+            ]
             if part
         ).strip(),
-        'full_address': record.site_addr_1 or '',
-        'city': record.situs_city,
-        'zip': record.situs_zip,
-        'market_value': record.market_value,
-        'legal1': record.legal_desc,
-        'legal2': record.abs_subdv_desc,
-        'legal3': record.legal_desc2,
-        'legal4': None,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.legal_acreage) if record.legal_acreage else None,
-        'parcel_id': record.prop_id,
-        'account': record.geo_id,
-        'subdivision': record.abs_subdv_desc,
-        'subdivision_code': record.abs_subdv_cd,
+        "full_address": record.site_addr_1 or "",
+        "city": record.situs_city,
+        "zip": record.situs_zip,
+        "market_value": record.market_value,
+        "legal1": record.legal_desc,
+        "legal2": record.abs_subdv_desc,
+        "legal3": record.legal_desc2,
+        "legal4": None,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.legal_acreage) if record.legal_acreage else None,
+        "parcel_id": record.prop_id,
+        "account": record.geo_id,
+        "subdivision": record.abs_subdv_desc,
+        "subdivision_code": record.abs_subdv_cd,
     }
 
 
 def _fort_bend_to_dict(record):
     """Convert a FortBendProperty to a display dict."""
     return {
-        'id': record.id,
-        'source': 'fort_bend',
-        'address': record.site_addr_1 or record.situs or '',
-        'full_address': record.site_addr_1 or record.situs or '',
-        'city': record.situs_city,
-        'zip': record.situs_zip,
-        'market_value': record.market_value,
-        'legal1': record.legal_desc,
-        'legal2': record.nbhd_desc,
-        'legal3': record.legal_location_desc,
-        'legal4': None,
-        'sq_ft': record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
-        'acreage': float(record.acreage) if record.acreage else (
-            float(record.legal_acres) if record.legal_acres else None
-        ),
-        'parcel_id': record.property_id,
-        'account': record.property_number,
-        'subdivision': record.nbhd_desc,
-        'subdivision_code': record.nbhd_code,
+        "id": record.id,
+        "source": "fort_bend",
+        "address": record.site_addr_1 or record.situs or "",
+        "full_address": record.site_addr_1 or record.situs or "",
+        "city": record.situs_city,
+        "zip": record.situs_zip,
+        "market_value": record.market_value,
+        "legal1": record.legal_desc,
+        "legal2": record.nbhd_desc,
+        "legal3": record.legal_location_desc,
+        "legal4": None,
+        "sq_ft": record.sq_ft if record.sq_ft and record.sq_ft > 0 else None,
+        "acreage": float(record.acreage)
+        if record.acreage
+        else (float(record.legal_acres) if record.legal_acres else None),
+        "parcel_id": record.property_id,
+        "account": record.property_number,
+        "subdivision": record.nbhd_desc,
+        "subdivision_code": record.nbhd_code,
     }
 
 
-def cache_search_result(source, subdivision, main_property_id, contact_id,
-                        zip_code, neighborhood_code=None, main_sq_ft=None,
-                        fuzzy_subdivision=False, subdivision_code=None,
-                        main_acreage=None):
+def cache_search_result(
+    source,
+    subdivision,
+    main_property_id,
+    contact_id,
+    zip_code,
+    neighborhood_code=None,
+    main_sq_ft=None,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    main_acreage=None,
+):
     """Store search params in Flask session for CSV download consistency."""
-    session['tax_protest_result'] = {
-        'source': source,
-        'subdivision': subdivision,
-        'main_property_id': main_property_id,
-        'contact_id': contact_id,
-        'zip_code': zip_code,
-        'neighborhood_code': neighborhood_code,
-        'subdivision_code': subdivision_code,
-        'main_sq_ft': main_sq_ft,
-        'main_acreage': main_acreage,
-        'fuzzy_subdivision': fuzzy_subdivision,
+    session["tax_protest_result"] = {
+        "source": source,
+        "subdivision": subdivision,
+        "main_property_id": main_property_id,
+        "contact_id": contact_id,
+        "zip_code": zip_code,
+        "neighborhood_code": neighborhood_code,
+        "subdivision_code": subdivision_code,
+        "main_sq_ft": main_sq_ft,
+        "main_acreage": main_acreage,
+        "fuzzy_subdivision": fuzzy_subdivision,
     }
 
 
 def get_cached_search_result():
     """Retrieve cached search params from Flask session."""
-    return session.get('tax_protest_result')
+    return session.get("tax_protest_result")
 
 
 def get_main_property_by_id(property_id, source):
     """Load a single property record by its ID and source."""
-    if source == 'chambers':
+    if source == "chambers":
         record = ChambersProperty.query.get(property_id)
         return _chambers_to_dict(record) if record else None
-    elif source == 'hcad':
+    elif source == "hcad":
         record = HcadProperty.query.get(property_id)
         if not record:
             return None
-        sq_ft = db.session.query(db.func.max(HcadBuilding.im_sq_ft)).filter(
-            HcadBuilding.acct == record.acct
-        ).scalar()
+        sq_ft = (
+            db.session.query(db.func.max(HcadBuilding.im_sq_ft))
+            .filter(HcadBuilding.acct == record.acct)
+            .scalar()
+        )
         return _hcad_to_dict(record, sq_ft)
-    elif source == 'liberty':
+    elif source == "liberty":
         record = LibertyProperty.query.get(property_id)
         return _liberty_to_dict(record) if record else None
-    elif source == 'fort_bend':
+    elif source == "fort_bend":
         record = FortBendProperty.query.get(property_id)
         return _fort_bend_to_dict(record) if record else None
     return None

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -441,6 +441,139 @@ def get_neighborhood_name(neighborhood_code):
     return nc.dscr if nc else None
 
 
+def get_subdivision_stats(
+    subdivision,
+    zip_code,
+    market_value,
+    source,
+    fuzzy_subdivision=False,
+    subdivision_code=None,
+    sibling_codes=None,
+):
+    """Compute subdivision-level statistics for the subject property.
+
+    Returns dict with:
+      total_homes: total residential homes in the subdivision
+      lower_values: how many have a lower market value
+      higher_values: how many have a higher market value
+      percentile: where the subject falls (e.g. 90 means 90% of homes are cheaper)
+      value_distribution: list of {label, count} buckets for charting
+    """
+    if source == "liberty" and subdivision_code:
+        codes = [subdivision_code]
+        if not sibling_codes:
+            sibling_codes = _find_liberty_sibling_codes(subdivision_code)
+        if sibling_codes:
+            codes.extend(sibling_codes)
+        rows = (
+            LibertyProperty.query.filter(
+                LibertyProperty.is_residential_home.is_(True),
+                LibertyProperty.market_value.isnot(None),
+                LibertyProperty.market_value > 0,
+                LibertyProperty.abs_subdv_cd.in_(codes),
+            )
+            .with_entities(
+                LibertyProperty.market_value,
+            )
+            .order_by(LibertyProperty.market_value.asc())
+            .all()
+        )
+    elif source == "fort_bend" and subdivision_code:
+        codes = [subdivision_code]
+        if not sibling_codes:
+            sibling_codes = _find_fort_bend_sibling_codes(subdivision_code)
+        if sibling_codes:
+            codes.extend(sibling_codes)
+        rows = (
+            FortBendProperty.query.filter(
+                FortBendProperty.is_residential_home.is_(True),
+                FortBendProperty.market_value.isnot(None),
+                FortBendProperty.market_value > 0,
+                FortBendProperty.nbhd_code.in_(codes),
+            )
+            .with_entities(
+                FortBendProperty.market_value,
+            )
+            .order_by(FortBendProperty.market_value.asc())
+            .all()
+        )
+    elif source == "hcad" and subdivision:
+        if fuzzy_subdivision:
+            sub_filter = HcadProperty.lgl_2.ilike(f"%{subdivision}%")
+        else:
+            sub_filter = HcadProperty.lgl_2 == subdivision
+        rows = (
+            HcadProperty.query.filter(
+                sub_filter,
+                HcadProperty.tot_mkt_val.isnot(None),
+                HcadProperty.tot_mkt_val > 0,
+            )
+            .with_entities(
+                HcadProperty.tot_mkt_val,
+            )
+            .order_by(HcadProperty.tot_mkt_val.asc())
+            .all()
+        )
+    elif source == "chambers" and subdivision:
+        rows = (
+            ChambersProperty.query.filter(
+                ChambersProperty.legal1.ilike(f"%{subdivision}%"),
+                ChambersProperty.market_value.isnot(None),
+                ChambersProperty.market_value > 0,
+            )
+            .with_entities(
+                ChambersProperty.market_value,
+            )
+            .order_by(ChambersProperty.market_value.asc())
+            .all()
+        )
+    else:
+        return None
+
+    values = [int(r[0]) for r in rows if r[0] is not None]
+    sorted_values = sorted(values)
+    total_homes = len(sorted_values)
+    lower_values = sum(1 for v in sorted_values if v < market_value)
+    higher_values = sum(1 for v in sorted_values if v > market_value)
+    percentile = (
+        round((lower_values / total_homes) * 100, 1) if total_homes > 0 else None
+    )
+
+    return {
+        "total_homes": total_homes,
+        "lower_values": lower_values,
+        "higher_values": higher_values,
+        "percentile": percentile,
+        "value_distribution": _bucket_values(sorted_values),
+        "min_value": sorted_values[0] if sorted_values else None,
+        "max_value": sorted_values[-1] if sorted_values else None,
+        "median_value": (
+            sorted_values[len(sorted_values) // 2] if sorted_values else None
+        ),
+    }
+
+
+def _bucket_values(values, num_buckets=8):
+    """Return evenly sized buckets across the full observed value range."""
+    if not values:
+        return []
+    min_val = min(values)
+    max_val = max(values)
+    if min_val == max_val:
+        return [{"label": f"${min_val / 1000:.0f}k", "count": len(values)}]
+    bucket_size = (max_val - min_val) / num_buckets
+    buckets = []
+    for i in range(num_buckets):
+        lo = min_val + i * bucket_size
+        hi = lo + bucket_size
+        if i == num_buckets - 1:
+            count = sum(1 for v in values if lo <= v <= hi)
+        else:
+            count = sum(1 for v in values if lo <= v < hi)
+        buckets.append({"label": f"${lo / 1000:.0f}k", "count": count})
+    return buckets
+
+
 def find_comparables(
     subdivision,
     zip_code,

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -24,14 +24,13 @@
                         <i class="fas fa-times"></i>
                     </button>
                 </div>
-                <!-- Dropdown results -->
                 <div id="searchDropdown"
                      class="absolute z-50 w-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto hidden">
                 </div>
             </div>
         </div>
 
-        <!-- Loading Spinner -->
+        <!-- Loading -->
         <div id="loadingState" class="hidden">
             <div class="premium-card p-12 text-center">
                 <div class="inline-flex items-center gap-3 text-slate-500">
@@ -44,7 +43,7 @@
             </div>
         </div>
 
-        <!-- Error State -->
+        <!-- Error -->
         <div id="errorState" class="hidden">
             <div class="premium-card p-6 border-l-4 border-red-400">
                 <div class="flex items-start gap-3">
@@ -57,9 +56,10 @@
             </div>
         </div>
 
-        <!-- Results Section -->
+        <!-- Results -->
         <div id="resultsSection" class="hidden">
-            <!-- Main Property Card -->
+
+            <!-- Subject Property -->
             <div class="premium-card p-5 mb-4 bg-amber-50/60 border border-amber-200/60">
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
                     <div>
@@ -91,16 +91,51 @@
                 </div>
             </div>
 
-            <!-- Results Count + Actions -->
+            <!-- Neighborhood Position Chart -->
+            <div id="statsCard" class="hidden premium-card mb-4 overflow-hidden">
+                <div class="flex items-center justify-between px-5 py-3 border-b border-slate-100">
+                    <div class="flex items-center gap-2.5">
+                        <i class="fas fa-chart-bar text-orange-500 text-sm"></i>
+                        <span class="text-sm font-semibold text-slate-700">Neighborhood Position</span>
+                        <span id="statsPctBadge" class="hidden rounded-full px-2.5 py-0.5 text-xs font-semibold"></span>
+                    </div>
+                    <span id="statsSubdivisionLabel" class="text-xs text-slate-400 truncate max-w-xs text-right"></span>
+                </div>
+                <div class="px-5 pt-4 pb-5">
+                    <!-- Summary row: ring + legend -->
+                    <div class="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-5 mb-5">
+                        <!-- Animated percentile ring -->
+                        <div class="flex-none flex flex-col items-center">
+                            <div class="relative w-16 h-16">
+                                <svg viewBox="0 0 100 100" width="64" height="64" class="-rotate-90">
+                                    <circle cx="50" cy="50" r="40" fill="none" stroke="#f1f5f9" stroke-width="14"/>
+                                    <circle id="statsRingFg" cx="50" cy="50" r="40" fill="none"
+                                            stroke="#10b981" stroke-width="14" stroke-linecap="round"
+                                            stroke-dasharray="251.33" stroke-dashoffset="251.33"
+                                            style="transition:stroke-dashoffset 0.9s ease,stroke 0.4s ease"/>
+                                </svg>
+                                <div class="absolute inset-0 flex flex-col items-center justify-center">
+                                    <span id="statsPercentilePct" class="text-base font-bold text-slate-900 leading-none tabular-nums"></span>
+                                    <span class="text-[8px] text-slate-400 font-medium mt-0.5">pctile</span>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Legend chips -->
+                        <div id="statsLine" class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm"></div>
+                    </div>
+                    <!-- Chart -->
+                    <div id="statsChartWrap" class="w-full"></div>
+                </div>
+            </div>
+
+            <!-- Count + Actions -->
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
                 <p id="resultsCount" class="text-sm text-slate-600"></p>
                 <div class="flex items-center gap-2">
-                    <a id="downloadBtn" href="#"
-                       class="crm-btn crm-btn-primary text-sm">
+                    <a id="downloadBtn" href="#" class="crm-btn crm-btn-primary text-sm">
                         <i class="fas fa-download text-xs mr-1"></i> Download CSV
                     </a>
-                    <button type="button" id="clearResults"
-                            class="crm-btn crm-btn-secondary text-sm">
+                    <button type="button" id="clearResults" class="crm-btn crm-btn-secondary text-sm">
                         <i class="fas fa-times text-xs mr-1"></i> Clear
                     </button>
                 </div>
@@ -133,70 +168,246 @@
                             <th>Legal Description</th>
                         </tr>
                     </thead>
-                    <tbody id="comparablesBody">
-                    </tbody>
+                    <tbody id="comparablesBody"></tbody>
                 </table>
             </div>
 
             <!-- Mobile Cards -->
-            <div id="mobileCards" class="md:hidden space-y-3 mt-4">
-            </div>
+            <div id="mobileCards" class="md:hidden space-y-3 mt-4"></div>
         </div>
     </div>
 </div>
 
 <script>
-(function() {
-    const searchInput = document.getElementById('contactSearch');
-    const searchDropdown = document.getElementById('searchDropdown');
-    const clearSearchBtn = document.getElementById('clearSearch');
-    const loadingState = document.getElementById('loadingState');
-    const errorState = document.getElementById('errorState');
-    const resultsSection = document.getElementById('resultsSection');
+(function () {
+    // ─── State ───────────────────────────────────────────────────────────
     let searchTimeout;
     let sortAsc = true;
     let currentComparables = [];
     let currentMainProperty = null;
 
-    function fmt(val) {
-        if (val == null || val === '') return '—';
-        return '$' + Number(val).toLocaleString();
+    const searchInput    = document.getElementById('contactSearch');
+    const searchDropdown = document.getElementById('searchDropdown');
+    const clearSearchBtn = document.getElementById('clearSearch');
+    const loadingState   = document.getElementById('loadingState');
+    const errorState     = document.getElementById('errorState');
+    const resultsSection = document.getElementById('resultsSection');
+
+    // ─── Formatters ──────────────────────────────────────────────────────
+    function fmt(v) {
+        if (v == null || v === '') return '—';
+        return '$' + Number(v).toLocaleString();
+    }
+    function fmtNum(v) {
+        if (v == null || v === '') return '—';
+        return Number(v).toLocaleString();
+    }
+    function fmtK(v) {
+        if (v == null) return '';
+        if (Math.abs(v) >= 1000000) return '$' + (v / 1000000).toFixed(1) + 'M';
+        return '$' + Math.round(v / 1000) + 'k';
+    }
+    function ordinalSuffix(v) {
+        var abs = Math.abs(Number(v));
+        var mod100 = abs % 100;
+        if (mod100 >= 11 && mod100 <= 13) return 'th';
+        switch (abs % 10) {
+            case 1: return 'st';
+            case 2: return 'nd';
+            case 3: return 'rd';
+            default: return 'th';
+        }
     }
 
-    function fmtNum(val) {
-        if (val == null || val === '') return '—';
-        return Number(val).toLocaleString();
-    }
+    // ─── Chart ───────────────────────────────────────────────────────────
+    function buildChart(dist, subjectValue, minVal, maxVal) {
+        if (!dist || dist.length === 0 || minVal == null || maxVal == null) return '';
 
-    // Debounced contact search
-    searchInput.addEventListener('input', function() {
-        const q = this.value.trim();
-        clearSearchBtn.classList.toggle('hidden', !q);
+        // SVG coordinate space
+        const W = 600, H = 170;
+        const PAD = { t: 28, r: 10, b: 28, l: 10 };
+        const cW = W - PAD.l - PAD.r;
+        const cH = H - PAD.t - PAD.b;
+        const n = dist.length;
+        const maxCnt = Math.max.apply(null, dist.map(function (b) { return b.count; })) || 1;
+        const range = maxVal > minVal ? maxVal - minVal : 1;
+        const bW = cW / n;
+        const bucketSize = range / n;
+        const barBottom = PAD.t + cH;
 
-        clearTimeout(searchTimeout);
-        if (q.length < 2) {
-            searchDropdown.classList.add('hidden');
-            return;
+        // Which bucket holds the subject?
+        var subjectIdx = Math.floor((subjectValue - minVal) / bucketSize);
+        subjectIdx = Math.max(0, Math.min(n - 1, subjectIdx));
+
+        // Subject vertical line X (exact value position)
+        var rawX = PAD.l + cW * (subjectValue - minVal) / range;
+        var mX = Math.max(PAD.l + 4, Math.min(W - PAD.r - 4, rawX));
+        var anchor = mX > W * 0.72 ? 'end' : mX < W * 0.28 ? 'start' : 'middle';
+
+        // ── Bars ─────────────────────────────────────────────────────────
+        var bars = '';
+        for (var i = 0; i < n; i++) {
+            var b = dist[i];
+            var x = PAD.l + i * bW;
+            var gap = Math.max(2, bW * 0.1);
+            var bH = b.count > 0 ? Math.max(8, cH * b.count / maxCnt) : 0;
+            var y = barBottom - bH;
+
+            // Color: green (cheaper), amber (subject bucket), slate (pricier)
+            var fill = i < subjectIdx  ? '#34d399'
+                     : i === subjectIdx ? '#fbbf24'
+                     :                   '#cbd5e1';
+
+            bars += '<rect'
+                + ' x="' + (x + gap).toFixed(1) + '"'
+                + ' y="' + y.toFixed(1) + '"'
+                + ' width="' + Math.max(2, bW - 2 * gap).toFixed(1) + '"'
+                + ' height="' + bH.toFixed(1) + '"'
+                + ' rx="4" fill="' + fill + '"/>';
+
+            // Count label — above bar, vertically clamped so it doesn't go off top
+            if (b.count > 0) {
+                var countY = Math.max(14, y - 6);
+                bars += '<text'
+                    + ' x="' + (x + bW / 2).toFixed(1) + '"'
+                    + ' y="' + countY.toFixed(1) + '"'
+                    + ' text-anchor="middle" font-size="12" fill="#475569" font-weight="600">'
+                    + b.count + '</text>';
+            }
         }
 
-        searchTimeout = setTimeout(() => {
-            fetch(`/tax-protest/search-contacts?q=${encodeURIComponent(q)}`)
-                .then(r => r.json())
-                .then(contacts => {
+        // ── Axis labels (first, last, + one mid if space) ────────────────
+        var axis = '';
+        // First bucket
+        axis += '<text x="' + (PAD.l + bW / 2).toFixed(1) + '" y="' + (H - 4)
+              + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + dist[0].label + '</text>';
+        // Last bucket
+        axis += '<text x="' + (PAD.l + (n - 0.5) * bW).toFixed(1) + '" y="' + (H - 4)
+              + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + fmtK(maxVal) + '</text>';
+        // Middle bucket (skip if too close to subject label)
+        var midI = Math.floor(n / 2);
+        if (Math.abs(midI - subjectIdx) > 1 && Math.abs(n - midI) > 1 && midI !== 0) {
+            var midX = PAD.l + (midI + 0.5) * bW;
+            if (Math.abs(midX - mX) > 50) {
+                axis += '<text x="' + midX.toFixed(1) + '" y="' + (H - 4)
+                      + '" text-anchor="middle" font-size="9" fill="#94a3b8">' + dist[midI].label + '</text>';
+            }
+        }
+
+        // ── Subject marker line + value label ────────────────────────────
+        var marker =
+            // Dashed vertical line
+            '<line'
+            + ' x1="' + mX.toFixed(1) + '" y1="' + PAD.t
+            + '" x2="' + mX.toFixed(1) + '" y2="' + (barBottom + 4).toFixed(1) + '"'
+            + ' stroke="#f59e0b" stroke-width="2" stroke-dasharray="5,3" opacity="0.85"/>'
+            // Small circle at line bottom
+            + '<circle cx="' + mX.toFixed(1) + '" cy="' + (barBottom + 4).toFixed(1)
+            + '" r="3.5" fill="#f59e0b"/>'
+            // Value label just below the circle, above the axis labels
+            + '<text'
+            + ' x="' + mX.toFixed(1) + '"'
+            + ' y="' + (barBottom + 18).toFixed(1) + '"'
+            + ' text-anchor="' + anchor + '"'
+            + ' font-size="10" fill="#b45309" font-weight="700">'
+            + fmtK(subjectValue) + ' \u2191 you'
+            + '</text>';
+
+        return '<svg viewBox="0 0 ' + W + ' ' + H + '" width="100%" height="' + H + '"'
+             + ' style="display:block;overflow:visible">'
+             + bars + axis + marker
+             + '</svg>';
+    }
+
+    // ─── Stats card renderer ──────────────────────────────────────────────
+    function renderStats(stats, subdivision, subjectValue) {
+        var card = document.getElementById('statsCard');
+        if (!stats || !stats.total_homes) { card.classList.add('hidden'); return; }
+
+        var lower  = stats.lower_values  || 0;
+        var higher = stats.higher_values || 0;
+        var total  = stats.total_homes   || 0;
+        var pct    = Math.round(stats.percentile || 0);
+
+        // Subdivision label
+        document.getElementById('statsSubdivisionLabel').textContent =
+            (subdivision || '') + ' \u00B7 ' + total + ' home' + (total === 1 ? '' : 's');
+
+        // Percentile pill in header
+        var pillCls = pct >= 75 ? 'bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200'
+                    : pct >= 50 ? 'bg-amber-100 text-amber-700 ring-1 ring-amber-200'
+                    : pct >= 25 ? 'bg-orange-100 text-orange-700 ring-1 ring-orange-200'
+                    :             'bg-slate-100 text-slate-500 ring-1 ring-slate-200';
+        var pill = document.getElementById('statsPctBadge');
+        pill.className = 'rounded-full px-2.5 py-0.5 text-xs font-semibold ' + pillCls;
+        pill.textContent = pct + ordinalSuffix(pct) + ' percentile';
+        pill.classList.remove('hidden');
+
+        // Animated ring  (r=40, circumference = 2π×40 ≈ 251.33)
+        var CIRC = 251.33;
+        var ringColor = pct >= 75 ? '#10b981' : pct >= 50 ? '#f59e0b' : pct >= 25 ? '#f97316' : '#94a3b8';
+        document.getElementById('statsPercentilePct').textContent = pct + '%';
+        var ring = document.getElementById('statsRingFg');
+        ring.style.stroke = ringColor;
+        ring.style.transition = 'none';
+        ring.style.strokeDashoffset = CIRC.toFixed(2);
+        ring.getBoundingClientRect();
+        ring.style.transition = 'stroke-dashoffset 0.9s ease,stroke 0.4s ease';
+        requestAnimationFrame(function () {
+            ring.style.strokeDashoffset = (CIRC * (1 - pct / 100)).toFixed(2);
+        });
+
+        // Summary legend row
+        document.getElementById('statsLine').innerHTML =
+            '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-emerald-400 flex-none"></span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + lower + '</span>'
+            + '<span class="text-slate-500">cheaper in subdivision</span>'
+            + '</span>'
+            + '<span class="text-slate-300 select-none">\u00B7</span>'
+            + '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-amber-400 flex-none"></span>'
+            + '<span class="text-slate-500">Subject</span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + fmt(subjectValue) + '</span>'
+            + '</span>'
+            + '<span class="text-slate-300 select-none">\u00B7</span>'
+            + '<span class="flex items-center gap-2">'
+            + '<span class="inline-block w-3 h-3 rounded-[3px] bg-slate-300 flex-none"></span>'
+            + '<span class="font-semibold text-slate-800 tabular-nums">' + higher + '</span>'
+            + '<span class="text-slate-500">more expensive</span>'
+            + '</span>';
+
+        // Chart
+        document.getElementById('statsChartWrap').innerHTML =
+            buildChart(stats.value_distribution, subjectValue, stats.min_value, stats.max_value);
+
+        card.classList.remove('hidden');
+    }
+
+    // ─── Contact search ───────────────────────────────────────────────────
+    searchInput.addEventListener('input', function () {
+        var q = this.value.trim();
+        clearSearchBtn.classList.toggle('hidden', !q);
+        clearTimeout(searchTimeout);
+        if (q.length < 2) { searchDropdown.classList.add('hidden'); return; }
+
+        searchTimeout = setTimeout(function () {
+            fetch('/tax-protest/search-contacts?q=' + encodeURIComponent(q))
+                .then(function (r) { return r.json(); })
+                .then(function (contacts) {
                     if (!contacts.length) {
                         searchDropdown.innerHTML = '<div class="px-4 py-3 text-sm text-slate-500">No contacts found</div>';
                     } else {
-                        searchDropdown.innerHTML = contacts.map(c => `
-                            <button type="button"
-                                    class="w-full text-left px-4 py-3 hover:bg-slate-50 border-b border-slate-100 last:border-0"
-                                    data-contact-id="${c.id}">
-                                <div class="font-medium text-slate-800 text-sm">${c.name}</div>
-                                <div class="text-xs text-slate-500 mt-0.5">${c.address || 'No address'}</div>
-                            </button>
-                        `).join('');
-
-                        searchDropdown.querySelectorAll('[data-contact-id]').forEach(btn => {
-                            btn.addEventListener('click', () => {
+                        searchDropdown.innerHTML = contacts.map(function (c) {
+                            return '<button type="button"'
+                                + ' class="w-full text-left px-4 py-3 hover:bg-slate-50 border-b border-slate-100 last:border-0"'
+                                + ' data-contact-id="' + c.id + '">'
+                                + '<div class="font-medium text-slate-800 text-sm">' + c.name + '</div>'
+                                + '<div class="text-xs text-slate-500 mt-0.5">' + (c.address || 'No address') + '</div>'
+                                + '</button>';
+                        }).join('');
+                        searchDropdown.querySelectorAll('[data-contact-id]').forEach(function (btn) {
+                            btn.addEventListener('click', function () {
                                 searchDropdown.classList.add('hidden');
                                 searchInput.value = btn.querySelector('.font-medium').textContent;
                                 runPropertySearch(btn.dataset.contactId);
@@ -208,23 +419,22 @@
         }, 300);
     });
 
-    clearSearchBtn.addEventListener('click', () => {
+    clearSearchBtn.addEventListener('click', function () {
         searchInput.value = '';
         clearSearchBtn.classList.add('hidden');
         searchDropdown.classList.add('hidden');
         hideAll();
     });
 
-    document.getElementById('clearResults').addEventListener('click', () => {
+    document.getElementById('clearResults').addEventListener('click', function () {
         searchInput.value = '';
         clearSearchBtn.classList.add('hidden');
         hideAll();
     });
 
-    document.addEventListener('click', (e) => {
-        if (!document.getElementById('searchContainer').contains(e.target)) {
+    document.addEventListener('click', function (e) {
+        if (!document.getElementById('searchContainer').contains(e.target))
             searchDropdown.classList.add('hidden');
-        }
     });
 
     function hideAll() {
@@ -233,28 +443,27 @@
         resultsSection.classList.add('hidden');
     }
 
+    // ─── Property search ─────────────────────────────────────────────────
     function runPropertySearch(contactId) {
         hideAll();
         loadingState.classList.remove('hidden');
 
         fetch('/tax-protest/search', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({contact_id: contactId}),
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ contact_id: contactId }),
         })
-        .then(r => r.json().then(data => ({status: r.status, data})))
-        .then(({status, data}) => {
+        .then(function (r) { return r.json().then(function (d) { return { status: r.status, data: d }; }); })
+        .then(function (res) {
             loadingState.classList.add('hidden');
-
-            if (status >= 400 || data.error) {
+            if (res.status >= 400 || res.data.error) {
                 errorState.classList.remove('hidden');
-                document.getElementById('errorMessage').textContent = data.error || 'An error occurred';
+                document.getElementById('errorMessage').textContent = res.data.error || 'An error occurred';
                 return;
             }
-
-            displayResults(data);
+            displayResults(res.data);
         })
-        .catch(err => {
+        .catch(function () {
             loadingState.classList.add('hidden');
             errorState.classList.remove('hidden');
             document.getElementById('errorMessage').textContent = 'Network error. Please try again.';
@@ -263,103 +472,91 @@
 
     function displayResults(data) {
         currentMainProperty = data.main_property;
-        currentComparables = data.comparables || [];
-        const county = {
-            chambers: 'Chambers County',
-            hcad: 'Harris County',
-            liberty: 'Liberty County',
-            fort_bend: 'Fort Bend County',
-        }[data.source] || 'County Tax Data';
+        currentComparables  = data.comparables || [];
 
-        document.getElementById('countyBadge').textContent = county;
-        document.getElementById('mainAddress').textContent = data.main_property.full_address || data.main_property.address;
-        document.getElementById('mainCityZip').textContent =
-            [data.main_property.city, data.main_property.zip].filter(Boolean).join(', ');
-        document.getElementById('mainValue').textContent = fmt(data.main_property.market_value);
+        var county = { chambers: 'Chambers County', hcad: 'Harris County',
+                       liberty: 'Liberty County', fort_bend: 'Fort Bend County' }[data.source]
+                   || 'County Tax Data';
+
+        document.getElementById('countyBadge').textContent    = county;
+        document.getElementById('mainAddress').textContent     = data.main_property.full_address || data.main_property.address;
+        document.getElementById('mainCityZip').textContent     = [data.main_property.city, data.main_property.zip].filter(Boolean).join(', ');
+        document.getElementById('mainValue').textContent       = fmt(data.main_property.market_value);
         document.getElementById('mainSubdivision').textContent = data.subdivision;
 
-        const sqFtWrap = document.getElementById('mainSqFtWrap');
+        var sqFtWrap = document.getElementById('mainSqFtWrap');
         if (data.main_property.sq_ft) {
             document.getElementById('mainSqFt').textContent = fmtNum(data.main_property.sq_ft);
             sqFtWrap.classList.remove('hidden');
-        } else {
-            sqFtWrap.classList.add('hidden');
-        }
+        } else { sqFtWrap.classList.add('hidden'); }
 
-        const acreageWrap = document.getElementById('mainAcreageWrap');
+        var acreageWrap = document.getElementById('mainAcreageWrap');
         if (data.main_property.acreage) {
             document.getElementById('mainAcreage').textContent = data.main_property.acreage.toFixed(2);
             acreageWrap.classList.remove('hidden');
-        } else {
-            acreageWrap.classList.add('hidden');
-        }
+        } else { acreageWrap.classList.add('hidden'); }
 
-        const zipSuffix = data.main_property.zip ? ` (${data.main_property.zip})` : '';
+        var zipSuffix = data.main_property.zip ? ' (' + data.main_property.zip + ')' : '';
         document.getElementById('resultsCount').textContent =
-            `Found ${data.total_comparables} propert${data.total_comparables === 1 ? 'y' : 'ies'} with lower market value in ${data.subdivision || 'neighborhood'}${zipSuffix}`;
+            'Found ' + data.total_comparables
+            + ' propert' + (data.total_comparables === 1 ? 'y' : 'ies')
+            + ' with lower market value in ' + (data.subdivision || 'neighborhood') + zipSuffix;
 
         document.getElementById('downloadBtn').href = '/tax-protest/download-csv';
+
+        renderStats(data.subdivision_stats, data.subdivision, data.main_property.market_value);
 
         sortAsc = true;
         renderTable();
         resultsSection.classList.remove('hidden');
     }
 
-    document.getElementById('sortValue').addEventListener('click', () => {
+    document.getElementById('sortValue').addEventListener('click', function () {
         sortAsc = !sortAsc;
-        const icon = document.querySelector('#sortValue i');
-        icon.className = sortAsc ? 'fas fa-sort-amount-up text-xs ml-1' : 'fas fa-sort-amount-down text-xs ml-1';
+        document.querySelector('#sortValue i').className =
+            sortAsc ? 'fas fa-sort-amount-up text-xs ml-1' : 'fas fa-sort-amount-down text-xs ml-1';
         renderTable();
     });
 
     function renderTable() {
-        const sorted = [...currentComparables].sort((a, b) =>
-            sortAsc ? (a.market_value || 0) - (b.market_value || 0)
-                    : (b.market_value || 0) - (a.market_value || 0)
-        );
+        var sorted = currentComparables.slice().sort(function (a, b) {
+            return sortAsc ? (a.market_value || 0) - (b.market_value || 0)
+                           : (b.market_value || 0) - (a.market_value || 0);
+        });
+        var allRows = [Object.assign({}, currentMainProperty, { _isMain: true })].concat(sorted);
 
-        const allRows = [
-            {...currentMainProperty, _isMain: true},
-            ...sorted,
-        ];
+        document.getElementById('comparablesBody').innerHTML = allRows.map(function (p) {
+            return '<tr class="' + (p._isMain ? 'bg-amber-50 font-medium' : 'hover:bg-slate-50') + '">'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.full_address || p.address || '') + '">'
+                + (p._isMain ? '<i class="fas fa-star text-amber-500 text-xs mr-1"></i>' : '')
+                + (p.full_address || p.address || '') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis">' + (p.city || '') + '</td>'
+                + '<td>' + (p.zip || '') + '</td>'
+                + '<td style="text-align:right">' + fmt(p.market_value) + '</td>'
+                + '<td style="text-align:right">' + (p.sq_ft ? fmtNum(p.sq_ft) : '—') + '</td>'
+                + '<td style="text-align:right">' + (p.acreage ? p.acreage.toFixed(2) : '—') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.subdivision || p.legal2 || '') + '">' + (p.subdivision || p.legal2 || '') + '</td>'
+                + '<td style="overflow:hidden;text-overflow:ellipsis" title="' + (p.legal1 || '') + '">' + (p.legal1 || '') + '</td>'
+                + '</tr>';
+        }).join('');
 
-        // Desktop table
-        const tbody = document.getElementById('comparablesBody');
-        tbody.innerHTML = allRows.map(p => `
-            <tr class="${p._isMain ? 'bg-amber-50 font-medium' : 'hover:bg-slate-50'}">
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.full_address || p.address || ''}">
-                    ${p._isMain ? '<i class="fas fa-star text-amber-500 text-xs mr-1"></i>' : ''}
-                    ${p.full_address || p.address || ''}
-                </td>
-                <td style="overflow:hidden;text-overflow:ellipsis">${p.city || ''}</td>
-                <td>${p.zip || ''}</td>
-                <td style="text-align:right">${fmt(p.market_value)}</td>
-                <td style="text-align:right">${p.sq_ft ? fmtNum(p.sq_ft) : '—'}</td>
-                <td style="text-align:right">${p.acreage ? p.acreage.toFixed(2) : '—'}</td>
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.subdivision || p.legal2 || ''}">${p.subdivision || p.legal2 || ''}</td>
-                <td style="overflow:hidden;text-overflow:ellipsis" title="${p.legal1 || ''}">${p.legal1 || ''}</td>
-            </tr>
-        `).join('');
-
-        // Mobile cards
-        const mobileContainer = document.getElementById('mobileCards');
-        mobileContainer.innerHTML = allRows.map(p => `
-            <div class="premium-card p-4 ${p._isMain ? 'bg-amber-50/60 border-amber-200/60' : ''}">
-                <div class="flex items-start justify-between mb-2">
-                    <div>
-                        ${p._isMain ? '<span class="text-xs font-bold text-amber-700 uppercase">Subject Property</span>' : ''}
-                        <p class="font-medium text-slate-800 text-sm">${p.full_address || p.address || ''}</p>
-                        <p class="text-xs text-slate-500">${[p.city, p.zip].filter(Boolean).join(', ')}</p>
-                    </div>
-                    <span class="font-semibold text-sm text-slate-900">${fmt(p.market_value)}</span>
-                </div>
-                <div class="flex gap-4 text-xs text-slate-500">
-                    ${p.sq_ft ? `<span>Sq Ft: ${fmtNum(p.sq_ft)}</span>` : ''}
-                    ${p.acreage ? `<span>Acres: ${p.acreage.toFixed(2)}</span>` : ''}
-                </div>
-            </div>
-        `).join('');
+        document.getElementById('mobileCards').innerHTML = allRows.map(function (p) {
+            return '<div class="premium-card p-4 ' + (p._isMain ? 'bg-amber-50/60 border-amber-200/60' : '') + '">'
+                + '<div class="flex items-start justify-between mb-2">'
+                + '<div>'
+                + (p._isMain ? '<span class="text-xs font-bold text-amber-700 uppercase">Subject Property</span>' : '')
+                + '<p class="font-medium text-slate-800 text-sm">' + (p.full_address || p.address || '') + '</p>'
+                + '<p class="text-xs text-slate-500">' + [p.city, p.zip].filter(Boolean).join(', ') + '</p>'
+                + '</div>'
+                + '<span class="font-semibold text-sm text-slate-900">' + fmt(p.market_value) + '</span>'
+                + '</div>'
+                + '<div class="flex gap-4 text-xs text-slate-500">'
+                + (p.sq_ft ? '<span>Sq Ft: ' + fmtNum(p.sq_ft) + '</span>' : '')
+                + (p.acreage ? '<span>Acres: ' + p.acreage.toFixed(2) + '</span>' : '')
+                + '</div>'
+                + '</div>';
+        }).join('');
     }
-})();
+}());
 </script>
 {% endblock %}

--- a/tests/test_tax_protest.py
+++ b/tests/test_tax_protest.py
@@ -1,0 +1,134 @@
+"""
+Regression tests for the tax protest stats flow.
+"""
+
+from types import SimpleNamespace
+
+import feature_flags as feature_flags_module
+import routes.tax_protest as tax_protest_route
+import services.tax_protest_service as tax_protest_service
+
+
+class _QueryStub:
+    def __init__(self, values):
+        self._rows = [(value,) for value in values]
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def with_entities(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+def test_get_subdivision_stats_returns_list_distribution(monkeypatch):
+    values = [390000, 420000, 450000, 610000, 615000, 700000, 820000]
+    monkeypatch.setattr(
+        tax_protest_service.LibertyProperty,
+        "query",
+        _QueryStub(values),
+    )
+    monkeypatch.setattr(
+        tax_protest_service,
+        "_find_liberty_sibling_codes",
+        lambda subdivision_code: [],
+    )
+
+    stats = tax_protest_service.get_subdivision_stats(
+        subdivision="LIBERTY OAKS",
+        zip_code="77327",
+        market_value=590000,
+        source="liberty",
+        subdivision_code="007206",
+    )
+
+    assert stats["total_homes"] == len(values)
+    assert stats["min_value"] == min(values)
+    assert stats["max_value"] == max(values)
+    assert isinstance(stats["value_distribution"], list)
+    assert sum(bucket["count"] for bucket in stats["value_distribution"]) == len(values)
+
+
+def test_search_property_returns_subdivision_stats(owner_a_client, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+
+    fake_contact = SimpleNamespace(
+        id=999,
+        street_address="156 Maryville Lane",
+        city="Cleveland",
+        zip_code="77327",
+    )
+    fake_property = {
+        "id": "liberty-1",
+        "address": "156 Maryville Lane",
+        "full_address": "156 Maryville Lane, Cleveland, TX 77327",
+        "city": "Cleveland",
+        "zip": "77327",
+        "market_value": 591000,
+        "sq_ft": 2184,
+        "acreage": 0.23,
+        "subdivision": "MARYVILLE",
+        "subdivision_code": "007206",
+        "neighborhood_code": None,
+    }
+    fake_stats = {
+        "total_homes": 21,
+        "lower_values": 2,
+        "higher_values": 18,
+        "percentile": 9.5,
+        "value_distribution": [
+            {"label": "$362k", "count": 7},
+            {"label": "$462k", "count": 7},
+            {"label": "$562k", "count": 2},
+            {"label": "$662k", "count": 1},
+            {"label": "$762k", "count": 0},
+            {"label": "$862k", "count": 2},
+            {"label": "$962k", "count": 0},
+            {"label": "$1062k", "count": 2},
+        ],
+        "min_value": 362000,
+        "max_value": 1162000,
+        "median_value": 505000,
+    }
+
+    monkeypatch.setattr(
+        tax_protest_route,
+        "_authorized_contact",
+        lambda contact_id: fake_contact,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_property_in_tax_data",
+        lambda street_address, city, zip_code: (fake_property, "liberty"),
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_comparables",
+        lambda *args, **kwargs: [{"id": "comp-1", "market_value": 420000}],
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "cache_search_result",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_subdivision_stats",
+        lambda *args, **kwargs: fake_stats,
+    )
+
+    response = owner_a_client.post(
+        "/tax-protest/search",
+        json={"contact_id": fake_contact.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["subdivision"] == "MARYVILLE"
+    assert payload["main_property"]["market_value"] == 591000
+    assert payload["subdivision_stats"] == fake_stats


### PR DESCRIPTION
## What changed
This PR publishes the current working tax protest neighborhood-stats rollout, including the existing route/service/template changes already in the branch plus the final regression fix and test coverage.

The tax protest search flow now returns subdivision stats without the tuple-unpack server error, keeps the original full-range neighborhood bar chart behavior, and adds the percentile badge/ring UI in the results card.

## Why it changed
The earlier implementation briefly changed the bucketing contract, and the revert left the runtime in an inconsistent state. That caused `/tax-protest/search` to fail with a `ValueError: too many values to unpack (expected 3)` in the subdivision stats path.

This PR standardizes the stats payload shape, preserves the chart behavior the user wanted, and hardens the frontend stats rendering so repeated searches animate and display correctly.

## User impact
Users can run tax protest searches again without the 500 error.

Users now see:
- the original neighborhood distribution chart behavior
- a percentile badge in the stats header
- an animated percentile ring beside the legend
- regression coverage for the stats payload and search route

## Root cause
`get_subdivision_stats()` and `_bucket_values()` temporarily diverged on their return contract during the chart-range rollback. The server path still expected the older tuple-style behavior in the deployed runtime, while the UI also needed safer ring-reset behavior across repeated searches.

## Validation
- `pytest tests/test_tax_protest.py`

## Notes
This PR intentionally includes the current working route/service/template changes already present in the branch. Local `.cursor/agent-images/` artifacts were not included in the PR.