### PR TITLE
feat(notifications): in-app notification center with bell icon and per-user preferences

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ from routes.gmail_integration import gmail_bp
 from routes.reports import reports_bp
 from routes.tax_protest import tax_protest_bp
 from routes.market_insights import market_insights_bp
+from routes.notifications import notifications_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
@@ -212,6 +213,7 @@ def create_app():
     app.register_blueprint(reports_bp)
     app.register_blueprint(tax_protest_bp)
     app.register_blueprint(market_insights_bp)
+    app.register_blueprint(notifications_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/jobs/task_reminder.py
+++ b/jobs/task_reminder.py
@@ -42,16 +42,18 @@ APP_BASE_URL = os.environ.get('APP_BASE_URL', 'https://www.origentechnolog.com')
 
 def send_task_reminders():
     """
-    Send batched task reminder emails for all organizations.
+    Send batched task reminder emails and in-app notifications for all organizations.
     
     For each organization:
     1. Query all pending tasks needing reminders
     2. Group tasks by user
     3. Send ONE digest email per user with all their tasks
-    4. Mark tasks as reminded (only if email succeeds)
+    4. Create in-app notifications (respects user preferences)
+    5. Mark tasks as reminded (only if email succeeds)
     """
     from models import db, Organization, Task, User
     from services.email_service import get_email_service
+    from services.notification_service import create_notification, is_channel_enabled
     from jobs.base import set_job_org_context
     
     now_utc = datetime.utcnow()
@@ -165,46 +167,71 @@ def send_task_reminders():
                     continue
                 
                 try:
-                    # Send the batched reminder email
-                    success = email_service.send_task_reminder_digest(user, tasks_by_type, base_url=APP_BASE_URL)
-                    
-                    if success:
-                        logger.info(
-                            f"Sent reminder to {user.email}: "
-                            f"{len(tasks_by_type['overdue'])} overdue, "
-                            f"{len(tasks_by_type['today'])} today, "
-                            f"{len(tasks_by_type['tomorrow'])} tomorrow, "
-                            f"{len(tasks_by_type['upcoming'])} upcoming"
+                    # ── Email channel (respects user preference) ──
+                    email_ok = False
+                    if is_channel_enabled(user_id, 'task_reminder', 'email'):
+                        email_ok = email_service.send_task_reminder_digest(
+                            user, tasks_by_type, base_url=APP_BASE_URL
                         )
-                        
-                        # Mark all tasks as reminded (only after successful send)
+                        if email_ok:
+                            logger.info(
+                                f"Sent reminder to {user.email}: "
+                                f"{len(tasks_by_type['overdue'])} overdue, "
+                                f"{len(tasks_by_type['today'])} today, "
+                                f"{len(tasks_by_type['tomorrow'])} tomorrow, "
+                                f"{len(tasks_by_type['upcoming'])} upcoming"
+                            )
+                            total_emails_sent += 1
+                        else:
+                            logger.error(f"Failed to send reminder to {user.email}")
+
+                    # ── In-app notification (respects user preference) ──
+                    parts = []
+                    if tasks_by_type['overdue']:
+                        parts.append(f"{len(tasks_by_type['overdue'])} overdue")
+                    if tasks_by_type['today']:
+                        parts.append(f"{len(tasks_by_type['today'])} due today")
+                    if tasks_by_type['tomorrow']:
+                        parts.append(f"{len(tasks_by_type['tomorrow'])} due tomorrow")
+                    if tasks_by_type['upcoming']:
+                        parts.append(f"{len(tasks_by_type['upcoming'])} upcoming")
+
+                    if parts:
+                        try:
+                            create_notification(
+                                user_id=user_id,
+                                organization_id=org_id,
+                                category='task_reminder',
+                                title='Task Reminder',
+                                body=', '.join(parts) + '.',
+                                icon='fa-tasks',
+                                action_url=f'{APP_BASE_URL}/tasks',
+                                respect_preference=True,
+                            )
+                        except Exception as notif_err:
+                            logger.warning(f"Could not create in-app notification for user {user_id}: {notif_err}")
+
+                    # Mark tasks as reminded when email sent or notification created
+                    if email_ok or is_channel_enabled(user_id, 'task_reminder', 'in_app'):
                         for task in tasks_by_type['overdue']:
                             task.overdue_reminder_sent = True
                             task.last_reminder_sent_at = now_utc
                             total_tasks_processed += 1
-                        
                         for task in tasks_by_type['today']:
                             task.today_reminder_sent = True
                             task.last_reminder_sent_at = now_utc
                             total_tasks_processed += 1
-                        
                         for task in tasks_by_type['tomorrow']:
                             task.one_day_reminder_sent = True
                             task.last_reminder_sent_at = now_utc
                             total_tasks_processed += 1
-                        
                         for task in tasks_by_type['upcoming']:
                             task.two_day_reminder_sent = True
                             task.last_reminder_sent_at = now_utc
                             total_tasks_processed += 1
-                        
-                        total_emails_sent += 1
-                    else:
-                        logger.error(f"Failed to send reminder to {user.email}")
-                        
+
                 except Exception as e:
                     logger.exception(f"Error sending reminder to user {user_id}: {e}")
-                    # Continue with other users even if one fails
                     continue
             
             # Commit changes for this org and clean up session

--- a/migrations/versions/add_notification_tables.py
+++ b/migrations/versions/add_notification_tables.py
@@ -1,0 +1,107 @@
+"""Add notifications and user_notification_preferences tables
+
+Revision ID: add_notification_tables
+Revises: add_market_insights_tables
+Create Date: 2026-04-25 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_notification_tables'
+down_revision = 'add_market_insights_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'notifications' not in tables:
+        op.create_table(
+            'notifications',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('category', sa.String(length=50), nullable=False),
+            sa.Column('title', sa.String(length=200), nullable=False),
+            sa.Column('body', sa.Text(), nullable=True),
+            sa.Column('icon', sa.String(length=60), server_default='fa-bell'),
+            sa.Column('action_url', sa.String(length=500), nullable=True),
+            sa.Column('is_read', sa.Boolean(), nullable=False, server_default=sa.text('0')),
+            sa.Column('read_at', sa.DateTime(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=False,
+                      server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.PrimaryKeyConstraint('id', name='pk_notifications'),
+            sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'],
+                                    name='fk_notifications_org',
+                                    ondelete='RESTRICT'),
+            sa.ForeignKeyConstraint(['user_id'], ['user.id'],
+                                    name='fk_notifications_user',
+                                    ondelete='CASCADE'),
+        )
+        op.create_index('ix_notifications_org_id', 'notifications',
+                        ['organization_id'], unique=False)
+        op.create_index('ix_notifications_user_id', 'notifications',
+                        ['user_id'], unique=False)
+        op.create_index('ix_notifications_category', 'notifications',
+                        ['category'], unique=False)
+        op.create_index('ix_notifications_is_read', 'notifications',
+                        ['is_read'], unique=False)
+        op.create_index('ix_notifications_created_at', 'notifications',
+                        ['created_at'], unique=False)
+
+    if 'user_notification_preferences' not in tables:
+        op.create_table(
+            'user_notification_preferences',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('category', sa.String(length=50), nullable=False),
+            sa.Column('in_app_enabled', sa.Boolean(), nullable=False,
+                      server_default=sa.text('1')),
+            sa.Column('email_enabled', sa.Boolean(), nullable=False,
+                      server_default=sa.text('1')),
+            sa.Column('updated_at', sa.DateTime(), nullable=False,
+                      server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.PrimaryKeyConstraint('id', name='pk_user_notification_preferences'),
+            sa.ForeignKeyConstraint(['user_id'], ['user.id'],
+                                    name='fk_user_notif_pref_user',
+                                    ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'],
+                                    name='fk_user_notif_pref_org',
+                                    ondelete='RESTRICT'),
+            sa.UniqueConstraint('user_id', 'category',
+                                name='uq_user_notification_pref'),
+        )
+        op.create_index('ix_user_notif_pref_user_id',
+                        'user_notification_preferences',
+                        ['user_id'], unique=False)
+        op.create_index('ix_user_notif_pref_org_id',
+                        'user_notification_preferences',
+                        ['organization_id'], unique=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'user_notification_preferences' in tables:
+        op.drop_index('ix_user_notif_pref_org_id',
+                      table_name='user_notification_preferences')
+        op.drop_index('ix_user_notif_pref_user_id',
+                      table_name='user_notification_preferences')
+        op.drop_table('user_notification_preferences')
+
+    if 'notifications' in tables:
+        op.drop_index('ix_notifications_created_at', table_name='notifications')
+        op.drop_index('ix_notifications_is_read', table_name='notifications')
+        op.drop_index('ix_notifications_category', table_name='notifications')
+        op.drop_index('ix_notifications_user_id', table_name='notifications')
+        op.drop_index('ix_notifications_org_id', table_name='notifications')
+        op.drop_table('notifications')

--- a/models.py
+++ b/models.py
@@ -1699,6 +1699,96 @@ class FortBendProperty(db.Model):
 
 
 # =============================================================================
+# IN-APP NOTIFICATIONS
+# =============================================================================
+
+class Notification(db.Model):
+    """In-app notification delivered to a specific user's bell icon."""
+    __tablename__ = 'notifications'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id',
+                        ondelete='CASCADE'), nullable=False, index=True)
+
+    # Category lets the preference system gate delivery per-type
+    category = db.Column(db.String(50), nullable=False, index=True)
+
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text)
+    icon = db.Column(db.String(60), default='fa-bell')
+    action_url = db.Column(db.String(500))
+
+    is_read = db.Column(db.Boolean, default=False, nullable=False, index=True)
+    read_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    user = db.relationship('User', backref=db.backref('notifications',
+                           lazy='dynamic', order_by='Notification.created_at.desc()'))
+
+    # Rows older than 90 days are safe to prune via a periodic job.
+    CATEGORIES = {
+        'task_reminder': 'Task Reminders',
+        'company_update': 'Company Updates',
+    }
+
+    def mark_read(self):
+        if not self.is_read:
+            self.is_read = True
+            self.read_at = datetime.utcnow()
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'category': self.category,
+            'title': self.title,
+            'body': self.body,
+            'icon': self.icon,
+            'action_url': self.action_url,
+            'is_read': self.is_read,
+            'created_at': self.created_at.isoformat() + 'Z' if self.created_at else None,
+            'read_at': self.read_at.isoformat() + 'Z' if self.read_at else None,
+        }
+
+    def __repr__(self):
+        return f'<Notification {self.id} cat={self.category} user={self.user_id}>'
+
+
+class UserNotificationPreference(db.Model):
+    """Per-user opt-in/out for each notification category + channel."""
+    __tablename__ = 'user_notification_preferences'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id',
+                        ondelete='CASCADE'), nullable=False, index=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+
+    category = db.Column(db.String(50), nullable=False)
+
+    # Channels — start with two; add push/sms later
+    in_app_enabled = db.Column(db.Boolean, default=True, nullable=False)
+    email_enabled = db.Column(db.Boolean, default=True, nullable=False)
+
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow,
+                           onupdate=datetime.utcnow, nullable=False)
+
+    user = db.relationship('User', backref=db.backref('notification_preferences',
+                           lazy='dynamic'))
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'category',
+                            name='uq_user_notification_pref'),
+    )
+
+    def __repr__(self):
+        return (f'<UserNotificationPreference user={self.user_id} '
+                f'cat={self.category} app={self.in_app_enabled} '
+                f'email={self.email_enabled}>')
+
+
+# =============================================================================
 # MARKET INSIGHTS (RentCast-backed, multi-tenant-agnostic lookup data)
 # =============================================================================
 

