### PR TITLE
[codex] Fix tax protest contact modal validation

### DIFF
--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -25,6 +25,7 @@ from openpyxl.drawing.image import Image as XLImage
 from openpyxl.styles import Alignment, Font, PatternFill
 from PIL import Image as PILImage, ImageDraw, ImageFont
 
+from forms import ContactForm
 from models import db, Contact, ContactGroup
 from feature_flags import feature_required
 from services.tenant_service import org_query, can_view_all_org_data
@@ -595,7 +596,11 @@ def index():
         .order_by(ContactGroup.sort_order.asc(), ContactGroup.name.asc())
         .all()
     )
-    return render_template("tax_protest/index.html", contact_groups=contact_groups)
+    return render_template(
+        "tax_protest/index.html",
+        contact_groups=contact_groups,
+        contact_form=ContactForm(),
+    )
 
 
 @tax_protest_bp.route("/search-contacts")

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -266,6 +266,7 @@
                     </div>
 
                     <form id="contactModalForm" class="space-y-8 p-6 sm:p-8">
+                        {{ contact_form.csrf_token(id="contactModalCsrfToken") }}
                         <div id="contactModalAlert" class="hidden rounded-2xl border px-4 py-3 text-sm"></div>
                         <div id="contactModalLoading" class="hidden rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-500">
                             <div class="flex items-center gap-3">
@@ -398,8 +399,6 @@
     let currentMainProperty = null;
     let isSavingContact = false;
     let isLoadingContact = false;
-    const contactCsrfToken = {{ (csrf_token() if csrf_token is defined else '')|tojson }};
-
     const searchContainer = document.getElementById('searchContainer');
     const searchInput = document.getElementById('contactSearch');
     const searchDropdown = document.getElementById('searchDropdown');
@@ -1040,9 +1039,6 @@
         clearModalErrors();
 
         var formData = new FormData(contactModal.form);
-        if (contactCsrfToken) {
-            formData.set('csrf_token', contactCsrfToken);
-        }
         formData.set('phone', formatPhoneInput(contactModal.fields.phone.value));
 
         var endpoint = modalState.mode === 'create'

--- a/tests/test_tax_protest.py
+++ b/tests/test_tax_protest.py
@@ -3,6 +3,7 @@ Regression tests for the tax protest stats flow.
 """
 
 from io import BytesIO
+import re
 from types import SimpleNamespace
 from zipfile import ZipFile
 
@@ -361,6 +362,45 @@ def test_create_contact_ajax_returns_json_summary(owner_a_client, seed):
     assert payload["contact"]["name"] == "Tax Modal"
     assert payload["contact"]["has_address"] is True
     assert "444 Cedar Lane" in payload["contact"]["address"]
+
+
+def test_tax_protest_modal_create_contact_includes_csrf_token(app, owner_a_client, seed, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+    original_csrf_setting = app.config["WTF_CSRF_ENABLED"]
+    app.config["WTF_CSRF_ENABLED"] = True
+
+    try:
+        page = owner_a_client.get("/tax-protest/")
+        assert page.status_code == 200
+
+        html = page.get_data(as_text=True)
+        match = re.search(
+            r'<input[^>]+id="contactModalCsrfToken"[^>]+name="csrf_token"[^>]+value="([^"]+)"',
+            html,
+        )
+        assert match, "tax protest contact modal should render a CSRF token"
+
+        response = owner_a_client.post(
+            "/contacts/create",
+            data={
+                "csrf_token": match.group(1),
+                "first_name": "Csrf",
+                "last_name": "Covered",
+                "street_address": "500 Cypress Creek",
+                "city": "Houston",
+                "state": "TX",
+                "zip_code": "77003",
+                "group_ids": str(seed["group_a1"]),
+            },
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["status"] == "success"
+        assert payload["contact"]["name"] == "Csrf Covered"
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = original_csrf_setting
 
 
 def test_download_xlsx_returns_report_with_embedded_chart(owner_a_client, monkeypatch):


### PR DESCRIPTION
## Summary
Fix contact creation from the tax protest modal by submitting a real WTForms CSRF token with the modal form.

## What changed
- pass a `ContactForm` instance into the tax protest page
- render the form's hidden CSRF field inside the modal form
- remove the custom JavaScript token injection path and submit the modal's `FormData` directly
- add a regression test that enables CSRF, loads `/tax-protest/`, extracts the modal token, and verifies AJAX contact creation succeeds

## Root cause
The tax protest modal posted into `ContactForm.validate_on_submit()` without a real CSRF token. That caused the server-side form validation to fail even when the visible contact fields were filled out.

## Impact
Contacts can now be created from the tax protest workflow without the false validation failure, and the regression test covers the CSRF-backed modal path.

## Validation
- `DATABASE_URL=sqlite:////tmp/test_tax_modal_csrf.db .venv/bin/python3 -m pytest tests/test_tax_protest.py -k "create_contact_ajax or csrf"`
- `.venv/bin/python3 -m pytest tests/test_contacts.py -k "create_contact_success or edit_contact"`