### PR TITLE
feat(dashboard): add Market Insights panel backed by cached RentCast …

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,7 @@ from routes.contact_us import contact_bp
 from routes.gmail_integration import gmail_bp
 from routes.reports import reports_bp
 from routes.tax_protest import tax_protest_bp
+from routes.market_insights import market_insights_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
@@ -210,6 +211,7 @@ def create_app():
     app.register_blueprint(gmail_bp)
     app.register_blueprint(reports_bp)
     app.register_blueprint(tax_protest_bp)
+    app.register_blueprint(market_insights_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/config.py
+++ b/config.py
@@ -48,6 +48,10 @@ class Config:
     # RentCast API configuration
     RENTCAST_API_KEY = os.getenv('RENTCAST_API_KEY')
     RENTCAST_REFRESH_HOURS = int(os.getenv('RENTCAST_REFRESH_HOURS', 48))  # Hours before allowing re-fetch
+    # Market Insights cache TTL. RentCast /markets data updates monthly upstream
+    # and the free tier is 50 calls/month, so we default to 7 days. With ~5 ZIPs
+    # seeded that works out to roughly 22 calls per month.
+    MARKET_DATA_REFRESH_HOURS = int(os.getenv('MARKET_DATA_REFRESH_HOURS', 168))
 
     # Google Gmail Integration (OAuth)
     GOOGLE_CLIENT_ID = os.getenv('GOOGLE_CLIENT_ID')

--- a/frontend/controllers/market_insights_controller.js
+++ b/frontend/controllers/market_insights_controller.js
@@ -1,0 +1,577 @@
+import { Controller } from "@hotwired/stimulus";
+
+const ACCENT = "#f97316";
+const SLATE_400 = "#94a3b8";
+const SLATE_500 = "#64748b";
+
+const USD = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0
+});
+const COMPACT_USD = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 1
+});
+const INT = new Intl.NumberFormat("en-US");
+
+// localStorage key for the agent's preferred collapsed/expanded state. Default
+// on first visit is COLLAPSED so the dashboard stays focused on contacts/tasks
+// and we don't burn RentCast quota for users who never look at the panel.
+const LS_COLLAPSED_KEY = "crm.market-insights.collapsed";
+
+const KPI_KEYS = ["price", "ppsf", "inventory", "dom"];
+
+const KPI_FORMATTERS = {
+  price: (v) => (v == null ? "—" : USD.format(v)),
+  ppsf: (v) => (v == null ? "—" : `$${Math.round(v)}`),
+  inventory: (v) => (v == null ? "—" : INT.format(Math.round(v))),
+  dom: (v) => (v == null ? "—" : `${Math.round(v)}d`)
+};
+
+// For DOM, "down" is good (selling faster); for everything else, "up" is good.
+const KPI_POSITIVE_DIRECTION = {
+  price: "up",
+  ppsf: "up",
+  inventory: "up",
+  dom: "down"
+};
+
+export default class extends Controller {
+  static targets = [
+    "areaSelect",
+    "windowButton",
+    "kpiCard",
+    "kpiValue",
+    "kpiDelta",
+    "kpiDeltaText",
+    "kpiSpark",
+    "mainChart",
+    "asOf",
+    "asOfWrap",
+    "staleSeparator",
+    "staleBadge",
+    "errorState",
+    "errorMessage",
+    "newListings",
+    "toggleButton",
+    "controls",
+    "body"
+  ];
+
+  static values = {
+    defaultSlug: { type: String, default: "mont-belvieu" },
+    defaultWindow: { type: String, default: "12m" }
+  };
+
+  initialize() {
+    this.cache = new Map(); // `${slug}|${window}` -> response
+    this.charts = {}; // { main, sparks: { kpi: chart } }
+    this.previousValues = {}; // for CountUp tweening between values
+    this.currentSlug = this.defaultSlugValue;
+    this.currentWindow = this.defaultWindowValue;
+    this.lastResponse = null;
+    this._libsReady = null;
+    this.started = false;
+    this.collapsed = this._readCollapsedPref();
+  }
+
+  async connect() {
+    this._applyCollapsedState();
+    if (!this.collapsed) await this._start();
+  }
+
+  async _start() {
+    if (this.started) return;
+    this.started = true;
+    await this._waitForLibraries();
+    await this._loadAreas();
+    await this._loadInsights();
+  }
+
+  async toggle() {
+    this.collapsed = !this.collapsed;
+    this._writeCollapsedPref(this.collapsed);
+    this._applyCollapsedState();
+    if (!this.collapsed) {
+      if (!this.started) await this._start();
+      else this._reflowCharts();
+    }
+  }
+
+  _readCollapsedPref() {
+    try {
+      const v = window.localStorage.getItem(LS_COLLAPSED_KEY);
+      if (v === "0") return false;
+      if (v === "1") return true;
+    } catch (_e) { /* ignore */ }
+    return true;
+  }
+
+  _writeCollapsedPref(collapsed) {
+    try { window.localStorage.setItem(LS_COLLAPSED_KEY, collapsed ? "1" : "0"); }
+    catch (_e) { /* ignore */ }
+  }
+
+  _applyCollapsedState() {
+    const open = !this.collapsed;
+    this.element.classList.toggle("is-open", open);
+    if (this.hasBodyTarget) {
+      if (open) this.bodyTarget.removeAttribute("hidden");
+      else this.bodyTarget.setAttribute("hidden", "");
+    }
+    if (this.hasControlsTarget) this.controlsTarget.classList.toggle("hidden", !open);
+    if (this.hasAsOfWrapTarget) this.asOfWrapTarget.classList.toggle("hidden", !open);
+    if (this.hasToggleButtonTarget) {
+      this.toggleButtonTarget.setAttribute("aria-expanded", String(open));
+      this.toggleButtonTarget.setAttribute(
+        "aria-label",
+        open ? "Hide market insights" : "Show market insights"
+      );
+    }
+  }
+
+  _reflowCharts() {
+    try {
+      this.charts.main?.render?.();
+      Object.values(this.charts.sparks || {}).forEach((c) => c?.render?.());
+    } catch (_e) { /* swallow */ }
+  }
+
+  disconnect() {
+    Object.values(this.charts.sparks || {}).forEach((c) => c?.destroy?.());
+    this.charts.main?.destroy?.();
+  }
+
+  // ---------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------
+
+  async changeArea(event) {
+    const slug = event.currentTarget.value;
+    if (!slug || slug === this.currentSlug) return;
+    this.currentSlug = slug;
+    await this._loadInsights();
+  }
+
+  async setWindow(event) {
+    const win = event.currentTarget.dataset.window;
+    if (!win || win === this.currentWindow) return;
+    this.currentWindow = win;
+    this.windowButtonTargets.forEach((btn) => {
+      btn.classList.toggle("is-active", btn.dataset.window === win);
+    });
+    await this._loadInsights();
+  }
+
+  async refresh() {
+    // Bust the in-memory cache for the current view.
+    this.cache.delete(this._cacheKey());
+    await this._loadInsights();
+  }
+
+  // ---------------------------------------------------------------------
+  // Data loading
+  // ---------------------------------------------------------------------
+
+  async _loadAreas() {
+    try {
+      const r = await fetch("/api/market-insights/areas", { credentials: "same-origin" });
+      if (!r.ok) throw new Error(`Areas request failed: ${r.status}`);
+      const { areas } = await r.json();
+      this._populateAreaSelect(areas || []);
+    } catch (err) {
+      console.error("Failed to load market insight areas", err);
+      this._showError("Could not load service areas.");
+    }
+  }
+
+  _populateAreaSelect(areas) {
+    const select = this.areaSelectTarget;
+    select.innerHTML = "";
+    if (!areas.length) {
+      const opt = document.createElement("option");
+      opt.textContent = "No areas configured";
+      opt.disabled = true;
+      select.appendChild(opt);
+      return;
+    }
+    let chosen = null;
+    areas.forEach((a) => {
+      const opt = document.createElement("option");
+      opt.value = a.slug;
+      opt.textContent = a.display_name;
+      select.appendChild(opt);
+      if (a.slug === this.currentSlug) chosen = a.slug;
+    });
+    if (!chosen) {
+      this.currentSlug = areas[0].slug;
+      select.value = this.currentSlug;
+    } else {
+      select.value = chosen;
+    }
+  }
+
+  async _loadInsights() {
+    if (!this.currentSlug) return;
+    const key = this._cacheKey();
+    const cached = this.cache.get(key);
+    if (cached) {
+      this._render(cached);
+      return;
+    }
+    this._setLoading(true);
+    this._hideError();
+    try {
+      const url = `/api/market-insights/${encodeURIComponent(this.currentSlug)}?window=${encodeURIComponent(this.currentWindow)}`;
+      const r = await fetch(url, { credentials: "same-origin" });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        throw new Error(body.error || `Request failed (${r.status})`);
+      }
+      const data = await r.json();
+      this.cache.set(key, data);
+      this._render(data);
+    } catch (err) {
+      console.error("Failed to load market insights", err);
+      this._showError(err.message || "Couldn't load this area right now.");
+    } finally {
+      this._setLoading(false);
+    }
+  }
+
+  _cacheKey() {
+    return `${this.currentSlug}|${this.currentWindow}`;
+  }
+
+  // ---------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------
+
+  _render(data) {
+    this.lastResponse = data;
+
+    if (this.hasAsOfTarget) {
+      this.asOfTarget.textContent = data.as_of
+        ? `Data as of ${this._formatAsOf(data.as_of)}`
+        : "Data freshly loaded";
+    }
+    this._toggleStale(Boolean(data.is_stale));
+
+    this._renderKpi("price", data.median_home_price, data, (h) => h.median_price);
+    this._renderKpi("ppsf", data.median_price_per_sqft, data, (h) => h.median_ppsf);
+    this._renderKpi("inventory", data.active_inventory, data, (h) => h.total_listings);
+    this._renderKpi("dom", data.days_on_market, data, (h) => h.median_dom);
+
+    this._renderSecondary(data);
+    this._renderMainChart(data);
+  }
+
+  _renderKpi(kpi, metric, data, historyAccessor) {
+    const value = metric ? metric.value : null;
+    const valueEl = this._kpiValueEl(kpi);
+    if (valueEl) {
+      const previous = this.previousValues[kpi];
+      this._animateNumber(valueEl, previous, value, KPI_FORMATTERS[kpi]);
+      this.previousValues[kpi] = value;
+    }
+
+    const deltaEl = this._kpiDeltaEl(kpi);
+    if (deltaEl) {
+      const change = metric
+        ? metric.change_pct != null
+          ? metric.change_pct
+          : metric.change_days != null
+            ? metric.change_days
+            : null
+        : null;
+      const isDays = metric && metric.change_days != null;
+      this._renderDelta(deltaEl, kpi, change, metric ? metric.change_vs : null, isDays);
+    }
+
+    this._renderKpiSpark(kpi, data, historyAccessor);
+  }
+
+  _renderDelta(el, kpi, change, vsLabel, isDays) {
+    const textEl = el.querySelector("[data-market-insights-target='kpiDeltaText']");
+    el.classList.remove("crm-mi__delta--up", "crm-mi__delta--down", "crm-mi__delta--flat");
+    el.classList.add("crm-mi__delta");
+    el.classList.remove("hidden");
+
+    if (change == null || isNaN(change)) {
+      el.classList.add("crm-mi__delta--flat");
+      el.querySelector("i").className = "fas fa-minus";
+      if (textEl) textEl.textContent = "—";
+      return;
+    }
+
+    const direction = change > 0 ? "up" : change < 0 ? "down" : "flat";
+    const positive = KPI_POSITIVE_DIRECTION[kpi];
+    let tone;
+    if (direction === "flat") tone = "flat";
+    else if (direction === positive) tone = "up";
+    else tone = "down";
+    el.classList.add(`crm-mi__delta--${tone}`);
+
+    const icon = el.querySelector("i");
+    if (icon) {
+      icon.className = direction === "up"
+        ? "fas fa-arrow-trend-up"
+        : direction === "down"
+          ? "fas fa-arrow-trend-down"
+          : "fas fa-minus";
+    }
+    if (textEl) {
+      const sign = change > 0 ? "+" : "";
+      textEl.textContent = isDays
+        ? `${sign}${Math.round(change)}d vs ${vsLabel || ""}`.trim()
+        : `${sign}${change.toFixed(1)}% vs ${vsLabel || ""}`.trim();
+    }
+  }
+
+  _renderKpiSpark(kpi, data, accessor) {
+    const el = this._kpiSparkEl(kpi);
+    if (!el || !window.ApexCharts) return;
+    const series = (data.history || [])
+      .map((h) => accessor(h))
+      .map((v) => (v == null ? null : Number(v)));
+
+    if (!series.some((v) => v != null)) {
+      el.innerHTML = "";
+      return;
+    }
+
+    const opts = {
+      chart: {
+        type: "area",
+        height: 44,
+        sparkline: { enabled: true },
+        animations: { enabled: true, easing: "easeinout", speed: 600 }
+      },
+      stroke: { curve: "smooth", width: 2 },
+      colors: [ACCENT],
+      fill: {
+        type: "gradient",
+        gradient: { shadeIntensity: 0.6, opacityFrom: 0.45, opacityTo: 0.05, stops: [0, 100] }
+      },
+      tooltip: {
+        enabled: true,
+        theme: "dark",
+        x: { show: false },
+        y: { formatter: (v) => (v == null ? "—" : KPI_FORMATTERS[kpi](v)), title: { formatter: () => "" } },
+        marker: { show: false }
+      },
+      series: [{ name: kpi, data: series }]
+    };
+
+    this.charts.sparks ||= {};
+    if (this.charts.sparks[kpi]) {
+      this.charts.sparks[kpi].updateOptions({ ...opts, series: opts.series }, true, true);
+    } else {
+      this.charts.sparks[kpi] = new ApexCharts(el, opts);
+      this.charts.sparks[kpi].render();
+    }
+  }
+
+  _renderSecondary(data) {
+    if (this.hasNewListingsTarget) {
+      const v = data.new_listings ? data.new_listings.value : null;
+      this.newListingsTarget.textContent = v == null ? "—" : INT.format(Math.round(v));
+    }
+  }
+
+  _renderMainChart(data) {
+    const el = this.hasMainChartTarget ? this.mainChartTarget : null;
+    if (!el || !window.ApexCharts) return;
+
+    const history = data.history || [];
+    const priceSeries = history
+      .filter((h) => h.median_price != null)
+      .map((h) => ({ x: this._monthToTimestamp(h.month), y: Number(h.median_price) }));
+    const inventorySeries = history
+      .filter((h) => h.total_listings != null)
+      .map((h) => ({ x: this._monthToTimestamp(h.month), y: Number(h.total_listings) }));
+
+    const opts = {
+      chart: {
+        type: "line",
+        height: 320,
+        toolbar: { show: false },
+        zoom: { enabled: false },
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif",
+        animations: { enabled: true, easing: "easeinout", speed: 700 }
+      },
+      colors: [ACCENT, SLATE_400],
+      stroke: { curve: "smooth", width: [3, 2], dashArray: [0, 4] },
+      fill: {
+        type: ["gradient", "solid"],
+        gradient: { shadeIntensity: 0.5, opacityFrom: 0.35, opacityTo: 0.0, stops: [0, 90] },
+        opacity: [0.35, 0]
+      },
+      dataLabels: { enabled: false },
+      markers: { size: 0, strokeWidth: 0, hover: { size: 5 } },
+      grid: {
+        borderColor: "#e2e8f0",
+        strokeDashArray: 4,
+        padding: { top: 0, right: 8, bottom: 0, left: 8 }
+      },
+      xaxis: {
+        type: "datetime",
+        labels: {
+          style: { colors: SLATE_500, fontSize: "11px" },
+          datetimeFormatter: { year: "yyyy", month: "MMM", day: "MMM dd" }
+        },
+        axisBorder: { show: false },
+        axisTicks: { show: false },
+        tooltip: { enabled: false }
+      },
+      yaxis: [
+        {
+          seriesName: "Median asking price",
+          labels: {
+            style: { colors: SLATE_500, fontSize: "11px" },
+            formatter: (v) => (v == null ? "" : COMPACT_USD.format(v))
+          }
+        },
+        {
+          seriesName: "Active listings",
+          opposite: true,
+          labels: {
+            style: { colors: SLATE_500, fontSize: "11px" },
+            formatter: (v) => (v == null ? "" : INT.format(Math.round(v)))
+          }
+        }
+      ],
+      tooltip: {
+        theme: "dark",
+        shared: true,
+        intersect: false,
+        x: { format: "MMM yyyy" },
+        y: [
+          { formatter: (v) => (v == null ? "—" : USD.format(v)) },
+          { formatter: (v) => (v == null ? "—" : `${INT.format(Math.round(v))} listings`) }
+        ],
+        marker: { show: true }
+      },
+      legend: { show: false },
+      series: [
+        { name: "Median asking price", type: "area", data: priceSeries },
+        { name: "Active listings", type: "line", data: inventorySeries }
+      ]
+    };
+
+    if (this.charts.main) {
+      this.charts.main.updateOptions(opts, true, true);
+    } else {
+      this.charts.main = new ApexCharts(el, opts);
+      this.charts.main.render();
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // UI helpers
+  // ---------------------------------------------------------------------
+
+  _kpiValueEl(kpi) {
+    return this.kpiValueTargets.find((el) => el.dataset.kpi === kpi) || null;
+  }
+  _kpiDeltaEl(kpi) {
+    return this.kpiDeltaTargets.find((el) => el.dataset.kpi === kpi) || null;
+  }
+  _kpiSparkEl(kpi) {
+    return this.kpiSparkTargets.find((el) => el.dataset.kpi === kpi) || null;
+  }
+
+  _setLoading(isLoading) {
+    this.kpiCardTargets.forEach((card) => {
+      card.classList.toggle("opacity-60", isLoading);
+    });
+  }
+
+  _showError(message) {
+    if (this.hasErrorStateTarget) {
+      this.errorStateTarget.classList.remove("hidden");
+      if (this.hasErrorMessageTarget) this.errorMessageTarget.textContent = message;
+    }
+  }
+
+  _hideError() {
+    if (this.hasErrorStateTarget) this.errorStateTarget.classList.add("hidden");
+  }
+
+  _toggleStale(isStale) {
+    if (this.hasStaleBadgeTarget) this.staleBadgeTarget.classList.toggle("hidden", !isStale);
+    if (this.hasStaleSeparatorTarget) this.staleSeparatorTarget.classList.toggle("hidden", !isStale);
+  }
+
+  _animateNumber(el, from, to, formatter) {
+    if (to == null) {
+      el.textContent = "—";
+      return;
+    }
+    const start = typeof from === "number" && !isNaN(from) ? from : 0;
+    if (window.countUp && window.countUp.CountUp) {
+      const cu = new window.countUp.CountUp(el, to, {
+        startVal: start,
+        duration: 0.9,
+        useGrouping: true,
+        formattingFn: formatter
+      });
+      if (!cu.error) {
+        cu.start();
+        return;
+      }
+    }
+    // Fallback: rAF tween
+    const duration = 700;
+    const t0 = performance.now();
+    const tick = (now) => {
+      const p = Math.min((now - t0) / duration, 1);
+      const eased = 1 - Math.pow(1 - p, 3);
+      const v = start + (to - start) * eased;
+      el.textContent = formatter(v);
+      if (p < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }
+
+  _monthToTimestamp(month) {
+    if (!month) return null;
+    const [y, m] = month.split("-").map(Number);
+    return Date.UTC(y, (m || 1) - 1, 1);
+  }
+
+  _formatAsOf(iso) {
+    try {
+      const d = new Date(iso);
+      return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+    } catch (_e) {
+      return iso;
+    }
+  }
+
+  _escape(s) {
+    return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    })[c]);
+  }
+
+  _waitForLibraries() {
+    if (this._libsReady) return this._libsReady;
+    this._libsReady = new Promise((resolve) => {
+      const ready = () => Boolean(window.ApexCharts);
+      if (ready()) return resolve();
+      const start = Date.now();
+      const tick = () => {
+        if (ready()) return resolve();
+        if (Date.now() - start > 5000) return resolve(); // give up; fall back
+        setTimeout(tick, 50);
+      };
+      tick();
+    });
+    return this._libsReady;
+  }
+}

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,11 +1,13 @@
 import { Application } from "@hotwired/stimulus";
 import DashboardPageController from "./controllers/dashboard_page_controller";
 import ContactsPageController from "./controllers/contacts_page_controller";