--- a/routes/company_updates.py
+++ b/routes/company_updates.py
@@ -251,7 +251,33 @@ def create_update():
         
         db.session.add(update)
         db.session.commit()
-        
+
+        # Notify every other user in the org
+        try:
+            from models import User
+            from services.notification_service import create_notifications_bulk
+            org_users = User.query.filter(
+                User.organization_id == current_user.organization_id,
+                User.id != current_user.id,
+            ).all()
+            if org_users:
+                preview = (title[:80] + '...') if len(title) > 80 else title
+                create_notifications_bulk([
+                    {
+                        'user_id': u.id,
+                        'organization_id': current_user.organization_id,
+                        'category': 'company_update',
+                        'title': 'New Company Update',
+                        'body': preview,
+                        'icon': 'fa-bullhorn',
+                        'action_url': url_for('company_updates.view_update',
+                                              update_id=update.id),
+                    }
+                    for u in org_users
+                ])
+        except Exception as e:
+            current_app.logger.warning(f"Could not create update notifications: {e}")
+
         flash('Update published successfully!', 'success')
         return redirect(url_for('company_updates.view_update', update_id=update.id))
     

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, jsonify
 from flask_login import login_required, current_user
-from models import db, Contact, ContactGroup, Task, User, CompanyUpdate, Transaction, TransactionParticipant, contact_groups as contact_groups_table
+from models import db, Contact, ContactGroup, Task, User, Transaction, TransactionParticipant, contact_groups as contact_groups_table
 from feature_flags import can_access_transactions, feature_required
 from services.tenant_service import org_query, can_view_all_org_data
 from datetime import datetime, timedelta, timezone, date
