### PR TITLE
[codex] add Excel tax protest report export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ bleach==6.1.0
 
 # Image processing (for signature image resizing)
 Pillow==12.1.0
+openpyxl==3.1.5
 
 # PDF rendering (for document extraction - renders pages to images)
 PyMuPDF==1.25.4

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -1,15 +1,29 @@
 """
 Tax Protest blueprint.
 Lets agents search their CRM contacts, locate properties in county tax data,
-extract subdivisions via LLM, find lower-value comparables, and download CSV.
+extract subdivisions via LLM, find lower-value comparables, and export results.
 """
 
 import csv
 import re
-from io import StringIO
+from functools import lru_cache
+from io import BytesIO, StringIO
 
-from flask import Blueprint, render_template, request, jsonify, Response, abort, session
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    jsonify,
+    Response,
+    abort,
+    send_file,
+    session,
+)
 from flask_login import login_required, current_user
+from openpyxl import Workbook
+from openpyxl.drawing.image import Image as XLImage
+from openpyxl.styles import Alignment, Font, PatternFill
+from PIL import Image as PILImage, ImageDraw, ImageFont
 
 from models import db, Contact
 from feature_flags import feature_required
@@ -28,6 +42,17 @@ from services.tax_protest_service import (
 
 tax_protest_bp = Blueprint("tax_protest", __name__, url_prefix="/tax-protest")
 
+COUNTY_LABELS = {
+    "chambers": "Chambers",
+    "hcad": "Harris",
+    "liberty": "Liberty",
+    "fort_bend": "Fort Bend",
+}
+EXPORT_XLSX_MIMETYPE = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+)
+EXPORT_FONT_PATH = "/System/Library/Fonts/Helvetica.ttc"
+
 
 def _authorized_contact(contact_id):
     """Load a contact with org + ownership checks. Returns contact or aborts 403."""
@@ -37,6 +62,505 @@ def _authorized_contact(contact_id):
     if not can_view_all_org_data() and contact.user_id != current_user.id:
         abort(403, description="You can only search your own contacts")
     return contact
