### PR TITLE
Enable immediate signup access

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -7,7 +7,6 @@ class RegistrationForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     first_name = StringField('First Name', validators=[DataRequired()])
     last_name = StringField('Last Name', validators=[DataRequired()])
-    phone = StringField('Phone Number', validators=[Optional(), Length(max=20)])
     license_number = StringField(
         'License Number',
         validators=[
@@ -29,7 +28,7 @@ class RegistrationForm(FlaskForm):
     licensed_supervisor_phone = StringField('Licensed Supervisor Phone', validators=[Optional(), Length(max=20)])
     password = PasswordField('Password', validators=[DataRequired()])
     confirm_password = PasswordField('Confirm Password',
-                                   validators=[DataRequired(), EqualTo('password')])
+                                   validators=[DataRequired(), EqualTo('password', message='Passwords must match.')])
     submit = SubmitField('Register')
 
 class LoginForm(FlaskForm):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -3,6 +3,11 @@ from flask_login import login_user, logout_user, login_required, current_user
 from models import User, db, Contact, ActionPlan, Organization, OrganizationInvite
 from forms import RegistrationForm, LoginForm, RequestResetForm, ResetPasswordForm
 from services.email_service import get_email_service
+from services.tenant_service import (
+    create_default_groups_for_org,
+    create_default_task_types_for_org,
+    create_default_transaction_types_for_org,
+)
 from functools import wraps
 from datetime import datetime, timedelta
 from utils import generate_unique_slug
@@ -46,8 +51,8 @@ def terms_privacy():
 @auth_bp.route('/register', methods=['GET', 'POST'])
 def register():
     """
-    Multi-tenant registration.
-    Creates a new organization in pending_approval status and the owner user.
+    Multi-tenant self-serve registration.
+    Creates an active organization and logs the owner in immediately.
     """
     if current_user.is_authenticated:
         return redirect(url_for('main.contacts'))
@@ -60,8 +65,7 @@ def register():
             # Bot detected! Return fake success to not tip them off
             current_app.logger.warning(f"Bot registration blocked (honeypot): {form.email.data}")
             flash(
-                'Registration submitted! You will receive an email once approved '
-                '(typically within 24 hours).', 
+                'Thanks for signing up. If your account was created successfully, you can log in shortly.',
                 'success'
             )
             return redirect(url_for('auth.login'))
@@ -74,12 +78,13 @@ def register():
         # Generate unique slug with collision handling
         slug = generate_unique_slug(company_name)
         
-        # Create org in pending_approval status (free tier)
+        # Self-serve signups are active immediately. Abuse is handled separately.
         org = Organization(
             name=company_name,
             slug=slug,
             subscription_tier='free',
-            status='pending_approval',
+            status='active',
+            approved_at=datetime.utcnow(),
             max_users=1,
             max_contacts=10000,
             can_invite_users=False
@@ -111,7 +116,6 @@ def register():
             email=form.email.data,
             first_name=form.first_name.data,
             last_name=form.last_name.data,
-            phone=form.phone.data if form.phone.data else None,
             license_number=form.license_number.data if form.license_number.data else None,
             licensed_supervisor=form.licensed_supervisor.data if form.licensed_supervisor.data else None,
             licensed_supervisor_license=form.licensed_supervisor_license.data if form.licensed_supervisor_license.data else None,
@@ -121,18 +125,30 @@ def register():
             is_super_admin=False
         )
         user.set_password(form.password.data)
+        user.last_login = datetime.utcnow()
         db.session.add(user)
         db.session.commit()
-        
-        # TODO: Notify platform admins for approval
-        # notify_platform_admins_new_org_registration(org, user)
-        
-        flash(
-            'Registration submitted! You will receive an email once approved '
-            '(typically within 24 hours).', 
-            'success'
-        )
-        return redirect(url_for('auth.login'))
+
+        try:
+            create_default_groups_for_org(org.id)
+            create_default_task_types_for_org(org.id)
+            create_default_transaction_types_for_org(org.id)
+        except Exception:
+            current_app.logger.exception(
+                'Failed to seed default org data during signup org_id=%s owner_email=%s',
+                org.id,
+                user.email,
+            )
+            flash(
+                'Your account was created, but we could not finish the default setup. '
+                'Please contact support before adding contacts.',
+                'warning'
+            )
+            return redirect(url_for('auth.login'))
+
+        login_user(user)
+        flash('Welcome to Origen. Your account is ready to use.', 'success')
+        return redirect(url_for('main.dashboard'))
 
     return render_template('auth/register.html', form=form)
 

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -329,14 +329,14 @@
                     <!-- Header -->
                     <div class="text-center mb-8">
                         <h2 class="text-3xl font-extrabold text-slate-900 mb-2 tracking-tight">Get Started Free</h2>
-                        <p class="text-slate-500">Create your account in seconds</p>
+                        <p class="text-slate-500">Create your account and start using it right away</p>
                     </div>
                     
                     <!-- Benefits -->
                     <div class="flex items-center justify-center gap-6 mb-8 text-sm text-slate-500">
                         <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Unlimited Contacts</span>
                         <span class="text-slate-300">·</span>
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>2-Min Setup</span>
+                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Instant Access</span>
                         <span class="text-slate-300">·</span>
                         <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Secure</span>
                     </div>
@@ -393,17 +393,6 @@
                             {% endif %}
                         </div>
 
-                        <!-- Phone -->
-                        <div class="input-group">
-                            {{ form.phone(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Phone number") }}
-                            <i class="input-icon fas fa-phone"></i>
-                            {% if form.phone.errors %}
-                                {% for error in form.phone.errors %}
-                                    <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                {% endfor %}
-                            {% endif %}
-                        </div>
-
                         <!-- Password Fields -->
                         <div class="grid grid-cols-2 gap-3">
                             <div class="input-group">
@@ -416,7 +405,7 @@
                                 {% endif %}
                             </div>
                             <div class="input-group">
-                                {{ form.confirm_password(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Confirm") }}
+                                {{ form.confirm_password(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Confirm password") }}
                                 <i class="input-icon fas fa-lock"></i>
                                 {% if form.confirm_password.errors %}
                                     {% for error in form.confirm_password.errors %}

--- a/templates/auth/terms_privacy.html
+++ b/templates/auth/terms_privacy.html
@@ -102,7 +102,7 @@
                                 <li>You are responsible for all activities that occur under your account</li>
                                 <li>You must notify us immediately of any unauthorized use of your account</li>
                             </ul>
-                            <p><strong>Account Approval:</strong> New organization registrations are subject to approval. We reserve the right to refuse service to anyone for any reason at any time.</p>
+                            <p><strong>Account Access:</strong> New organization registrations may receive immediate access. We reserve the right to suspend, restrict, or refuse service at any time to prevent abuse or protect the platform.</p>
                             <p><strong>Account Security:</strong> You agree to use a strong password and to not share your account credentials with others. We are not liable for any loss or damage arising from your failure to maintain account security.</p>
                         </div>
                     </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,8 +4,10 @@ Integration tests for authentication routes.
 Covers: login, logout, registration, profile view/update, password reset,
 user management (admin), and access control.
 """
+from pathlib import Path
 import pytest
 from conftest import login
+from models import ContactGroup, TaskType, TransactionType, User
 
 
 class TestLogin:
@@ -95,6 +97,55 @@ class TestRegistration:
     def test_register_page_loads(self, client, seed):
         resp = client.get('/register')
         assert resp.status_code in (200, 302)
+
+    def test_register_template_shows_confirm_password_and_not_phone(self, seed):
+        template = Path(__file__).resolve().parents[1] / 'templates' / 'auth' / 'register.html'
+        contents = template.read_text()
+        assert 'form.confirm_password' in contents
+        assert 'Confirm password' in contents
+        assert 'form.phone' not in contents
+
+    def test_register_allows_immediate_login(self, client, seed):
+        resp = client.post('/register', data={
+            'company_name': 'Fast Lane Realty',
+            'first_name': 'Nina',
+            'last_name': 'Agent',
+            'email': 'nina@test.com',
+            'password': 'supersecure123',
+            'confirm_password': 'supersecure123',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        resp = client.get('/logout', follow_redirects=True)
+        assert resp.status_code == 200
+
+        login_resp = client.post('/login', data={
+            'username': 'nina@test.com',
+            'password': 'supersecure123',
+        }, follow_redirects=True)
+
+        assert login_resp.status_code == 200
+        assert b'pending approval' not in login_resp.data.lower()
+        assert b'Dashboard' in login_resp.data or b'dashboard' in login_resp.data.lower()
+
+    def test_register_seeds_default_org_data(self, client, app, seed):
+        resp = client.post('/register', data={
+            'company_name': 'Seeded Realty',
+            'first_name': 'Sam',
+            'last_name': 'Seeder',
+            'email': 'sam.seeded@test.com',
+            'password': 'supersecure123',
+            'confirm_password': 'supersecure123',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+
+        with app.app_context():
+            user = User.query.filter_by(email='sam.seeded@test.com').first()
+            assert user is not None
+            assert ContactGroup.query.filter_by(organization_id=user.organization_id).count() > 0
+            assert TaskType.query.filter_by(organization_id=user.organization_id).count() > 0
+            assert TransactionType.query.filter_by(organization_id=user.organization_id).count() > 0
 
     def test_terms_privacy_page(self, client, seed):
         resp = client.get('/terms-privacy')


### PR DESCRIPTION
## Summary

This PR removes the manual approval step from signup so new users can create an account and start using the product immediately.

It also reduces signup friction by removing the phone requirement and making password confirmation explicit.

## What Changed

- activate new organizations immediately on signup instead of creating them as `pending_approval`
- log the new user in right away after registration
- seed the default org setup during signup so new accounts have:
  - default contact groups
  - default task types/subtypes
  - default transaction types
- remove phone number from the signup form and registration processing
- clarify the confirm-password field on signup
- update terms/privacy copy to match the new immediate-access flow
- add regression coverage for:
  - immediate post-signup login
  - removal of phone from signup
  - default org data seeding for new accounts

## Validation

Ran:

```bash
.venv/bin/python3 -m pytest tests/test_auth.py -x -v --tb=short
```

Result:
- `29 passed`

## Notes

This PR is intentionally limited to the signup/self-serve flow.
A separate follow-up branch will contain the database/test safety changes so the production-hardening work can be reviewed independently.