@@ -530,9 +530,6 @@ def dashboard():
         if task.scheduled_time:
             task.scheduled_time = task.scheduled_time.replace(tzinfo=timezone.utc).astimezone(user_tz)
 
-    # Get latest company update for dashboard teaser (within this org)
-    latest_update = org_query(CompanyUpdate).order_by(CompanyUpdate.created_at.desc()).first()
-
     # Transaction Pipeline Data (only for users with access)
     show_transactions = can_access_transactions(current_user)
     transactions_by_status = {}
@@ -643,6 +640,39 @@ def dashboard():
             else:
                 ytd_closed_value += commission
 
+    # Create an in-app notification if the user has overdue tasks and hasn't
+    # been notified today.  Runs only on dashboard load (lightweight query).
+    try:
+        from models import Notification
+        from services.notification_service import create_notification
+        today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        already_notified = Notification.query.filter(
+            Notification.user_id == current_user.id,
+            Notification.category == 'task_reminder',
+            Notification.created_at >= today_start,
+        ).first() is not None
+
+        if not already_notified:
+            overdue_count = Task.query.filter(
+                Task.organization_id == current_user.organization_id,
+                Task.assigned_to_id == current_user.id,
+                Task.status == 'pending',
+                Task.due_date < datetime.utcnow(),
+            ).count()
+            if overdue_count:
+                create_notification(
+                    user_id=current_user.id,
+                    organization_id=current_user.organization_id,
+                    category='task_reminder',
+                    title='Overdue Tasks',
+                    body=f'You have {overdue_count} overdue task{"s" if overdue_count != 1 else ""}.',
+                    icon='fa-exclamation-circle',
+                    action_url='/tasks?status=overdue',
+                    respect_preference=True,
+                )
+    except Exception:
+        pass
+
     return render_template('dashboard.html',
                          show_all=show_all,
                          total_commission=total_commission,
@@ -652,7 +682,6 @@ def dashboard():
                          top_contacts=top_contacts,
                          upcoming_tasks=upcoming_tasks,
                          task_window_days=task_window_days,
-                         latest_update=latest_update,
                          now=now,
                          show_transactions=show_transactions,
                          transactions_by_status=transactions_by_status,

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,0 +1,78 @@
+"""
+Notification routes — bell popover API + preference settings page.
+"""
+from flask import Blueprint, jsonify, request, render_template, flash, redirect, url_for
+from flask_login import login_required, current_user
+from services import notification_service as ns
+from models import Notification
+
+notifications_bp = Blueprint('notifications', __name__)
+
+
+# ── JSON API (consumed by the bell icon JS) ──────────────────────────────
+
+@notifications_bp.route('/api/notifications')
+@login_required
+def list_notifications():
+    include_read = request.args.get('include_read', '0') == '1'
+    limit = min(int(request.args.get('limit', 20)), 50)
+    notifs = ns.get_notifications(current_user.id, limit=limit,
+                                  include_read=include_read)
+    return jsonify({
+        'notifications': [n.to_dict() for n in notifs],
+        'unread_count': ns.get_unread_count(current_user.id),
+    })
+
+
+@notifications_bp.route('/api/notifications/unread-count')
+@login_required
+def unread_count():
+    return jsonify({'unread_count': ns.get_unread_count(current_user.id)})
+
+
+@notifications_bp.route('/api/notifications/<int:notif_id>/read', methods=['POST'])
+@login_required
+def mark_read(notif_id):
+    ok = ns.mark_read(notif_id, current_user.id)
+    return jsonify({'ok': ok, 'unread_count': ns.get_unread_count(current_user.id)})
+
+
+@notifications_bp.route('/api/notifications/read-all', methods=['POST'])
+@login_required
+def mark_all_read():
+    count = ns.mark_all_read(current_user.id)
+    return jsonify({'marked': count, 'unread_count': 0})
+
+
+@notifications_bp.route('/api/notifications/clear-all', methods=['POST'])
+@login_required
+def clear_all():
+    count = ns.clear_all(current_user.id)
+    return jsonify({'cleared': count, 'unread_count': 0})
+
+
+# ── Preference settings (HTML page) ─────────────────────────────────────
+
+@notifications_bp.route('/settings/notifications')
+@login_required
+def settings_page():
+    prefs = ns.get_all_preferences(current_user.id)
+    return render_template('notifications/settings.html', prefs=prefs,
+                           categories=Notification.CATEGORIES)
+
+
+@notifications_bp.route('/settings/notifications', methods=['POST'])
+@login_required
+def save_settings():
+    for cat_key in Notification.CATEGORIES:
+        in_app = request.form.get(f'{cat_key}_in_app') == 'on'
+        email = request.form.get(f'{cat_key}_email') == 'on'
+        ns.set_preference(
+            user_id=current_user.id,
+            organization_id=current_user.organization_id,
+            category=cat_key,
+            in_app=in_app,
+            email=email,
+        )
+    flash('Notification preferences saved.', 'success')
+    return redirect(url_for('notifications.settings_page'))

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -1,0 +1,182 @@
+"""
+In-app notification service.
+
+Handles creation, retrieval, marking-read, and preference checks
+for the per-user notification system.
+"""
+from datetime import datetime, timedelta
+from flask import current_app
+from models import db, Notification, UserNotificationPreference
+
+
+# ---------------------------------------------------------------------------
+# Preference helpers
+# ---------------------------------------------------------------------------
+
+def get_user_preference(user_id, category):
+    """Return the preference row for a user + category, or None (= default on)."""
+    return UserNotificationPreference.query.filter_by(
+        user_id=user_id, category=category
+    ).first()
+
+
+def is_channel_enabled(user_id, category, channel='in_app'):
+    """Check whether *channel* is enabled for *category*.
+
+    When no explicit preference row exists the default is **enabled**.
+    """
+    pref = get_user_preference(user_id, category)
+    if pref is None:
+        return True
+    return getattr(pref, f'{channel}_enabled', True)
+
+
+def set_preference(user_id, organization_id, category, *, in_app=None, email=None):
+    """Create or update a notification preference row.
+
+    Only the channels whose keyword argument is not None are touched.
+    """
+    pref = get_user_preference(user_id, category)
+    if pref is None:
+        pref = UserNotificationPreference(
+            user_id=user_id,
+            organization_id=organization_id,
+            category=category,
+        )
+        db.session.add(pref)
+
+    if in_app is not None:
+        pref.in_app_enabled = in_app
+    if email is not None:
+        pref.email_enabled = email
+
+    db.session.commit()
+    return pref
+
+
+def get_all_preferences(user_id):
+    """Return a dict keyed by category with the current preference state.
+
+    Categories that have no explicit row are filled in with defaults.
+    """
+    rows = UserNotificationPreference.query.filter_by(user_id=user_id).all()
+    prefs = {r.category: r for r in rows}
+
+    result = {}
+    for cat_key, cat_label in Notification.CATEGORIES.items():
+        row = prefs.get(cat_key)
+        result[cat_key] = {
+            'label': cat_label,
+            'in_app': row.in_app_enabled if row else True,
+            'email': row.email_enabled if row else True,
+        }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Notification CRUD
+# ---------------------------------------------------------------------------
+
+def create_notification(*, user_id, organization_id, category, title,
+                        body=None, icon='fa-bell', action_url=None,
+                        respect_preference=True):
+    """Create an in-app notification if the user's preferences allow it.
+
+    Returns the Notification row or None if suppressed by preference.
+    """
+    if respect_preference and not is_channel_enabled(user_id, category, 'in_app'):
+        return None
+
+    notif = Notification(
+        user_id=user_id,
+        organization_id=organization_id,
+        category=category,
+        title=title,
+        body=body,
+        icon=icon,
+        action_url=action_url,
+    )
+    db.session.add(notif)
+    db.session.commit()
+    return notif
+
+
+def create_notifications_bulk(items, *, respect_preference=True):
+    """Create many notifications in one commit.
+
+    *items* is a list of dicts with the same keys as create_notification().
+    Returns the list of created Notification objects (skipped ones omitted).
+    """
+    created = []
+    for item in items:
+        if respect_preference and not is_channel_enabled(
+                item['user_id'], item['category'], 'in_app'):
+            continue
+        notif = Notification(
+            user_id=item['user_id'],
+            organization_id=item['organization_id'],
+            category=item['category'],
+            title=item['title'],
+            body=item.get('body'),
+            icon=item.get('icon', 'fa-bell'),
+            action_url=item.get('action_url'),
+        )
+        db.session.add(notif)
+        created.append(notif)
+
+    if created:
+        db.session.commit()
+    return created
+
+
+def get_unread_count(user_id):
+    """Return the number of unread notifications for a user."""
+    return Notification.query.filter_by(
+        user_id=user_id, is_read=False
+    ).count()
+
+
+def get_notifications(user_id, *, limit=20, include_read=False):
+    """Return recent notifications for the bell popover."""
+    q = Notification.query.filter_by(user_id=user_id)
+    if not include_read:
+        q = q.filter_by(is_read=False)
+    return q.order_by(Notification.created_at.desc()).limit(limit).all()
+
+
+def mark_read(notification_id, user_id):
+    """Mark a single notification read. Returns True on success."""
+    notif = Notification.query.filter_by(
+        id=notification_id, user_id=user_id
+    ).first()
+    if notif:
+        notif.mark_read()
+        db.session.commit()
+        return True
+    return False
+
+
+def mark_all_read(user_id):
+    """Mark every unread notification for a user as read."""
+    now = datetime.utcnow()
+    count = Notification.query.filter_by(
+        user_id=user_id, is_read=False
+    ).update({'is_read': True, 'read_at': now})
+    db.session.commit()
+    return count
+
+
+def clear_all(user_id):
+    """Delete all notifications for a user."""
+    count = Notification.query.filter_by(user_id=user_id).delete()
+    db.session.commit()
+    return count
+
+
+def prune_old_notifications(days=90):
+    """Delete notifications older than *days*. Intended for a periodic job."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    count = Notification.query.filter(Notification.created_at < cutoff).delete()
+    db.session.commit()
+    current_app.logger.info(f"Pruned {count} notifications older than {days} days")
+    return count

--- a/templates/auth/user_profile.html
+++ b/templates/auth/user_profile.html
@@ -455,6 +455,23 @@
                 </div>
                 {% endif %}
 
+                <!-- Notification Settings Card -->
+                {% if not is_admin_edit %}
+                <a href="{{ url_for('notifications.settings_page') }}"
+                   class="block bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2 no-underline hover:border-orange-200 transition-colors">
+                    <div class="p-5 flex items-center gap-3">
+                        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-orange-400 to-orange-600 flex items-center justify-center">
+                            <i class="fas fa-bell text-white text-sm"></i>
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <h2 class="text-base font-semibold text-slate-800">Notification Settings</h2>
+                            <p class="text-xs text-slate-500 mt-0.5">Manage in-app and email notification preferences</p>
+                        </div>
+                        <i class="fas fa-chevron-right text-xs text-slate-400"></i>
+                    </div>
+                </a>
+                {% endif %}
+
                 <!-- Quick Stats Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">

--- a/templates/base.html
+++ b/templates/base.html
@@ -493,7 +493,7 @@
             color: #0f172a;
         }
 
-        /* Notifications: wider control + popover (fills space from removed menu chevron) */
+        /* ── Notifications ── */
         .crm-notifications-wrap {
             position: relative;
             display: inline-flex;
@@ -503,30 +503,48 @@
             width: 3.25rem;
             min-width: 3.25rem;
             height: 2.25rem;
+            position: relative;
         }
-        .crm-utility-icon-btn--bell i {
-            font-size: 1.05rem;
+        .crm-utility-icon-btn--bell i { font-size: 1.05rem; }
+
+        /* Badge */
+        .crm-notif-badge {
+            position: absolute;
+            top: 0.1rem;
+            right: 0.35rem;
+            min-width: 1.05rem;
+            height: 1.05rem;
+            padding: 0 0.3rem;
+            border-radius: 9999px;
+            background: #f97316;
+            color: #fff;
+            font-size: 0.6rem;
+            font-weight: 700;
+            line-height: 1.05rem;
+            text-align: center;
+            pointer-events: none;
+            box-shadow: 0 0 0 2px #0f172a;
         }
+
+        /* Popover shell */
         .crm-notification-popover {
             position: absolute;
             top: calc(100% + 0.35rem);
             right: 0;
-            min-width: 13rem;
-            padding: 0.85rem 1rem;
+            width: 23rem;
             background: #ffffff;
             border: 1px solid #e2e8f0;
-            border-radius: 0.5rem;
-            box-shadow: 0 10px 28px -8px rgba(15, 23, 42, 0.18), 0 4px 12px -4px rgba(15, 23, 42, 0.1);
+            border-radius: 0.625rem;
+            box-shadow: 0 12px 36px -8px rgba(15,23,42,.22),
+                        0 4px 14px -4px rgba(15,23,42,.08);
             z-index: 70;
-            font-size: 0.875rem;
-            font-weight: 500;
-            color: #64748b;
-            line-height: 1.35;
-            text-align: center;
             opacity: 0;
             transform: translateY(-4px);
             pointer-events: none;
-            transition: opacity 0.2s ease, transform 0.2s ease;
+            transition: opacity 0.15s ease, transform 0.15s ease;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
         }
         .crm-notification-popover.is-open {
             opacity: 1;
@@ -534,10 +552,177 @@
             pointer-events: auto;
         }
         @media (prefers-reduced-motion: reduce) {
-            .crm-notification-popover {
-                transition-duration: 0.01ms;
-            }
+            .crm-notification-popover { transition-duration: 0.01ms; }
         }
+
+        /* Header */
+        .crm-notif-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.7rem 0.9rem;
+            border-bottom: 1px solid #e2e8f0;
+        }
+        .crm-notif-header__title {
+            font-size: 0.8125rem;
+            font-weight: 700;
+            color: #0f172a;
+            letter-spacing: -0.01em;
+        }
+        .crm-notif-header__action {
+            font-size: 0.6875rem;
+            font-weight: 600;
+            color: #f97316;
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 0.15rem 0.4rem;
+            border-radius: 0.25rem;
+            transition: background 0.1s ease;
+        }
+        .crm-notif-header__action:hover {
+            background: #fff7ed;
+        }
+        .crm-notif-header__actions {
+            display: flex;
+            align-items: center;
+            gap: 0.15rem;
+        }
+        .crm-notif-header__action--danger { color: #64748b; }
+        .crm-notif-header__action--danger:hover {
+            color: #dc2626;
+            background: #fef2f2;
+        }
+
+        /* List */
+        .crm-notif-list {
+            max-height: 22rem;
+            overflow-y: auto;
+            overscroll-behavior: contain;
+        }
+        .crm-notif-list::-webkit-scrollbar { width: 4px; }
+        .crm-notif-list::-webkit-scrollbar-thumb {
+            background: #cbd5e1; border-radius: 4px;
+        }
+
+        /* ── Item: READ state (light / receded) ── */
+        .crm-notif-item {
+            display: flex;
+            gap: 0.65rem;
+            padding: 0.7rem 0.9rem;
+            border-bottom: 1px solid #f1f5f9;
+            cursor: pointer;
+            text-decoration: none;
+            color: inherit;
+            transition: background 0.1s ease;
+        }
+        .crm-notif-item:last-child { border-bottom: none; }
+        .crm-notif-item:hover { background: #f8fafc; }
+
+        /* Read items are visually subdued */
+        .crm-notif-item.is-read { opacity: 0.55; }
+        .crm-notif-item.is-read:hover { opacity: 0.75; background: #f8fafc; }
+
+        /* ── Item: UNREAD state (highlighted) ── */
+        .crm-notif-item.is-unread {
+            background: #fff7ed;
+            border-left: 3px solid #f97316;
+            padding-left: calc(0.9rem - 3px);
+        }
+        .crm-notif-item.is-unread:hover { background: #ffedd5; }
+
+        /* Icon */
+        .crm-notif-item__icon {
+            flex-shrink: 0;
+            width: 2rem;
+            height: 2rem;
+            border-radius: 0.5rem;
+            background: #f1f5f9;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            color: #64748b;
+        }
+        .crm-notif-item.is-unread .crm-notif-item__icon {
+            background: #fdba74;
+            color: #7c2d12;
+        }
+
+        /* Body text */
+        .crm-notif-item__body { min-width: 0; flex: 1; }
+        .crm-notif-item__title {
+            font-size: 0.8125rem;
+            font-weight: 600;
+            color: #1e293b;
+            line-height: 1.35;
+        }
+        .crm-notif-item.is-read .crm-notif-item__title { font-weight: 500; }
+        .crm-notif-item__text {
+            font-size: 0.75rem;
+            color: #64748b;
+            line-height: 1.3;
+            margin-top: 0.15rem;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+        .crm-notif-item__time {
+            font-size: 0.625rem;
+            color: #94a3b8;
+            margin-top: 0.25rem;
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+        .crm-notif-item.is-unread .crm-notif-item__time::before {
+            content: '';
+            width: 0.375rem;
+            height: 0.375rem;
+            border-radius: 50%;
+            background: #f97316;
+            flex-shrink: 0;
+        }
+
+        /* Empty state */
+        .crm-notif-empty {
+            padding: 2.5rem 1rem;
+            text-align: center;
+        }
+        .crm-notif-empty__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 2.5rem;
+            height: 2.5rem;
+            border-radius: 0.625rem;
+            background: #f1f5f9;
+            color: #94a3b8;
+            font-size: 1rem;
+            margin-bottom: 0.5rem;
+        }
+        .crm-notif-empty__text {
+            font-size: 0.8125rem;
+            font-weight: 500;
+            color: #94a3b8;
+        }
+
+        /* Footer */
+        .crm-notif-footer {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35rem;
+            padding: 0.55rem;
+            border-top: 1px solid #e2e8f0;
+            font-size: 0.6875rem;
+            font-weight: 500;
+            color: #64748b;
+            text-decoration: none;
+            transition: background 0.1s ease, color 0.1s ease;
+        }
+        .crm-notif-footer:hover { background: #f8fafc; color: #334155; }
 
         .crm-utility-btn .assistant-star {
             color: #f97316;
@@ -745,9 +930,29 @@
                 <button type="button" id="crmNotificationsBtn" class="crm-utility-icon-btn crm-utility-icon-btn--bell"
                         aria-label="Notifications" aria-expanded="false" aria-controls="crmNotificationPopover">
                     <i class="fas fa-bell" aria-hidden="true"></i>
+                    <span id="crmNotifBadge" class="crm-notif-badge" hidden></span>
                 </button>
                 <div id="crmNotificationPopover" class="crm-notification-popover" role="status" aria-hidden="true">
-                    No notifications
+                    <div class="crm-notif-header">
+                        <span class="crm-notif-header__title">Notifications</span>
+                        <div class="crm-notif-header__actions">
+                            <button type="button" id="crmNotifMarkAll" class="crm-notif-header__action" hidden>
+                                Mark all read
+                            </button>
+                            <button type="button" id="crmNotifClearAll" class="crm-notif-header__action crm-notif-header__action--danger" hidden>
+                                Clear all
+                            </button>
+                        </div>
+                    </div>
+                    <div id="crmNotifList" class="crm-notif-list">
+                        <div class="crm-notif-empty">
+                            <div class="crm-notif-empty__icon"><i class="fas fa-bell-slash"></i></div>
+                            <div class="crm-notif-empty__text">No notifications</div>
+                        </div>
+                    </div>
+                    <a href="{{ url_for('notifications.settings_page') }}" class="crm-notif-footer">
+                        <i class="fas fa-cog text-[10px]"></i> Notification Settings
+                    </a>
                 </div>
             </div>
         </div>
@@ -903,7 +1108,7 @@
                     <i class="fas fa-key w-5 mr-3 text-gray-400"></i>
                     Change Password
                 </a>
-                <a href="#" class="flex items-center px-6 py-3 text-base text-gray-700 hover:bg-gray-50">
+                <a href="{{ url_for('notifications.settings_page') }}" class="flex items-center px-6 py-3 text-base text-gray-700 hover:bg-gray-50">
                     <i class="fas fa-bell w-5 mr-3 text-gray-400"></i>
                     Notifications
                 </a>
@@ -1502,73 +1707,156 @@
         })();
     </script>
 
-    <!-- Desktop notifications popover (placeholder until real notifications exist) -->
+    <!-- Notification bell -->
     <script>
         (function () {
-            var wrap = document.getElementById('crmNotificationsWrap');
-            var btn = document.getElementById('crmNotificationsBtn');
-            var pop = document.getElementById('crmNotificationPopover');
+            var wrap     = document.getElementById('crmNotificationsWrap');
+            var btn      = document.getElementById('crmNotificationsBtn');
+            var pop      = document.getElementById('crmNotificationPopover');
+            var badge    = document.getElementById('crmNotifBadge');
+            var list     = document.getElementById('crmNotifList');
+            var markAll  = document.getElementById('crmNotifMarkAll');
+            var clearAll = document.getElementById('crmNotifClearAll');
             if (!wrap || !btn || !pop) return;
 
+            /* ── popover open / close ── */
             var hideTimer = null;
-            function clearHideTimer() {
-                if (hideTimer) {
-                    clearTimeout(hideTimer);
-                    hideTimer = null;
-                }
-            }
-            function hidePopover() {
-                clearHideTimer();
-                if (!pop.classList.contains('is-open')) {
-                    btn.setAttribute('aria-expanded', 'false');
-                    return;
-                }
+            function clearHide() { if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; } }
+            function hide() {
+                clearHide();
                 pop.classList.remove('is-open');
                 pop.setAttribute('aria-hidden', 'true');
                 btn.setAttribute('aria-expanded', 'false');
             }
-            function showPopover() {
-                clearHideTimer();
+            function show() {
+                clearHide();
                 pop.setAttribute('aria-hidden', 'false');
                 btn.setAttribute('aria-expanded', 'true');
                 requestAnimationFrame(function () {
-                    requestAnimationFrame(function () {
-                        pop.classList.add('is-open');
+                    requestAnimationFrame(function () { pop.classList.add('is-open'); });
+                });
+                load();
+            }
+            btn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                pop.classList.contains('is-open') ? hide() : show();
+            });
+            wrap.addEventListener('mouseout', function (e) {
+                if (!pop.classList.contains('is-open')) return;
+                if (e.relatedTarget && wrap.contains(e.relatedTarget)) return;
+                clearHide(); hideTimer = setTimeout(hide, 2500);
+            });
+            wrap.addEventListener('mouseover', function () {
+                if (pop.classList.contains('is-open')) clearHide();
+            });
+            document.addEventListener('click', function (e) { if (!wrap.contains(e.target)) hide(); });
+            document.addEventListener('keydown', function (e) { if (e.key === 'Escape') hide(); });
+
+            /* ── helpers ── */
+            function setBadge(n) {
+                if (n > 0) { badge.textContent = n > 99 ? '99+' : n; badge.hidden = false; }
+                else { badge.hidden = true; }
+            }
+            function ago(iso) {
+                var s = (Date.now() - new Date(iso).getTime()) / 1000;
+                if (s < 60)    return 'just now';
+                if (s < 3600)  return Math.floor(s / 60) + 'm ago';
+                if (s < 86400) return Math.floor(s / 3600) + 'h ago';
+                var d = Math.floor(s / 86400);
+                return d === 1 ? 'yesterday' : d + 'd ago';
+            }
+            function esc(t) {
+                var d = document.createElement('div'); d.textContent = t; return d.innerHTML;
+            }
+
+            /* ── render ── */
+            function render(data) {
+                setBadge(data.unread_count);
+                var hasAny = data.notifications.length > 0;
+                if (markAll)  markAll.hidden  = data.unread_count === 0;
+                if (clearAll) clearAll.hidden = !hasAny;
+
+                if (!hasAny) {
+                    list.innerHTML =
+                        '<div class="crm-notif-empty">' +
+                        '  <div class="crm-notif-empty__icon"><i class="fas fa-bell-slash"></i></div>' +
+                        '  <div class="crm-notif-empty__text">All caught up</div>' +
+                        '</div>';
+                    return;
+                }
+
+                var html = '';
+                data.notifications.forEach(function (n) {
+                    var read = n.is_read;
+                    var cls  = 'crm-notif-item ' + (read ? 'is-read' : 'is-unread');
+                    html +=
+                        '<div class="' + cls + '" data-notif-id="' + n.id + '"' +
+                        (n.action_url ? ' data-href="' + esc(n.action_url) + '"' : '') + '>' +
+                        '  <div class="crm-notif-item__icon"><i class="fas ' + esc(n.icon || 'fa-bell') + '"></i></div>' +
+                        '  <div class="crm-notif-item__body">' +
+                        '    <div class="crm-notif-item__title">' + esc(n.title) + '</div>' +
+                        (n.body ? '    <div class="crm-notif-item__text">' + esc(n.body) + '</div>' : '') +
+                        '    <div class="crm-notif-item__time">' + ago(n.created_at) + '</div>' +
+                        '  </div>' +
+                        '</div>';
+                });
+                list.innerHTML = html;
+
+                list.querySelectorAll('.crm-notif-item').forEach(function (el) {
+                    el.addEventListener('click', function (e) {
+                        e.preventDefault();
+                        var id   = el.getAttribute('data-notif-id');
+                        var href = el.getAttribute('data-href');
+
+                        // Mark read first, then navigate
+                        if (el.classList.contains('is-unread')) {
+                            fetch('/api/notifications/' + id + '/read', { method: 'POST' })
+                                .then(function (r) { return r.json(); })
+                                .then(function (d) {
+                                    setBadge(d.unread_count);
+                                    el.classList.remove('is-unread');
+                                    el.classList.add('is-read');
+                                    if (href) window.location.href = href;
+                                });
+                        } else if (href) {
+                            window.location.href = href;
+                        }
                     });
                 });
             }
-            function scheduleHidePopover() {
-                clearHideTimer();
-                hideTimer = setTimeout(hidePopover, 2000);
+
+            function load() {
+                fetch('/api/notifications?include_read=1&limit=20')
+                    .then(function (r) { return r.json(); })
+                    .then(render)
+                    .catch(function () {});
             }
 
-            btn.addEventListener('click', function (e) {
-                e.stopPropagation();
-                if (!pop.classList.contains('is-open')) {
-                    showPopover();
-                } else {
-                    hidePopover();
-                }
-            });
+            /* ── header actions ── */
+            if (markAll) {
+                markAll.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    fetch('/api/notifications/read-all', { method: 'POST' })
+                        .then(function () { load(); });
+                });
+            }
+            if (clearAll) {
+                clearAll.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    fetch('/api/notifications/clear-all', { method: 'POST' })
+                        .then(function () { load(); });
+                });
+            }
 
-            /* Moving between bell and panel must not start the timer; leaving the
-               whole control (relatedTarget outside wrap) does. */
-            wrap.addEventListener('mouseout', function (e) {
-                if (!pop.classList.contains('is-open')) return;
-                var rt = e.relatedTarget;
-                if (rt && wrap.contains(rt)) return;
-                scheduleHidePopover();
-            });
-            wrap.addEventListener('mouseover', function () {
-                if (pop.classList.contains('is-open')) clearHideTimer();
-            });
-
-            document.addEventListener('click', function (e) {
-                if (!wrap.contains(e.target)) hidePopover();
-            });
-            document.addEventListener('keydown', function (e) {
-                if (e.key === 'Escape') hidePopover();
-            });
+            /* ── badge polling ── */
+            function poll() {
+                fetch('/api/notifications/unread-count')
+                    .then(function (r) { return r.json(); })
+                    .then(function (d) { setBadge(d.unread_count); })
+                    .catch(function () {});
+            }
+            poll();
+            setInterval(poll, 60000);
         })();
     </script>
     <script type="module" src="{{ url_for('static', filename='dist/app.js') }}"></script>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -33,19 +33,6 @@
             {% endif %}
         {% endcall %}
 
-        {% if latest_update and not is_first_run %}
-        <a href="{{ url_for('company_updates.view_update', update_id=latest_update.id) }}"
-           class="mb-6 flex items-center justify-between gap-4 rounded-md bg-slate-800 px-4 py-2.5 transition-colors hover:bg-slate-700">
-            <div class="flex min-w-0 items-center gap-3">
-                <i class="fas fa-bullhorn text-xs text-slate-400"></i>
-                <span class="truncate text-sm font-medium text-slate-200">{{ latest_update.title }}</span>
-            </div>
-            <span class="shrink-0 text-xs font-medium text-slate-400">
-                Read <i class="fas fa-arrow-right ml-1"></i>
-            </span>
-        </a>
-        {% endif %}
-
         {% if current_user.role == 'admin' %}
         <div class="mb-4">
             <div class="crm-segment">

--- a/templates/notifications/settings.html
+++ b/templates/notifications/settings.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+{% from "components/ui.html" import page_header %}
+
+{% block content %}
+<div class="crm-page">
+    <div class="crm-page__inner">
+        {% call page_header('Notification Settings', 'Choose how and when you want to be notified.', 'Settings') %}
+            <a href="{{ url_for('auth.view_user_profile') }}" class="crm-btn crm-btn-secondary">
+                <i class="fas fa-arrow-left text-xs"></i>
+                Back to Profile
+            </a>
+        {% endcall %}
+
+        <form method="POST" action="{{ url_for('notifications.save_settings') }}">
+            <div class="crm-surface">
+                <div class="crm-surface-header">
+                    <div class="flex items-center gap-3">
+                        <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100">
+                            <i class="fas fa-sliders-h text-sm text-slate-600"></i>
+                        </div>
+                        <div>
+                            <h2 class="crm-section-title">Delivery Channels</h2>
+                            <p class="crm-section-description">Toggle notifications per category and channel.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="divide-y divide-slate-100">
+                    <div class="grid grid-cols-[1fr_80px_80px] items-center gap-4 px-5 py-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                        <span>Category</span>
+                        <span class="text-center">In-App</span>
+                        <span class="text-center">Email</span>
+                    </div>
+
+                    {% for cat_key, cat_label in categories.items() %}
+                    {% set p = prefs[cat_key] %}
+                    <div class="grid grid-cols-[1fr_80px_80px] items-center gap-4 px-5 py-4">
+                        <div>
+                            <p class="text-sm font-medium text-slate-800">{{ cat_label }}</p>
+                            {% if cat_key == 'task_reminder' %}
+                            <p class="mt-0.5 text-xs text-slate-500">
+                                Get notified when tasks are due soon or overdue.
+                            </p>
+                            {% elif cat_key == 'company_update' %}
+                            <p class="mt-0.5 text-xs text-slate-500">
+                                Get notified when your team posts a company update.
+                            </p>
+                            {% endif %}
+                        </div>
+
+                        <!-- In-App toggle -->
+                        <div class="flex justify-center">
+                            <label class="crm-toggle">
+                                <input type="checkbox" name="{{ cat_key }}_in_app"
+                                       {% if p.in_app %}checked{% endif %}>
+                                <span class="crm-toggle__track">
+                                    <span class="crm-toggle__thumb"></span>
+                                </span>
+                            </label>
+                        </div>
+
+                        <!-- Email toggle -->
+                        <div class="flex justify-center">
+                            <label class="crm-toggle">
+                                <input type="checkbox" name="{{ cat_key }}_email"
+                                       {% if p.email %}checked{% endif %}>
+                                <span class="crm-toggle__track">
+                                    <span class="crm-toggle__thumb"></span>
+                                </span>
+                            </label>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+
+                <div class="flex items-center justify-between border-t border-slate-100 px-5 py-4">
+                    <p class="text-xs text-slate-400">
+                        <i class="fas fa-info-circle mr-1"></i>
+                        Changes take effect immediately for new notifications.
+                    </p>
+                    <button type="submit" class="crm-btn crm-btn-primary">
+                        <i class="fas fa-check text-xs"></i>
+                        Save Preferences
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<style>
+.crm-toggle {
+    position: relative;
+    display: inline-flex;
+    cursor: pointer;
+}
+.crm-toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+.crm-toggle__track {
+    display: inline-flex;
+    align-items: center;
+    width: 2.5rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+    background-color: #cbd5e1;
+    transition: background-color 0.15s ease;
+}
+.crm-toggle input:checked + .crm-toggle__track {
+    background-color: #f97316;
+}
+.crm-toggle__thumb {
+    display: block;
+    width: 1.125rem;
+    height: 1.125rem;
+    border-radius: 9999px;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,.15);
+    margin-left: 0.1875rem;
+    transition: transform 0.15s ease;
+}
+.crm-toggle input:checked + .crm-toggle__track .crm-toggle__thumb {
+    transform: translateX(1rem);
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a first-class in-app notification surface so users get immediate, in-product feedback for things they previously only learned about via email.

- **New tables** via `migrations/versions/add_notification_tables.py` (chained to `add_market_insights_tables`):
  - `notifications` — per-user, per-org rows with category, title, body, icon, action URL, read state
  - `user_notification_preferences` — per-user opt-in/out for each (category, channel) pair
- **Service layer** (`services/notification_service.py`): `create_notification()` and `is_channel_enabled()` so producers can fan out to in-app + email while respecting user preferences.
- **API** (`routes/notifications.py`): list, unread-count, mark-read, read-all, clear-all, plus a settings page for toggling channels per category.
- **Bell UI** in `templates/base.html`: badge with 60s polling, hover-to-stay-open popover, inline mark-read on click, click-outside / Escape to close, all using the existing CRM design tokens.
- **Producers wired up:**
  - Task reminder job creates an in-app notification alongside the digest email, gated by preference.
  - Company-update publish creates a notification per recipient, replacing the inline banner on the dashboard.
- **Profile page** links to the new notification settings page.

## Test plan

- [ ] `python3 manage_db.py upgrade` runs cleanly against both SQLite and Supabase Postgres.
- [ ] Bell icon renders for all authenticated users; badge hidden when zero unread.
- [ ] Clicking a notification marks it read, decrements the badge, and navigates to `action_url` if present.
- [ ] "Mark all read" and "Clear all" both update state and re-render correctly.
- [ ] Notification settings page toggles persist and gate delivery on the next task-reminder run.
- [ ] Task reminder job still sends email digests when the email channel is enabled, and skips silently when disabled.
- [ ] Publishing a company update produces an in-app notification for all org members.

Made with [Cursor](https://cursor.com)