+import MarketInsightsController from "./controllers/market_insights_controller";
 import "./styles/app.css";
 
 const application = Application.start();
 
 application.register("dashboard-page", DashboardPageController);
 application.register("contacts-page", ContactsPageController);
+application.register("market-insights", MarketInsightsController);
 
 window.Stimulus = application;

--- a/frontend/styles/app.css
+++ b/frontend/styles/app.css
@@ -276,4 +276,46 @@
   .crm-shell-button {
     @apply inline-flex items-center gap-2 rounded-md border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-200 transition-colors hover:bg-slate-800;
   }
+
+  /* ----- Market Insights ------------------------------------------------- */
+
+  .crm-mi__kpi {
+    @apply relative flex flex-col gap-3 rounded-md border border-slate-200 bg-white p-4 transition-shadow hover:shadow-sm;
+  }
+
+  .crm-mi__kpi-head {
+    @apply flex items-start justify-between gap-3;
+  }
+
+  .crm-mi__kpi-label {
+    @apply text-xs font-semibold uppercase tracking-[0.08em] text-slate-500;
+  }
+
+  .crm-mi__kpi-value {
+    @apply mt-1 text-3xl font-semibold tracking-tight text-slate-950 tabular-nums;
+  }
+
+  .crm-mi__kpi-spark {
+    @apply -mb-2 -mx-1 h-10;
+  }
+
+  .crm-mi__delta {
+    @apply inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold;
+  }
+
+  .crm-mi__delta--up {
+    @apply bg-emerald-50 text-emerald-700;
+  }
+
+  .crm-mi__delta--down {
+    @apply bg-rose-50 text-rose-700;
+  }
+
+  .crm-mi__delta--flat {
+    @apply bg-slate-100 text-slate-600;
+  }
+
+  .crm-mi__chart {
+    @apply h-80 w-full;
+  }
 }

