### PR TITLE
Codex/tax protest timeout stability

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --max-requests 10000 --max-requests-jitter 500
+web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500

--- a/app.py
+++ b/app.py
@@ -16,6 +16,8 @@ if nr_license:
 import warnings
 import html
 import time
+import logging
+import sys
 import pytz
 from datetime import datetime
 from sqlalchemy.exc import SAWarning
@@ -30,6 +32,7 @@ except ImportError:  # pragma: no cover - psutil is installed in production
     psutil = None
 
 from flask import Flask, render_template, session, redirect, url_for, flash, request, g
+from flask.logging import default_handler
 from flask_login import LoginManager, current_user, logout_user
 from flask_mail import Mail
 from flask_migrate import Migrate
@@ -57,6 +60,40 @@ from routes.tax_protest import tax_protest_bp
 SLOW_REQUEST_WARNING_MS = 2000
 
 
+class _MaxLevelFilter(logging.Filter):
+    def __init__(self, exclusive_upper_bound):
+        super().__init__()
+        self.exclusive_upper_bound = exclusive_upper_bound
+
+    def filter(self, record):
+        return record.levelno < self.exclusive_upper_bound
+
+
+def configure_application_logging():
+    """Send non-error app logs to stdout so Railway reserves red for real errors."""
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter('%(levelname)s:%(name)s:%(message)s')
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.addFilter(_MaxLevelFilter(logging.ERROR))
+    stdout_handler.setFormatter(formatter)
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+    stderr_handler.setFormatter(formatter)
+
+    root_logger.addHandler(stdout_handler)
+    root_logger.addHandler(stderr_handler)
+    logging.captureWarnings(True)
+
+
+configure_application_logging()
+
+
 def _current_rss_mb():
     if psutil is None:
         return None
@@ -69,6 +106,11 @@ def _current_rss_mb():
 def create_app():
     app = Flask(__name__)
     app.config.from_object('config.Config')
+
+    if default_handler in app.logger.handlers:
+        app.logger.removeHandler(default_handler)
+    app.logger.propagate = True
+    app.logger.setLevel(logging.INFO)
 
     # Initialize extensions
     db.init_app(app)

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,4 @@ cmds = ["pip install -r requirements.txt", "npm ci"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --max-requests 10000 --max-requests-jitter 500"
+cmd = "gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500"

--- a/routes/action_plan.py
+++ b/routes/action_plan.py
@@ -9,7 +9,6 @@ import logging
 
 # Set up logging for action plan generation
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 action_plan_bp = Blueprint('action_plan', __name__)
 


### PR DESCRIPTION
  ## Summary

  Follow-up to `#202` to clean up Railway log severity so normal application telemetry no longer appears as red `error` logs.

  This PR does not change tax protest business logic. It changes how logs are emitted so Railway can better distinguish routine app activity from actual failures.

  ## Problem

  After deploying the new tax protest observability logs, Railway was showing many normal app log lines as red `error` entries, including:

  - `INFO:app:request_summary ...`
  - `INFO:routes.tax_protest:...`

  That made the log stream noisy and made it harder to spot real failures such as:

  - `WORKER TIMEOUT`
  - `SIGKILL`
  - Flask exceptions / tracebacks

  The issue was not the content of the messages. The issue was that normal logs were being emitted on the error stream, which Railway classifies as `error`.

  ## What Changed

  ### Application logging
  - Configure application logging centrally so:
    - `INFO` and `WARNING` logs go to `stdout`
    - `ERROR` and `CRITICAL` logs go to `stderr`
  - Remove Flask’s default handler and let the app logger propagate through the centralized logging setup.

  ### Route-level cleanup
  - Remove `logging.basicConfig(...)` from `routes/action_plan.py`
  - This prevents route import side effects from resetting logging behavior back to the default stderr-based setup

  ### Gunicorn noise reduction
  - Set Gunicorn log level to `warning`
  - This suppresses startup/info noise that Railway was also surfacing as red log entries

  ## Why This Helps

  After this PR, Railway logs should be much easier to read:

  - normal request telemetry should appear as normal logs instead of red errors
  - intentional slow-request warnings can still stand out
  - real failures should remain clearly visible as red/error entries

  This keeps the observability added in `#202` while making the Railway log viewer much more usable in production.

  ## Behavior Impact

  There is no intended feature behavior change in this PR.

  This is an operational/logging cleanup only:
  - no tax protest result logic changed
  - no export logic changed
  - no UI behavior changed

  ## Validation

  Validated locally with:

  ```bash
  .venv/bin/python3 -c "from app import app; print('app_import_ok')"
  .venv/bin/python3 -m pytest tests/test_tax_protest.py

  Result:

  - app import succeeded
  - 14 passed

  ## Files Updated

  - app.py
  - routes/action_plan.py
  - Procfile
  - nixpacks.toml

  ## Expected Result In Railway

  After deploy:

  - INFO:app:request_summary ... should no longer show as red error
  - INFO:routes.tax_protest:... should no longer show as red error
  - actual failures like timeouts, exceptions, and other true errors should still appear as red/error entries