### PR TITLE
[codex] Improve tax protest timeout visibility and stability

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120 --max-requests 10000 --max-requests-jitter 500
+web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --max-requests 10000 --max-requests-jitter 500

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ if nr_license:
 
 import warnings
 import html
+import time
 import pytz
 from datetime import datetime
 from sqlalchemy.exc import SAWarning
@@ -23,7 +24,12 @@ warnings.filterwarnings('ignore', category=SAWarning, message='.*relationship .*
 # Timezone for display (Central Time)
 CENTRAL_TZ = pytz.timezone('America/Chicago')
 
-from flask import Flask, render_template, session, redirect, url_for, flash
+try:
+    import psutil
+except ImportError:  # pragma: no cover - psutil is installed in production
+    psutil = None
+
+from flask import Flask, render_template, session, redirect, url_for, flash, request, g
 from flask_login import LoginManager, current_user, logout_user
 from flask_mail import Mail
 from flask_migrate import Migrate
@@ -47,6 +53,18 @@ from routes.contact_us import contact_bp
 from routes.gmail_integration import gmail_bp
 from routes.reports import reports_bp
 from routes.tax_protest import tax_protest_bp
+
+SLOW_REQUEST_WARNING_MS = 2000
+
+
+def _current_rss_mb():
+    if psutil is None:
+        return None
+    try:
+        process = psutil.Process(os.getpid())
+        return round(process.memory_info().rss / 1024 / 1024, 1)
+    except Exception:
+        return None
 
 def create_app():
     app = Flask(__name__)
@@ -162,6 +180,10 @@ def create_app():
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT
     # =========================================================================
+
+    @app.before_request
+    def start_request_timer():
+        g._request_started_at = time.perf_counter()
     
     @app.before_request
     def set_tenant_context():
@@ -234,6 +256,34 @@ def create_app():
         """Record when session was created for invalidation checks."""
         if current_user.is_authenticated and '_session_created_at' not in session:
             session['_session_created_at'] = datetime.utcnow().timestamp()
+
+        started_at = getattr(g, '_request_started_at', None)
+        if started_at is not None:
+            duration_ms = round((time.perf_counter() - started_at) * 1000, 1)
+            endpoint = request.endpoint or 'unknown'
+            user_id = current_user.id if current_user.is_authenticated else None
+            org_id = current_user.organization_id if current_user.is_authenticated else None
+            should_log = (
+                endpoint.startswith('tax_protest.')
+                or duration_ms >= SLOW_REQUEST_WARNING_MS
+                or response.status_code >= 500
+            )
+            if should_log:
+                log_fn = app.logger.warning if (
+                    duration_ms >= SLOW_REQUEST_WARNING_MS or response.status_code >= 500
+                ) else app.logger.info
+                log_fn(
+                    'request_summary method=%s path=%s endpoint=%s status=%s duration_ms=%s rss_mb=%s user_id=%s org_id=%s pid=%s',
+                    request.method,
+                    request.path,
+                    endpoint,
+                    response.status_code,
+                    duration_ms,
+                    _current_rss_mb(),
+                    user_id,
+                    org_id,
+                    os.getpid(),
+                )
         return response
 
     @app.teardown_appcontext

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,4 @@ cmds = ["pip install -r requirements.txt", "npm ci"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "gunicorn app:app --bind 0.0.0.0:5011 --workers 4 --timeout 120 --max-requests 10000 --max-requests-jitter 500"
+cmd = "gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --max-requests 10000 --max-requests-jitter 500"

--- a/routes/tax_protest.py
+++ b/routes/tax_protest.py
@@ -5,7 +5,10 @@ extract subdivisions via LLM, find lower-value comparables, and export results.
 """
 
 import csv
+import logging
+import os
 import re
+import time
 from functools import lru_cache
 from io import BytesIO, StringIO
 
@@ -24,6 +27,12 @@ from openpyxl import Workbook
 from openpyxl.drawing.image import Image as XLImage
 from openpyxl.styles import Alignment, Font, PatternFill
 from PIL import Image as PILImage, ImageDraw, ImageFont
+from werkzeug.exceptions import HTTPException
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - psutil is available in production
+    psutil = None
 
 from forms import ContactForm
 from models import db, Contact, ContactGroup
@@ -44,6 +53,7 @@ from services.tax_protest_service import (
 )
 
 tax_protest_bp = Blueprint("tax_protest", __name__, url_prefix="/tax-protest")
+logger = logging.getLogger(__name__)
 
 COUNTY_LABELS = {
     "chambers": "Chambers",
@@ -55,6 +65,38 @@ EXPORT_XLSX_MIMETYPE = (
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 )
 EXPORT_FONT_PATH = "/System/Library/Fonts/Helvetica.ttc"
+SEARCH_COMPARABLE_LIMIT = 250
+
+
+def _elapsed_ms(started_at):
+    return round((time.perf_counter() - started_at) * 1000, 1)
+
+
+def _current_rss_mb():
+    if psutil is None:
+        return None
+    try:
+        process = psutil.Process(os.getpid())
+        return round(process.memory_info().rss / 1024 / 1024, 1)
+    except Exception:
+        return None
+
+
+def _log_tax_event(event, **fields):
+    payload = " ".join(
+        f"{key}={value}"
+        for key, value in fields.items()
+        if value is not None and value != ""
+    )
+    logger.info("tax_protest_%s %s", event, payload)
+
+
+def _coerce_positive_number(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
 
 
 def _authorized_contact(contact_id):
@@ -644,46 +686,162 @@ def search_property():
         return jsonify({"error": "contact_id required"}), 400
 
     contact = _authorized_contact(data["contact_id"])
+    source = None
+    route_started = time.perf_counter()
+    log_context = {
+        "contact_id": contact.id,
+        "user_id": current_user.id,
+        "org_id": current_user.organization_id,
+    }
+    _log_tax_event("search_started", **log_context, rss_mb=_current_rss_mb())
 
     if not contact.street_address:
         return jsonify({"error": "Contact has no street address on file"}), 400
 
-    property_record, source = find_property_in_tax_data(
-        contact.street_address, contact.city, contact.zip_code
-    )
+    try:
+        lookup_started = time.perf_counter()
+        property_record, source = find_property_in_tax_data(
+            contact.street_address, contact.city, contact.zip_code
+        )
+        lookup_ms = _elapsed_ms(lookup_started)
+        _log_tax_event(
+            "search_lookup_complete",
+            **log_context,
+            source=source,
+            lookup_ms=lookup_ms,
+            rss_mb=_current_rss_mb(),
+        )
 
-    if not property_record:
-        return jsonify(
-            {
-                "error": f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
-            }
-        ), 404
-
-    market_value = property_record.get("market_value")
-    zip_code = property_record.get("zip")
-    neighborhood_code = property_record.get("neighborhood_code")
-    subdivision_code = property_record.get("subdivision_code")
-    main_sq_ft = property_record.get("sq_ft")
-    main_acreage = property_record.get("acreage")
-    subdivision = None
-    fuzzy = False
-    subdivision_match_terms = None
-
-    if source == "hcad":
-        lgl_2 = property_record.get("legal2") or ""
-        if _is_valid_subdivision(lgl_2):
-            subdivision = lgl_2.strip()
-        else:
-            subdivision = extract_subdivision_llm(property_record.get("legal1", ""))
-            fuzzy = True
-        if not subdivision:
+        if not property_record:
             return jsonify(
                 {
-                    "error": "Could not determine subdivision from property legal description",
+                    "error": f'No property found matching "{contact.street_address}" in Chambers, Harris, Liberty, or Fort Bend County tax records'
+                }
+            ), 404
+
+        market_value = _coerce_positive_number(property_record.get("market_value"))
+        if market_value is None:
+            _log_tax_event(
+                "search_invalid_market_value",
+                **log_context,
+                source=source,
+                property_id=property_record.get("id"),
+                rss_mb=_current_rss_mb(),
+            )
+            return jsonify(
+                {
+                    "error": "Property has no market value available in tax data",
                     "main_property": property_record,
                     "source": source,
                 }
             ), 422
+
+        zip_code = property_record.get("zip")
+        neighborhood_code = property_record.get("neighborhood_code")
+        subdivision_code = property_record.get("subdivision_code")
+        main_sq_ft = property_record.get("sq_ft")
+        main_acreage = property_record.get("acreage")
+        subdivision = None
+        fuzzy = False
+        subdivision_match_terms = None
+        llm_ms = 0.0
+
+        if source == "hcad":
+            lgl_2 = property_record.get("legal2") or ""
+            if _is_valid_subdivision(lgl_2):
+                subdivision = lgl_2.strip()
+            else:
+                _log_tax_event("search_llm_started", **log_context, source=source)
+                llm_started = time.perf_counter()
+                subdivision = extract_subdivision_llm(property_record.get("legal1", ""))
+                llm_ms = _elapsed_ms(llm_started)
+                fuzzy = True
+                _log_tax_event(
+                    "search_llm_complete",
+                    **log_context,
+                    source=source,
+                    llm_ms=llm_ms,
+                    subdivision_found=bool(subdivision),
+                    rss_mb=_current_rss_mb(),
+                )
+            if not subdivision:
+                return jsonify(
+                    {
+                        "error": "Could not determine subdivision from property legal description",
+                        "main_property": property_record,
+                        "source": source,
+                    }
+                ), 422
+        elif source == "liberty":
+            subdivision = property_record.get("subdivision")
+            if not subdivision or not subdivision_code:
+                return jsonify(
+                    {
+                        "error": "Could not determine Liberty subdivision from tax data",
+                        "main_property": property_record,
+                        "source": source,
+                    }
+                ), 422
+        elif source == "fort_bend":
+            subdivision = property_record.get("subdivision")
+            if not subdivision or not subdivision_code:
+                return jsonify(
+                    {
+                        "error": "Could not determine Fort Bend neighborhood from tax data",
+                        "main_property": property_record,
+                        "source": source,
+                    }
+                ), 422
+        else:
+            legal_desc = property_record.get("legal1", "")
+            if source == "chambers":
+                _log_tax_event("search_llm_started", **log_context, source=source)
+                llm_started = time.perf_counter()
+                subdivision = extract_chambers_subdivision(legal_desc)
+                llm_ms = _elapsed_ms(llm_started)
+                subdivision_match_terms = build_chambers_subdivision_match_terms(
+                    subdivision,
+                    legal_desc,
+                )
+                _log_tax_event(
+                    "search_llm_complete",
+                    **log_context,
+                    source=source,
+                    llm_ms=llm_ms,
+                    subdivision_found=bool(subdivision),
+                    rss_mb=_current_rss_mb(),
+                )
+            else:
+                _log_tax_event("search_llm_started", **log_context, source=source)
+                llm_started = time.perf_counter()
+                subdivision = extract_subdivision_llm(legal_desc)
+                llm_ms = _elapsed_ms(llm_started)
+                _log_tax_event(
+                    "search_llm_complete",
+                    **log_context,
+                    source=source,
+                    llm_ms=llm_ms,
+                    subdivision_found=bool(subdivision),
+                    rss_mb=_current_rss_mb(),
+                )
+            if not subdivision:
+                return jsonify(
+                    {
+                        "error": "Could not extract subdivision from property legal description",
+                        "main_property": property_record,
+                        "source": source,
+                    }
+                ), 422
+
+        _log_tax_event(
+            "search_comparables_started",
+            **log_context,
+            source=source,
+            limit=SEARCH_COMPARABLE_LIMIT,
+            fuzzy=fuzzy,
+            rss_mb=_current_rss_mb(),
+        )
+        comparables_started = time.perf_counter()
         comparables = find_comparables(
             subdivision,
             zip_code,
@@ -691,108 +849,104 @@ def search_property():
             source,
             main_sq_ft=main_sq_ft,
             fuzzy_subdivision=fuzzy,
-            main_acreage=main_acreage,
-        )
-    elif source == "liberty":
-        subdivision = property_record.get("subdivision")
-        if not subdivision or not subdivision_code:
-            return jsonify(
-                {
-                    "error": "Could not determine Liberty subdivision from tax data",
-                    "main_property": property_record,
-                    "source": source,
-                }
-            ), 422
-        comparables = find_comparables(
-            subdivision,
-            zip_code,
-            market_value,
-            source,
-            main_sq_ft=main_sq_ft,
             subdivision_code=subdivision_code,
             main_acreage=main_acreage,
+            subdivision_match_terms=subdivision_match_terms,
+            limit=SEARCH_COMPARABLE_LIMIT,
         )
-    elif source == "fort_bend":
-        subdivision = property_record.get("subdivision")
-        if not subdivision or not subdivision_code:
-            return jsonify(
-                {
-                    "error": "Could not determine Fort Bend neighborhood from tax data",
-                    "main_property": property_record,
-                    "source": source,
-                }
-            ), 422
-        comparables = find_comparables(
-            subdivision,
-            zip_code,
-            market_value,
-            source,
-            main_sq_ft=main_sq_ft,
+        comparables_ms = _elapsed_ms(comparables_started)
+        comparables_truncated = len(comparables) > SEARCH_COMPARABLE_LIMIT
+        if comparables_truncated:
+            comparables = comparables[:SEARCH_COMPARABLE_LIMIT]
+        _log_tax_event(
+            "search_comparables_complete",
+            **log_context,
+            source=source,
+            comparables_ms=comparables_ms,
+            comparables_returned=len(comparables),
+            comparables_truncated=comparables_truncated,
+            rss_mb=_current_rss_mb(),
+        )
+
+        cache_search_result(
+            source=source,
+            subdivision=subdivision,
+            main_property_id=property_record["id"],
+            contact_id=contact.id,
+            zip_code=zip_code,
+            neighborhood_code=neighborhood_code,
             subdivision_code=subdivision_code,
-            main_acreage=main_acreage,
-        )
-    else:
-        legal_desc = property_record.get("legal1", "")
-        if source == "chambers":
-            subdivision = extract_chambers_subdivision(legal_desc)
-            subdivision_match_terms = build_chambers_subdivision_match_terms(
-                subdivision,
-                legal_desc,
-            )
-        else:
-            subdivision = extract_subdivision_llm(legal_desc)
-        if not subdivision:
-            return jsonify(
-                {
-                    "error": "Could not extract subdivision from property legal description",
-                    "main_property": property_record,
-                    "source": source,
-                }
-            ), 422
-        comparables = find_comparables(
-            subdivision,
-            zip_code,
-            market_value,
-            source,
             main_sq_ft=main_sq_ft,
             main_acreage=main_acreage,
+            fuzzy_subdivision=fuzzy,
             subdivision_match_terms=subdivision_match_terms,
         )
 
-    cache_search_result(
-        source=source,
-        subdivision=subdivision,
-        main_property_id=property_record["id"],
-        contact_id=contact.id,
-        zip_code=zip_code,
-        neighborhood_code=neighborhood_code,
-        subdivision_code=subdivision_code,
-        main_sq_ft=main_sq_ft,
-        main_acreage=main_acreage,
-        fuzzy_subdivision=fuzzy,
-        subdivision_match_terms=subdivision_match_terms,
-    )
+        _log_tax_event(
+            "search_stats_started",
+            **log_context,
+            source=source,
+            rss_mb=_current_rss_mb(),
+        )
+        stats_started = time.perf_counter()
+        subdivision_stats = get_subdivision_stats(
+            subdivision,
+            zip_code,
+            market_value,
+            source,
+            fuzzy_subdivision=fuzzy,
+            subdivision_code=subdivision_code,
+            subdivision_match_terms=subdivision_match_terms,
+        )
+        stats_ms = _elapsed_ms(stats_started)
+        _log_tax_event(
+            "search_stats_complete",
+            **log_context,
+            source=source,
+            stats_ms=stats_ms,
+            total_homes=(subdivision_stats or {}).get("total_homes"),
+            rss_mb=_current_rss_mb(),
+        )
 
-    subdivision_stats = get_subdivision_stats(
-        subdivision,
-        zip_code,
-        market_value,
-        source,
-        fuzzy_subdivision=fuzzy,
-        subdivision_code=subdivision_code,
-        subdivision_match_terms=subdivision_match_terms,
-    )
+        total_ms = _elapsed_ms(route_started)
+        _log_tax_event(
+            "search_complete",
+            **log_context,
+            source=source,
+            total_ms=total_ms,
+            lookup_ms=lookup_ms,
+            llm_ms=llm_ms,
+            comparables_ms=comparables_ms,
+            stats_ms=stats_ms,
+            comparables_returned=len(comparables),
+            comparables_truncated=comparables_truncated,
+            rss_mb=_current_rss_mb(),
+        )
 
-    return jsonify(
-        {
-            "source": source,
-            "subdivision": subdivision,
-            "main_property": property_record,
-            "comparables": comparables,
-            "total_comparables": len(comparables),
-            "subdivision_stats": subdivision_stats,
-        }
-    )
+        return jsonify(
+            {
+                "source": source,
+                "subdivision": subdivision,
+                "main_property": property_record,
+                "comparables": comparables,
+                "total_comparables": len(comparables),
+                "comparables_displayed": len(comparables),
+                "comparables_truncated": comparables_truncated,
+                "subdivision_stats": subdivision_stats,
+            }
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(
+            "tax_protest_search_failed contact_id=%s user_id=%s org_id=%s source=%s rss_mb=%s",
+            contact.id,
+            current_user.id,
+            current_user.organization_id,
+            source,
+            _current_rss_mb(),
+        )
+        raise
 
 
 @tax_protest_bp.route("/download-csv")
@@ -800,6 +954,7 @@ def search_property():
 @feature_required("TAX_PROTEST")
 def download_csv():
     """Download CSV of comparables using cached search result."""
+    started_at = time.perf_counter()
     export_data = _load_cached_export_data()
     output = StringIO()
     writer = csv.writer(output)
@@ -822,6 +977,16 @@ def download_csv():
 
     output.seek(0)
     filename = _safe_filename(export_data["contact"].street_address, ".csv")
+    _log_tax_event(
+        "download_csv_complete",
+        contact_id=export_data["contact"].id,
+        user_id=current_user.id,
+        org_id=current_user.organization_id,
+        source=export_data["cached"].get("source"),
+        rows=len(export_data["rows"]),
+        total_ms=_elapsed_ms(started_at),
+        rss_mb=_current_rss_mb(),
+    )
 
     return Response(
         output.getvalue(),
@@ -838,10 +1003,30 @@ def download_csv():
 @feature_required("TAX_PROTEST")
 def download_xlsx():
     """Download an Excel report with a summary sheet and embedded chart."""
+    started_at = time.perf_counter()
     export_data = _load_cached_export_data()
+    _log_tax_event(
+        "download_xlsx_started",
+        contact_id=export_data["contact"].id,
+        user_id=current_user.id,
+        org_id=current_user.organization_id,
+        source=export_data["cached"].get("source"),
+        rows=len(export_data["rows"]),
+        rss_mb=_current_rss_mb(),
+    )
     workbook_stream = _build_xlsx_report(export_data)
     filename = _safe_filename(
         export_data["contact"].street_address, "_tax_protest_report.xlsx"
+    )
+    _log_tax_event(
+        "download_xlsx_complete",
+        contact_id=export_data["contact"].id,
+        user_id=current_user.id,
+        org_id=current_user.organization_id,
+        source=export_data["cached"].get("source"),
+        rows=len(export_data["rows"]),
+        total_ms=_elapsed_ms(started_at),
+        rss_mb=_current_rss_mb(),
     )
 
     return send_file(

--- a/services/tax_protest_service.py
+++ b/services/tax_protest_service.py
@@ -727,6 +727,12 @@ def _bucket_values(values, num_buckets=8):
     return buckets
 
 
+def _limit_query(query, limit):
+    if limit is None:
+        return query
+    return query.limit(limit + 1)
+
+
 def find_comparables(
     subdivision,
     zip_code,
@@ -737,6 +743,7 @@ def find_comparables(
     subdivision_code=None,
     main_acreage=None,
     subdivision_match_terms=None,
+    limit=None,
 ):
     """
     Find properties in the same subdivision and zip with lower market value.
@@ -783,21 +790,25 @@ def find_comparables(
 
         if zip_code:
             results = (
-                ChambersProperty.query.filter(
-                    ChambersProperty.prop_zip5 == zip_code,
-                    *base_filters,
+                _limit_query(
+                    ChambersProperty.query.filter(
+                        ChambersProperty.prop_zip5 == zip_code,
+                        *base_filters,
+                    ).order_by(ChambersProperty.market_value.asc()),
+                    limit,
                 )
-                .order_by(ChambersProperty.market_value.asc())
                 .all()
             )
             if results:
                 return [_chambers_to_dict(r) for r in results]
 
         results = (
-            ChambersProperty.query.filter(
-                *base_filters,
+            _limit_query(
+                ChambersProperty.query.filter(
+                    *base_filters,
+                ).order_by(ChambersProperty.market_value.asc()),
+                limit,
             )
-            .order_by(ChambersProperty.market_value.asc())
             .all()
         )
         return [_chambers_to_dict(r) for r in results]
@@ -840,7 +851,10 @@ def find_comparables(
                         main_sq_ft + SQ_FT_RANGE,
                     )
                 )
-            return q.order_by(HcadProperty.tot_mkt_val.asc()).all()
+            return _limit_query(
+                q.order_by(HcadProperty.tot_mkt_val.asc()),
+                limit,
+            ).all()
 
         results = _hcad_query(use_zip=True)
         if not results:
@@ -866,6 +880,7 @@ def find_comparables(
             zip_code,
             main_acreage,
             use_zip=True,
+            limit=limit,
         )
         if not results:
             results = _liberty_comparable_query(
@@ -875,9 +890,10 @@ def find_comparables(
                 zip_code,
                 main_acreage,
                 use_zip=False,
+                limit=limit,
             )
 
-        if len(results) < MIN_COMPARABLES:
+        if len(results) < MIN_COMPARABLES and (limit is None or len(results) <= limit):
             sibling_codes = _find_liberty_sibling_codes(subdivision_code)
             if sibling_codes:
                 logger.info(
@@ -904,6 +920,7 @@ def find_comparables(
                         zip_code,
                         main_acreage,
                         use_zip=True,
+                        limit=None if limit is None else max(limit + 1 - len(results), 1),
                     )
                     if not sibling_results:
                         sibling_results = _liberty_comparable_query(
@@ -913,9 +930,12 @@ def find_comparables(
                             zip_code,
                             main_acreage,
                             use_zip=False,
+                            limit=None if limit is None else max(limit + 1 - len(results), 1),
                         )
                     results.extend(sibling_results)
-                    if len(results) >= MIN_COMPARABLES:
+                    if len(results) >= MIN_COMPARABLES or (
+                        limit is not None and len(results) > limit
+                    ):
                         break
 
         return [_liberty_to_dict(r) for r in results]
@@ -930,6 +950,7 @@ def find_comparables(
             main_sq_ft,
             zip_code,
             use_zip=True,
+            limit=limit,
         )
         if not results:
             results = _fort_bend_comparable_query(
@@ -938,9 +959,10 @@ def find_comparables(
                 main_sq_ft,
                 zip_code,
                 use_zip=False,
+                limit=limit,
             )
 
-        if len(results) < MIN_COMPARABLES:
+        if len(results) < MIN_COMPARABLES and (limit is None or len(results) <= limit):
             sibling_codes = _find_fort_bend_sibling_codes(subdivision_code)
             if sibling_codes:
                 logger.info(
@@ -956,6 +978,7 @@ def find_comparables(
                         main_sq_ft,
                         zip_code,
                         use_zip=True,
+                        limit=None if limit is None else max(limit + 1 - len(results), 1),
                     )
                     if not sibling_results:
                         sibling_results = _fort_bend_comparable_query(
@@ -964,9 +987,12 @@ def find_comparables(
                             main_sq_ft,
                             zip_code,
                             use_zip=False,
+                            limit=None if limit is None else max(limit + 1 - len(results), 1),
                         )
                     results.extend(sibling_results)
-                    if len(results) >= MIN_COMPARABLES:
+                    if len(results) >= MIN_COMPARABLES or (
+                        limit is not None and len(results) > limit
+                    ):
                         break
 
         return [_fort_bend_to_dict(r) for r in results]
@@ -1026,7 +1052,7 @@ def _find_liberty_sibling_codes(subdivision_code):
 
 
 def _liberty_comparable_query(
-    subdivision_code, market_value, strategy, zip_code, main_acreage, use_zip
+    subdivision_code, market_value, strategy, zip_code, main_acreage, use_zip, limit=None
 ):
     """Execute a Liberty County comparable property query."""
     base_filters = [
@@ -1054,7 +1080,10 @@ def _liberty_comparable_query(
                 ),
             )
 
-    return q.order_by(LibertyProperty.market_value.asc()).all()
+    return _limit_query(
+        q.order_by(LibertyProperty.market_value.asc()),
+        limit,
+    ).all()
 
 
 def _find_fort_bend_sibling_codes(subdivision_code):
@@ -1092,7 +1121,7 @@ def _find_fort_bend_sibling_codes(subdivision_code):
 
 
 def _fort_bend_comparable_query(
-    subdivision_code, market_value, main_sq_ft, zip_code, use_zip
+    subdivision_code, market_value, main_sq_ft, zip_code, use_zip, limit=None
 ):
     """Execute a Fort Bend County comparable property query."""
     base_filters = [
@@ -1116,7 +1145,10 @@ def _fort_bend_comparable_query(
                 main_sq_ft + SQ_FT_RANGE,
             ),
         )
-    return q.order_by(FortBendProperty.market_value.asc()).all()
+    return _limit_query(
+        q.order_by(FortBendProperty.market_value.asc()),
+        limit,
+    ).all()
 
 
 def _chambers_to_dict(record):

--- a/templates/tax_protest/index.html
+++ b/templates/tax_protest/index.html
@@ -1130,10 +1130,18 @@
         } else { acreageWrap.classList.add('hidden'); }
 
         var zipSuffix = data.main_property.zip ? ' (' + data.main_property.zip + ')' : '';
-        document.getElementById('resultsCount').textContent =
-            'Found ' + data.total_comparables
-            + ' propert' + (data.total_comparables === 1 ? 'y' : 'ies')
-            + ' with lower market value in ' + (data.subdivision || 'neighborhood') + zipSuffix;
+        if (data.comparables_truncated) {
+            document.getElementById('resultsCount').textContent =
+                'Showing the first ' + data.comparables_displayed
+                + ' lower-value propert' + (data.comparables_displayed === 1 ? 'y' : 'ies')
+                + ' in ' + (data.subdivision || 'neighborhood') + zipSuffix
+                + '. Download CSV or Excel for the full result set.';
+        } else {
+            document.getElementById('resultsCount').textContent =
+                'Found ' + data.total_comparables
+                + ' propert' + (data.total_comparables === 1 ? 'y' : 'ies')
+                + ' with lower market value in ' + (data.subdivision || 'neighborhood') + zipSuffix;
+        }
 
         document.getElementById('downloadExcelBtn').href = '/tax-protest/download-xlsx';
         document.getElementById('downloadCsvBtn').href = '/tax-protest/download-csv';

--- a/tests/test_tax_protest.py
+++ b/tests/test_tax_protest.py
@@ -227,6 +227,127 @@ def test_search_property_returns_subdivision_stats(owner_a_client, monkeypatch):
     assert payload["subdivision"] == "MARYVILLE"
     assert payload["main_property"]["market_value"] == 591000
     assert payload["subdivision_stats"] == fake_stats
+    assert payload["comparables_truncated"] is False
+
+
+def test_search_property_truncates_large_comparable_payload(owner_a_client, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+
+    fake_contact = SimpleNamespace(
+        id=999,
+        street_address="156 Maryville Lane",
+        city="Cleveland",
+        zip_code="77327",
+    )
+    fake_property = {
+        "id": "liberty-1",
+        "address": "156 Maryville Lane",
+        "full_address": "156 Maryville Lane, Cleveland, TX 77327",
+        "city": "Cleveland",
+        "zip": "77327",
+        "market_value": 591000,
+        "sq_ft": 2184,
+        "acreage": 0.23,
+        "subdivision": "MARYVILLE",
+        "subdivision_code": "007206",
+        "neighborhood_code": None,
+    }
+    fake_stats = {
+        "total_homes": 21,
+        "lower_values": 2,
+        "higher_values": 18,
+        "percentile": 9.5,
+        "value_distribution": [{"label": "$362k", "count": 21}],
+        "min_value": 362000,
+        "max_value": 1162000,
+        "median_value": 505000,
+    }
+    fake_comparables = [
+        {"id": f"comp-{index}", "market_value": 400000 + index}
+        for index in range(tax_protest_route.SEARCH_COMPARABLE_LIMIT + 5)
+    ]
+
+    monkeypatch.setattr(
+        tax_protest_route,
+        "_authorized_contact",
+        lambda contact_id: fake_contact,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_property_in_tax_data",
+        lambda street_address, city, zip_code: (fake_property, "liberty"),
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_comparables",
+        lambda *args, **kwargs: fake_comparables,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "cache_search_result",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "get_subdivision_stats",
+        lambda *args, **kwargs: fake_stats,
+    )
+
+    response = owner_a_client.post(
+        "/tax-protest/search",
+        json={"contact_id": fake_contact.id},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["comparables_truncated"] is True
+    assert payload["comparables_displayed"] == tax_protest_route.SEARCH_COMPARABLE_LIMIT
+    assert len(payload["comparables"]) == tax_protest_route.SEARCH_COMPARABLE_LIMIT
+
+
+def test_search_property_returns_422_when_market_value_missing(owner_a_client, monkeypatch):
+    monkeypatch.setattr(feature_flags_module, "org_has_feature", lambda *args, **kwargs: True)
+
+    fake_contact = SimpleNamespace(
+        id=999,
+        street_address="156 Maryville Lane",
+        city="Cleveland",
+        zip_code="77327",
+    )
+    fake_property = {
+        "id": "hcad-1",
+        "address": "156 Maryville Lane",
+        "full_address": "156 Maryville Lane, Cleveland, TX 77327",
+        "city": "Cleveland",
+        "zip": "77327",
+        "market_value": None,
+        "sq_ft": 2184,
+        "acreage": 0.23,
+        "legal1": "MARYVILLE SEC 1",
+        "legal2": "MARYVILLE",
+        "subdivision_code": None,
+        "neighborhood_code": None,
+    }
+
+    monkeypatch.setattr(
+        tax_protest_route,
+        "_authorized_contact",
+        lambda contact_id: fake_contact,
+    )
+    monkeypatch.setattr(
+        tax_protest_route,
+        "find_property_in_tax_data",
+        lambda street_address, city, zip_code: (fake_property, "hcad"),
+    )
+
+    response = owner_a_client.post(
+        "/tax-protest/search",
+        json={"contact_id": fake_contact.id},
+    )
+
+    assert response.status_code == 422
+    payload = response.get_json()
+    assert payload["error"] == "Property has no market value available in tax data"
 
 
 def test_search_property_expands_chambers_subdivision_match_terms(owner_a_client, monkeypatch):


### PR DESCRIPTION
## Summary
- add detailed Railway-visible request and tax protest step timing logs
- guard tax protest comparable searches when the source property has no market value
- reduce web worker count from 4 to 2 to lower timeout thrash under load
- cap the on-screen comparable payload to the first 250 results while keeping exports on the full result set

## Why
Railway logs showed repeated gunicorn worker timeouts after heavy tax protest usage, plus a real `/tax-protest/search` failure when HCAD comparable filtering received a `None` market value. This PR adds enough visibility to identify the slow step in production and hardens the search path so one large request is less likely to stall or kill a worker.

## Validation
- `.venv/bin/python3 -m pytest tests/test_tax_protest.py`