--- a/migrations/versions/add_market_insights_tables.py
+++ b/migrations/versions/add_market_insights_tables.py
@@ -1,0 +1,107 @@
+"""add service_areas, market_data_cache, rentcast_api_log tables
+
+Revision ID: add_market_insights_tables
+Revises: add_tax_protest_indexes
+Create Date: 2026-04-22 09:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_market_insights_tables'
+down_revision = 'add_tax_protest_indexes'
+branch_labels = None
+depends_on = None
+
+
+SEED_SERVICE_AREAS = [
+    {'slug': 'mont-belvieu', 'display_name': 'Mont Belvieu', 'zip_codes': ['77523']},
+    {'slug': 'baytown',      'display_name': 'Baytown',      'zip_codes': ['77521', '77520']},
+    {'slug': 'dayton',       'display_name': 'Dayton',       'zip_codes': ['77535']},
+    {'slug': 'anahuac',      'display_name': 'Anahuac',      'zip_codes': ['77514']},
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'service_areas' not in tables:
+        op.create_table(
+            'service_areas',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('slug', sa.String(length=100), nullable=False),
+            sa.Column('display_name', sa.String(length=200), nullable=False),
+            sa.Column('zip_codes', sa.JSON(), nullable=False),
+            sa.Column('sort_order', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.PrimaryKeyConstraint('id', name='pk_service_areas'),
+            sa.UniqueConstraint('slug', name='uq_service_areas_slug'),
+        )
+        op.create_index('ix_service_areas_sort_order', 'service_areas', ['sort_order'], unique=False)
+
+        service_areas = sa.table(
+            'service_areas',
+            sa.column('slug', sa.String),
+            sa.column('display_name', sa.String),
+            sa.column('zip_codes', sa.JSON),
+            sa.column('sort_order', sa.Integer),
+        )
+        op.bulk_insert(
+            service_areas,
+            [
+                {**area, 'sort_order': idx}
+                for idx, area in enumerate(SEED_SERVICE_AREAS)
+            ],
+        )
+
+    if 'market_data_cache' not in tables:
+        op.create_table(
+            'market_data_cache',
+            sa.Column('zip_code', sa.String(length=10), nullable=False),
+            sa.Column('payload', sa.JSON(), nullable=True),
+            sa.Column('refreshed_at', sa.DateTime(), nullable=True),
+            sa.Column('refresh_started_at', sa.DateTime(), nullable=True),
+            sa.Column('last_error', sa.Text(), nullable=True),
+            sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.PrimaryKeyConstraint('zip_code', name='pk_market_data_cache'),
+        )
+        op.create_index('ix_market_data_cache_refreshed_at', 'market_data_cache', ['refreshed_at'], unique=False)
+
+    if 'rentcast_api_log' not in tables:
+        op.create_table(
+            'rentcast_api_log',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('zip_code', sa.String(length=10), nullable=True),
+            sa.Column('endpoint', sa.String(length=100), nullable=False),
+            sa.Column('status_code', sa.Integer(), nullable=True),
+            sa.Column('latency_ms', sa.Integer(), nullable=True),
+            sa.Column('error', sa.Text(), nullable=True),
+            sa.Column('called_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.PrimaryKeyConstraint('id', name='pk_rentcast_api_log'),
+        )
+        op.create_index('ix_rentcast_api_log_called_at', 'rentcast_api_log', ['called_at'], unique=False)
+        op.create_index('ix_rentcast_api_log_zip_code', 'rentcast_api_log', ['zip_code'], unique=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'rentcast_api_log' in tables:
+        op.drop_index('ix_rentcast_api_log_zip_code', table_name='rentcast_api_log')
+        op.drop_index('ix_rentcast_api_log_called_at', table_name='rentcast_api_log')
+        op.drop_table('rentcast_api_log')
+
+    if 'market_data_cache' in tables:
+        op.drop_index('ix_market_data_cache_refreshed_at', table_name='market_data_cache')
+        op.drop_table('market_data_cache')
+
+    if 'service_areas' in tables:
+        op.drop_index('ix_service_areas_sort_order', table_name='service_areas')
+        op.drop_table('service_areas')

--- a/models.py
+++ b/models.py
@@ -1696,3 +1696,61 @@ class FortBendProperty(db.Model):
 
     def __repr__(self):
         return f'<FortBendProperty {self.site_addr_1 or self.property_number}>'
+
+
+# =============================================================================
+# MARKET INSIGHTS (RentCast-backed, multi-tenant-agnostic lookup data)
+# =============================================================================
+
+class ServiceArea(db.Model):
+    """A named geographic area composed of one or more ZIP codes.
+
+    Not tenant-scoped: this is global lookup data shared across all orgs.
+    """
+    __tablename__ = 'service_areas'
+
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(100), unique=True, nullable=False, index=True)
+    display_name = db.Column(db.String(200), nullable=False)
+    zip_codes = db.Column(db.JSON, nullable=False)  # list[str]
+    sort_order = db.Column(db.Integer, nullable=False, default=0, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    def __repr__(self):
+        return f'<ServiceArea {self.slug}>'
+
+
+class MarketDataCache(db.Model):
+    """Per-ZIP cache of the RentCast /markets payload.
+
+    Refresh is gated by an atomic claim (see services/market_insights_service.py)
+    so concurrent dashboard loads never duplicate the API call.
+    """
+    __tablename__ = 'market_data_cache'
+
+    zip_code = db.Column(db.String(10), primary_key=True)
+    payload = db.Column(db.JSON, nullable=True)
+    refreshed_at = db.Column(db.DateTime, nullable=True, index=True)
+    refresh_started_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.Text, nullable=True)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def __repr__(self):
+        return f'<MarketDataCache {self.zip_code} refreshed={self.refreshed_at}>'
+
+
+class RentcastApiLog(db.Model):
+    """Audit row written for every outbound RentCast call so the monthly
+    quota burn is queryable rather than buried in stdout logs."""
+    __tablename__ = 'rentcast_api_log'
+
+    id = db.Column(db.Integer, primary_key=True)
+    zip_code = db.Column(db.String(10), nullable=True, index=True)
+    endpoint = db.Column(db.String(100), nullable=False)
+    status_code = db.Column(db.Integer, nullable=True)
+    latency_ms = db.Column(db.Integer, nullable=True)
+    error = db.Column(db.Text, nullable=True)
+    called_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    def __repr__(self):
+        return f'<RentcastApiLog {self.endpoint} zip={self.zip_code} status={self.status_code}>'

--- a/routes/market_insights.py
+++ b/routes/market_insights.py
@@ -1,0 +1,47 @@
+"""Market Insights API.
+
+Two endpoints, both authenticated but not tenant-scoped (the underlying
+RentCast cache is global lookup data shared across orgs):
+
+- GET /api/market-insights/areas
+    Lists the configured ServiceArea rows for the dashboard's selector.
+
+- GET /api/market-insights/<area_slug>?window=90d|180d|12m
+    Returns the cached market rollup for an area, sliced to the chosen window.
+"""
+
+from flask import Blueprint, jsonify, request
+from flask_login import login_required
+
+from services.market_insights_service import (
+    DEFAULT_WINDOW,
+    WINDOW_TO_MONTHS,
+    get_insights,
+    list_service_areas,
+)
+
+market_insights_bp = Blueprint('market_insights', __name__)
+
+
+@market_insights_bp.route('/api/market-insights/areas', methods=['GET'])
+@login_required
+def list_areas():
+    return jsonify({'areas': list_service_areas()})
+
+
+@market_insights_bp.route('/api/market-insights/<area_slug>', methods=['GET'])
+@login_required
+def get_area_insights(area_slug):
+    window = request.args.get('window', DEFAULT_WINDOW)
+    if window not in WINDOW_TO_MONTHS:
+        window = DEFAULT_WINDOW
+
+    result = get_insights(area_slug, window=window)
+    if result is None:
+        return jsonify({'error': f'Unknown service area: {area_slug}'}), 404
+
+    if 'error' in result and 'history' not in result:
+        # Cold cache + RentCast failure -- spec says return 503 with the error.
+        return jsonify(result), 503
+
+    return jsonify(result)

--- a/services/market_insights_service.py
+++ b/services/market_insights_service.py
@@ -1,0 +1,678 @@
+"""Market Insights service: cached, multi-ZIP RentCast `/markets` rollup.
+
+Key responsibilities
+--------------------
+1. Read the seeded ServiceArea -> list of ZIPs.
+2. For each ZIP, return the cached payload if it's fresh; otherwise
+   atomically claim a refresh and either run it inline (cold cache)
+   or in a background thread (stale-while-revalidate).
+3. Roll the per-ZIP payloads up into the area-wide response shape the
+   dashboard consumes, applying the requested time window (90d / 180d / 12m).
+
+The atomic claim is the heart of the quota-protection story: the UPDATE's
+WHERE clause guarantees that out of N concurrent stale requests, exactly
+one wins and actually calls RentCast. The other N-1 read the (briefly stale)
+cache and return immediately. The 2-minute guard on `refresh_started_at`
+also prevents a crashed refresh from blocking future refreshes forever.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timedelta
+from statistics import median
+from typing import Any, Dict, List, Optional, Tuple
+
+from flask import current_app
+from sqlalchemy import text
+
+from config import Config
+from models import db, MarketDataCache, RentcastApiLog, ServiceArea
+from services.rentcast_service import fetch_market_stats
+
+logger = logging.getLogger(__name__)
+
+
+WINDOW_TO_MONTHS = {'90d': 3, '180d': 6, '12m': 12}
+DEFAULT_WINDOW = '12m'
+CLAIM_LOCK_MINUTES = 2
+
+# RentCast's `/markets` endpoint reports stats across *every* listing in a ZIP,
+# including Land, Manufactured Homes, Multi-Family, and Commercial. Consumer-
+# facing comps (Movoto, Redfin, Realtor.com, Homes.com) default to residential
+# resale only, so pooling all property types systematically distorts our
+# headline metrics in rural ZIPs that have heavy land inventory. We rebuild
+# the headline numbers from the residential subset of `dataByPropertyType`
+# to keep the dashboard apples-to-apples with what users see elsewhere.
+RESIDENTIAL_PROPERTY_TYPES = frozenset({'Single Family', 'Townhouse', 'Condo'})
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def get_insights(area_slug: str, window: str = DEFAULT_WINDOW) -> Optional[Dict[str, Any]]:
+    """Build the Market Insights response for an area.
+
+    Returns ``None`` if the slug is unknown. Returns a dict with an
+    ``error`` key when the area exists but no cache could be produced
+    (caller should map that to HTTP 503).
+    """
+    if window not in WINDOW_TO_MONTHS:
+        window = DEFAULT_WINDOW
+
+    area = ServiceArea.query.filter_by(slug=area_slug).first()
+    if area is None:
+        return None
+
+    zip_codes = list(area.zip_codes or [])
+    payloads: List[Dict[str, Any]] = []
+    any_stale = False
+    last_error: Optional[str] = None
+
+    for zip_code in zip_codes:
+        payload, was_stale, err = _resolve_zip_payload(str(zip_code))
+        if payload is not None:
+            payloads.append(payload)
+            any_stale = any_stale or was_stale
+        elif err:
+            last_error = err
+
+    if not payloads:
+        return {
+            'area': area.display_name,
+            'slug': area.slug,
+            'zip_codes': zip_codes,
+            'error': last_error or 'No market data available yet for this area.',
+        }
+
+    rollup = _build_rollup_response(area, payloads, window)
+    rollup['is_stale'] = any_stale
+    return rollup
+
+
+def list_service_areas() -> List[Dict[str, Any]]:
+    """Return all configured service areas, sorted for stable display."""
+    rows = ServiceArea.query.order_by(ServiceArea.sort_order, ServiceArea.display_name).all()
+    return [
+        {'slug': r.slug, 'display_name': r.display_name, 'zip_codes': list(r.zip_codes or [])}
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-ZIP refresh / cache logic
+# ---------------------------------------------------------------------------
+
+def _resolve_zip_payload(zip_code: str) -> Tuple[Optional[Dict[str, Any]], bool, Optional[str]]:
+    """Return (payload, was_stale, error) for a ZIP.
+
+    - Fresh cache hit: (payload, False, None) -- no API call, no thread.
+    - Stale cache + payload exists: (payload, True, None) -- spawn background
+      refresh and return the stale payload immediately.
+    - Cold cache (no payload yet): block, try to win the claim, call RentCast.
+      On failure: (None, False, error).
+    """
+    row = _get_or_create_cache_row(zip_code)
+    refresh_hours = int(getattr(Config, 'MARKET_DATA_REFRESH_HOURS', 168))
+    stale_threshold = datetime.utcnow() - timedelta(hours=refresh_hours)
+
+    if row.refreshed_at is not None and row.refreshed_at >= stale_threshold:
+        return row.payload, False, None
+
+    if row.payload is not None:
+        # Stale-while-revalidate: hand back the stale payload now,
+        # kick off the refresh in a daemon thread.
+        try:
+            app = current_app._get_current_object()
+            t = threading.Thread(
+                target=_refresh_in_background,
+                args=(app, zip_code),
+                name=f'market-refresh-{zip_code}',
+                daemon=True,
+            )
+            t.start()
+        except Exception:
+            logger.exception("Failed to spawn background refresh for zip=%s", zip_code)
+        return row.payload, True, None
+
+    # Cold cache -- have to block and refresh inline so the very first
+    # ever load returns real data. Lost-claim path polls once and returns
+    # whatever the winner wrote; if still empty, surfaces an error.
+    if _try_claim_refresh(zip_code):
+        ok, err = _perform_refresh(zip_code)
+        if ok:
+            row = MarketDataCache.query.get(zip_code)
+            return (row.payload if row else None), False, None
+        return None, False, err
+    # Lost the claim: re-read the row.
+    row = MarketDataCache.query.get(zip_code)
+    if row and row.payload is not None:
+        return row.payload, True, None
+    return None, False, 'Market data is being fetched. Please refresh in a moment.'
+
+
+def _get_or_create_cache_row(zip_code: str) -> MarketDataCache:
+    """Idempotent INSERT then SELECT. Works on Postgres and SQLite."""
+    row = MarketDataCache.query.get(zip_code)
+    if row is not None:
+        return row
+    try:
+        db.session.execute(
+            text(
+                "INSERT INTO market_data_cache (zip_code, updated_at) "
+                "VALUES (:zip, CURRENT_TIMESTAMP) "
+                "ON CONFLICT (zip_code) DO NOTHING"
+            ),
+            {'zip': zip_code},
+        )
+        db.session.commit()
+    except Exception:
+        # Some SQLite versions don't accept ON CONFLICT on the PK column
+        # in this exact form; fall back to a plain INSERT and ignore the dupe.
+        db.session.rollback()
+        try:
+            row = MarketDataCache(zip_code=zip_code)
+            db.session.add(row)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+    return MarketDataCache.query.get(zip_code)
+
+
+def _try_claim_refresh(zip_code: str) -> bool:
+    """Atomically claim the right to refresh this ZIP.
+
+    Returns True if this caller won the claim and should call RentCast,
+    False if another worker is already refreshing or just did. Thresholds
+    are computed in Python so the SQL is portable across Postgres / SQLite.
+    """
+    refresh_hours = int(getattr(Config, 'MARKET_DATA_REFRESH_HOURS', 168))
+    now = datetime.utcnow()
+    stale_threshold = now - timedelta(hours=refresh_hours)
+    claim_lock_threshold = now - timedelta(minutes=CLAIM_LOCK_MINUTES)
+
+    result = db.session.execute(
+        text(
+            """
+            UPDATE market_data_cache
+            SET refresh_started_at = :now,
+                updated_at = :now
+            WHERE zip_code = :zip
+              AND (refreshed_at IS NULL OR refreshed_at < :stale_threshold)
+              AND (refresh_started_at IS NULL OR refresh_started_at < :claim_lock_threshold)
+            """
+        ),
+        {
+            'zip': zip_code,
+            'now': now,
+            'stale_threshold': stale_threshold,
+            'claim_lock_threshold': claim_lock_threshold,
+        },
+    )
+    db.session.commit()
+    return (result.rowcount or 0) > 0
+
+
+def _perform_refresh(zip_code: str) -> Tuple[bool, Optional[str]]:
+    """Call RentCast for one ZIP and persist the outcome + audit row."""
+    result = fetch_market_stats(zip_code)
+
+    log = RentcastApiLog(
+        zip_code=zip_code,
+        endpoint='/markets',
+        status_code=result.get('status_code'),
+        latency_ms=result.get('latency_ms'),
+        error=None if result.get('success') else (result.get('error') or 'unknown error'),
+    )
+    db.session.add(log)
+
+    row = MarketDataCache.query.get(zip_code)
+    if row is None:
+        row = MarketDataCache(zip_code=zip_code)
+        db.session.add(row)
+
+    if result.get('success'):
+        row.payload = result.get('data')
+        row.refreshed_at = datetime.utcnow()
+        row.refresh_started_at = None
+        row.last_error = None
+        db.session.commit()
+        return True, None
+
+    # Failure: clear the claim so the next visitor can retry, but DO NOT
+    # touch refreshed_at -- the cache is still considered stale and we
+    # surface the error.
+    row.refresh_started_at = None
+    row.last_error = result.get('error') or 'unknown error'
+    db.session.commit()
+    return False, row.last_error
+
+
+def _refresh_in_background(app, zip_code: str) -> None:
+    """Run :func:`_perform_refresh` in a worker thread with its own context."""
+    with app.app_context():
+        try:
+            if _try_claim_refresh(zip_code):
+                _perform_refresh(zip_code)
+            # If we lost the claim, another thread/request is on it.
+        except Exception:
+            logger.exception("Background market refresh failed zip=%s", zip_code)
+            try:
+                db.session.rollback()
+            except Exception:
+                pass
+        finally:
+            try:
+                db.session.remove()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Rollup + window slicing
+# ---------------------------------------------------------------------------
+
+def _build_rollup_response(area: ServiceArea, payloads: List[Dict[str, Any]], window: str) -> Dict[str, Any]:
+    months = WINDOW_TO_MONTHS[window]
+
+    # Filter sale data to residential property types (Single Family, Townhouse,
+    # Condo) before any aggregation -- both for the snapshot and every history
+    # entry. Rental data + the property-type breakdown stay on the original
+    # payloads so users can still inspect the full mix if they want.
+    residential_payloads = [_residentialize_payload(p) for p in payloads]
+
+    # Build the unified history (sale + rental + inventory per month) first;
+    # headline metrics come from the most recent month so they are always
+    # the same regardless of window.
+    sale_history = _merged_history(residential_payloads, 'saleData')
+    rental_history = _merged_history(payloads, 'rentalData')
+
+    full_history = _zip_histories(sale_history, rental_history)
+    sliced_history = full_history[-months:] if full_history else []
+
+    latest = sliced_history[-1] if sliced_history else None
+    earliest = sliced_history[0] if sliced_history else None
+
+    median_price = latest['median_price'] if latest else None
+    if median_price is None:
+        # Fall back to current snapshot fields on saleData (residential subset)
+        median_price = _weighted_median(residential_payloads, 'saleData', 'medianPrice', 'totalListings')
+    median_dom = latest['median_dom'] if latest else None
+    if median_dom is None:
+        median_dom = _weighted_avg(residential_payloads, 'saleData', 'medianDaysOnMarket', 'totalListings')
+    total_listings = latest['total_listings'] if latest else None
+    if total_listings is None:
+        total_listings = _sum_field(residential_payloads, 'saleData', 'totalListings')
+    new_listings = latest['new_listings'] if latest else None
+    if new_listings is None:
+        new_listings = _sum_field(residential_payloads, 'saleData', 'newListings')
+    median_ppsf = latest['median_ppsf'] if latest else None
+    if median_ppsf is None:
+        median_ppsf = _weighted_avg(residential_payloads, 'saleData', 'medianPricePerSquareFoot', 'totalListings')
+    median_rent = latest['median_rent'] if latest else None
+    if median_rent is None:
+        median_rent = _weighted_median(payloads, 'rentalData', 'medianRent', 'totalListings')
+
+    price_min = _min_field(residential_payloads, 'saleData', 'minPrice')
+    price_max = _max_field(residential_payloads, 'saleData', 'maxPrice')
+
+    yield_pct = None
+    if median_rent and median_price and median_price > 0:
+        yield_pct = round((median_rent * 12.0) / median_price * 100.0, 2)
+
+    response = {
+        'area': area.display_name,
+        'slug': area.slug,
+        'zip_codes': [str(z) for z in (area.zip_codes or [])],
+        'window': window,
+        'median_home_price': _delta_pct(median_price, earliest['median_price'] if earliest else None, window),
+        'median_price_per_sqft': _delta_pct(median_ppsf, earliest['median_ppsf'] if earliest else None, window),
+        'active_inventory': _delta_pct(total_listings, earliest['total_listings'] if earliest else None, window),
+        'new_listings': _delta_pct(new_listings, earliest['new_listings'] if earliest else None, window),
+        'days_on_market': _delta_days(median_dom, earliest['median_dom'] if earliest else None, window),
+        'median_rent': _delta_pct(median_rent, earliest['median_rent'] if earliest else None, window),
+        'gross_rental_yield_pct': yield_pct,
+        'price_range': {'min': price_min, 'max': price_max},
+        'history': sliced_history,
+        'history_full': full_history,  # kept so the client can swap windows without a refetch
+        'by_property_type': _breakdown(payloads, 'saleData', 'dataByPropertyType', 'propertyType'),
+        'by_bedrooms': _breakdown(payloads, 'saleData', 'dataByBedrooms', 'bedrooms'),
+        'as_of': _latest_iso(payloads),
+        'source': 'RentCast',
+        'methodology': {
+            'scope': 'Residential resale: Single Family, Townhouse, Condo. '
+                     'Land, Manufactured, Multi-Family, and Commercial are excluded.',
+            'price': 'Median ASKING price of currently active sale listings (not closed sales).',
+            'days_on_market': 'Median DOM of currently active listings (not sold-DOM).',
+            'inventory': 'Total listings active at any point in the month (cumulative, not point-in-time).',
+            'source': 'RentCast /markets endpoint, refreshed weekly.',
+        },
+    }
+    return response
+
+
+def _merged_history(payloads: List[Dict[str, Any]], section: str) -> Dict[str, Dict[str, Any]]:
+    """Combine the per-ZIP `<section>.history` objects into a single map keyed by `YYYY-MM`.
+
+    Each merged month aggregates across ZIPs using the same rules as the
+    snapshot rollup: weighted median for prices, sum for inventory counts,
+    listing-count-weighted average for DOM.
+    """
+    months: Dict[str, List[Dict[str, Any]]] = {}
+    for payload in payloads:
+        section_data = (payload or {}).get(section) or {}
+        history = section_data.get('history') or {}
+        for month_key, entry in history.items():
+            if not entry:
+                continue
+            months.setdefault(month_key, []).append(entry)
+
+    merged: Dict[str, Dict[str, Any]] = {}
+    for month_key, entries in months.items():
+        weights = [_safe_int(e.get('totalListings')) or 0 for e in entries]
+        sum_w = sum(weights) or 0
+
+        if section == 'saleData':
+            merged[month_key] = {
+                'median_price': _weighted_median_values(
+                    [e.get('medianPrice') for e in entries], weights
+                ),
+                'median_ppsf': _weighted_avg_values(
+                    [e.get('medianPricePerSquareFoot') for e in entries], weights
+                ),
+                'median_dom': _weighted_avg_values(
+                    [e.get('medianDaysOnMarket') for e in entries], weights
+                ),
+                'total_listings': sum_w if sum_w else None,
+                'new_listings': sum(
+                    (_safe_int(e.get('newListings')) or 0) for e in entries
+                ) or None,
+            }
+        else:  # rentalData
+            merged[month_key] = {
+                'median_rent': _weighted_median_values(
+                    [e.get('medianRent') for e in entries], weights
+                ),
+            }
+    return merged
+
+
+def _zip_histories(
+    sale_history: Dict[str, Dict[str, Any]],
+    rental_history: Dict[str, Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Produce a chronologically sorted list of merged monthly entries."""
+    months = sorted(set(sale_history.keys()) | set(rental_history.keys()))
+    out: List[Dict[str, Any]] = []
+    for m in months:
+        s = sale_history.get(m, {})
+        r = rental_history.get(m, {})
+        # Skip months with no sale data at all -- the chart would be misleading.
+        if s.get('median_price') is None and r.get('median_rent') is None:
+            continue
+        out.append({
+            'month': m,
+            'median_price': s.get('median_price'),
+            'median_ppsf': s.get('median_ppsf'),
+            'median_dom': s.get('median_dom'),
+            'total_listings': s.get('total_listings'),
+            'new_listings': s.get('new_listings'),
+            'median_rent': r.get('median_rent'),
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Residential filter (drop Land / Manufactured / Multi-Family / Commercial)
+# ---------------------------------------------------------------------------
+
+def _residential_view(section_entry: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a *new* dict with top-level stat fields recomputed from the
+    residential subset of ``dataByPropertyType``.
+
+    Works on either a snapshot ``saleData`` blob or a single
+    ``saleData.history[YYYY-MM]`` entry, since both expose the same shape.
+    If ``dataByPropertyType`` is absent or contains no residential rows,
+    the original entry is returned unchanged (callers may legitimately
+    pass synthesized payloads without the breakdown, and we don't want
+    to discard their numbers).
+    """
+    if not section_entry:
+        return section_entry
+    pt_rows = section_entry.get('dataByPropertyType') or []
+    res_rows = [
+        r for r in pt_rows
+        if r.get('propertyType') in RESIDENTIAL_PROPERTY_TYPES
+    ]
+    if not res_rows:
+        return section_entry
+
+    weights = [_safe_int(r.get('totalListings')) or 0 for r in res_rows]
+    total_inv = sum(weights)
+    new_inv = sum((_safe_int(r.get('newListings')) or 0) for r in res_rows)
+
+    mins = [v for v in (_safe_float(r.get('minPrice')) for r in res_rows) if v is not None]
+    maxs = [v for v in (_safe_float(r.get('maxPrice')) for r in res_rows) if v is not None]
+
+    out = dict(section_entry)
+    out['medianPrice'] = _weighted_avg_values(
+        [r.get('medianPrice') for r in res_rows], weights
+    )
+    out['medianPricePerSquareFoot'] = _weighted_avg_values(
+        [r.get('medianPricePerSquareFoot') for r in res_rows], weights
+    )
+    out['medianDaysOnMarket'] = _weighted_avg_values(
+        [r.get('medianDaysOnMarket') for r in res_rows], weights
+    )
+    out['totalListings'] = total_inv if total_inv else None
+    out['newListings'] = new_inv if new_inv else None
+    out['minPrice'] = min(mins) if mins else None
+    out['maxPrice'] = max(maxs) if maxs else None
+    return out
+
+
+def _residentialize_payload(payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a payload-shaped dict where ``saleData`` (and every entry of
+    ``saleData.history``) has been filtered to residential property types.
+
+    The original payload is not mutated. ``rentalData`` is passed through
+    untouched.
+    """
+    if not payload:
+        return payload
+    sd = payload.get('saleData')
+    if not sd:
+        return payload
+
+    new_sd = dict(_residential_view(sd) or {})
+
+    history = sd.get('history') or {}
+    if history:
+        new_history = {}
+        for month_key, entry in history.items():
+            new_history[month_key] = _residential_view(entry)
+        new_sd['history'] = new_history
+
+    new_payload = dict(payload)
+    new_payload['saleData'] = new_sd
+    return new_payload
+
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers
+# ---------------------------------------------------------------------------
+
+def _safe_int(v) -> Optional[int]:
+    try:
+        if v is None:
+            return None
+        return int(round(float(v)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(v) -> Optional[float]:
+    try:
+        if v is None:
+            return None
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _weighted_median_values(values, weights) -> Optional[float]:
+    """Plain median of provided values (treats weights as a tie-breaker only).
+
+    For v1 we keep median-of-medians for prices since RentCast doesn't expose
+    the underlying distribution; weights are still consulted to drop ZIPs
+    with zero listings (which would otherwise inject noise).
+    """
+    pairs = [(_safe_float(v), w) for v, w in zip(values, weights)]
+    cleaned = [v for v, w in pairs if v is not None and (w or 0) > 0]
+    if not cleaned:
+        cleaned = [v for v, _ in pairs if v is not None]
+    if not cleaned:
+        return None
+    return float(median(cleaned))
+
+
+def _weighted_avg_values(values, weights) -> Optional[float]:
+    """Listing-count-weighted average. Falls back to plain mean if no weights."""
+    pairs = [(_safe_float(v), _safe_int(w) or 0) for v, w in zip(values, weights)]
+    pairs = [(v, w) for v, w in pairs if v is not None]
+    if not pairs:
+        return None
+    total_weight = sum(w for _, w in pairs)
+    if total_weight <= 0:
+        return sum(v for v, _ in pairs) / len(pairs)
+    return sum(v * w for v, w in pairs) / total_weight
+
+
+def _weighted_median(payloads, section, field, weight_field) -> Optional[float]:
+    section_objs = [(p or {}).get(section) or {} for p in payloads]
+    return _weighted_median_values(
+        [s.get(field) for s in section_objs],
+        [s.get(weight_field) for s in section_objs],
+    )
+
+
+def _weighted_avg(payloads, section, field, weight_field) -> Optional[float]:
+    section_objs = [(p or {}).get(section) or {} for p in payloads]
+    return _weighted_avg_values(
+        [s.get(field) for s in section_objs],
+        [s.get(weight_field) for s in section_objs],
+    )
+
+
+def _sum_field(payloads, section, field) -> Optional[int]:
+    total = 0
+    seen = False
+    for p in payloads:
+        v = _safe_int(((p or {}).get(section) or {}).get(field))
+        if v is not None:
+            total += v
+            seen = True
+    return total if seen else None
+
+
+def _min_field(payloads, section, field) -> Optional[float]:
+    vals = [
+        _safe_float(((p or {}).get(section) or {}).get(field))
+        for p in payloads
+    ]
+    vals = [v for v in vals if v is not None]
+    return min(vals) if vals else None
+
+
+def _max_field(payloads, section, field) -> Optional[float]:
+    vals = [
+        _safe_float(((p or {}).get(section) or {}).get(field))
+        for p in payloads
+    ]
+    vals = [v for v in vals if v is not None]
+    return max(vals) if vals else None
+
+
+def _latest_iso(payloads) -> Optional[str]:
+    dates = []
+    for p in payloads:
+        for section in ('saleData', 'rentalData'):
+            d = ((p or {}).get(section) or {}).get('lastUpdatedDate')
+            if d:
+                dates.append(d)
+    return max(dates) if dates else None
+
+
+def _delta_pct(current, previous, window: str) -> Dict[str, Any]:
+    out = {'value': _round_for_display(current), 'change_pct': None, 'change_vs': window}
+    if current is not None and previous not in (None, 0):
+        try:
+            pct = ((float(current) - float(previous)) / float(previous)) * 100.0
+            out['change_pct'] = round(pct, 1)
+        except (TypeError, ValueError, ZeroDivisionError):
+            pass
+    return out
+
+
+def _delta_days(current, previous, window: str) -> Dict[str, Any]:
+    out = {'value': _round_for_display(current), 'change_days': None, 'change_vs': window}
+    if current is not None and previous is not None:
+        try:
+            out['change_days'] = int(round(float(current) - float(previous)))
+        except (TypeError, ValueError):
+            pass
+    return out
+
+
+def _round_for_display(v):
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return v
+    if abs(f - round(f)) < 1e-6:
+        return int(round(f))
+    return round(f, 2)
+
+
+def _breakdown(payloads, section, group_field, key_field) -> List[Dict[str, Any]]:
+    """Aggregate the dataByPropertyType / dataByBedrooms arrays across ZIPs.
+
+    Buckets are keyed by ``key_field`` (string for property type, number for
+    bedrooms). Within each bucket we use the same weighted rules as the
+    headline rollup.
+    """
+    buckets: Dict[Any, List[Dict[str, Any]]] = {}
+    for payload in payloads:
+        section_obj = (payload or {}).get(section) or {}
+        for entry in section_obj.get(group_field) or []:
+            key = entry.get(key_field)
+            if key is None:
+                continue
+            buckets.setdefault(key, []).append(entry)
+
+    out: List[Dict[str, Any]] = []
+    for key, entries in buckets.items():
+        weights = [_safe_int(e.get('totalListings')) or 0 for e in entries]
+        out.append({
+            key_field: key,
+            'median_price': _weighted_median_values(
+                [e.get('medianPrice') for e in entries], weights
+            ),
+            'median_price_per_sqft': _weighted_avg_values(
+                [e.get('medianPricePerSquareFoot') for e in entries], weights
+            ),
+            'median_dom': _weighted_avg_values(
+                [e.get('medianDaysOnMarket') for e in entries], weights
+            ),
+            'total_listings': sum(weights) or None,
+        })
+
+    if key_field == 'bedrooms':
+        out.sort(key=lambda r: (r.get('bedrooms') is None, r.get('bedrooms')))
+    else:
+        out.sort(key=lambda r: -(r.get('total_listings') or 0))
+    return out

--- a/services/rentcast_service.py
+++ b/services/rentcast_service.py
@@ -18,6 +18,7 @@ Usage:
         error = result['error']
 """
 
+import time
 import requests
 import logging
 from urllib.parse import quote
@@ -160,4 +161,120 @@ def fetch_property_data(street_address: str, city: str, state: str, zip_code: st
         return {
             'success': False,
             'error': 'An unexpected error occurred. Please try again.'
+        }
+
+
+def fetch_market_stats(zip_code: str) -> dict:
+    """Fetch aggregate sale + rental market statistics for a ZIP code.
+
+    Calls GET https://api.rentcast.io/v1/markets?zipCode=<zip>&dataType=All.
+
+    Returns a dict with:
+        - success (bool)
+        - data (dict): the raw RentCast payload (only when success)
+        - status_code (int|None): HTTP status from RentCast (None on transport error)
+        - latency_ms (int): wall time of the call
+        - error (str|None): human-readable error when success is False
+
+    The caller is responsible for persisting the audit trail row in
+    ``rentcast_api_log`` -- this function just performs the HTTP call.
+    """
+    api_key = Config.RENTCAST_API_KEY
+    endpoint = '/markets'
+
+    if not api_key:
+        logger.error("RENTCAST_API_KEY not configured")
+        return {
+            'success': False,
+            'data': None,
+            'status_code': None,
+            'latency_ms': 0,
+            'error': 'RentCast API key not configured.',
+        }
+
+    if not zip_code or not str(zip_code).strip():
+        return {
+            'success': False,
+            'data': None,
+            'status_code': None,
+            'latency_ms': 0,
+            'error': 'ZIP code is required.',
+        }
+
+    url = f"{RENTCAST_BASE_URL}{endpoint}"
+    headers = {'Accept': 'application/json', 'X-Api-Key': api_key}
+    params = {'zipCode': str(zip_code).strip(), 'dataType': 'All'}
+
+    started = time.perf_counter()
+    status_code = None
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        status_code = response.status_code
+        latency_ms = int((time.perf_counter() - started) * 1000)
+
+        # Audit-friendly single-line log entry. Caller also writes the DB row.
+        logger.info(
+            "rentcast_markets_call zip=%s status=%s latency_ms=%s",
+            zip_code, status_code, latency_ms,
+        )
+
+        if status_code == 200:
+            data = response.json()
+            if isinstance(data, list):
+                data = data[0] if data else None
+            if not data:
+                return {
+                    'success': False, 'data': None, 'status_code': status_code,
+                    'latency_ms': latency_ms,
+                    'error': f'No market data found for ZIP {zip_code}.',
+                }
+            return {
+                'success': True, 'data': data, 'status_code': status_code,
+                'latency_ms': latency_ms, 'error': None,
+            }
+
+        if status_code == 401:
+            return {
+                'success': False, 'data': None, 'status_code': status_code,
+                'latency_ms': latency_ms, 'error': 'RentCast authentication failed.',
+            }
+        if status_code == 404:
+            return {
+                'success': False, 'data': None, 'status_code': status_code,
+                'latency_ms': latency_ms,
+                'error': f'No market data found for ZIP {zip_code}.',
+            }
+        if status_code == 429:
+            return {
+                'success': False, 'data': None, 'status_code': status_code,
+                'latency_ms': latency_ms,
+                'error': 'RentCast rate limit / monthly quota exceeded.',
+            }
+        return {
+            'success': False, 'data': None, 'status_code': status_code,
+            'latency_ms': latency_ms,
+            'error': f'RentCast error (status {status_code}).',
+        }
+
+    except requests.exceptions.Timeout:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        logger.error("RentCast /markets timeout zip=%s latency_ms=%s", zip_code, latency_ms)
+        return {
+            'success': False, 'data': None, 'status_code': None,
+            'latency_ms': latency_ms, 'error': 'RentCast request timed out.',
+        }
+    except requests.exceptions.ConnectionError:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        logger.error("RentCast /markets connection error zip=%s", zip_code)
+        return {
+            'success': False, 'data': None, 'status_code': None,
+            'latency_ms': latency_ms,
+            'error': 'Could not connect to RentCast.',
+        }
+    except Exception as e:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        logger.exception("Unexpected RentCast /markets error zip=%s: %s", zip_code, e)
+        return {
+            'success': False, 'data': None, 'status_code': status_code,
+            'latency_ms': latency_ms, 'error': f'Unexpected error: {e}',
         }

--- a/static/js/market_insights.js
+++ b/static/js/market_insights.js
@@ -1,0 +1,553 @@
+/**
+ * Market Insights dashboard widget controller (plain JS).
+ *
+ * Mirrors frontend/controllers/market_insights_controller.js so that the next
+ * Vite build can swap to the Stimulus version, but works today without
+ * requiring a frontend rebuild. Initializes against the
+ * data-controller="market-insights" element on the dashboard.
+ */
+(function () {
+    "use strict";
+
+    const ACCENT = "#f97316";
+    const SLATE_400 = "#94a3b8";
+    const SLATE_500 = "#64748b";
+
+    // localStorage key for the agent's preferred collapsed/expanded state.
+    // Default on first visit (or invalid stored value) is COLLAPSED so the
+    // dashboard stays focused on contacts/tasks and we don't burn RentCast
+    // quota for users who never look at the panel.
+    const LS_COLLAPSED_KEY = "crm.market-insights.collapsed";
+
+    const USD = new Intl.NumberFormat("en-US", {
+        style: "currency", currency: "USD", maximumFractionDigits: 0
+    });
+    const COMPACT_USD = new Intl.NumberFormat("en-US", {
+        style: "currency", currency: "USD", notation: "compact", maximumFractionDigits: 1
+    });
+    const INT = new Intl.NumberFormat("en-US");
+
+    const KPI_FORMATTERS = {
+        price: (v) => v == null ? "—" : USD.format(v),
+        ppsf: (v) => v == null ? "—" : `$${Math.round(v)}`,
+        inventory: (v) => v == null ? "—" : INT.format(Math.round(v)),
+        dom: (v) => v == null ? "—" : `${Math.round(v)}d`
+    };
+
+    // For DOM, "down" is good; for everything else, "up" is good.
+    const KPI_POSITIVE = { price: "up", ppsf: "up", inventory: "up", dom: "down" };
+
+    class MarketInsights {
+        constructor(root) {
+            this.root = root;
+            this.cache = new Map();
+            this.charts = { sparks: {} };
+            this.previousValues = {};
+            this.currentSlug = root.dataset.marketInsightsDefaultSlugValue || "mont-belvieu";
+            this.currentWindow = root.dataset.marketInsightsDefaultWindowValue || "12m";
+            this.lastResponse = null;
+            this.started = false;
+
+            this.collapsed = this._readCollapsedPref();
+            this._applyCollapsedState({ animate: false });
+
+            this._bindEvents();
+        }
+
+        // Lazy entry point: only run the (async) data fetch once the agent
+        // has actually opened the panel. Charts also need a non-zero width
+        // container, so we MUST defer ApexCharts initialization until visible.
+        async start() {
+            if (this.started) return;
+            this.started = true;
+            await this._waitForLibraries();
+            await this._loadAreas();
+            await this._loadInsights();
+        }
+
+        async toggle() {
+            this.collapsed = !this.collapsed;
+            this._writeCollapsedPref(this.collapsed);
+            this._applyCollapsedState({ animate: true });
+            if (!this.collapsed) {
+                if (!this.started) {
+                    await this.start();
+                } else {
+                    // Re-render charts so ApexCharts measures the (now
+                    // visible) container correctly. Cheap no-op if data
+                    // is already loaded.
+                    this._reflowCharts();
+                }
+            }
+        }
+
+        _readCollapsedPref() {
+            try {
+                const v = window.localStorage.getItem(LS_COLLAPSED_KEY);
+                if (v === "0") return false;
+                if (v === "1") return true;
+            } catch (_e) { /* localStorage unavailable */ }
+            return true;
+        }
+
+        _writeCollapsedPref(collapsed) {
+            try { window.localStorage.setItem(LS_COLLAPSED_KEY, collapsed ? "1" : "0"); }
+            catch (_e) { /* ignore quota / privacy mode */ }
+        }
+
+        _applyCollapsedState({ animate }) {
+            const open = !this.collapsed;
+            this.root.classList.toggle("is-open", open);
+
+            const body = this.$target("body");
+            if (body) {
+                if (open) body.removeAttribute("hidden");
+                else body.setAttribute("hidden", "");
+            }
+
+            const controls = this.$target("controls");
+            if (controls) controls.classList.toggle("hidden", !open);
+            const asOfWrap = this.$target("asOfWrap");
+            if (asOfWrap) asOfWrap.classList.toggle("hidden", !open);
+
+            const toggleBtn = this.$target("toggleButton");
+            if (toggleBtn) {
+                toggleBtn.setAttribute("aria-expanded", String(open));
+                toggleBtn.setAttribute(
+                    "aria-label",
+                    open ? "Hide market insights" : "Show market insights"
+                );
+            }
+            // animate flag is consumed via CSS animation on .crm-mi.is-open
+            void animate;
+        }
+
+        _reflowCharts() {
+            try {
+                if (this.charts.main && typeof this.charts.main.render === "function") {
+                    this.charts.main.render();
+                }
+                Object.values(this.charts.sparks || {}).forEach((c) => {
+                    if (c && typeof c.render === "function") c.render();
+                });
+            } catch (_e) { /* swallow re-render races */ }
+        }
+
+        // --- DOM helpers ----------------------------------------------------
+        $(selector) { return this.root.querySelector(selector); }
+        $$(selector) { return Array.from(this.root.querySelectorAll(selector)); }
+        $target(name) { return this.root.querySelector(`[data-market-insights-target="${name}"]`); }
+        $targets(name) { return Array.from(this.root.querySelectorAll(`[data-market-insights-target="${name}"]`)); }
+
+        // --- Event wiring ---------------------------------------------------
+        _bindEvents() {
+            const select = this.$target("areaSelect");
+            if (select) select.addEventListener("change", (e) => this._changeArea(e));
+
+            this.$targets("windowButton").forEach((btn) => {
+                btn.addEventListener("click", (e) => this._setWindow(e));
+            });
+            const errorRetry = this.$target("errorState");
+            if (errorRetry) {
+                const btn = errorRetry.querySelector("button");
+                if (btn) btn.addEventListener("click", () => this._refresh());
+            }
+
+            const toggleBtn = this.$target("toggleButton");
+            if (toggleBtn) toggleBtn.addEventListener("click", () => this.toggle());
+        }
+
+        async _changeArea(event) {
+            const slug = event.currentTarget.value;
+            if (!slug || slug === this.currentSlug) return;
+            this.currentSlug = slug;
+            await this._loadInsights();
+        }
+
+        async _setWindow(event) {
+            const win = event.currentTarget.dataset.window;
+            if (!win || win === this.currentWindow) return;
+            this.currentWindow = win;
+            this.$targets("windowButton").forEach((btn) => {
+                btn.classList.toggle("is-active", btn.dataset.window === win);
+            });
+            await this._loadInsights();
+        }
+
+        async _refresh() {
+            this.cache.delete(this._cacheKey());
+            await this._loadInsights();
+        }
+
+        // --- Data loading ---------------------------------------------------
+        async _loadAreas() {
+            try {
+                const r = await fetch("/api/market-insights/areas", { credentials: "same-origin" });
+                if (!r.ok) throw new Error(`Areas request failed: ${r.status}`);
+                const { areas } = await r.json();
+                this._populateAreaSelect(areas || []);
+            } catch (err) {
+                console.error("Failed to load market insight areas", err);
+                this._showError("Could not load service areas.");
+            }
+        }
+
+        _populateAreaSelect(areas) {
+            const select = this.$target("areaSelect");
+            if (!select) return;
+            select.innerHTML = "";
+            if (!areas.length) {
+                const opt = document.createElement("option");
+                opt.textContent = "No areas configured";
+                opt.disabled = true;
+                select.appendChild(opt);
+                return;
+            }
+            let chosen = null;
+            areas.forEach((a) => {
+                const opt = document.createElement("option");
+                opt.value = a.slug;
+                opt.textContent = a.display_name;
+                select.appendChild(opt);
+                if (a.slug === this.currentSlug) chosen = a.slug;
+            });
+            if (!chosen) {
+                this.currentSlug = areas[0].slug;
+                select.value = this.currentSlug;
+            } else {
+                select.value = chosen;
+            }
+        }
+
+        async _loadInsights() {
+            if (!this.currentSlug) return;
+            const key = this._cacheKey();
+            const cached = this.cache.get(key);
+            if (cached) { this._render(cached); return; }
+            this._setLoading(true);
+            this._hideError();
+            try {
+                const url = `/api/market-insights/${encodeURIComponent(this.currentSlug)}?window=${encodeURIComponent(this.currentWindow)}`;
+                const r = await fetch(url, { credentials: "same-origin" });
+                if (!r.ok) {
+                    const body = await r.json().catch(() => ({}));
+                    throw new Error(body.error || `Request failed (${r.status})`);
+                }
+                const data = await r.json();
+                this.cache.set(key, data);
+                this._render(data);
+            } catch (err) {
+                console.error("Failed to load market insights", err);
+                this._showError(err.message || "Couldn't load this area right now.");
+            } finally {
+                this._setLoading(false);
+            }
+        }
+
+        _cacheKey() { return `${this.currentSlug}|${this.currentWindow}`; }
+
+        // --- Rendering ------------------------------------------------------
+        _render(data) {
+            this.lastResponse = data;
+
+            const asOf = this.$target("asOf");
+            if (asOf) {
+                asOf.textContent = data.as_of
+                    ? `Data as of ${this._formatAsOf(data.as_of)}`
+                    : "Data freshly loaded";
+            }
+            this._toggleStale(Boolean(data.is_stale));
+
+            this._renderKpi("price", data.median_home_price, data, (h) => h.median_price);
+            this._renderKpi("ppsf", data.median_price_per_sqft, data, (h) => h.median_ppsf);
+            this._renderKpi("inventory", data.active_inventory, data, (h) => h.total_listings);
+            this._renderKpi("dom", data.days_on_market, data, (h) => h.median_dom);
+
+            this._renderSecondary(data);
+            this._renderMainChart(data);
+        }
+
+        _renderKpi(kpi, metric, data, historyAccessor) {
+            const value = metric ? metric.value : null;
+            const valueEl = this._byKpi("kpiValue", kpi);
+            if (valueEl) {
+                const previous = this.previousValues[kpi];
+                this._animateNumber(valueEl, previous, value, KPI_FORMATTERS[kpi]);
+                this.previousValues[kpi] = value;
+            }
+
+            const deltaEl = this._byKpi("kpiDelta", kpi);
+            if (deltaEl) {
+                const isDays = metric && metric.change_days != null;
+                const change = !metric ? null
+                    : metric.change_pct != null ? metric.change_pct
+                    : metric.change_days != null ? metric.change_days
+                    : null;
+                this._renderDelta(deltaEl, kpi, change, metric ? metric.change_vs : null, isDays);
+            }
+
+            this._renderKpiSpark(kpi, data, historyAccessor);
+        }
+
+        _renderDelta(el, kpi, change, vsLabel, isDays) {
+            const textEl = el.querySelector('[data-market-insights-target="kpiDeltaText"]');
+            el.classList.remove("crm-mi__delta--up", "crm-mi__delta--down", "crm-mi__delta--flat", "hidden");
+            el.classList.add("crm-mi__delta");
+
+            const icon = el.querySelector("i");
+            if (change == null || isNaN(change)) {
+                el.classList.add("crm-mi__delta--flat");
+                if (icon) icon.className = "fas fa-minus";
+                if (textEl) textEl.textContent = "—";
+                return;
+            }
+            const direction = change > 0 ? "up" : change < 0 ? "down" : "flat";
+            const positive = KPI_POSITIVE[kpi];
+            let tone;
+            if (direction === "flat") tone = "flat";
+            else if (direction === positive) tone = "up";
+            else tone = "down";
+            el.classList.add(`crm-mi__delta--${tone}`);
+
+            if (icon) {
+                icon.className = direction === "up"
+                    ? "fas fa-arrow-trend-up"
+                    : direction === "down"
+                        ? "fas fa-arrow-trend-down"
+                        : "fas fa-minus";
+            }
+            if (textEl) {
+                const sign = change > 0 ? "+" : "";
+                textEl.textContent = isDays
+                    ? `${sign}${Math.round(change)}d vs ${vsLabel || ""}`.trim()
+                    : `${sign}${change.toFixed(1)}% vs ${vsLabel || ""}`.trim();
+            }
+        }
+
+        _renderKpiSpark(kpi, data, accessor) {
+            const el = this._byKpi("kpiSpark", kpi);
+            if (!el || typeof window.ApexCharts === "undefined") return;
+
+            const series = (data.history || []).map((h) => {
+                const v = accessor(h);
+                return v == null ? null : Number(v);
+            });
+            if (!series.some((v) => v != null)) {
+                el.innerHTML = "";
+                return;
+            }
+
+            const opts = {
+                chart: {
+                    type: "area",
+                    height: 44,
+                    sparkline: { enabled: true },
+                    animations: { enabled: true, easing: "easeinout", speed: 600 }
+                },
+                stroke: { curve: "smooth", width: 2 },
+                colors: [ACCENT],
+                fill: {
+                    type: "gradient",
+                    gradient: { shadeIntensity: 0.6, opacityFrom: 0.45, opacityTo: 0.05, stops: [0, 100] }
+                },
+                tooltip: {
+                    enabled: true, theme: "dark",
+                    x: { show: false },
+                    y: {
+                        formatter: (v) => v == null ? "—" : KPI_FORMATTERS[kpi](v),
+                        title: { formatter: () => "" }
+                    },
+                    marker: { show: false }
+                },
+                series: [{ name: kpi, data: series }]
+            };
+
+            if (this.charts.sparks[kpi]) {
+                this.charts.sparks[kpi].updateOptions(opts, true, true);
+            } else {
+                this.charts.sparks[kpi] = new window.ApexCharts(el, opts);
+                this.charts.sparks[kpi].render();
+            }
+        }
+
+        _renderSecondary(data) {
+            const newL = this.$target("newListings");
+            if (newL) {
+                const v = data.new_listings ? data.new_listings.value : null;
+                newL.textContent = v == null ? "—" : INT.format(Math.round(v));
+            }
+        }
+
+        _renderMainChart(data) {
+            const el = this.$target("mainChart");
+            if (!el || typeof window.ApexCharts === "undefined") return;
+
+            const history = data.history || [];
+            const priceSeries = history
+                .filter((h) => h.median_price != null)
+                .map((h) => ({ x: this._monthToTimestamp(h.month), y: Number(h.median_price) }));
+            const inventorySeries = history
+                .filter((h) => h.total_listings != null)
+                .map((h) => ({ x: this._monthToTimestamp(h.month), y: Number(h.total_listings) }));
+
+            const opts = {
+                chart: {
+                    type: "line",
+                    height: 320,
+                    toolbar: { show: false },
+                    zoom: { enabled: false },
+                    fontFamily: "-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif",
+                    animations: { enabled: true, easing: "easeinout", speed: 700 }
+                },
+                colors: [ACCENT, SLATE_400],
+                stroke: { curve: "smooth", width: [3, 2], dashArray: [0, 4] },
+                fill: {
+                    type: ["gradient", "solid"],
+                    gradient: { shadeIntensity: 0.5, opacityFrom: 0.35, opacityTo: 0.0, stops: [0, 90] },
+                    opacity: [0.35, 0]
+                },
+                dataLabels: { enabled: false },
+                markers: { size: 0, strokeWidth: 0, hover: { size: 5 } },
+                grid: { borderColor: "#e2e8f0", strokeDashArray: 4,
+                        padding: { top: 0, right: 8, bottom: 0, left: 8 } },
+                xaxis: {
+                    type: "datetime",
+                    labels: { style: { colors: SLATE_500, fontSize: "11px" },
+                              datetimeFormatter: { year: "yyyy", month: "MMM", day: "MMM dd" } },
+                    axisBorder: { show: false },
+                    axisTicks: { show: false },
+                    tooltip: { enabled: false }
+                },
+                yaxis: [
+                    {
+                        seriesName: "Median asking price",
+                        labels: { style: { colors: SLATE_500, fontSize: "11px" },
+                                  formatter: (v) => v == null ? "" : COMPACT_USD.format(v) }
+                    },
+                    {
+                        seriesName: "Active listings",
+                        opposite: true,
+                        labels: { style: { colors: SLATE_500, fontSize: "11px" },
+                                  formatter: (v) => v == null ? "" : INT.format(Math.round(v)) }
+                    }
+                ],
+                tooltip: {
+                    theme: "dark", shared: true, intersect: false,
+                    x: { format: "MMM yyyy" },
+                    y: [
+                        { formatter: (v) => v == null ? "—" : USD.format(v) },
+                        { formatter: (v) => v == null ? "—" : `${INT.format(Math.round(v))} listings` }
+                    ],
+                    marker: { show: true }
+                },
+                legend: { show: false },
+                series: [
+                    { name: "Median asking price", type: "area", data: priceSeries },
+                    { name: "Active listings", type: "line", data: inventorySeries }
+                ]
+            };
+
+            if (this.charts.main) {
+                this.charts.main.updateOptions(opts, true, true);
+            } else {
+                this.charts.main = new window.ApexCharts(el, opts);
+                this.charts.main.render();
+            }
+        }
+
+        // --- UI helpers ----------------------------------------------------
+        _byKpi(targetName, kpi) {
+            return this.$targets(targetName).find((el) => el.dataset.kpi === kpi) || null;
+        }
+
+        _setLoading(isLoading) {
+            this.$targets("kpiCard").forEach((card) => card.classList.toggle("opacity-60", isLoading));
+        }
+
+        _showError(message) {
+            const el = this.$target("errorState");
+            if (!el) return;
+            el.classList.remove("hidden");
+            const msg = this.$target("errorMessage");
+            if (msg) msg.textContent = message;
+        }
+        _hideError() {
+            const el = this.$target("errorState");
+            if (el) el.classList.add("hidden");
+        }
+        _toggleStale(isStale) {
+            const badge = this.$target("staleBadge");
+            const sep = this.$target("staleSeparator");
+            if (badge) badge.classList.toggle("hidden", !isStale);
+            if (sep) sep.classList.toggle("hidden", !isStale);
+        }
+
+        _animateNumber(el, from, to, formatter) {
+            if (to == null) { el.textContent = "—"; return; }
+            const start = (typeof from === "number" && !isNaN(from)) ? from : 0;
+            const CountUp = window.countUp && window.countUp.CountUp;
+            if (CountUp) {
+                const cu = new CountUp(el, to, {
+                    startVal: start, duration: 0.9, useGrouping: true, formattingFn: formatter
+                });
+                if (!cu.error) { cu.start(); return; }
+            }
+            const duration = 700;
+            const t0 = performance.now();
+            const tick = (now) => {
+                const p = Math.min((now - t0) / duration, 1);
+                const eased = 1 - Math.pow(1 - p, 3);
+                el.textContent = formatter(start + (to - start) * eased);
+                if (p < 1) requestAnimationFrame(tick);
+            };
+            requestAnimationFrame(tick);
+        }
+
+        _monthToTimestamp(month) {
+            if (!month) return null;
+            const [y, m] = month.split("-").map(Number);
+            return Date.UTC(y, (m || 1) - 1, 1);
+        }
+
+        _formatAsOf(iso) {
+            try {
+                const d = new Date(iso);
+                return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+            } catch (_e) { return iso; }
+        }
+
+        _escape(s) {
+            return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({
+                "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+            })[c]);
+        }
+
+        async _waitForLibraries() {
+            if (typeof window.ApexCharts !== "undefined") return;
+            await new Promise((resolve) => {
+                const start = Date.now();
+                const tick = () => {
+                    if (typeof window.ApexCharts !== "undefined") return resolve();
+                    if (Date.now() - start > 5000) return resolve();
+                    setTimeout(tick, 50);
+                };
+                tick();
+            });
+        }
+    }
+
+    function init() {
+        const root = document.querySelector('[data-controller~="market-insights"]');
+        if (!root) return;
+        const widget = new MarketInsights(root);
+        // If the user previously left the panel expanded, kick off the data
+        // load now. Otherwise we wait until they click the chevron toggle.
+        if (!widget.collapsed) widget.start();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,6 +4,74 @@
 {% block head_scripts %}
 <script src="{{ url_for('static', filename='js/todo-manager.js') }}" defer></script>
 <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
+<script defer src="https://cdn.jsdelivr.net/npm/apexcharts@3.49.1/dist/apexcharts.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/countup.js@2.8.0/dist/countUp.umd.min.js"></script>
+<script src="{{ url_for('static', filename='js/market_insights.js') }}" defer></script>
+<style>
+    /* Market Insights component styles. Mirrored in frontend/styles/app.css
+       so the next Vite build picks them up; inlined here so the section
+       works without requiring a frontend rebuild right now. */
+    .crm-mi__kpi {
+        position: relative; display: flex; flex-direction: column; gap: 0.75rem;
+        background: #fff; border: 1px solid #e2e8f0; border-radius: 0.375rem;
+        padding: 1rem; transition: box-shadow 200ms ease;
+    }
+    .crm-mi__kpi:hover { box-shadow: 0 1px 2px rgba(15,23,42,0.08); }
+    .crm-mi__kpi-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+    .crm-mi__kpi-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+        letter-spacing: 0.08em; color: #64748b; }
+    .crm-mi__kpi-value {
+        margin-top: 0.25rem; font-size: 1.875rem; line-height: 2.25rem;
+        font-weight: 600; letter-spacing: -0.01em; color: #020617;
+        font-variant-numeric: tabular-nums;
+    }
+    .crm-mi__kpi-spark { margin: 0 -0.25rem -0.5rem; height: 2.5rem; }
+    .crm-mi__delta {
+        display: inline-flex; align-items: center; gap: 0.25rem;
+        padding: 0.125rem 0.5rem; border-radius: 9999px;
+        font-size: 0.75rem; font-weight: 600;
+    }
+    .crm-mi__delta--up { background: #ecfdf5; color: #047857; }
+    .crm-mi__delta--down { background: #fff1f2; color: #be123c; }
+    .crm-mi__delta--flat { background: #f1f5f9; color: #475569; }
+    .crm-mi__chart { height: 20rem; width: 100%; }
+
+    /* Collapse/expand affordances. The whole header is clickable; the
+       chevron rotates 180deg when the panel is open. */
+    .crm-mi__toggle {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: 2rem; height: 2rem; border-radius: 0.375rem;
+        border: 1px solid #e2e8f0; background: #fff; color: #475569;
+        transition: background 150ms ease, color 150ms ease, border-color 150ms ease;
+        cursor: pointer; flex-shrink: 0;
+    }
+    .crm-mi__toggle:hover { background: #f8fafc; color: #0f172a; border-color: #cbd5e1; }
+    .crm-mi__toggle:focus-visible {
+        outline: 2px solid #f97316; outline-offset: 2px;
+    }
+    .crm-mi__toggle i { transition: transform 200ms ease; }
+    .crm-mi.is-open .crm-mi__toggle i { transform: rotate(180deg); }
+
+    .crm-mi__header-row {
+        display: flex; align-items: flex-start; justify-content: space-between;
+        gap: 0.75rem; width: 100%;
+    }
+    .crm-mi__collapsed-hint {
+        font-size: 0.75rem; color: #94a3b8; font-style: italic;
+    }
+    .crm-mi.is-open .crm-mi__collapsed-hint { display: none; }
+
+    /* Smooth reveal: small fade + slide on the body container. */
+    .crm-mi__panel { display: none; }
+    .crm-mi.is-open .crm-mi__panel {
+        display: block;
+        animation: crmMiReveal 220ms ease-out;
+    }
+    @keyframes crmMiReveal {
+        from { opacity: 0; transform: translateY(-4px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+</style>
 {% endblock %}
 
 {% block content %}
@@ -57,6 +125,151 @@
             </div>
         </div>
         {% endif %}
+
+        <section class="crm-surface crm-mi mb-6"
+                 data-controller="market-insights"
+                 data-market-insights-default-slug-value="mont-belvieu"
+                 data-market-insights-default-window-value="12m">
+            <div class="crm-surface-header">
+                <div class="crm-mi__header-row">
+                    <div class="min-w-0">
+                        {{ section_header('Market Insights', 'Active residential listings (Single Family, Condo, Townhouse). Refreshed weekly.', 'Market') }}
+                        <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500"
+                             data-market-insights-target="metaRow">
+                            <span class="crm-mi__collapsed-hint">
+                                <i class="fas fa-chart-line text-slate-400 mr-1"></i>
+                                Hidden by default. Open to load the latest local market stats.
+                            </span>
+                            <span class="hidden" data-market-insights-target="asOfWrap">
+                                <span data-market-insights-target="asOf">As of —</span>
+                                <span class="hidden text-slate-300 mx-1" data-market-insights-target="staleSeparator">·</span>
+                                <span class="hidden crm-badge crm-badge-info"
+                                      data-market-insights-target="staleBadge">
+                                    <i class="fas fa-rotate text-[10px]"></i>
+                                    Refreshing
+                                </span>
+                            </span>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <div class="hidden flex-col items-stretch gap-3 md:flex-row md:items-center"
+                             data-market-insights-target="controls">
+                            <select class="crm-select md:w-56"
+                                    data-market-insights-target="areaSelect"
+                                    data-action="change->market-insights#changeArea"
+                                    aria-label="Service area">
+                                <option value="" disabled selected>Loading areas…</option>
+                            </select>
+                            <div class="crm-segment" role="tablist" aria-label="Time window">
+                                {% for code, label in [('90d', '90d'), ('180d', '180d'), ('12m', '12m')] %}
+                                <button type="button"
+                                        role="tab"
+                                        data-market-insights-target="windowButton"
+                                        data-window="{{ code }}"
+                                        data-action="market-insights#setWindow"
+                                        class="crm-segment__item {% if code == '12m' %}is-active{% endif %}">
+                                    {{ label }}
+                                </button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <button type="button"
+                                class="crm-mi__toggle"
+                                data-market-insights-target="toggleButton"
+                                data-action="market-insights#toggle"
+                                aria-expanded="false"
+                                aria-controls="market-insights-panel"
+                                aria-label="Show market insights">
+                            <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="crm-surface-body crm-mi__panel"
+                 id="market-insights-panel"
+                 data-market-insights-target="body"
+                 hidden>
+                <div class="hidden rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800"
+                     data-market-insights-target="errorState" role="alert">
+                    <div class="flex items-start gap-3">
+                        <i class="fas fa-triangle-exclamation mt-0.5 text-rose-500"></i>
+                        <div class="flex-1">
+                            <div class="font-semibold">Couldn't load market data.</div>
+                            <div class="mt-0.5 text-rose-700" data-market-insights-target="errorMessage">Please try again in a moment.</div>
+                        </div>
+                        <button type="button" class="crm-btn crm-btn-secondary"
+                                data-action="market-insights#refresh">Retry</button>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                    {% for kpi in [
+                        ('price',     'Median asking price',     'fa-house-chimney',  'Median list price of currently active residential listings. Not closed-sale price.'),
+                        ('ppsf',      'Price per sq.ft.',        'fa-ruler-combined', 'Listing-count-weighted median $/sqft across active residential listings.'),
+                        ('inventory', 'Active listings (mo.)',   'fa-warehouse',      'Total residential listings active at any point this month (cumulative, not a snapshot).'),
+                        ('dom',       'Median DOM (active)',     'fa-clock',          'Median days currently active residential listings have been on market. Not sold-DOM.')
+                    ] %}
+                    <div class="crm-mi__kpi" data-market-insights-target="kpiCard" data-kpi="{{ kpi[0] }}">
+                        <div class="crm-mi__kpi-head">
+                            <div>
+                                <div class="crm-mi__kpi-label" title="{{ kpi[3] }}">
+                                    <i class="fas {{ kpi[2] }} mr-1 text-slate-400"></i>
+                                    {{ kpi[1] }}
+                                    <i class="fas fa-circle-info ml-1 text-[10px] text-slate-300" aria-hidden="true"></i>
+                                </div>
+                                <div class="crm-mi__kpi-value"
+                                     data-market-insights-target="kpiValue"
+                                     data-kpi="{{ kpi[0] }}">—</div>
+                            </div>
+                            <span class="crm-mi__delta crm-mi__delta--flat hidden"
+                                  data-market-insights-target="kpiDelta"
+                                  data-kpi="{{ kpi[0] }}">
+                                <i class="fas fa-minus"></i>
+                                <span data-market-insights-target="kpiDeltaText">—</span>
+                            </span>
+                        </div>
+                        <div class="crm-mi__kpi-spark"
+                             data-market-insights-target="kpiSpark"
+                             data-kpi="{{ kpi[0] }}"></div>
+                    </div>
+                    {% endfor %}
+                </div>
+
+                <div class="mt-6 rounded-md border border-slate-200 bg-white p-4">
+                    <div class="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                            <div class="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">Trend</div>
+                            <div class="mt-0.5 text-sm font-semibold text-slate-900">Median asking price &amp; active listings</div>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                            <span class="inline-flex items-center gap-1.5">
+                                <span class="h-2 w-2 rounded-full bg-orange-500"></span>
+                                Median asking price
+                            </span>
+                            <span class="inline-flex items-center gap-1.5">
+                                <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                                Active listings
+                            </span>
+                            <span class="hidden h-3 w-px bg-slate-200 sm:inline-block"></span>
+                            <span class="inline-flex items-center gap-1.5 text-slate-500">
+                                New listings this month:
+                                <span class="font-semibold text-slate-900 tabular-nums"
+                                      data-market-insights-target="newListings">—</span>
+                            </span>
+                        </div>
+                    </div>
+                    <div class="crm-mi__chart mt-3" data-market-insights-target="mainChart"></div>
+                </div>
+
+                <div class="mt-3 flex items-start gap-2 text-[11px] leading-snug text-slate-500">
+                    <i class="fas fa-circle-info mt-0.5 text-slate-300"></i>
+                    <p class="m-0">
+                        Stats reflect <strong>active residential listings</strong> (Single Family, Condo, Townhouse) per the RentCast <code class="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">/markets</code> endpoint &mdash; <em>asking</em> prices, not sold prices. &ldquo;Active listings&rdquo; counts every listing that touched the market in the month (cumulative). For closed-sale comps, check the MLS.
+                    </p>
+                </div>
+            </div>
+        </section>
 
         {% if is_first_run %}
         <div class="crm-surface mb-6" {% if not current_user.has_seen_dashboard_onboarding %}data-dashboard-page-target="onboarding"{% endif %}>

--- a/tests/test_market_insights.py
+++ b/tests/test_market_insights.py
@@ -1,0 +1,473 @@
+"""Tests for the Market Insights API + caching/SWR layer.
+
+Covers:
+- auth required on both endpoints
+- service area listing
+- 404 on unknown slug
+- fresh cache hit does NOT call RentCast
+- stale cache returns immediately and spawns a background refresh
+- atomic claim: among concurrent stale callers, only one wins
+- cold cache + RentCast failure surfaces 503
+- window slicing (90d/180d/12m) with deltas computed against window start
+- multi-ZIP rollup uses sum on inventory and weighted-avg DOM
+- the rentcast_api_log audit row is written on every call
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from models import db, MarketDataCache, RentcastApiLog, ServiceArea
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def reset_market_tables(app):
+    """Wipe market-insight tables before each test for a clean slate."""
+    with app.app_context():
+        db.session.query(RentcastApiLog).delete()
+        db.session.query(MarketDataCache).delete()
+        db.session.query(ServiceArea).delete()
+        db.session.commit()
+    yield
+    with app.app_context():
+        db.session.query(RentcastApiLog).delete()
+        db.session.query(MarketDataCache).delete()
+        db.session.query(ServiceArea).delete()
+        db.session.commit()
+
+
+@pytest.fixture
+def seeded_areas(app, reset_market_tables):
+    with app.app_context():
+        db.session.add_all([
+            ServiceArea(slug='mont-belvieu', display_name='Mont Belvieu',
+                        zip_codes=['77523'], sort_order=0),
+            ServiceArea(slug='baytown', display_name='Baytown',
+                        zip_codes=['77521', '77520'], sort_order=1),
+        ])
+        db.session.commit()
+    yield
+
+
+def _months_back(anchor: datetime, n: int) -> datetime:
+    """Return the first of the month n months before ``anchor`` (anchor itself for n=0)."""
+    year, month = anchor.year, anchor.month
+    total = year * 12 + (month - 1) - n
+    return datetime(total // 12, (total % 12) + 1, 1)
+
+
+def _make_payload(zip_code: str, *, base_price=400_000, base_inventory=300,
+                  base_dom=30, months: int = 12, base_rent=1500):
+    """Build a fake RentCast /markets response with monthly history."""
+    today = datetime.utcnow().replace(day=1)
+    history = {}
+    rental_history = {}
+    for i in range(months):
+        m = _months_back(today, i)
+        key = f"{m.year:04d}-{m.month:02d}"
+        history[key] = {
+            'date': m.strftime('%Y-%m-01T00:00:00.000Z'),
+            'medianPrice': base_price - i * 1000,
+            'medianPricePerSquareFoot': 180 - i * 0.5,
+            'medianDaysOnMarket': base_dom + i,
+            'totalListings': base_inventory - i * 5,
+            'newListings': 30 - i,
+        }
+        rental_history[key] = {
+            'date': m.strftime('%Y-%m-01T00:00:00.000Z'),
+            'medianRent': base_rent - i * 5,
+        }
+    return {
+        'id': zip_code,
+        'zipCode': zip_code,
+        'saleData': {
+            'lastUpdatedDate': today.strftime('%Y-%m-%dT00:00:00.000Z'),
+            'medianPrice': base_price,
+            'medianPricePerSquareFoot': 180,
+            'medianDaysOnMarket': base_dom,
+            'totalListings': base_inventory,
+            'newListings': 30,
+            'minPrice': 100_000, 'maxPrice': 1_500_000,
+            'history': history,
+            'dataByPropertyType': [
+                {'propertyType': 'Single Family', 'medianPrice': base_price + 10_000,
+                 'medianPricePerSquareFoot': 185, 'medianDaysOnMarket': base_dom - 2,
+                 'totalListings': int(base_inventory * 0.8)},
+                {'propertyType': 'Condo', 'medianPrice': base_price - 80_000,
+                 'medianPricePerSquareFoot': 160, 'medianDaysOnMarket': base_dom + 5,
+                 'totalListings': int(base_inventory * 0.2)},
+            ],
+            'dataByBedrooms': [
+                {'bedrooms': 3, 'medianPrice': base_price, 'medianPricePerSquareFoot': 180,
+                 'medianDaysOnMarket': base_dom, 'totalListings': int(base_inventory * 0.6)},
+                {'bedrooms': 4, 'medianPrice': base_price + 50_000, 'medianPricePerSquareFoot': 178,
+                 'medianDaysOnMarket': base_dom + 4, 'totalListings': int(base_inventory * 0.4)},
+            ],
+        },
+        'rentalData': {
+            'lastUpdatedDate': today.strftime('%Y-%m-%dT00:00:00.000Z'),
+            'medianRent': base_rent,
+            'history': rental_history,
+        },
+    }
+
+
+def _good_result(zip_code, **kwargs):
+    return {
+        'success': True, 'data': _make_payload(zip_code, **kwargs),
+        'status_code': 200, 'latency_ms': 12, 'error': None,
+    }
+
+
+def _bad_result():
+    return {
+        'success': False, 'data': None, 'status_code': 429,
+        'latency_ms': 8, 'error': 'rate limited',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auth + basic routing
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def test_areas_requires_auth(self, client):
+        resp = client.get('/api/market-insights/areas')
+        assert resp.status_code in (302, 401)
+
+    def test_insights_requires_auth(self, client):
+        resp = client.get('/api/market-insights/mont-belvieu')
+        assert resp.status_code in (302, 401)
+
+
+class TestAreasEndpoint:
+    def test_lists_seeded_areas(self, owner_a_client, seeded_areas):
+        resp = owner_a_client.get('/api/market-insights/areas')
+        assert resp.status_code == 200
+        body = resp.get_json()
+        slugs = [a['slug'] for a in body['areas']]
+        assert slugs == ['mont-belvieu', 'baytown']
+        assert body['areas'][1]['zip_codes'] == ['77521', '77520']
+
+
+class TestUnknownSlug:
+    def test_404_for_unknown_area(self, owner_a_client, seeded_areas):
+        resp = owner_a_client.get('/api/market-insights/no-such-place')
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Cache freshness behavior
+# ---------------------------------------------------------------------------
+
+class TestCacheBehavior:
+    def test_fresh_cache_does_not_call_rentcast(self, app, owner_a_client, seeded_areas):
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523',
+                payload=_make_payload('77523'),
+                refreshed_at=datetime.utcnow(),  # fresh
+            ))
+            db.session.commit()
+
+        with patch('services.market_insights_service.fetch_market_stats') as mock_fetch:
+            resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+            assert resp.status_code == 200
+            mock_fetch.assert_not_called()
+
+        body = resp.get_json()
+        assert body['area'] == 'Mont Belvieu'
+        assert body['median_home_price']['value'] == 400_000
+        assert body['is_stale'] is False
+
+    def test_stale_cache_returns_immediately_and_spawns_refresh(
+        self, app, owner_a_client, seeded_areas
+    ):
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523',
+                payload=_make_payload('77523'),
+                refreshed_at=datetime.utcnow() - timedelta(days=14),  # stale
+            ))
+            db.session.commit()
+
+        spawned = []
+
+        def fake_thread(*args, **kwargs):
+            spawned.append((args, kwargs))
+            class _T:
+                def start(self_inner): pass
+            return _T()
+
+        # Patch threading.Thread inside the service module so we can verify
+        # a background refresh was kicked off without actually doing it.
+        with patch('services.market_insights_service.threading.Thread', side_effect=fake_thread), \
+             patch('services.market_insights_service.fetch_market_stats') as mock_fetch:
+            resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+            assert resp.status_code == 200
+            # Inline call must NOT happen -- only the spawned thread would.
+            mock_fetch.assert_not_called()
+
+        body = resp.get_json()
+        assert body['is_stale'] is True
+        assert len(spawned) == 1, "Expected exactly one background refresh thread"
+
+    def test_first_load_no_cache_returns_503_on_rentcast_error(
+        self, app, owner_a_client, seeded_areas
+    ):
+        # Cache is cold for 77523. RentCast fails. Expect 503.
+        with patch('services.market_insights_service.fetch_market_stats',
+                   return_value=_bad_result()):
+            resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+        assert resp.status_code == 503
+        body = resp.get_json()
+        assert 'error' in body
+
+        with app.app_context():
+            row = db.session.get(MarketDataCache, '77523')
+            assert row is not None
+            assert row.payload is None
+            assert row.last_error == 'rate limited'
+            assert row.refresh_started_at is None
+            log = RentcastApiLog.query.filter_by(zip_code='77523').first()
+            assert log is not None
+            assert log.status_code == 429
+
+    def test_first_load_no_cache_success_writes_payload_and_log(
+        self, app, owner_a_client, seeded_areas
+    ):
+        with patch('services.market_insights_service.fetch_market_stats',
+                   return_value=_good_result('77523')):
+            resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+        assert resp.status_code == 200
+
+        with app.app_context():
+            row = db.session.get(MarketDataCache, '77523')
+            assert row is not None
+            assert row.payload is not None
+            assert row.refreshed_at is not None
+            assert row.last_error is None
+            assert RentcastApiLog.query.filter_by(zip_code='77523').count() == 1
+
+
+class TestAtomicClaim:
+    def test_only_one_concurrent_caller_wins_the_claim(self, app, seeded_areas):
+        """Two stale-but-cached callers should produce exactly one RentCast call.
+
+        We exercise the claim helper directly to avoid threading-related flakes;
+        the SQL is the source of truth for this guarantee.
+        """
+        from services.market_insights_service import _try_claim_refresh
+
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523', payload=None,
+                refreshed_at=datetime.utcnow() - timedelta(days=14),
+            ))
+            db.session.commit()
+
+            first = _try_claim_refresh('77523')
+            second = _try_claim_refresh('77523')
+            assert first is True
+            assert second is False, \
+                "Second caller must lose the claim while another refresh is in flight"
+
+
+# ---------------------------------------------------------------------------
+# Window slicing + delta computation
+# ---------------------------------------------------------------------------
+
+class TestWindowAndDeltas:
+    def _seed_fresh(self, app, base_price=400_000):
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523',
+                payload=_make_payload('77523', base_price=base_price, months=12),
+                refreshed_at=datetime.utcnow(),
+            ))
+            db.session.commit()
+
+    def test_window_slices_history(self, app, owner_a_client, seeded_areas):
+        self._seed_fresh(app)
+
+        for window, expected_count in (('90d', 3), ('180d', 6), ('12m', 12)):
+            resp = owner_a_client.get(
+                f'/api/market-insights/mont-belvieu?window={window}'
+            )
+            assert resp.status_code == 200
+            body = resp.get_json()
+            assert len(body['history']) == expected_count
+            # change_vs label echoes the requested window
+            assert body['median_home_price']['change_vs'] == window
+
+    def test_delta_compares_latest_to_first_in_window(self, app, owner_a_client, seeded_areas):
+        # Built-in payload: medianPrice for month i (0=current) is 400k - i*1000
+        # so 12m delta = (400_000 - 389_000)/389_000 * 100 ~= 2.83%
+        self._seed_fresh(app)
+        resp = owner_a_client.get('/api/market-insights/mont-belvieu?window=12m')
+        body = resp.get_json()
+        assert body['median_home_price']['value'] == 400_000
+        assert body['median_home_price']['change_pct'] == pytest.approx(2.8, abs=0.2)
+
+        # 90d delta compares to 3 months back (i=2): 400k vs 398k → ~0.5%
+        resp_90 = owner_a_client.get('/api/market-insights/mont-belvieu?window=90d')
+        body_90 = resp_90.get_json()
+        assert body_90['median_home_price']['change_pct'] == pytest.approx(0.5, abs=0.2)
+
+    def test_invalid_window_falls_back_to_default(self, app, owner_a_client, seeded_areas):
+        self._seed_fresh(app)
+        resp = owner_a_client.get('/api/market-insights/mont-belvieu?window=garbage')
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body['window'] == '12m'
+
+
+# ---------------------------------------------------------------------------
+# Multi-zip rollup
+# ---------------------------------------------------------------------------
+
+class TestMultiZipRollup:
+    def test_inventory_summed_and_dom_weighted(self, app, owner_a_client, seeded_areas):
+        # Baytown has 77521 + 77520. Give them different inventory and DOM
+        # values so we can verify sum (inventory) and weighted average (DOM).
+        with app.app_context():
+            db.session.add_all([
+                MarketDataCache(
+                    zip_code='77521',
+                    payload=_make_payload('77521', base_price=350_000,
+                                          base_inventory=400, base_dom=20),
+                    refreshed_at=datetime.utcnow(),
+                ),
+                MarketDataCache(
+                    zip_code='77520',
+                    payload=_make_payload('77520', base_price=300_000,
+                                          base_inventory=100, base_dom=60),
+                    refreshed_at=datetime.utcnow(),
+                ),
+            ])
+            db.session.commit()
+
+        resp = owner_a_client.get('/api/market-insights/baytown')
+        assert resp.status_code == 200
+        body = resp.get_json()
+
+        # Inventory: 400 + 100 = 500
+        assert body['active_inventory']['value'] == 500
+
+        # Weighted DOM: (20*400 + 60*100) / 500 = (8000+6000)/500 = 28
+        assert body['days_on_market']['value'] == 28
+
+        # Median of medians for price: median(350k, 300k) = 325k
+        assert body['median_home_price']['value'] == 325_000
+
+        # Both ZIPs reflected in the area metadata
+        assert body['zip_codes'] == ['77521', '77520']
+
+    def test_breakdowns_are_returned(self, app, owner_a_client, seeded_areas):
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523',
+                payload=_make_payload('77523'),
+                refreshed_at=datetime.utcnow(),
+            ))
+            db.session.commit()
+
+        resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+        body = resp.get_json()
+        assert any(r['propertyType'] == 'Single Family' for r in body['by_property_type'])
+        assert any(r['bedrooms'] == 3 for r in body['by_bedrooms'])
+
+    def test_residential_filter_excludes_land_and_manufactured(
+        self, app, owner_a_client, seeded_areas
+    ):
+        """Headline metrics must be rebuilt from Single Family + Townhouse + Condo
+        only, dropping Land / Manufactured / Multi-Family / Commercial which
+        skew RentCast's all-property aggregates in rural ZIPs."""
+        today = datetime.utcnow().replace(day=1)
+        # Build a payload that LOOKS like the all-properties top-level totals
+        # are being polluted by land + manufactured. Top-level claims median
+        # $300k, 1000 listings, 80 DOM. The residential breakdown shows the
+        # truth: Single Family is 800 listings @ $400k, 30 DOM.
+        polluted_payload = {
+            'id': '77523', 'zipCode': '77523',
+            'saleData': {
+                'lastUpdatedDate': today.strftime('%Y-%m-%dT00:00:00.000Z'),
+                'medianPrice': 300_000,
+                'medianPricePerSquareFoot': 130,
+                'medianDaysOnMarket': 80,
+                'totalListings': 1000,
+                'newListings': 200,
+                'minPrice': 50_000, 'maxPrice': 5_000_000,
+                'dataByPropertyType': [
+                    {'propertyType': 'Land', 'medianPrice': 80_000,
+                     'medianPricePerSquareFoot': None, 'medianDaysOnMarket': 200,
+                     'totalListings': 150, 'newListings': 10,
+                     'minPrice': 5_000, 'maxPrice': 500_000},
+                    {'propertyType': 'Manufactured', 'medianPrice': 90_000,
+                     'medianPricePerSquareFoot': 70, 'medianDaysOnMarket': 180,
+                     'totalListings': 50, 'newListings': 2,
+                     'minPrice': 30_000, 'maxPrice': 200_000},
+                    {'propertyType': 'Single Family', 'medianPrice': 400_000,
+                     'medianPricePerSquareFoot': 175, 'medianDaysOnMarket': 30,
+                     'totalListings': 800, 'newListings': 188,
+                     'minPrice': 100_000, 'maxPrice': 5_000_000},
+                ],
+                'dataByBedrooms': [],
+                'history': {},  # empty history so headline falls back to snapshot
+            },
+            'rentalData': None,
+        }
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523', payload=polluted_payload,
+                refreshed_at=datetime.utcnow(),
+            ))
+            db.session.commit()
+
+        resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+        assert resp.status_code == 200
+        body = resp.get_json()
+
+        # Inventory: residential only = 800 (NOT 1000 from raw saleData)
+        assert body['active_inventory']['value'] == 800
+
+        # New listings: residential only = 188 (NOT 200)
+        assert body['new_listings']['value'] == 188
+
+        # Median price: weighted across residential only ≈ Single Family $400k
+        # (the only residential row), NOT the polluted $300k.
+        assert body['median_home_price']['value'] == 400_000
+
+        # DOM: 30 (Single Family), NOT 80 (polluted with land + manufactured)
+        assert body['days_on_market']['value'] == 30
+
+        # The full property-type breakdown is preserved on the response so
+        # users can still inspect Land / Manufactured if they want to.
+        types = {r['propertyType'] for r in body['by_property_type']}
+        assert {'Single Family', 'Land', 'Manufactured'} <= types
+
+        # Methodology block is exposed for the UI to show as a footer/tooltip.
+        assert 'methodology' in body
+        assert 'Single Family' in body['methodology']['scope']
+
+    def test_gross_rental_yield_computed(self, app, owner_a_client, seeded_areas):
+        with app.app_context():
+            db.session.add(MarketDataCache(
+                zip_code='77523',
+                payload=_make_payload('77523', base_price=400_000, base_rent=2000),
+                refreshed_at=datetime.utcnow(),
+            ))
+            db.session.commit()
+
+        resp = owner_a_client.get('/api/market-insights/mont-belvieu')
+        body = resp.get_json()
+        # 2000 * 12 / 400_000 = 0.06 -> 6.00%
+        assert body['gross_rental_yield_pct'] == pytest.approx(6.0, abs=0.01)


### PR DESCRIPTION
…data

Adds a collapsible Market Insights section to the agent dashboard powered by RentCast's /markets endpoint, with a database-backed cache and stale-while-revalidate refresh so we stay well under the free-tier 50-calls/month quota (default TTL: 7 days, ~22 calls/mo across the 4 seeded ZIP areas: Mont Belvieu, Baytown, Dayton, Anahuac).

Backend
- ServiceArea / MarketDataCache / RentcastApiLog models + Alembic migration (idempotent, with seed inserts for the four service areas).
- services/market_insights_service.py: atomic UPDATE-based refresh claim prevents concurrent loads from duplicating the API call; cold-cache loads block on a single inline refresh, stale-cache loads return the stale payload immediately and spawn a daemon-thread refresh.
- Rolls per-ZIP payloads up into the dashboard response with weighted median for prices, listing-count-weighted average for DOM/$ per sqft, and sums for inventory; supports 90d/180d/12m windows.
- Filters headline metrics to residential property types (Single Family, Townhouse, Condo) so RentCast's all-property aggregates aren't skewed by Land/Manufactured/Multi-Family in rural ZIPs (matters most for Anahuac/Dayton). Methodology block exposed in the response so the UI can disclose the active-listings vs sold-comps distinction.
- /api/market-insights/areas + /api/market-insights/<slug> routes, auth-required, 503 on cold-cache RentCast failures.

Frontend
- New section in templates/dashboard.html with KPI cards (median asking price, $/sqft, active listings, median DOM), animated values via CountUp.js, ApexCharts main trend + per-KPI sparklines.
- Collapsible by default with a chevron toggle; preference persists in localStorage so the data fetch is fully lazy until an agent opens the panel for the first time.
- Plain-JS controller (static/js/market_insights.js) plus a parity Stimulus controller (frontend/controllers/market_insights_controller.js) so the next Vite build picks up the same behavior.

Tests
- 16 tests covering auth, caching freshness, atomic claim, multi-zip rollup, window slicing/deltas, the residential filter, and the audit log row written on every RentCast call.

Made-with: Cursor