+
+
+def _safe_filename(address, suffix):
+    addr = address or "unknown"
+    base = re.sub(r"[^a-zA-Z0-9]+", "_", addr).strip("_") or "unknown"
+    return f"{base}{suffix}"
+
+
+def _format_axis_value(value):
+    if value is None:
+        return ""
+    if abs(value) >= 1000000:
+        return f"${value / 1000000:.1f}M"
+    return f"${round(value / 1000):.0f}k"
+
+
+def _format_currency(value):
+    if value in (None, ""):
+        return "—"
+    return f"${value:,.0f}"
+
+
+def _ordinal_suffix(value):
+    value = abs(int(value))
+    if 10 <= value % 100 <= 20:
+        return "th"
+    return {1: "st", 2: "nd", 3: "rd"}.get(value % 10, "th")
+
+
+@lru_cache(maxsize=None)
+def _load_export_font(size):
+    try:
+        return ImageFont.truetype(EXPORT_FONT_PATH, size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+def _text_size(draw, text, font):
+    left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+    return right - left, bottom - top
+
+
+def _wrap_text(draw, text, font, max_width):
+    words = text.split()
+    if not words:
+        return [""]
+
+    lines = []
+    current = words[0]
+    for word in words[1:]:
+        candidate = f"{current} {word}"
+        if _text_size(draw, candidate, font)[0] <= max_width:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+    lines.append(current)
+    return lines
+
+
+def _draw_dashed_line(draw, x, y1, y2, dash_length=10, gap=7, fill="#f59e0b", width=3):
+    y = y1
+    while y < y2:
+        dash_end = min(y + dash_length, y2)
+        draw.line((x, y, x, dash_end), fill=fill, width=width)
+        y = dash_end + gap
+
+
+def _has_positive_market_value(prop):
+    value = prop.get("market_value")
+    try:
+        return float(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _build_export_rows(main_property, comparables, subdivision, county):
+    rows = []
+
+    def build_row(prop, row_type):
+        if not _has_positive_market_value(prop):
+            return
+        rows.append(
+            [
+                row_type,
+                prop.get("full_address", ""),
+                prop.get("city", ""),
+                prop.get("zip", ""),
+                prop.get("market_value", ""),
+                prop.get("sq_ft", ""),
+                prop.get("acreage", ""),
+                subdivision,
+                prop.get("legal1", ""),
+                prop.get("account", ""),
+                county,
+            ]
+        )
+
+    build_row(main_property, "Subject Property")
+    for comp in comparables:
+        build_row(comp, "Comparable")
+    return rows
+
+
+def _load_cached_export_data():
+    cached = get_cached_search_result()
+    if not cached:
+        abort(400, description="No search results to download. Run a search first.")
+
+    contact = _authorized_contact(cached["contact_id"])
+    main_property = get_main_property_by_id(
+        cached["main_property_id"], cached["source"]
+    )
+    if not main_property:
+        abort(404, description="Main property no longer found in tax data")
+
+    comparables = find_comparables(
+        cached["subdivision"],
+        cached["zip_code"],
+        main_property["market_value"],
+        cached["source"],
+        main_sq_ft=cached.get("main_sq_ft"),
+        fuzzy_subdivision=cached.get("fuzzy_subdivision", False),
+        subdivision_code=cached.get("subdivision_code"),
+        main_acreage=cached.get("main_acreage"),
+    )
+    subdivision_stats = get_subdivision_stats(
+        cached["subdivision"],
+        cached["zip_code"],
+        main_property["market_value"],
+        cached["source"],
+        fuzzy_subdivision=cached.get("fuzzy_subdivision", False),
+        subdivision_code=cached.get("subdivision_code"),
+    )
+
+    county = COUNTY_LABELS.get(cached["source"], cached["source"].title())
+    subdivision = cached.get("subdivision", "")
+
+    return {
+        "cached": cached,
+        "contact": contact,
+        "main_property": main_property,
+        "comparables": comparables,
+        "subdivision_stats": subdivision_stats,
+        "county": county,
+        "subdivision": subdivision,
+        "rows": _build_export_rows(main_property, comparables, subdivision, county),
+    }
+
+
+def _build_chart_image(stats, subdivision, subject_value):
+    if (
+        not stats
+        or not stats.get("value_distribution")
+        or stats.get("min_value") is None
+        or stats.get("max_value") is None
+    ):
+        return None
+
+    image_width = 1280
+    image_height = 760
+    image = PILImage.new("RGB", (image_width, image_height), "white")
+    draw = ImageDraw.Draw(image)
+
+    title_font = _load_export_font(34)
+    subtitle_font = _load_export_font(20)
+    label_font = _load_export_font(18)
+    card_label_font = _load_export_font(15)
+    value_font = _load_export_font(28)
+    chart_title_font = _load_export_font(22)
+    chart_label_font = _load_export_font(18)
+    axis_font = _load_export_font(16)
+
+    slate_950 = "#0f172a"
+    slate_700 = "#334155"
+    slate_500 = "#64748b"
+    slate_300 = "#cbd5e1"
+    slate_200 = "#e2e8f0"
+    slate_50 = "#f8fafc"
+    emerald = "#34d399"
+    amber = "#fbbf24"
+    amber_dark = "#b45309"
+    orange = "#f97316"
+
+    outer_box = (30, 30, image_width - 30, image_height - 30)
+    draw.rounded_rectangle(outer_box, radius=28, fill="white", outline=slate_200, width=2)
+
+    draw.text((72, 62), "Neighborhood Position", font=title_font, fill=slate_950)
+    subtitle = f"{subdivision or 'Subdivision'} · {stats['total_homes']} homes"
+    draw.text((72, 108), subtitle, font=subtitle_font, fill=slate_500)
+
+    pct = round(stats.get("percentile") or 0)
+    pill_text = f"{pct}{_ordinal_suffix(pct)} percentile"
+    pill_fill = "#dcfce7" if pct >= 75 else "#fef3c7" if pct >= 50 else "#ffedd5" if pct >= 25 else "#e2e8f0"
+    pill_text_fill = "#047857" if pct >= 75 else "#b45309" if pct >= 50 else orange if pct >= 25 else slate_700
+    pill_width = _text_size(draw, pill_text, subtitle_font)[0] + 32
+    pill_x = image_width - pill_width - 72
+    pill_y = 68
+    draw.rounded_rectangle(
+        (pill_x, pill_y, pill_x + pill_width, pill_y + 40),
+        radius=20,
+        fill=pill_fill,
+    )
+    draw.text((pill_x + 16, pill_y + 8), pill_text, font=subtitle_font, fill=pill_text_fill)
+
+    cards = [
+        ("# of homes valued for less", str(stats.get("lower_values") or 0), "#ecfdf5", emerald),
+        ("Subject Value", _format_currency(subject_value), "#fffbeb", amber),
+        (
+            "# of homes valued for more",
+            str(stats.get("higher_values") or 0),
+            slate_50,
+            slate_300,
+        ),
+        (
+            "Neighborhood Median",
+            _format_currency(stats.get("median_value")),
+            "#fff7ed",
+            orange,
+        ),
+    ]
+    card_y = 156
+    card_w = 268
+    card_h = 110
+    card_gap = 20
+    card_x = 72
+    for label, value, fill, accent in cards:
+        draw.rounded_rectangle(
+            (card_x, card_y, card_x + card_w, card_y + card_h),
+            radius=22,
+            fill=fill,
+            outline=slate_200,
+            width=2,
+        )
+        draw.rounded_rectangle(
+            (card_x + 18, card_y + 18, card_x + 34, card_y + 34),
+            radius=5,
+            fill=accent,
+        )
+        label_lines = _wrap_text(draw, label, card_label_font, card_w - 72)
+        line_height = _text_size(draw, "Ag", card_label_font)[1]
+        label_y = card_y + 12
+        for line in label_lines:
+            draw.text((card_x + 46, label_y), line, font=card_label_font, fill=slate_500)
+            label_y += line_height + 2
+        value_y = max(card_y + 56, label_y + 8)
+        draw.text((card_x + 18, value_y), value, font=value_font, fill=slate_950)
+        card_x += card_w + card_gap
+
+    chart_panel = (72, 304, image_width - 72, image_height - 90)
+    draw.rounded_rectangle(chart_panel, radius=24, fill="white", outline=slate_200, width=2)
+    draw.text(
+        (chart_panel[0] + 24, chart_panel[1] + 20),
+        "Market value distribution",
+        font=chart_title_font,
+        fill=slate_950,
+    )
+    draw.text(
+        (chart_panel[0] + 24, chart_panel[1] + 52),
+        "Green buckets show homes valued for less, amber marks the subject bucket, slate shows homes valued for more.",
+        font=label_font,
+        fill=slate_500,
+    )
+
+    dist = stats["value_distribution"]
+    min_value = stats["min_value"]
+    max_value = stats["max_value"]
+    chart_left = chart_panel[0] + 42
+    chart_top = chart_panel[1] + 96
+    chart_right = chart_panel[2] - 42
+    chart_bottom = chart_panel[3] - 74
+    chart_width = chart_right - chart_left
+    chart_height = chart_bottom - chart_top
+
+    draw.line((chart_left, chart_bottom, chart_right, chart_bottom), fill=slate_200, width=2)
+
+    max_count = max(bucket["count"] for bucket in dist) or 1
+    bucket_count = len(dist)
+    value_range = max(max_value - min_value, 1)
+    bucket_width = chart_width / max(bucket_count, 1)
+    bucket_size = value_range / max(bucket_count, 1)
+    subject_index = int((subject_value - min_value) / bucket_size) if bucket_size else 0
+    subject_index = max(0, min(bucket_count - 1, subject_index))
+
+    for index, bucket in enumerate(dist):
+        bucket_x = chart_left + index * bucket_width
+        gap = max(6, bucket_width * 0.11)
+        bar_height = max(14, chart_height * bucket["count"] / max_count) if bucket["count"] else 0
+        bar_top = chart_bottom - bar_height
+        fill = emerald if index < subject_index else amber if index == subject_index else slate_300
+        if bar_height:
+            draw.rounded_rectangle(
+                (
+                    bucket_x + gap,
+                    bar_top,
+                    bucket_x + bucket_width - gap,
+                    chart_bottom,
+                ),
+                radius=10,
+                fill=fill,
+            )
+            count_text = str(bucket["count"])
+            count_width, count_height = _text_size(draw, count_text, chart_label_font)
+            draw.text(
+                (
+                    bucket_x + (bucket_width - count_width) / 2,
+                    max(chart_top, bar_top - count_height - 10),
+                ),
+                count_text,
+                font=chart_label_font,
+                fill=slate_700,
+            )
+
+    marker_x = chart_left + chart_width * ((subject_value - min_value) / value_range)
+    marker_x = max(chart_left + 6, min(chart_right - 6, marker_x))
+    _draw_dashed_line(draw, marker_x, chart_top, chart_bottom + 6, fill=amber_dark, width=3)
+    draw.ellipse(
+        (marker_x - 7, chart_bottom - 7, marker_x + 7, chart_bottom + 7),
+        fill=amber,
+        outline=amber_dark,
+        width=2,
+    )
+    subject_label = f"{_format_axis_value(subject_value)} subject"
+    subject_label_width, _ = _text_size(draw, subject_label, chart_label_font)
+    label_x = min(max(chart_left, marker_x - subject_label_width / 2), chart_right - subject_label_width)
+    draw.text(
+        (label_x, chart_bottom + 18),
+        subject_label,
+        font=chart_label_font,
+        fill=amber_dark,
+    )
+
+    axis_labels = [
+        (chart_left + bucket_width / 2, dist[0]["label"]),
+        (chart_left + (bucket_count - 0.5) * bucket_width, _format_axis_value(max_value)),
+    ]
+    midpoint = bucket_count // 2
+    if midpoint not in (0, bucket_count - 1):
+        axis_labels.append((chart_left + (midpoint + 0.5) * bucket_width, dist[midpoint]["label"]))
+
+    for center_x, label in axis_labels:
+        label_width, _ = _text_size(draw, label, axis_font)
+        draw.text(
+            (center_x - label_width / 2, chart_bottom + 48),
+            label,
+            font=axis_font,
+            fill=slate_500,
+        )
+
+    output = BytesIO()
+    image.save(output, format="PNG")
+    output.seek(0)
+    return output
+
+
+def _build_xlsx_report(export_data):
+    workbook = Workbook()
+    summary = workbook.active
+    summary.title = "Summary"
+    summary.sheet_view.showGridLines = False
+
+    comparables_sheet = workbook.create_sheet("Comparables")
+    distribution_sheet = workbook.create_sheet("Distribution")
+
+    title_font = Font(name="Aptos", size=18, bold=True, color="0F172A")
+    label_font = Font(name="Aptos", size=11, bold=True, color="334155")
+    value_font = Font(name="Aptos", size=11, color="0F172A")
+    header_font = Font(name="Aptos", size=11, bold=True, color="FFFFFF")
+    header_fill = PatternFill("solid", fgColor="0F172A")
+    section_fill = PatternFill("solid", fgColor="F8FAFC")
+    label_alignment = Alignment(horizontal="left", vertical="center")
+    value_alignment = Alignment(horizontal="right", vertical="center")
+
+    for column, width in {
+        "A": 28,
+        "B": 34,
+        "C": 28,
+        "D": 18,
+        "E": 20,
+        "F": 18,
+        "G": 18,
+    }.items():
+        summary.column_dimensions[column].width = width
+
+    summary.merge_cells("A1:G1")
+    summary["A1"] = "Tax Protest Neighborhood Report"
+    summary["A1"].font = title_font
+    summary["A1"].alignment = Alignment(horizontal="left", vertical="center")
+
+    summary.merge_cells("A2:G2")
+    summary["A2"] = export_data["main_property"].get("full_address", "")
+    summary["A2"].font = Font(name="Aptos", size=12, color="64748B")
+    summary["A2"].alignment = label_alignment
+
+    summary["A4"] = "Subdivision"
+    summary["B4"] = export_data["subdivision"]
+    summary["C4"] = "County"
+    summary["D4"] = export_data["county"]
+    summary["E4"] = "Exported Rows"
+    summary["F4"] = len(export_data["rows"])
+
+    stats = export_data["subdivision_stats"] or {}
+    pct = round(stats.get("percentile") or 0)
+    summary["A5"] = "Subject Market Value"
+    summary["B5"] = export_data["main_property"].get("market_value")
+    summary["C5"] = "Neighborhood Median"
+    summary["D5"] = stats.get("median_value")
+    summary["E5"] = "Percentile"
+    summary["F5"] = f"{pct}{_ordinal_suffix(pct)} percentile"
+
+    summary["A6"] = "# of homes valued for less"
+    summary["B6"] = stats.get("lower_values")
+    summary["C6"] = "# of homes valued for more"
+    summary["D6"] = stats.get("higher_values")
+    summary["E6"] = "Total Homes"
+    summary["F6"] = stats.get("total_homes")
+
+    for cell in ("A4", "C4", "E4", "A5", "C5", "E5", "A6", "C6", "E6"):
+        summary[cell].font = label_font
+        summary[cell].alignment = label_alignment
+    for cell in ("B4", "D4", "F4", "B5", "D5", "F5", "B6", "D6", "F6"):
+        summary[cell].font = value_font
+        summary[cell].fill = section_fill
+        summary[cell].alignment = value_alignment
+
+    for cell in ("B5", "D5"):
+        summary[cell].number_format = "$#,##0"
+
+    summary["A8"] = "Neighborhood Distribution"
+    summary["A8"].font = label_font
+    summary["A9"] = "This chart is embedded as an image so the exported workbook preserves the same visual story as the app."
+    summary["A9"].font = Font(name="Aptos", size=10, color="64748B")
+
+    chart_image = _build_chart_image(
+        export_data["subdivision_stats"],
+        export_data["subdivision"],
+        export_data["main_property"].get("market_value"),
+    )
+    if chart_image:
+        xl_image = XLImage(chart_image)
+        xl_image.width = 1100
+        xl_image.height = 654
+        summary.add_image(xl_image, "A11")
+
+    headers = [
+        "Type",
+        "Address",
+        "City",
+        "Zip",
+        "Market Value",
+        "Sq Ft",
+        "Acreage",
+        "Subdivision",
+        "Legal Description",
+        "Account",
+        "County",
+    ]
+    comparables_sheet.append(headers)
+    for row in export_data["rows"]:
+        comparables_sheet.append(row)
+
+    for cell in comparables_sheet[1]:
+        cell.font = header_font
+        cell.fill = header_fill
+
+    comparables_sheet.freeze_panes = "A2"
+    for column, width in enumerate((18, 34, 18, 12, 16, 12, 12, 22, 38, 16, 14), start=1):
+        comparables_sheet.column_dimensions[chr(64 + column)].width = width
+
+    for row in range(2, comparables_sheet.max_row + 1):
+        comparables_sheet[f"E{row}"].number_format = "$#,##0"
+        comparables_sheet[f"F{row}"].number_format = "#,##0"
+        comparables_sheet[f"G{row}"].number_format = "0.00"
+
+    distribution_sheet.append(["Bucket Label", "Home Count"])
+    for cell in distribution_sheet[1]:
+        cell.font = header_font
+        cell.fill = header_fill
+    for bucket in stats.get("value_distribution", []):
+        distribution_sheet.append([bucket["label"], bucket["count"]])
+    distribution_sheet["D1"] = "Subject Value"
+    distribution_sheet["E1"] = export_data["main_property"].get("market_value")
+    distribution_sheet["D2"] = "Minimum Value"
+    distribution_sheet["E2"] = stats.get("min_value")
+    distribution_sheet["D3"] = "Maximum Value"
+    distribution_sheet["E3"] = stats.get("max_value")
+    distribution_sheet["D4"] = "Percentile"
+    distribution_sheet["E4"] = stats.get("percentile")
+    distribution_sheet.column_dimensions["A"].width = 18
+    distribution_sheet.column_dimensions["B"].width = 12
+    distribution_sheet.column_dimensions["D"].width = 18
+    distribution_sheet.column_dimensions["E"].width = 14
+    for cell in ("E1", "E2", "E3"):
+        distribution_sheet[cell].number_format = "$#,##0"
+
+    output = BytesIO()
+    workbook.save(output)
+    output.seek(0)
+    return output
 
 
 @tax_protest_bp.route("/")
@@ -247,30 +771,8 @@ def search_property():
 @login_required
 @feature_required("TAX_PROTEST")
 def download_csv():
-    """Download CSV of comparables using cached search result (no LLM re-run)."""
-    cached = get_cached_search_result()
-    if not cached:
-        abort(400, description="No search results to download. Run a search first.")
-
-    contact = _authorized_contact(cached["contact_id"])
-
-    main_property = get_main_property_by_id(
-        cached["main_property_id"], cached["source"]
-    )
-    if not main_property:
-        abort(404, description="Main property no longer found in tax data")
-
-    comparables = find_comparables(
-        cached["subdivision"],
-        cached["zip_code"],
-        main_property["market_value"],
-        cached["source"],
-        main_sq_ft=cached.get("main_sq_ft"),
-        fuzzy_subdivision=cached.get("fuzzy_subdivision", False),
-        subdivision_code=cached.get("subdivision_code"),
-        main_acreage=cached.get("main_acreage"),
-    )
-
+    """Download CSV of comparables using cached search result."""
+    export_data = _load_cached_export_data()
     output = StringIO()
     writer = csv.writer(output)
 
@@ -288,40 +790,10 @@ def download_csv():
         "County",
     ]
     writer.writerow(headers)
-
-    county = {
-        "chambers": "Chambers",
-        "hcad": "Harris",
-        "liberty": "Liberty",
-        "fort_bend": "Fort Bend",
-    }.get(cached["source"], cached["source"].title())
-    subdivision = cached.get("subdivision", "")
-
-    def write_row(prop, row_type="Comparable"):
-        writer.writerow(
-            [
-                row_type,
-                prop.get("full_address", ""),
-                prop.get("city", ""),
-                prop.get("zip", ""),
-                prop.get("market_value", ""),
-                prop.get("sq_ft", ""),
-                prop.get("acreage", ""),
-                subdivision,
-                prop.get("legal1", ""),
-                prop.get("account", ""),
-                county,
-            ]
-        )
-
-    write_row(main_property, "Subject Property")
-    for comp in comparables:
-        write_row(comp)
+    writer.writerows(export_data["rows"])
 
     output.seek(0)
-
-    addr = contact.street_address or "unknown"
-    filename = re.sub(r"[^a-zA-Z0-9]+", "_", addr).strip("_") + ".csv"
+    filename = _safe_filename(export_data["contact"].street_address, ".csv")
 
     return Response(
         output.getvalue(),
@@ -330,4 +802,23 @@ def download_csv():
             "Content-Disposition": f"attachment; filename={filename}",
             "Content-Type": "text/csv",
         },
+    )
+
+
+@tax_protest_bp.route("/download-xlsx")
+@login_required
+@feature_required("TAX_PROTEST")
+def download_xlsx():
+    """Download an Excel report with a summary sheet and embedded chart."""
+    export_data = _load_cached_export_data()
+    workbook_stream = _build_xlsx_report(export_data)
+    filename = _safe_filename(
+        export_data["contact"].street_address, "_tax_protest_report.xlsx"
+    )
+
+    return send_file(
+        workbook_stream,
+        mimetype=EXPORT_XLSX_MIMETYPE,
+        as_attachment=True,
+        download_name=filename,
     )

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -503,23 +503,43 @@ def get_subdivision_stats(
         else:
             sub_filter = HcadProperty.lgl_2 == subdivision
         rows = (
-            HcadProperty.query.filter(
+            db.session.query(HcadProperty.tot_mkt_val)
+            .join(HcadBuilding, HcadProperty.acct == HcadBuilding.acct)
+            .filter(
                 sub_filter,
                 HcadProperty.tot_mkt_val.isnot(None),
                 HcadProperty.tot_mkt_val > 0,
+                HcadProperty.site_addr_1.isnot(None),
+                HcadProperty.site_addr_1 != "",
+                HcadProperty.str_num.isnot(None),
+                HcadProperty.str_num != "0",
+                HcadBuilding.im_sq_ft.isnot(None),
+                HcadBuilding.im_sq_ft > 0,
             )
-            .with_entities(
-                HcadProperty.tot_mkt_val,
-            )
+            .group_by(HcadProperty.id)
             .order_by(HcadProperty.tot_mkt_val.asc())
             .all()
         )
     elif source == "chambers" and subdivision:
+        has_improvement = db.or_(
+            db.and_(
+                ChambersProperty.improvement_hs_val.isnot(None),
+                ChambersProperty.improvement_hs_val > 0,
+            ),
+            db.and_(
+                ChambersProperty.improvement_nhs_val.isnot(None),
+                ChambersProperty.improvement_nhs_val > 0,
+            ),
+        )
         rows = (
             ChambersProperty.query.filter(
                 ChambersProperty.legal1.ilike(f"%{subdivision}%"),
                 ChambersProperty.market_value.isnot(None),
                 ChambersProperty.market_value > 0,
+                ChambersProperty.prop_street_number.isnot(None),
+                ChambersProperty.prop_street_number != "0",
+                ChambersProperty.prop_street.isnot(None),
+                has_improvement,
             )
             .with_entities(
                 ChambersProperty.market_value,

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -132,8 +132,11 @@
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
                 <p id="resultsCount" class="text-sm text-slate-600"></p>
                 <div class="flex items-center gap-2">
-                    <a id="downloadBtn" href="#" class="crm-btn crm-btn-primary text-sm">
-                        <i class="fas fa-download text-xs mr-1"></i> Download CSV
+                    <a id="downloadExcelBtn" href="#" class="crm-btn crm-btn-primary text-sm">
+                        <i class="fas fa-file-excel text-xs mr-1"></i> Download Excel Report
+                    </a>
+                    <a id="downloadCsvBtn" href="#" class="crm-btn crm-btn-secondary text-sm">
+                        <i class="fas fa-file-csv text-xs mr-1"></i> CSV
                     </a>
                     <button type="button" id="clearResults" class="crm-btn crm-btn-secondary text-sm">
                         <i class="fas fa-times text-xs mr-1"></i> Clear
@@ -502,7 +505,8 @@
             + ' propert' + (data.total_comparables === 1 ? 'y' : 'ies')
             + ' with lower market value in ' + (data.subdivision || 'neighborhood') + zipSuffix;
 
-        document.getElementById('downloadBtn').href = '/tax-protest/download-csv';
+        document.getElementById('downloadExcelBtn').href = '/tax-protest/download-xlsx';
+        document.getElementById('downloadCsvBtn').href = '/tax-protest/download-csv';
 
         renderStats(data.subdivision_stats, data.subdivision, data.main_property.market_value);
 

--- a/tests/test_tax_protest.py
+++ b/tests/test_tax_protest.py
@@ -2,11 +2,14 @@
 Regression tests for the tax protest stats flow.
 """
 
+from io import BytesIO
 from types import SimpleNamespace
+from zipfile import ZipFile
 
 import feature_flags as feature_flags_module
 import routes.tax_protest as tax_protest_route
 import services.tax_protest_service as tax_protest_service
+from openpyxl import load_workbook
 
 
 class _QueryStub:
@@ -24,6 +27,22 @@ class _QueryStub:
 
     def all(self):
         return list(self._rows)
+
+
+class _RecordingQueryStub(_QueryStub):
+    def __init__(self, values):
+        super().__init__(values)
+        self.filters = []
+
+    def filter(self, *args, **kwargs):
+        self.filters.extend(args)
+        return self
+
+    def join(self, *args, **kwargs):
+        return self
+
+    def group_by(self, *args, **kwargs):
+        return self
 
 
 def test_get_subdivision_stats_returns_list_distribution(monkeypatch):
@@ -52,6 +71,29 @@ def test_get_subdivision_stats_returns_list_distribution(monkeypatch):
     assert stats["max_value"] == max(values)
     assert isinstance(stats["value_distribution"], list)
     assert sum(bucket["count"] for bucket in stats["value_distribution"]) == len(values)
+
+
+def test_chambers_subdivision_stats_uses_home_filters(monkeypatch):
+    query = _RecordingQueryStub([420000, 565000, 617950])
+    monkeypatch.setattr(
+        tax_protest_service.ChambersProperty,
+        "query",
+        query,
+    )
+
+    stats = tax_protest_service.get_subdivision_stats(
+        subdivision="SELLERS STATION",
+        zip_code="77523",
+        market_value=565340,
+        source="chambers",
+    )
+
+    filter_sql = " ".join(str(expr) for expr in query.filters)
+    assert "improvement_hs_val" in filter_sql
+    assert "improvement_nhs_val" in filter_sql
+    assert "prop_street_number" in filter_sql
+    assert "prop_street" in filter_sql
+    assert stats["total_homes"] == 3
 
 
 def test_search_property_returns_subdivision_stats(owner_a_client, monkeypatch):
@@ -132,3 +174,130 @@ def test_search_property_returns_subdivision_stats(owner_a_client, monkeypatch):
     assert payload["subdivision"] == "MARYVILLE"
     assert payload["main_property"]["market_value"] == 591000
     assert payload["subdivision_stats"] == fake_stats
+
+
+def test_download_xlsx_returns_report_with_embedded_chart(owner_a_client, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+
+    fake_contact = SimpleNamespace(
+        id=999,
+        street_address="156 Maryville Lane",
+        city="Cleveland",
+        zip_code="77327",
+    )
+    fake_cached = {
+        "contact_id": fake_contact.id,
+        "main_property_id": "liberty-1",
+        "source": "liberty",
+        "subdivision": "MARYVILLE",
+        "zip_code": "77327",
+        "main_sq_ft": 2184,
+        "main_acreage": 0.23,
+        "subdivision_code": "007206",
+        "fuzzy_subdivision": False,
+    }
+    fake_main_property = {
+        "id": "liberty-1",
+        "address": "156 Maryville Lane",
+        "full_address": "156 Maryville Lane, Cleveland, TX 77327",
+        "city": "Cleveland",
+        "zip": "77327",
+        "market_value": 591000,
+        "sq_ft": 2184,
+        "acreage": 0.23,
+        "legal1": "MARYVILLE SEC 1",
+        "account": "007206000001",
+    }
+    fake_comparables = [
+        {
+            "id": "comp-1",
+            "full_address": "144 Maryville Lane, Cleveland, TX 77327",
+            "city": "Cleveland",
+            "zip": "77327",
+            "market_value": 420000,
+            "sq_ft": 2030,
+            "acreage": 0.22,
+            "legal1": "MARYVILLE SEC 1",
+            "account": "007206000002",
+        },
+        {
+            "id": "comp-2",
+            "full_address": "148 Maryville Lane, Cleveland, TX 77327",
+            "city": "Cleveland",
+            "zip": "77327",
+            "market_value": 0,
+            "sq_ft": 1900,
+            "acreage": 0.20,
+            "legal1": "MARYVILLE SEC 1",
+            "account": "007206000003",
+        }
+    ]
+    fake_stats = {
+        "total_homes": 21,
+        "lower_values": 2,
+        "higher_values": 18,
+        "percentile": 9.5,
+        "value_distribution": [
+            {"label": "$362k", "count": 7},
+            {"label": "$462k", "count": 7},
+            {"label": "$562k", "count": 2},
+            {"label": "$662k", "count": 1},
+            {"label": "$762k", "count": 0},
+            {"label": "$862k", "count": 2},
+            {"label": "$962k", "count": 0},
+            {"label": "$1062k", "count": 2},
+        ],
+        "min_value": 362000,
+        "max_value": 1162000,
+        "median_value": 505000,
+    }
+
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_cached_search_result",
+        lambda: fake_cached,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "_authorized_contact",
+        lambda contact_id: fake_contact,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_main_property_by_id",
+        lambda property_id, source: fake_main_property,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_comparables",
+        lambda *args, **kwargs: fake_comparables,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_subdivision_stats",
+        lambda *args, **kwargs: fake_stats,
+    )
+
+    response = owner_a_client.get("/tax-protest/download-xlsx")
+
+    assert response.status_code == 200
+    assert response.mimetype == (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+    workbook = load_workbook(BytesIO(response.data))
+    assert workbook.sheetnames == ["Summary", "Comparables", "Distribution"]
+    assert workbook["Summary"]["A1"].value == "Tax Protest Neighborhood Report"
+    assert workbook["Summary"]["F4"].value == 2
+    assert workbook["Summary"]["B5"].value == 591000
+    assert workbook["Summary"]["A6"].value == "# of homes valued for less"
+    assert workbook["Summary"]["C6"].value == "# of homes valued for more"
+    assert workbook["Comparables"]["A2"].value == "Subject Property"
+    assert workbook["Comparables"]["A3"].value == "Comparable"
+    assert workbook["Comparables"].max_row == 3
+
+    with ZipFile(BytesIO(response.data)) as workbook_zip:
+        media_files = [
+            name for name in workbook_zip.namelist() if name.startswith("xl/media/")
+        ]
+    assert media_files


### PR DESCRIPTION
## What changed
This PR adds an analyst-friendly Excel export for the tax protest tool while keeping CSV available.

Key changes:
- add `/tax-protest/download-xlsx` and make the Excel report the primary export action in the UI
- generate a workbook with `Summary`, `Comparables`, and `Distribution` sheets
- embed a styled neighborhood-position chart image into the workbook summary sheet
- align export wording with the stakeholder request:
  - `# of homes valued for less`
  - `# of homes valued for more`
- exclude properties with `market_value <= 0` from exported rows
- tighten subdivision stats queries so Chambers and HCAD chart/report stats only include actual homes, preventing `$0k` distribution buckets from land/non-improved records
- add regression coverage for the workbook export and stats filtering

## Why it changed
CSV cannot carry the visual summary stakeholders wanted. The Excel report preserves the chart and presents the same narrative as the app in a format that can be downloaded and shared.

The follow-up stats filtering also fixes a data-quality issue where non-home records could still leak into the neighborhood distribution and produce misleading `$0k` buckets.

## User impact
Users can now download a polished `.xlsx` report that includes:
- the subject property summary
- comparable rows
- an embedded neighborhood distribution chart suitable for stakeholder sharing

## Validation
- `pytest tests/test_tax_protest.py`

## Notes
Local `.cursor/agent-images/` artifacts were not included in this PR.