### PR TITLE
feat: add Magic Inbox contact import

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,7 @@ from routes.reports import reports_bp
 from routes.tax_protest import tax_protest_bp
 from routes.market_insights import market_insights_bp
 from routes.notifications import notifications_bp
+from routes.inbound_email import inbound_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
@@ -214,6 +215,7 @@ def create_app():
     app.register_blueprint(tax_protest_bp)
     app.register_blueprint(market_insights_bp)
     app.register_blueprint(notifications_bp)
+    app.register_blueprint(inbound_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT
@@ -288,6 +290,16 @@ def create_app():
             # If setting fails (e.g., not PostgreSQL), continue anyway
             # RLS won't work but app-level filtering still protects data
             pass
+
+        # Magic Inbox safety net: any user without an address gets one on
+        # their first request. Covers backfill races, manually-created
+        # accounts, and edge cases. Best-effort only; never fail the request.
+        if not getattr(current_user, 'inbox_address', None):
+            try:
+                from services.inbox_provisioning import ensure_inbox_for
+                ensure_inbox_for(current_user)
+            except Exception:
+                pass
 
     @app.after_request
     def record_session_creation(response):

--- a/documentation/magic_inbox.md
+++ b/documentation/magic_inbox.md
@@ -1,0 +1,315 @@
+# Magic Inbox — Operator Runbook
+
+The Magic Inbox auto-creates contacts from any message sent to a user's
+private forwarding address (e.g. `chris.nichols-7f3a4b8c@inbox.origentechnolog.com`).
+
+This document covers what's wired up in the codebase, the operator
+checklist for first-time provisioning, environment variables, day-to-day
+debugging, and the known-good rollback path.
+
+---
+
+## Architecture in one paragraph
+
+SendGrid Inbound Parse posts each forwarded message to
+`POST /webhooks/sendgrid/inbound-parse`. We verify the shared-secret query
+parameter or header, look the user up by their token (the `<slug>-<token>` part of the
+recipient), persist a row in `inbound_messages`, archive the raw payload to
+Supabase Storage, normalize the body and attachments, send the bundle to
+`gpt-5.4-nano` (vision-capable) with a strict `json_schema`, dedupe
+candidates against the user's existing contacts, create new `Contact` rows,
+emit an in-app notification, and reply by email with a 24-hour signed undo
+link. The webhook always returns `200 OK` so SendGrid never retries — even
+parser bugs are recorded in `inbound_messages.status='failed'` instead of
+filling the SendGrid dead-letter queue.
+
+---
+
+## Code map
+
+| Concern | File |
+| --- | --- |
+| Webhook + UI routes | `routes/inbound_email.py` |
+| Address provisioning | `services/inbox_provisioning.py` |
+| SendGrid payload normalizer | `services/inbound_payload.py` |
+| AI extraction (single call, vision + json_schema) | `services/ai_service.py` (`generate_contact_extraction`) |
+| Orchestrator (dedupe → create → notify) | `services/contact_extraction.py` |
+| Outbound receipt / welcome / over-limit emails | `services/sendgrid_outbound.py` |
+| Models | `models.py` (`User.inbox_*`, `InboundMessage`) |
+| Migration | `migrations/versions/add_inbox_and_inbound_messages.py` |
+| Inbox UI page | `templates/inbox/home.html` |
+| Sidebar / dashboard / contacts surfaces | `templates/base.html`, `templates/dashboard.html`, `templates/contacts/list.html`, `templates/auth/user_profile.html` |
+| Backfill + announcement script | `scripts/backfill_inbox_addresses.py` |
+| Tests | `tests/test_magic_inbox.py` |
+
+---
+
+## Environment variables
+
+All optional for local dev. The webhook accepts unverified requests with a
+warning if neither webhook auth variable is set, so developers can iterate
+without SendGrid.
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `INBOUND_EMAIL_DOMAIN` | Subdomain SendGrid Inbound Parse routes to. | `inbox.origentechnolog.com` |
+| `SENDGRID_INBOUND_WEBHOOK_SECRET` | Shared secret for SendGrid Inbound Parse. Add it to the destination URL as `?secret=...`, or forward it as `X-Inbound-Secret`. **Set this in production.** | _unset_ |
+| `SENDGRID_INBOUND_PUBLIC_KEY` | Optional SendGrid Signed Event Webhook public key fallback. Inbound Parse does not natively sign requests, so prefer `SENDGRID_INBOUND_WEBHOOK_SECRET`. | _unset_ |
+| `INBOUND_REPLY_FROM` | From-address for receipt and welcome emails. Must be a verified SendGrid sender. | `info@origentechnolog.com` |
+| `SENDGRID_INBOX_WELCOME_TEMPLATE_ID` | SendGrid Dynamic Template for the Magic Inbox welcome email. | `d-d89070c074554464a728867471e173e1` |
+| `SENDGRID_INBOX_RECEIPT_TEMPLATE_ID` | SendGrid Dynamic Template for the "contacts added" receipt email. | `d-f3ef49fcfb80406ab22ec2d0bf87c0e7` |
+| `INBOUND_RAW_BUCKET` | Supabase Storage bucket name for raw payload archives. | `inbound-email-raw` |
+| `INBOX_EXTRACTION_MODEL` | Primary OpenAI model. | `gpt-5.4-nano` |
+| `INBOX_EXTRACTION_FALLBACK_MODEL` | Fallback if primary returns auth/rate/parse error. | `gpt-5-mini` |
+
+Reused secrets: `SENDGRID_API_KEY` (outbound replies), `OPENAI_API_KEY`
+(extraction), `SUPABASE_URL` + `SUPABASE_KEY` (raw payload archive),
+`SECRET_KEY` (used to sign undo tokens via `itsdangerous`).
+
+---
+
+## First-time operator checklist
+
+These are the steps a human has to do once before the feature works in
+production. Order matters.
+
+1. **Buy / claim the subdomain.** `inbox.origentechnolog.com` (or whatever
+   you set `INBOUND_EMAIL_DOMAIN` to).
+2. **DNS — MX record.** Point the subdomain at SendGrid:
+   ```
+   inbox.origentechnolog.com.   MX   10 mx.sendgrid.net.
+   ```
+   (TTL 3600. Confirm with `dig mx inbox.origentechnolog.com +short`.)
+3. **DNS — SPF (optional but recommended).** Many forwarders rewrite Return-Path,
+   so SPF on the inbox subdomain isn't strictly required, but adding
+   `v=spf1 include:sendgrid.net ~all` doesn't hurt.
+4. **SendGrid → Settings → Inbound Parse.** Add a host:
+   - Receiving Domain: `inbox.origentechnolog.com`
+   - Destination URL: `https://app.origentechnolog.com/webhooks/sendgrid/inbound-parse?secret=<SENDGRID_INBOUND_WEBHOOK_SECRET>`
+   - Tick **POST the raw, full MIME message** (we store it for debugging).
+   - Tick **Check incoming emails for spam** (we read `spam_score`).
+5. **SendGrid → Sender Authentication / Verified Senders.** Make sure
+   `INBOUND_REPLY_FROM` is a verified outbound sender. In local testing,
+   `info@origentechnolog.com` is known-good.
+6. **Supabase → Storage → New bucket.** Create `inbound-email-raw`. Mark
+   it private. Set lifecycle policy to delete after 30 days.
+7. **Run the migration:**
+   ```bash
+   python3 manage_db.py upgrade
+   ```
+8. **Backfill existing users:**
+   ```bash
+   # Dry run first
+   python3 scripts/backfill_inbox_addresses.py
+   # Apply for real
+   python3 scripts/backfill_inbox_addresses.py --commit
+   # Optional: send the announcement email at the same time
+   python3 scripts/backfill_inbox_addresses.py --commit --announce
+   ```
+9. **Smoke test:**
+   - Log in as yourself. Visit `/inbox`. Confirm the address renders, the
+     QR code displays, and the address copies.
+   - From your personal email, forward any message to your inbox address.
+     Within ~5 seconds you should see a new contact, an in-app
+     notification, and a reply email with an Undo link.
+
+---
+
+## Local end-to-end test
+
+Use this path before pointing SendGrid at a local ngrok tunnel. It exercises
+the same webhook route and the same SendGrid-shaped multipart fields.
+
+1. Confirm `.env` has the required local values:
+   ```bash
+   DATABASE_URL=sqlite:////Users/christophernichols/PycharmProjects/CRM/instance/crm_dev.db
+   INBOUND_EMAIL_DOMAIN=inbox.origentechnolog.com
+   SENDGRID_INBOUND_WEBHOOK_SECRET=<secret>
+   INBOUND_REPLY_FROM=info@origentechnolog.com
+   OPENAI_API_KEY=<key>
+   SENDGRID_API_KEY=<key>
+   SENDGRID_INBOX_WELCOME_TEMPLATE_ID=d-d89070c074554464a728867471e173e1
+   SENDGRID_INBOX_RECEIPT_TEMPLATE_ID=d-f3ef49fcfb80406ab22ec2d0bf87c0e7
+   SUPABASE_URL=<url>
+   SUPABASE_KEY=<service_role_key>
+   ```
+2. Apply migrations and provision inbox addresses:
+   ```bash
+   python3 manage_db.py upgrade
+   python3 scripts/backfill_inbox_addresses.py --commit
+   python3 scripts/simulate_inbound.py who-am-i
+   ```
+3. Start the dev server on port 5011:
+   ```bash
+   python3 app.py
+   ```
+4. From another terminal, hit the local HTTP webhook:
+   ```bash
+   python3 scripts/simulate_inbound.py csv \
+     --user chrisnichols17@gmail.com \
+     --sender chrisnichols17@gmail.com
+   ```
+   Expected result: `http status : 200`, `status processed`, and new contacts
+   listed under `created_contacts`.
+5. Test other payload shapes:
+   ```bash
+   python3 scripts/simulate_inbound.py text --user chrisnichols17@gmail.com
+   python3 scripts/simulate_inbound.py vcard --user chrisnichols17@gmail.com
+   python3 scripts/simulate_inbound.py image --user chrisnichols17@gmail.com
+   python3 scripts/simulate_inbound.py signature --user chrisnichols17@gmail.com
+   ```
+6. To test the real SendGrid inbound route locally, expose Flask with ngrok:
+   ```bash
+   ngrok http 5011
+   ```
+   Then set the SendGrid Inbound Parse destination URL to:
+   ```text
+   https://<ngrok-host>/webhooks/sendgrid/inbound-parse?secret=<SENDGRID_INBOUND_WEBHOOK_SECRET>
+   ```
+   Send an email to the user's Magic Inbox address and watch for a processed
+   `inbound_messages` row, new contacts, an in-app notification, and the
+   receipt email.
+
+Known-good local smoke result on 2026-04-25:
+
+- `csv` fixture posted to `http://127.0.0.1:5011/webhooks/sendgrid/inbound-parse`
+- `InboundMessage id=4`, `status=processed`, `source_kind=csv`
+- Contacts created: Janet Hill, Daniel Reyes, Aisha Khan
+- Raw payload archived to `inbound-email-raw`
+- In-app notifications created
+- Receipt email send succeeds once `INBOUND_REPLY_FROM=info@origentechnolog.com`
+  is loaded by the process
+
+---
+
+## How the address is constructed
+
+```
+<slug>-<token>+<plus_alias>@<INBOUND_EMAIL_DOMAIN>
+└─human bit─┘ └─auth─┘ └─optional─┘
+```
+
+- `slug` is `first.last` slugified to ASCII (`Renée O'Brien` → `renee.o.brien`).
+  Reserved system slugs like `admin` get `.user` appended.
+- `token` is 8 chars from a 31-char base32 alphabet (no `0/O/1/I/l`),
+  ~40 bits. **The token is the auth.** Anyone who can post to it can add
+  a contact. Rotate via the profile page if leaked.
+- `plus_alias` is optional. `+buyers` will drop the new contact into the
+  user's `Buyers` ContactGroup (case-insensitive name match within their
+  org). Unmatched aliases are recorded but otherwise ignored.
+
+---
+
+## Cost ceilings
+
+The normalizer enforces these so a single weird payload can't spike the
+OpenAI bill:
+
+- 16 KB cap on the cleaned text body (after HTML stripping).
+- First 5 image attachments only; rest counted in `skipped_images`.
+- Images downscaled to 1024px long-edge, re-encoded as JPEG quality 82.
+- CSV attachments capped at 500 data rows. Larger CSVs route to the
+  existing CSV importer (out of scope for the inbox).
+
+Per-call cost is recorded on `inbound_messages.ai_cost_cents` using the
+model's published per-million-token pricing. Treat it as an estimate — the
+authoritative number lives in the OpenAI billing console.
+
+Rate limits (per 24h, in `routes/inbound_email.py`):
+
+- 200 messages per user
+- 1000 messages per organization
+
+Exceeding either replies with a polite "limit reached" email and marks the
+inbound row `over_limit` rather than returning a 4xx.
+
+---
+
+## Day-to-day debugging
+
+### "I forwarded an email and nothing happened"
+
+```sql
+-- Did the webhook see it?
+SELECT id, status, source_kind, error_message,
+       sender_email, recipient_address, created_at, processed_at
+  FROM inbound_messages
+ WHERE user_id = <user_id>
+ ORDER BY created_at DESC
+ LIMIT 20;
+```
+
+Common values:
+
+| `status` | Meaning |
+| --- | --- |
+| `received` | Webhook hit landed but the orchestrator hasn't finished. If this stays for >30s, check application logs for an unhandled exception. |
+| `processed` | At least one new contact created. See `created_contact_ids`. |
+| `rejected` | Empty payload, all candidates were dupes/self-references, or low-confidence with no email/phone. |
+| `failed` | AI call or DB commit blew up. `error_message` has the trimmed exception. |
+| `over_limit` | Daily user/org rate cap or contact-cap on the org. |
+
+If there is **no row at all** for the user, the webhook didn't reach us:
+
+- Check `dig mx inbox.origentechnolog.com +short` returns SendGrid's MX.
+- Check SendGrid → Inbound Parse → Activity Feed for delivery attempts and
+  any 4xx/5xx responses from our server.
+- Check our server logs for `Magic Inbox: webhook signature invalid` (means
+  `SENDGRID_INBOUND_PUBLIC_KEY` is wrong) or `unknown recipient` (means
+  the user isn't yet provisioned — run the backfill script).
+
+### Pulling the raw payload
+
+```python
+from services.supabase_storage import download_file
+raw = download_file('inbound-email-raw', message.raw_storage_path)
+```
+
+The raw blob is the verbatim multipart body SendGrid posted, suitable for
+re-feeding into the normalizer for repro tests.
+
+---
+
+## Rolling the feature back
+
+The feature is additive. To disable without dropping data:
+
+1. SendGrid → Inbound Parse → delete the `inbox.origentechnolog.com` host
+   (mail will start bouncing back to senders cleanly).
+2. Hide the sidebar nav item by removing the `<a href="…inbox_home">`
+   block in `templates/base.html` (two spots: mobile + desktop).
+3. Skip the dashboard onboarding card by deleting the `{% if … inbox_address …%}`
+   block in `templates/dashboard.html`.
+
+The `User.inbox_address`, `User.inbox_token`, and `inbound_messages` table
+can stay in place — they're harmless if the webhook is unreachable.
+
+To fully remove, downgrade the migration:
+
+```bash
+python3 manage_db.py downgrade <previous_revision>
+```
+
+---
+
+## Tests
+
+`pytest tests/test_magic_inbox.py` covers:
+
+- Slug + token shape, reserved-slug handling
+- Address provisioning idempotence + rotation
+- `parse_recipient` accepts/rejects edge cases (wrong domain, short token,
+  invalid alphabet, plus alias, mixed case)
+- Undo token round-trip + tamper detection
+- Normalizer: empty/text/HTML/vCard/CSV/image, attachment classification,
+  CSV truncation, image-count cap
+- Orchestrator: contact creation, dedupe, plus-alias group resolution,
+  self-reference suppression, low-confidence drop, empty-payload reject
+- `/inbox` UI route (auth + render)
+- vCard download
+- Onboarding dismiss persistence
+- Webhook end-to-end happy path, AI failure, spam-score drop, unknown
+  recipient — all returning 200
+
+The AI is mocked. There are no live OpenAI or SendGrid calls in the test
+suite.

--- a/email_templates/magic_link_contact_added.html
+++ b/email_templates/magic_link_contact_added.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{subject}}</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap" rel="stylesheet">
+<style>
+  body, table, td, p, a, li { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+  table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+  img { -ms-interpolation-mode: bicubic; border:0; height:auto; line-height:100%; outline:none; text-decoration:none; }
+  body { margin:0 !important; padding:0 !important; width:100% !important; font-family:'DM Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#f0f4f8; }
+  @media only screen and (max-width: 600px) {
+    .container { width: 100% !important; }
+    .pad-lg { padding: 28px 22px !important; }
+    .hero-pad { padding: 36px 26px 30px !important; }
+    .hero-title { font-size: 30px !important; }
+    .stack-cell { display:block !important; width:100% !important; padding: 0 0 10px 0 !important; }
+  }
+</style>
+</head>
+<body style="margin:0; padding:0; background:#f0f4f8;">
+
+<div style="display:none; max-height:0; overflow:hidden;">
+  {{count_label}} added to your CRM. Undo any contact within 24 hours if needed.
+</div>
+
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f0f4f8;">
+<tr><td align="center" style="padding:40px 16px;">
+
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" class="container" style="max-width:600px; background:#ffffff; border-radius:18px; overflow:hidden; box-shadow:0 4px 32px rgba(16,42,67,0.08);">
+
+  <!-- Header -->
+  <tr><td style="padding:22px 32px; background:#ffffff; border-bottom:1px solid #eef2f7;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:700; letter-spacing:0.2px;">
+          <span style="color:#102a43;">Origen Technol</span><span style="color:#f97316;">OG</span>
+        </td>
+        <td align="right" style="font-family:'DM Sans',sans-serif; font-size:11px; font-weight:600; color:#94a3b8; letter-spacing:1.2px; text-transform:uppercase;">
+          Magic Inbox &middot; Receipt
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- Hero — quieter than the welcome -->
+  <tr><td class="hero-pad" style="background:linear-gradient(160deg,#0b1b2b 0%,#102a43 55%,#1a3a5c 100%); padding:44px 48px 40px;">
+    <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#86efac; letter-spacing:2.4px; text-transform:uppercase;">
+      ✓ &nbsp;Saved to your CRM
+    </p>
+    <h1 class="hero-title" style="margin:0 0 12px 0; font-family:'Fraunces','DM Sans',serif; font-size:36px; line-height:1.1; font-weight:500; color:#ffffff; letter-spacing:-0.4px;">
+      {{count_label}} <em style="font-style:italic; color:#f97316; font-weight:500;">added.</em>
+    </h1>
+    <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:15px; line-height:1.6; color:#a8c3df; max-width:460px;">
+      We pulled the details out of what you forwarded and saved {{saved_pronoun}} to your contacts.
+      Sent {{sent_at}} from <span style="color:#cbd5e1;">{{sender_email}}</span>.
+    </p>
+  </td></tr>
+
+  <!-- Contact list -->
+  <tr><td class="pad-lg" style="padding:36px 48px 8px; background:#ffffff;">
+    <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#627d98; letter-spacing:1.6px; text-transform:uppercase;">
+      What we saved
+    </p>
+
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f8fafc; border:1px solid #e8eff5; border-radius:12px;">
+      {{#each contacts}}
+        <tr><td style="padding:16px 18px; border-bottom:1px solid #e8eff5;">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td valign="middle" width="42" style="padding-right:14px;">
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr><td style="width:42px; height:42px; background:linear-gradient(135deg,#fb923c 0%,#ea580c 100%); border-radius:50%; text-align:center; vertical-align:middle; font-family:'DM Sans',sans-serif; font-size:14px; font-weight:700; color:#ffffff; letter-spacing:0.4px;">
+                    {{initials}}
+                  </td></tr>
+                </table>
+              </td>
+              <td valign="middle">
+                <p style="margin:0 0 3px 0; font-family:'DM Sans',sans-serif; font-size:15px; font-weight:600; color:#102a43; line-height:1.3;">
+                  {{name}}
+                </p>
+                {{#if title}}
+                  <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.4;">
+                    {{title}}{{#if company}} &middot; {{company}}{{/if}}
+                  </p>
+                {{else}}{{#if company}}
+                  <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.4;">{{company}}</p>
+                {{/if}}{{/if}}
+                <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:12.5px; color:#829ab1; line-height:1.5;">
+                  {{#if email}}{{email}}{{/if}}{{#if email}}{{#if phone}} &nbsp;·&nbsp; {{/if}}{{/if}}{{#if phone}}{{phone}}{{/if}}
+                </p>
+              </td>
+              <td align="right" valign="top" width="64">
+                {{#if is_duplicate_merged}}
+                  <span style="display:inline-block; background:#e0f2fe; color:#075985; font-family:'DM Sans',sans-serif; font-size:9.5px; font-weight:700; letter-spacing:0.6px; text-transform:uppercase; padding:4px 8px; border-radius:6px;">Updated</span>
+                {{else}}
+                  <span style="display:inline-block; background:#dcfce7; color:#166534; font-family:'DM Sans',sans-serif; font-size:9.5px; font-weight:700; letter-spacing:0.6px; text-transform:uppercase; padding:4px 8px; border-radius:6px;">New</span>
+                {{/if}}
+              </td>
+            </tr>
+            {{#if group_name}}
+              <tr><td colspan="3" style="padding:10px 0 0 56px;">
+                <span style="display:inline-block; font-family:'DM Sans',sans-serif; font-size:11.5px; color:#7c2d12; background:#fff7ed; border:1px solid #fed7aa; padding:3px 8px; border-radius:6px;">
+                  Filed under {{group_name}}
+                </span>
+              </td></tr>
+            {{/if}}
+            <tr><td colspan="3" style="padding:12px 0 0 56px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="padding-right:8px;">
+                    <a href="{{view_url}}" style="display:inline-block; font-family:'DM Sans',sans-serif; background:#fff7ed; color:#c2410c; font-size:12px; font-weight:700; text-decoration:none; padding:7px 11px; border-radius:7px; border:1px solid #fed7aa;">
+                      View
+                    </a>
+                  </td>
+                  {{#if undo_url}}
+                    <td>
+                      <a href="{{undo_url}}" style="display:inline-block; font-family:'DM Sans',sans-serif; background:#ffffff; color:#475569; font-size:12px; font-weight:700; text-decoration:none; padding:7px 11px; border-radius:7px; border:1px solid #cbd5e1;">
+                        Undo
+                      </a>
+                    </td>
+                  {{/if}}
+                </tr>
+              </table>
+            </td></tr>
+          </table>
+        </td></tr>
+      {{/each}}
+    </table>
+  </td></tr>
+
+  <!-- CTAs -->
+  <tr><td class="pad-lg" style="padding:24px 48px 8px; background:#ffffff;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td class="stack-cell" valign="top" style="padding-right:8px;">
+          <a href="{{contacts_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:linear-gradient(135deg,#f97316 0%,#ea580c 100%); color:#ffffff; font-size:15px; font-weight:600; text-decoration:none; padding:15px 16px; border-radius:10px; box-shadow:0 8px 22px rgba(249,115,22,0.32);">
+            Open Contacts &nbsp;→
+          </a>
+        </td>
+        <td class="stack-cell" valign="top" style="padding-left:8px;">
+          <a href="{{inbox_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:#ffffff; color:#102a43; font-size:15px; font-weight:600; text-decoration:none; padding:13px 16px; border-radius:10px; border:1.5px solid #e2e8f0;">
+            Open Magic Inbox
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- Skipped / dupes notice (optional) -->
+  {{#if has_skipped}}
+    <tr><td class="pad-lg" style="padding:28px 48px 0; background:#ffffff;">
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f1f5f9; border-radius:10px;">
+        <tr><td style="padding:14px 18px;">
+          <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13px; color:#475569; line-height:1.6;">
+            <strong style="color:#102a43;">Heads up:</strong> we skipped {{skipped_label}} that already existed in your contacts. Nothing was overwritten.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  {{/if}}
+
+  <!-- Source line -->
+  <tr><td class="pad-lg" style="padding:32px 48px 40px; background:#ffffff;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td style="border-top:1px dashed #cbd5e1; padding-top:20px;">
+          <p style="margin:0 0 6px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#94a3b8; letter-spacing:1.4px; text-transform:uppercase;">
+            Source
+          </p>
+          <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.6;">
+            <strong style="color:#334e68;">{{source_kind}}</strong>{{#if source_subject}} &middot; &ldquo;{{source_subject}}&rdquo;{{/if}}<br>
+            <span style="color:#94a3b8;">From {{sender_email}} &rarr;</span> <span style="font-family:'SF Mono',Menlo,monospace; font-size:12px; color:#475569;">{{inbox_address}}</span>
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td style="background:#f8fafc; border-top:1px solid #e8eff5; padding:24px 40px; text-align:center;">
+    <p style="margin:0 0 8px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#627d98; line-height:1.6;">
+      Each <strong style="color:#334e68;">Undo</strong> link works for 24 hours. After that, edit or remove the contact from your CRM.
+    </p>
+    <p style="margin:0 0 12px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#cbd5e1; letter-spacing:8px;">• • •</p>
+    <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:11px; color:#9fb3c8;">
+      © {{year}} Origen TechnolOG &middot; {{inbound_domain}}
+    </p>
+  </td></tr>
+
+</table>
+
+</td></tr>
+</table>
+
+</body>
+</html>
+
+  <!-- test data -->
+{
+    "subject": "Saved 2 contacts to your CRM",
+    "headline": "Saved 2 contacts to your CRM.",
+    "count": 2,
+    "count_label": "2 new contacts",
+    "saved_pronoun": "them",
+    "sent_at": "Apr 25 at 12:04 PM",
+    "sender_email": "chrisnichols17@gmail.com",
+    "contacts": [
+      {
+        "name": "Janet Hill",
+        "initials": "JH",
+        "email": "janet.hill@example.com",
+        "phone": "(281) 555-0133",
+        "view_url": "https://app.origentechnolog.com/contact/4",
+        "undo_url": "https://app.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_4",
+        "is_duplicate_merged": false,
+        "group_name": "Open House Leads"
+      },
+      {
+        "name": "Daniel Reyes",
+        "initials": "DR",
+        "email": "dreyes@example.com",
+        "phone": "(713) 555-0109",
+        "view_url": "https://app.origentechnolog.com/contact/5",
+        "undo_url": "https://app.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_5",
+        "is_duplicate_merged": false
+      }
+    ],
+    "contacts_url": "https://app.origentechnolog.com/contacts",
+    "inbox_url": "https://app.origentechnolog.com/inbox",
+    "source_kind": "CSV",
+    "source_subject": "Leads from this weekend",
+    "has_skipped": true,
+    "skipped_count": 1,
+    "skipped_label": "1 entry",
+    "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
+    "inbound_domain": "inbox.origentechnolog.com",
+    "year": "2026"
+  }

--- a/email_templates/magic_link_inbox.html
+++ b/email_templates/magic_link_inbox.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>Your Magic Inbox is live</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap" rel="stylesheet">
+<style>
+  body, table, td, p, a, li { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+  table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+  img { -ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+  body { margin: 0 !important; padding: 0 !important; width: 100% !important; font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f0f4f8; }
+  @media only screen and (max-width: 600px) {
+    .container { width: 100% !important; }
+    .pad-lg { padding: 32px 24px !important; }
+    .hero-title { font-size: 38px !important; }
+    .hero-pad { padding: 40px 28px 36px !important; }
+    .stack-cell { display: block !important; width: 100% !important; padding: 0 0 12px 0 !important; }
+  }
+</style>
+</head>
+<body style="margin:0; padding:0; background:#f0f4f8;">
+
+<div style="display:none; max-height:0; overflow:hidden;">
+  Forward a business card. Get a contact back. Your private Magic Inbox is ready.
+</div>
+
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f0f4f8;">
+<tr><td align="center" style="padding:40px 16px;">
+
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" class="container" style="max-width:600px; background:#ffffff; border-radius:18px; overflow:hidden; box-shadow:0 4px 32px rgba(16,42,67,0.08);">
+
+  <!-- ===== Header ===== -->
+  <tr><td style="padding:22px 32px; background:#ffffff; border-bottom:1px solid #eef2f7;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:700; letter-spacing:0.2px;">
+          <span style="color:#102a43;">Origen Technol</span><span style="color:#f97316;">OG</span>
+        </td>
+        <td align="right" style="font-family:'DM Sans',sans-serif; font-size:11px; font-weight:600; color:#94a3b8; letter-spacing:1.2px; text-transform:uppercase;">
+          New &middot; Magic Inbox
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== Hero ===== -->
+  <tr><td class="hero-pad" style="background:linear-gradient(160deg,#0b1b2b 0%,#102a43 55%,#1a3a5c 100%); padding:56px 48px 52px; position:relative;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr><td>
+        <p style="margin:0 0 18px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#f97316; letter-spacing:2.4px; text-transform:uppercase;">
+          ✦ &nbsp;Introducing Magic Inbox
+        </p>
+        <h1 class="hero-title" style="margin:0 0 18px 0; font-family:'Fraunces','DM Sans',serif; font-size:46px; line-height:1.05; font-weight:500; color:#ffffff; letter-spacing:-0.5px;">
+          Forward&nbsp;anything.<br>
+          <em style="font-style:italic; color:#f97316; font-weight:500;">Get a contact back.</em>
+        </h1>
+        <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:16px; line-height:1.6; color:#a8c3df; max-width:440px;">
+          Photos of business cards. Forwarded intros. Messy email signatures. CSVs from the conference.
+          Send any of it to one private address &mdash; we'll handle the typing.
+        </p>
+      </td></tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== The Address (the hero asset) ===== -->
+  <tr><td style="padding:36px 48px 8px; background:#ffffff;">
+    <p style="margin:0 0 12px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#627d98; letter-spacing:1.6px; text-transform:uppercase;">
+      Your private address
+    </p>
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#0b1b2b; border-radius:12px;">
+      <tr><td style="padding:18px 22px;">
+        <p style="margin:0; font-family:'SF Mono','JetBrains Mono',Menlo,Consolas,monospace; font-size:14px; line-height:1.4; color:#7dd3fc; word-break:break-all; letter-spacing:-0.2px;">
+          <span style="color:#94a3b8;">→ </span>{{inbox_address}}
+        </p>
+      </td></tr>
+    </table>
+    <p style="margin:10px 0 0 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#94a3b8; line-height:1.5;">
+      Private to your account. Rotate anytime from your profile.
+    </p>
+  </td></tr>
+
+  <!-- ===== CTAs ===== -->
+  <tr><td style="padding:24px 48px 8px; background:#ffffff;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td class="stack-cell" valign="top" style="padding-right:8px;">
+          <a href="{{vcard_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:linear-gradient(135deg,#f97316 0%,#ea580c 100%); color:#ffffff; font-size:15px; font-weight:600; text-decoration:none; padding:15px 16px; border-radius:10px; box-shadow:0 8px 22px rgba(249,115,22,0.32);">
+            Add to my phone contacts &nbsp;↓
+          </a>
+        </td>
+        <td class="stack-cell" valign="top" style="padding-left:8px;">
+          <a href="{{inbox_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:#ffffff; color:#102a43; font-size:15px; font-weight:600; text-decoration:none; padding:13px 16px; border-radius:10px; border:1.5px solid #e2e8f0;">
+            Open Magic Inbox
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== Three-step story ===== -->
+  <tr><td class="pad-lg" style="padding:44px 48px 32px; background:#ffffff;">
+    <p style="margin:0 0 22px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#627d98; letter-spacing:1.6px; text-transform:uppercase;">
+      How it works
+    </p>
+
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td valign="top" style="padding:0 0 22px 0;">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">01</td>
+              <td valign="top">
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">Forward, share, or snap.</p>
+                <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
+                  An email signature, a vCard, a photo of a business card &mdash; whatever's in front of you.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top" style="padding:0 0 22px 0;">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">02</td>
+              <td valign="top">
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">We read between the lines.</p>
+                <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
+                  Name, role, company, phone, email, address. Deduped against your contacts. No copy-paste.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">03</td>
+              <td valign="top">
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">A reply lands in your inbox.</p>
+                <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
+                  With a <strong style="color:#102a43;">View</strong> link and a 24-hour <strong style="color:#102a43;">Undo</strong>. Mistakes happen. We've got you.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== Pro tip callout ===== -->
+  <tr><td style="padding:0 48px 40px; background:#ffffff;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#fff7ed; border-radius:14px;">
+      <tr><td style="padding:22px 24px;">
+        <p style="margin:0 0 6px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#c2410c; letter-spacing:1.4px; text-transform:uppercase;">
+          ★ &nbsp;Pro tip
+        </p>
+        <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14.5px; color:#7c2d12; line-height:1.6;">
+          Save the address as <strong>&ldquo;Origen Inbox&rdquo;</strong> in your phone contacts.
+          Next handshake at an open house, snap the card, share it to that contact &mdash; done before you walk to your car.
+        </p>
+      </td></tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== Power-user line ===== -->
+  <tr><td style="padding:0 48px 40px; background:#ffffff;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td style="border-top:1px dashed #cbd5e1; padding-top:22px;">
+          <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.7;">
+            <strong style="color:#102a43;">Power move:</strong>
+            append <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+buyers</code>
+            or <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+sellers</code>
+            before the @ to drop new contacts straight into the right group.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- ===== Footer ===== -->
+  <tr><td style="background:#f8fafc; border-top:1px solid #e8eff5; padding:28px 40px; text-align:center;">
+    <p style="margin:0 0 6px 0; font-family:'DM Sans',sans-serif; font-size:14px; font-weight:700;">
+      <span style="color:#334e68;">Origen Technol</span><span style="color:#f97316;">OG</span>
+    </p>
+    <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#829ab1;">
+      The Real Estate CRM Built for Serious Agents
+    </p>
+    <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#cbd5e1; letter-spacing:8px;">
+      • • •
+    </p>
+    <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:11px; color:#9fb3c8;">
+      Sent to you because you have a Magic Inbox at {{inbound_domain}}
+    </p>
+    <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:11px; color:#9fb3c8;">
+      © {{year}} Origen TechnolOG. All rights reserved.
+    </p>
+  </td></tr>
+
+</table>
+
+</td></tr>
+</table>
+
+</body>
+</html>
+
+<!-- test data -->
+{
+    "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
+    "vcard_url": "https://app.origentechnolog.com/inbox/vcard",
+    "inbox_url": "https://app.origentechnolog.com/inbox",
+    "inbound_domain": "inbox.origentechnolog.com",
+    "year": "2026"
+  }

--- a/migrations/versions/add_inbox_and_inbound_messages.py
+++ b/migrations/versions/add_inbox_and_inbound_messages.py
@@ -1,0 +1,133 @@
+"""Add magic inbox columns and inbound_messages table
+
+Revision ID: add_inbox_and_inbound_messages
+Revises: add_notification_tables
+Create Date: 2026-04-25 11:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_inbox_and_inbound_messages'
+down_revision = 'add_notification_tables'
+branch_labels = None
+depends_on = None
+
+
+def _has_column(inspector, table, column):
+    return any(c['name'] == column for c in inspector.get_columns(table))
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    # --- User columns -------------------------------------------------------
+    if 'user' in tables:
+        with op.batch_alter_table('user') as batch_op:
+            if not _has_column(inspector, 'user', 'inbox_address'):
+                batch_op.add_column(sa.Column('inbox_address', sa.String(length=200),
+                                              nullable=True))
+            if not _has_column(inspector, 'user', 'inbox_token'):
+                batch_op.add_column(sa.Column('inbox_token', sa.String(length=16),
+                                              nullable=True))
+            if not _has_column(inspector, 'user', 'has_seen_inbox_onboarding'):
+                batch_op.add_column(sa.Column('has_seen_inbox_onboarding',
+                                              sa.Boolean(), nullable=True,
+                                              server_default=sa.text('0')))
+
+        # Re-inspect after the column adds so the unique index check is accurate.
+        inspector = inspect(conn)
+        existing_indexes = {ix['name'] for ix in inspector.get_indexes('user')}
+        if 'ix_user_inbox_address' not in existing_indexes:
+            op.create_index('ix_user_inbox_address', 'user',
+                            ['inbox_address'], unique=True)
+        if 'ix_user_inbox_token' not in existing_indexes:
+            op.create_index('ix_user_inbox_token', 'user',
+                            ['inbox_token'], unique=True)
+
+    # --- inbound_messages table --------------------------------------------
+    if 'inbound_messages' not in tables:
+        op.create_table(
+            'inbound_messages',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('recipient_address', sa.String(length=200), nullable=False),
+            sa.Column('sender_email', sa.String(length=200), nullable=True),
+            sa.Column('subject', sa.String(length=500), nullable=True),
+            sa.Column('plus_alias', sa.String(length=100), nullable=True),
+            sa.Column('raw_storage_path', sa.String(length=500), nullable=True),
+            sa.Column('source_kind', sa.String(length=20), nullable=False,
+                      server_default='text'),
+            sa.Column('ai_model', sa.String(length=60), nullable=True),
+            sa.Column('ai_tokens_in', sa.Integer(), nullable=True),
+            sa.Column('ai_tokens_out', sa.Integer(), nullable=True),
+            sa.Column('ai_cost_cents', sa.Numeric(10, 4), nullable=True),
+            sa.Column('status', sa.String(length=20), nullable=False,
+                      server_default='received'),
+            sa.Column('error_message', sa.Text(), nullable=True),
+            sa.Column('created_contact_ids', sa.JSON(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=False,
+                      server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.Column('processed_at', sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint('id', name='pk_inbound_messages'),
+            sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'],
+                                    name='fk_inbound_messages_org',
+                                    ondelete='RESTRICT'),
+            sa.ForeignKeyConstraint(['user_id'], ['user.id'],
+                                    name='fk_inbound_messages_user',
+                                    ondelete='CASCADE'),
+        )
+        op.create_index('ix_inbound_messages_org_id', 'inbound_messages',
+                        ['organization_id'], unique=False)
+        op.create_index('ix_inbound_messages_user_id', 'inbound_messages',
+                        ['user_id'], unique=False)
+        op.create_index('ix_inbound_messages_recipient_address',
+                        'inbound_messages', ['recipient_address'], unique=False)
+        op.create_index('ix_inbound_messages_sender_email',
+                        'inbound_messages', ['sender_email'], unique=False)
+        op.create_index('ix_inbound_messages_source_kind',
+                        'inbound_messages', ['source_kind'], unique=False)
+        op.create_index('ix_inbound_messages_status', 'inbound_messages',
+                        ['status'], unique=False)
+        op.create_index('ix_inbound_messages_created_at',
+                        'inbound_messages', ['created_at'], unique=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'inbound_messages' in tables:
+        op.drop_index('ix_inbound_messages_created_at',
+                      table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_status', table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_source_kind',
+                      table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_sender_email',
+                      table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_recipient_address',
+                      table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_user_id', table_name='inbound_messages')
+        op.drop_index('ix_inbound_messages_org_id', table_name='inbound_messages')
+        op.drop_table('inbound_messages')
+
+    if 'user' in tables:
+        existing_indexes = {ix['name'] for ix in inspector.get_indexes('user')}
+        if 'ix_user_inbox_token' in existing_indexes:
+            op.drop_index('ix_user_inbox_token', table_name='user')
+        if 'ix_user_inbox_address' in existing_indexes:
+            op.drop_index('ix_user_inbox_address', table_name='user')
+
+        with op.batch_alter_table('user') as batch_op:
+            if _has_column(inspector, 'user', 'has_seen_inbox_onboarding'):
+                batch_op.drop_column('has_seen_inbox_onboarding')
+            if _has_column(inspector, 'user', 'inbox_token'):
+                batch_op.drop_column('inbox_token')
+            if _has_column(inspector, 'user', 'inbox_address'):
+                batch_op.drop_column('inbox_address')

--- a/models.py
+++ b/models.py
@@ -241,7 +241,13 @@ class User(UserMixin, db.Model):
     # Onboarding flags
     has_seen_contacts_onboarding = db.Column(db.Boolean, default=False)
     has_seen_dashboard_onboarding = db.Column(db.Boolean, default=False)
-    
+    has_seen_inbox_onboarding = db.Column(db.Boolean, default=False)
+
+    # Magic Inbox — per-user forwarding address. The token suffix is the auth.
+    # Address format: <slug>-<token>@inbox.origentechnolog.com
+    inbox_address = db.Column(db.String(200), unique=True, index=True, nullable=True)
+    inbox_token = db.Column(db.String(16), unique=True, nullable=True)
+
     # Organization relationship
     organization = db.relationship('Organization', backref=db.backref('users', lazy='dynamic'),
                                    foreign_keys=[organization_id])
@@ -1731,6 +1737,7 @@ class Notification(db.Model):
     CATEGORIES = {
         'task_reminder': 'Task Reminders',
         'company_update': 'Company Updates',
+        'magic_inbox': 'Magic Inbox',
     }
 
     def mark_read(self):
@@ -1786,6 +1793,66 @@ class UserNotificationPreference(db.Model):
         return (f'<UserNotificationPreference user={self.user_id} '
                 f'cat={self.category} app={self.in_app_enabled} '
                 f'email={self.email_enabled}>')
+
+
+# =============================================================================
+# MAGIC INBOX (per-user forwarding address → AI-extracted contacts)
+# =============================================================================
+
+class InboundMessage(db.Model):
+    """An inbound email to a user's magic inbox.
+
+    One row per inbound message, kept for analytics, debugging, undo, and
+    rate-limiting. The raw payload is offloaded to Supabase Storage so this
+    table stays small.
+    """
+    __tablename__ = 'inbound_messages'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id',
+                        ondelete='CASCADE'), nullable=False, index=True)
+
+    recipient_address = db.Column(db.String(200), nullable=False, index=True)
+    sender_email = db.Column(db.String(200), nullable=True, index=True)
+    subject = db.Column(db.String(500), nullable=True)
+    plus_alias = db.Column(db.String(100), nullable=True)
+
+    # Where the raw MIME payload lives in Supabase Storage. Kept ~30 days
+    # for debugging and abuse review (pruned by a periodic job).
+    raw_storage_path = db.Column(db.String(500), nullable=True)
+
+    # vcard | csv | image | text | mixed — set from attachment MIME types so
+    # we can see which formats users actually forward, even though the AI
+    # path is identical for all of them.
+    source_kind = db.Column(db.String(20), nullable=False, default='text', index=True)
+
+    # AI observability so we can see real per-user cost.
+    ai_model = db.Column(db.String(60), nullable=True)
+    ai_tokens_in = db.Column(db.Integer, nullable=True)
+    ai_tokens_out = db.Column(db.Integer, nullable=True)
+    ai_cost_cents = db.Column(db.Numeric(10, 4), nullable=True)
+
+    # received | processed | failed | rejected | over_limit
+    status = db.Column(db.String(20), nullable=False, default='received', index=True)
+    error_message = db.Column(db.Text, nullable=True)
+
+    # JSON list of Contact ids created from this message — drives the undo flow.
+    created_contact_ids = db.Column(db.JSON, nullable=True)
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+    processed_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship('User', backref=db.backref('inbound_messages',
+                           lazy='dynamic', order_by='InboundMessage.created_at.desc()'))
+
+    SOURCE_KINDS = {'vcard', 'csv', 'image', 'text', 'mixed'}
+    STATUSES = {'received', 'processed', 'failed', 'rejected', 'over_limit'}
+
+    def __repr__(self):
+        return (f'<InboundMessage {self.id} status={self.status} '
+                f'kind={self.source_kind} user={self.user_id}>')
 
 
 # =============================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,9 @@ bleach==6.1.0
 Pillow==12.1.0
 openpyxl==3.1.5
 
+# QR codes (Magic Inbox: scan-from-phone for the inbox address)
+segno==1.6.1
+
 # PDF rendering (for document extraction - renders pages to images)
 PyMuPDF==1.25.4
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -3,6 +3,7 @@ from flask_login import login_user, logout_user, login_required, current_user
 from models import User, db, Contact, ActionPlan, Organization, OrganizationInvite
 from forms import RegistrationForm, LoginForm, RequestResetForm, ResetPasswordForm
 from services.email_service import get_email_service
+from services.inbox_provisioning import provision_inbox_address
 from services.tenant_service import (
     create_default_groups_for_org,
     create_default_task_types_for_org,
@@ -151,6 +152,26 @@ def register():
                 'warning'
             )
             return redirect(url_for('auth.login'))
+
+        # Provision the user's magic inbox before sending the welcome email so
+        # the address can be included. Never fail the signup over this.
+        try:
+            provision_inbox_address(user)
+        except Exception:
+            current_app.logger.exception(
+                'Failed to provision magic inbox during signup user_id=%s',
+                user.id,
+            )
+
+        try:
+            from services.sendgrid_outbound import send_inbox_welcome
+            if user.inbox_address:
+                send_inbox_welcome(user)
+        except Exception:
+            current_app.logger.exception(
+                'Failed to send magic inbox welcome email user_id=%s',
+                user.id,
+            )
 
         login_user(user)
         flash('Welcome to Origen. Your account is ready to use.', 'success')
@@ -334,7 +355,24 @@ def complete_invite(token):
     
     db.session.add(user)
     db.session.commit()
-    
+
+    try:
+        provision_inbox_address(user)
+    except Exception:
+        current_app.logger.exception(
+            'Failed to provision magic inbox after invite completion user_id=%s',
+            user.id,
+        )
+
+    try:
+        from services.sendgrid_outbound import send_inbox_welcome
+        if user.inbox_address:
+            send_inbox_welcome(user)
+    except Exception:
+        current_app.logger.exception(
+            'Failed to send magic inbox welcome email user_id=%s', user.id,
+        )
+
     login_user(user)
     flash(f'Welcome to {invite.organization.name}!', 'success')
     return redirect(url_for('main.dashboard'))

--- a/routes/inbound_email.py
+++ b/routes/inbound_email.py
@@ -1,0 +1,504 @@
+"""
+Magic Inbox — SendGrid Inbound Parse webhook + lightweight UI routes.
+
+Public surface:
+- ``POST /webhooks/sendgrid/inbound-parse`` — signed webhook from SendGrid.
+- ``GET  /inbox/undo/<token>`` — signed-token soft-delete for the receipt
+  email's "Undo" link.
+- ``GET  /inbox`` — the user's Magic Inbox home page.
+- ``GET  /inbox/vcard`` — downloadable .vcf so the user can save the
+  address as "Origen Inbox" on their phone.
+- ``POST /inbox/dismiss-onboarding`` — hide the dashboard onboarding card.
+- ``POST /inbox/rotate`` — re-issue the user's token suffix.
+
+The webhook always returns 200. SendGrid retries 4xx forever, and we
+never want a parsing bug to fill our logs with delivery failures.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta
+from io import BytesIO
+
+from flask import (
+    Blueprint, Response, abort, current_app, flash, redirect, render_template,
+    request, send_file, url_for,
+)
+from flask_login import current_user, login_required
+from markupsafe import Markup
+from sqlalchemy import text
+
+from models import Contact, InboundMessage, User, db
+from services.contact_extraction import process_inbound
+from services.inbound_payload import normalize_sendgrid_payload
+from services.inbox_provisioning import (
+    ensure_inbox_for, get_inbox_domain, parse_recipient, rotate_inbox_address,
+)
+from services.sendgrid_outbound import (
+    parse_undo_token, send_over_limit_notice,
+)
+
+logger = logging.getLogger(__name__)
+
+inbound_bp = Blueprint('inbound_email', __name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PER_USER_DAILY_LIMIT = 200
+PER_ORG_DAILY_LIMIT = 1000
+RAW_RETENTION_BUCKET = os.getenv('INBOUND_RAW_BUCKET', 'inbound-email-raw')
+
+
+# ---------------------------------------------------------------------------
+# Webhook
+# ---------------------------------------------------------------------------
+
+@inbound_bp.route('/webhooks/sendgrid/inbound-parse', methods=['POST'])
+def sendgrid_inbound_parse():
+    """SendGrid Inbound Parse handler. Always returns 200."""
+    try:
+        if not _verify_signature(request):
+            logger.warning('Magic Inbox: webhook signature invalid — dropping.')
+            return ('ok', 200)
+
+        recipient = _resolve_recipient(request.form)
+        slug, token, plus_alias = parse_recipient(recipient or '')
+        if not token:
+            logger.info('Magic Inbox: unknown recipient %r — dropping.', recipient)
+            return ('ok', 200)
+
+        user = User.query.filter_by(inbox_token=token).first()
+        if user is None or user.organization_id is None:
+            logger.info('Magic Inbox: no user for token %r — dropping.', token)
+            return ('ok', 200)
+
+        # Set RLS context for the rest of the request so downstream queries
+        # can rely on it (Postgres-only; no-op on SQLite).
+        try:
+            db.session.execute(
+                text('SET LOCAL app.current_org_id = :org_id'),
+                {'org_id': user.organization_id},
+            )
+        except Exception:
+            pass
+
+        # Spam scoring — drop anything SendGrid flagged hard.
+        try:
+            spam_score = float(request.form.get('spam_score') or 0)
+        except ValueError:
+            spam_score = 0.0
+        if spam_score >= 7.0:
+            logger.info(
+                'Magic Inbox: spam_score=%.2f over threshold — dropping for user_id=%s',
+                spam_score, user.id,
+            )
+            return ('ok', 200)
+
+        sender_email = _sender_email(request.form)
+
+        # Persist the row first so even crashes downstream leave a trace.
+        message = InboundMessage(
+            organization_id=user.organization_id,
+            user_id=user.id,
+            recipient_address=recipient,
+            sender_email=sender_email,
+            subject=(request.form.get('subject') or '')[:500] or None,
+            plus_alias=(plus_alias or None),
+            source_kind='text',
+            status='received',
+        )
+        db.session.add(message)
+        db.session.commit()
+
+        # Rate limits — written as friendly replies, not 4xx.
+        over_user, over_org = _over_rate_limits(user)
+        if over_user or over_org:
+            reason = ('Daily limit reached (200 inbox messages/user). '
+                      'Try again tomorrow.' if over_user else
+                      'Your team has hit today\'s 1,000 inbox messages limit.')
+            message.status = 'rejected'
+            message.error_message = reason
+            message.processed_at = datetime.utcnow()
+            db.session.commit()
+            try:
+                send_over_limit_notice(user, reason=reason)
+            except Exception:
+                logger.exception('Failed to send over-limit notice user_id=%s',
+                                 user.id)
+            return ('ok', 200)
+
+        # Stash the raw payload to Supabase Storage (best-effort).
+        try:
+            message.raw_storage_path = _archive_raw_payload(user, request)
+        except Exception:
+            logger.exception('Magic Inbox: raw archive upload failed inbound_id=%s',
+                             message.id)
+        # Persist the path even if no body change downstream.
+        db.session.commit()
+
+        # Normalize → AI → contacts. Orchestrator owns all DB writes from here.
+        bundle = normalize_sendgrid_payload(
+            request.form, request.files, plus_alias=plus_alias,
+        )
+        message.source_kind = bundle.source_kind
+        db.session.commit()
+
+        process_inbound(user, message, bundle)
+        return ('ok', 200)
+
+    except Exception:
+        logger.exception('Magic Inbox: unhandled error in inbound webhook.')
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+        return ('ok', 200)
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+@inbound_bp.route('/inbox/undo/<token>')
+def undo(token):
+    """Soft-delete one contact, or the full batch for older receipt links."""
+    payload = parse_undo_token(token or '')
+    if payload is None:
+        flash('That undo link is invalid or has expired.', 'error')
+        return redirect(url_for('inbound_email.inbox_home')
+                        if current_user.is_authenticated
+                        else url_for('auth.login'))
+
+    message = InboundMessage.query.get(payload['inbound_id'])
+    if message is None:
+        flash('Nothing to undo — the message could not be found.', 'error')
+        return redirect(url_for('inbound_email.inbox_home')
+                        if current_user.is_authenticated
+                        else url_for('auth.login'))
+
+    # If logged in, require the same user. If not logged in, the signed
+    # token alone is the auth (24h, single-purpose, low-risk soft delete).
+    if current_user.is_authenticated and current_user.id != message.user_id:
+        abort(403)
+
+    original_ids = list(message.created_contact_ids or [])
+    contact_id = payload.get('contact_id')
+    target_ids = [contact_id] if contact_id else original_ids
+
+    deleted = 0
+    deleted_ids = set()
+    for cid in target_ids:
+        if cid not in original_ids:
+            continue
+        contact = Contact.query.filter_by(id=cid,
+                                          user_id=message.user_id).first()
+        if contact is None:
+            continue
+        try:
+            db.session.delete(contact)
+            deleted += 1
+            deleted_ids.add(cid)
+        except Exception:
+            logger.exception('Magic Inbox undo: failed deleting contact_id=%s', cid)
+
+    remaining_ids = [cid for cid in original_ids if cid not in deleted_ids]
+    message.created_contact_ids = remaining_ids
+    if remaining_ids:
+        message.error_message = (
+            f'Partially undone via signed link at '
+            f'{datetime.utcnow().isoformat()}Z'
+        )
+    else:
+        message.status = 'rejected'
+        message.error_message = (
+            f'Undone via signed link at {datetime.utcnow().isoformat()}Z'
+        )
+    db.session.commit()
+
+    flash(
+        f"Removed {deleted} contact{'s' if deleted != 1 else ''} from your CRM.",
+        'success',
+    )
+    return redirect(url_for('inbound_email.inbox_home')
+                    if current_user.is_authenticated
+                    else url_for('auth.login'))
+
+
+# ---------------------------------------------------------------------------
+# Magic Inbox home page
+# ---------------------------------------------------------------------------
+
+@inbound_bp.route('/inbox')
+@login_required
+def inbox_home():
+    ensure_inbox_for(current_user)
+
+    recent = (InboundMessage.query
+              .filter_by(user_id=current_user.id)
+              .order_by(InboundMessage.created_at.desc())
+              .limit(20)
+              .all())
+
+    # Resolve created Contact rows for inline display.
+    activity = []
+    for m in recent:
+        ids = m.created_contact_ids or []
+        contacts = []
+        if ids:
+            contacts = (Contact.query
+                        .filter(Contact.id.in_(ids),
+                                Contact.user_id == current_user.id)
+                        .all())
+        activity.append({'message': m, 'contacts': contacts})
+
+    qr_svg = _qr_svg_markup(f'mailto:{current_user.inbox_address}'
+                            if current_user.inbox_address else '')
+
+    return render_template(
+        'inbox/home.html',
+        inbox_address=current_user.inbox_address or '',
+        inbox_domain=get_inbox_domain(),
+        activity=activity,
+        total_inbound=InboundMessage.query.filter_by(
+            user_id=current_user.id).count(),
+        qr_svg=qr_svg,
+    )
+
+
+def _qr_svg_markup(payload: str) -> Markup:
+    """Render an inline SVG QR pointing at ``payload`` (typically ``mailto:``).
+
+    Falls back to an empty string if ``segno`` is unavailable so the page
+    still renders without the QR.
+    """
+    if not payload:
+        return Markup('')
+    try:
+        import segno
+        qr = segno.make(payload, error='m')
+        buf = BytesIO()
+        qr.save(buf, kind='svg', scale=4, border=2, dark='#0f172a',
+                light='#ffffff', xmldecl=False, svgns=False, omitsize=False)
+        return Markup(buf.getvalue().decode('utf-8'))
+    except Exception:
+        logger.exception('Magic Inbox: QR generation failed.')
+        return Markup('')
+
+
+# ---------------------------------------------------------------------------
+# vCard download — "Save Origen Inbox to your phone contacts"
+# ---------------------------------------------------------------------------
+
+@inbound_bp.route('/inbox/vcard')
+@login_required
+def download_vcard():
+    """Return a .vcf file with the user's inbox address as 'Origen Inbox'."""
+    ensure_inbox_for(current_user)
+    address = current_user.inbox_address
+    if not address:
+        flash('Your magic inbox is still being set up. Try again in a moment.',
+              'info')
+        return redirect(url_for('inbound_email.inbox_home'))
+
+    vcf = (
+        'BEGIN:VCARD\r\n'
+        'VERSION:3.0\r\n'
+        'PRODID:-//OrigenTechnolOG//Magic Inbox//EN\r\n'
+        'N:Inbox;Origen;;;\r\n'
+        'FN:Origen Inbox\r\n'
+        'ORG:Origen TechnolOG\r\n'
+        f'EMAIL;TYPE=INTERNET;TYPE=PREF:{address}\r\n'
+        'NOTE:Forward emails or share photos to this contact and they '
+        'land in your CRM automatically.\r\n'
+        'END:VCARD\r\n'
+    )
+    return send_file(
+        BytesIO(vcf.encode('utf-8')),
+        mimetype='text/vcard',
+        as_attachment=True,
+        download_name='origen-inbox.vcf',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Onboarding dismiss + rotate token
+# ---------------------------------------------------------------------------
+
+@inbound_bp.route('/inbox/dismiss-onboarding', methods=['POST'])
+@login_required
+def dismiss_onboarding():
+    current_user.has_seen_inbox_onboarding = True
+    db.session.commit()
+    if request.headers.get('Accept', '').startswith('application/json'):
+        return ('', 204)
+    return redirect(request.referrer or url_for('main.dashboard'))
+
+
+@inbound_bp.route('/inbox/rotate', methods=['POST'])
+@login_required
+def rotate():
+    rotate_inbox_address(current_user)
+    flash('Your magic inbox address has been rotated. Save the new one.',
+          'success')
+    return redirect(request.referrer or url_for('inbound_email.inbox_home'))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _verify_signature(req) -> bool:
+    """Authorize an inbound webhook hit.
+
+    SendGrid Inbound Parse does NOT natively sign the request the way the
+    Event Webhook does. The conventional way to authenticate it is to put a
+    shared secret in the destination URL configured in SendGrid:
+
+        https://app.example.com/webhooks/sendgrid/inbound-parse?secret=XXXXXXXX
+
+    We accept the secret from either:
+      * ``?secret=...``    (easiest, what SendGrid supports natively)
+      * ``X-Inbound-Secret: ...`` header (set by a reverse proxy if you
+        prefer not to expose the value in URLs)
+
+    For full end-to-end signing (e.g. when using SendGrid's Signed Event
+    Webhook in front of a proxy), ``SENDGRID_INBOUND_PUBLIC_KEY`` is also
+    honoured for backwards compatibility.
+
+    Auth precedence::
+
+        SENDGRID_INBOUND_WEBHOOK_SECRET   →  shared-secret check
+        SENDGRID_INBOUND_PUBLIC_KEY       →  signed event webhook check
+        (neither set)                     →  accept with a warning
+    """
+    secret = os.getenv('SENDGRID_INBOUND_WEBHOOK_SECRET')
+    if secret:
+        provided = (req.args.get('secret')
+                    or req.headers.get('X-Inbound-Secret')
+                    or '')
+        if not _consteq(provided.strip(), secret.strip()):
+            logger.warning(
+                'Magic Inbox: shared-secret check failed (provided_len=%d).',
+                len(provided or ''),
+            )
+            return False
+        return True
+
+    pub_key = os.getenv('SENDGRID_INBOUND_PUBLIC_KEY')
+    if pub_key:
+        sig = (req.headers.get('X-Twilio-Email-Event-Webhook-Signature')
+               or req.headers.get('X-Sendgrid-Signature'))
+        ts = (req.headers.get('X-Twilio-Email-Event-Webhook-Timestamp')
+              or req.headers.get('X-Sendgrid-Timestamp'))
+        if not sig or not ts:
+            return False
+        try:
+            from sendgrid.helpers.eventwebhook import EventWebhook
+            verifier = EventWebhook(public_key=pub_key)
+            return verifier.verify_signature(
+                req.get_data(as_text=True), sig, ts)
+        except Exception:
+            logger.exception(
+                'Magic Inbox signature verification raised — rejecting.')
+            return False
+
+    logger.warning(
+        'Magic Inbox: no SENDGRID_INBOUND_WEBHOOK_SECRET / '
+        'SENDGRID_INBOUND_PUBLIC_KEY configured — accepting unverified.'
+    )
+    return True
+
+
+def _consteq(a: str, b: str) -> bool:
+    """Constant-time string compare (avoid hmac dep). Python's `==` would
+    short-circuit on the first mismatch and leak length info via timing.
+    """
+    if len(a) != len(b):
+        return False
+    result = 0
+    for x, y in zip(a.encode(), b.encode()):
+        result |= x ^ y
+    return result == 0
+
+
+def _resolve_recipient(form) -> str | None:
+    """Pull the recipient address out of a SendGrid Inbound Parse payload.
+
+    The SMTP envelope is the most reliable source (the real RCPT TO).
+    Falls back to the literal ``to`` header field for resilience.
+    """
+    envelope_raw = form.get('envelope') or ''
+    if envelope_raw:
+        try:
+            env = json.loads(envelope_raw)
+            tos = env.get('to') or []
+            if tos:
+                return _strip_address(tos[0])
+        except Exception:
+            pass
+
+    raw_to = form.get('to') or ''
+    if raw_to:
+        first = raw_to.split(',', 1)[0].strip()
+        return _strip_address(first)
+
+    return None
+
+
+def _strip_address(value: str) -> str:
+    """Return just the bare email from a "Name <addr@x>" string."""
+    value = (value or '').strip()
+    if '<' in value and '>' in value:
+        value = value[value.find('<') + 1:value.find('>')]
+    return value.strip()
+
+
+def _sender_email(form) -> str | None:
+    raw = form.get('from') or ''
+    bare = _strip_address(raw)
+    return bare.lower() if bare else None
+
+
+def _over_rate_limits(user: User) -> tuple[bool, bool]:
+    """Return ``(over_user_limit, over_org_limit)`` for today (UTC)."""
+    cutoff = datetime.utcnow() - timedelta(hours=24)
+    base = InboundMessage.query.filter(InboundMessage.created_at >= cutoff)
+    user_count = base.filter(InboundMessage.user_id == user.id).count()
+    org_count = base.filter(
+        InboundMessage.organization_id == user.organization_id).count()
+    return (user_count > PER_USER_DAILY_LIMIT,
+            org_count > PER_ORG_DAILY_LIMIT)
+
+
+def _archive_raw_payload(user: User, req) -> str | None:
+    """Stash the raw multipart payload in Supabase Storage. Best-effort.
+
+    Returns the storage path on success, ``None`` if unconfigured.
+    """
+    if not (os.getenv('SUPABASE_URL') and os.getenv('SUPABASE_KEY')):
+        return None
+
+    from services.supabase_storage import upload_file
+
+    today = datetime.utcnow().strftime('%Y/%m/%d')
+    storage_path = (f'{user.organization_id}/{user.id}/{today}/'
+                    f'{uuid.uuid4().hex}.eml')
+
+    raw = req.get_data() or b''
+    if not raw:
+        # Fall back to whatever the form has if there's no body.
+        try:
+            raw = json.dumps({k: req.form.get(k)
+                              for k in req.form.keys()}).encode('utf-8')
+        except Exception:
+            raw = b''
+
+    upload_file(RAW_RETENTION_BUCKET, storage_path, raw,
+                'inbound.eml', content_type='message/rfc822')
+    return storage_path

--- a/scripts/backfill_inbox_addresses.py
+++ b/scripts/backfill_inbox_addresses.py
@@ -1,0 +1,135 @@
+"""
+Backfill Magic Inbox addresses for all existing users.
+
+By default this script does a dry run that reports how many users still
+need provisioning. Pass ``--commit`` to actually allocate addresses, and
+``--announce`` to send the welcome/announcement email at the same time.
+
+Usage:
+    # Show how many users still need an address (no writes).
+    python3 scripts/backfill_inbox_addresses.py
+
+    # Provision missing addresses but skip the announcement email.
+    python3 scripts/backfill_inbox_addresses.py --commit
+
+    # Provision + send the announcement to every user that just got one.
+    python3 scripts/backfill_inbox_addresses.py --commit --announce
+
+    # Re-send the announcement to users who already had an address
+    # (useful for a one-off relaunch email — pair with --commit).
+    python3 scripts/backfill_inbox_addresses.py --commit --announce \
+        --include-existing
+
+Safety:
+- The provisioning loop commits per user, so a single bad row does not
+  poison the rest of the run.
+- ``--announce`` is best-effort. SendGrid failures are logged and the
+  script keeps going. Re-running with the same flags is safe.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app import app  # noqa: E402  -- needs sys.path patched first.
+from models import User, db  # noqa: E402
+from services.inbox_provisioning import provision_inbox_address  # noqa: E402
+from services.sendgrid_outbound import send_inbox_welcome  # noqa: E402
+
+
+logger = logging.getLogger('backfill_inbox')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(name)s — %(message)s',
+)
+
+
+def _eligible_users(include_existing: bool):
+    """Return users that should get an inbox address (and optionally email)."""
+    q = User.query.filter(User.organization_id.isnot(None))
+    if not include_existing:
+        q = q.filter((User.inbox_address.is_(None))
+                     | (User.inbox_token.is_(None)))
+    return q.order_by(User.id.asc()).all()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--commit', action='store_true',
+                        help='Actually write to the database. '
+                             'Default is dry-run.')
+    parser.add_argument('--announce', action='store_true',
+                        help='Send send_inbox_welcome() to each affected user.')
+    parser.add_argument('--include-existing', action='store_true',
+                        help='Also process users that already have an address. '
+                             'Useful for re-sending the announcement.')
+    parser.add_argument('--limit', type=int, default=0,
+                        help='Stop after N users (0 = no limit).')
+    args = parser.parse_args()
+
+    with app.app_context():
+        users = _eligible_users(args.include_existing)
+        if args.limit:
+            users = users[: args.limit]
+
+        logger.info('Found %d users to process (commit=%s, announce=%s, '
+                    'include_existing=%s).',
+                    len(users), args.commit, args.announce,
+                    args.include_existing)
+
+        provisioned = 0
+        skipped = 0
+        emailed = 0
+        failed_provision = 0
+        failed_email = 0
+
+        for u in users:
+            had_address = bool(u.inbox_address)
+
+            if not had_address:
+                if not args.commit:
+                    logger.info('  [dry-run] would provision user_id=%s '
+                                'email=%s', u.id, u.email)
+                    provisioned += 1
+                    continue
+                try:
+                    provision_inbox_address(u, commit=False)
+                    db.session.commit()
+                    provisioned += 1
+                    logger.info('  provisioned user_id=%s → %s',
+                                u.id, u.inbox_address)
+                except Exception:
+                    db.session.rollback()
+                    failed_provision += 1
+                    logger.exception('  failed provisioning user_id=%s', u.id)
+                    continue
+            else:
+                skipped += 1
+
+            if args.announce and (args.commit or had_address):
+                try:
+                    send_inbox_welcome(u)
+                    emailed += 1
+                except Exception:
+                    failed_email += 1
+                    logger.exception('  failed announcement email user_id=%s',
+                                     u.id)
+
+        logger.info(
+            'Done. provisioned=%d skipped(existing)=%d emailed=%d '
+            'errors(provision)=%d errors(email)=%d',
+            provisioned, skipped, emailed, failed_provision, failed_email,
+        )
+
+        if not args.commit:
+            logger.warning('Dry run only. Re-run with --commit to apply.')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/simulate_inbound.py
+++ b/scripts/simulate_inbound.py
@@ -1,0 +1,470 @@
+"""
+Simulate a SendGrid Inbound Parse webhook hit against the local Flask app.
+
+Useful for iterating on the Magic Inbox pipeline without re-routing real
+SendGrid traffic through ngrok every time. The script POSTs a realistic
+multipart payload — same field names SendGrid Inbound Parse uses — to
+``http://127.0.0.1:5011/webhooks/sendgrid/inbound-parse``.
+
+Usage:
+
+    # Make sure the dev server is up first:
+    #   set -a && source ./.env && set +a
+    #   python3 app.py
+
+    # Find your inbox address:
+    #   python3 scripts/simulate_inbound.py --who-am-i
+
+    # Send a plain text email with a contact in the body:
+    python3 scripts/simulate_inbound.py text
+
+    # Email with a signature block at the bottom:
+    python3 scripts/simulate_inbound.py signature
+
+    # Forward a .vcf attachment:
+    python3 scripts/simulate_inbound.py vcard
+
+    # Synthesized 'business card' image (requires Pillow):
+    python3 scripts/simulate_inbound.py image
+
+    # CSV of leads:
+    python3 scripts/simulate_inbound.py csv
+
+    # Use the +alias suffix to drop into a contact group:
+    python3 scripts/simulate_inbound.py text --plus buyers
+
+    # Skip the OpenAI call and use a canned 'Sarah Chen' response:
+    python3 scripts/simulate_inbound.py text --mock-ai
+
+    # Send to a specific user (default: first user that has an inbox):
+    python3 scripts/simulate_inbound.py text --user chrisnichols17@gmail.com
+
+    # Point at a deployed instance instead of localhost:
+    python3 scripts/simulate_inbound.py text \\
+        --base-url https://app.origentechnolog.com
+
+The script reads ``SENDGRID_INBOUND_WEBHOOK_SECRET`` from the environment
+(or .env) and appends it as ``?secret=...`` so the webhook accepts the hit
+exactly the way real SendGrid traffic would.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+# Best-effort load of .env so the script "just works" when invoked with
+# `python3 scripts/simulate_inbound.py` from a fresh shell.
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv(REPO / '.env', override=True)
+except Exception:
+    pass
+
+import requests  # noqa: E402
+
+logger = logging.getLogger('simulate_inbound')
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(name)s — %(message)s')
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURES = {
+    'text': {
+        'subject': 'New lead — please add',
+        'text': (
+            "Hey, just met Sarah Chen at the open house in Mont Belvieu. "
+            "She's looking in the $400k range, single family. "
+            "Email: sarah.chen@example.com, cell 281-555-0142.\n\n"
+            "Would love it if you could follow up Monday."
+        ),
+    },
+    'signature': {
+        'subject': 'Re: 123 Maple Ln — buyer interest',
+        'text': (
+            "Thanks for the showing. We'd like to put in an offer.\n"
+            "Talk soon,\n\n"
+            "—\n"
+            "Marcus Whitman\n"
+            "Senior Investment Officer\n"
+            "Whitman Capital LLC\n"
+            "marcus@whitmancap.example\n"
+            "Direct: (713) 555-0188\n"
+            "Mobile: 713.555.0190\n"
+            "1500 Louisiana St, Suite 2200, Houston TX 77002\n"
+        ),
+    },
+    'vcard': {
+        'subject': 'Card from Realtor mixer',
+        'text': 'Met this guy last night. Shared his vCard.',
+        'attachment': {
+            'filename': 'card.vcf',
+            'mime': 'text/vcard',
+            'data': (
+                "BEGIN:VCARD\r\n"
+                "VERSION:3.0\r\n"
+                "FN:Priya Patel\r\n"
+                "N:Patel;Priya;;;\r\n"
+                "ORG:Lone Star Mortgage\r\n"
+                "TITLE:Senior Loan Officer\r\n"
+                "EMAIL;TYPE=INTERNET;TYPE=PREF:priya@lonestarmtg.example\r\n"
+                "TEL;TYPE=CELL,VOICE:+12815550174\r\n"
+                "ADR;TYPE=WORK:;;1200 Smith St;Houston;TX;77002;USA\r\n"
+                "END:VCARD\r\n"
+            ).encode('utf-8'),
+        },
+    },
+    'csv': {
+        'subject': 'Leads from this weekend',
+        'text': 'CSV attached.',
+        'attachment': {
+            'filename': 'leads.csv',
+            'mime': 'text/csv',
+            'data': (
+                "first_name,last_name,email,phone,notes\n"
+                "Janet,Hill,janet.hill@example.com,2815550133,Open house Sat\n"
+                "Daniel,Reyes,dreyes@example.com,7135550109,Wants 4bd in Katy\n"
+                "Aisha,Khan,aisha.k@example.com,8325550120,Pre-approved\n"
+            ).encode('utf-8'),
+        },
+    },
+    'image': {
+        'subject': 'Card from broker breakfast',
+        'text': 'Snapped this card. Can you add him?',
+        # Image attachment is generated on the fly so we don't ship a binary.
+    },
+}
+
+
+# Canned AI response for --mock-ai. Mirrors the json_schema shape.
+MOCK_AI_PAYLOAD = {
+    'contacts': [{
+        'first_name': 'Sarah',
+        'last_name': 'Chen',
+        'email': 'sarah.chen@example.com',
+        'phone': '2815550142',
+        'street_address': None,
+        'city': 'Mont Belvieu',
+        'state': 'TX',
+        'zip_code': None,
+        'notes': 'Buyer ~$400k. Met at open house.',
+        'confidence': 'high',
+    }],
+    '_meta': {
+        'model': 'gpt-5.4-nano',
+        'tokens_in': 220,
+        'tokens_out': 80,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_recipient(user_email: str | None) -> tuple[str, str]:
+    """Boot the Flask app context just long enough to look up an inbox.
+
+    Returns ``(recipient_address, login_email)``.
+    """
+    from app import create_app
+    from models import User
+
+    application = create_app()
+    with application.app_context():
+        q = User.query.filter(User.inbox_address.isnot(None))
+        if user_email:
+            q = q.filter(User.email.ilike(user_email))
+        user = q.order_by(User.id.asc()).first()
+        if user is None:
+            raise SystemExit(
+                'No user with an inbox address found. Run:\n'
+                '  set -a && source ./.env && set +a\n'
+                '  python3 scripts/backfill_inbox_addresses.py --commit'
+            )
+        return user.inbox_address, user.email
+
+
+def _make_image_bytes(name: str = 'Marcus Whitman',
+                      title: str = 'Senior Investment Officer',
+                      org: str = 'Whitman Capital',
+                      email: str = 'marcus@whitmancap.example',
+                      phone: str = '(713) 555-0188') -> bytes:
+    """Render a tiny PNG that looks vaguely like a business card.
+
+    The AI cares about pixels, not aesthetics — we just need it to be a
+    real, decodable image with text on it.
+    """
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except ImportError as e:
+        raise SystemExit('Pillow is required for the `image` fixture. '
+                         'Install with: python3 -m pip install --break-system-packages '
+                         'Pillow') from e
+
+    img = Image.new('RGB', (640, 360), color=(252, 250, 245))
+    draw = ImageDraw.Draw(img)
+    try:
+        font_big = ImageFont.truetype('/System/Library/Fonts/Helvetica.ttc', 36)
+        font_med = ImageFont.truetype('/System/Library/Fonts/Helvetica.ttc', 22)
+        font_sm = ImageFont.truetype('/System/Library/Fonts/Helvetica.ttc', 18)
+    except Exception:
+        font_big = font_med = font_sm = ImageFont.load_default()
+
+    draw.rectangle((0, 0, 640, 12), fill=(15, 23, 42))
+    draw.text((40, 60), name, fill=(15, 23, 42), font=font_big)
+    draw.text((40, 110), title, fill=(100, 116, 139), font=font_med)
+    draw.text((40, 142), org, fill=(100, 116, 139), font=font_med)
+    draw.line((40, 200, 600, 200), fill=(226, 232, 240), width=1)
+    draw.text((40, 220), email, fill=(15, 23, 42), font=font_sm)
+    draw.text((40, 250), phone, fill=(15, 23, 42), font=font_sm)
+    draw.text((40, 280), '1500 Louisiana St, Suite 2200, Houston TX 77002',
+              fill=(15, 23, 42), font=font_sm)
+
+    buf = io.BytesIO()
+    img.save(buf, format='PNG', optimize=True)
+    return buf.getvalue()
+
+
+def _build_request(fixture_name: str, recipient: str, sender: str,
+                   plus_alias: str | None, spam_score: float) -> tuple[dict, dict]:
+    """Build the form + files dicts for a SendGrid-shaped POST."""
+    if fixture_name not in FIXTURES:
+        raise SystemExit(f'Unknown fixture: {fixture_name}. '
+                         f'Pick one of: {", ".join(FIXTURES)}')
+
+    if plus_alias:
+        local, _, domain = recipient.partition('@')
+        recipient = f'{local}+{plus_alias}@{domain}'
+
+    fixture = FIXTURES[fixture_name]
+    form = {
+        'to': recipient,
+        'from': f'Test Sender <{sender}>',
+        'subject': fixture.get('subject', '(test)'),
+        'text': fixture.get('text', ''),
+        'envelope': json.dumps({'to': [recipient], 'from': sender}),
+        'spam_score': str(spam_score),
+        'spam_report': '',
+        'attachments': '0',
+    }
+
+    files = {}
+    if fixture_name == 'image':
+        png = _make_image_bytes()
+        files['attachment1'] = ('card.png', png, 'image/png')
+        form['attachments'] = '1'
+        form['attachment-info'] = json.dumps({'attachment1': {
+            'filename': 'card.png', 'name': 'attachment1',
+            'type': 'image/png',
+        }})
+    elif 'attachment' in fixture:
+        a = fixture['attachment']
+        files['attachment1'] = (a['filename'], a['data'], a['mime'])
+        form['attachments'] = '1'
+        form['attachment-info'] = json.dumps({'attachment1': {
+            'filename': a['filename'], 'name': 'attachment1',
+            'type': a['mime'],
+        }})
+
+    return form, files
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+def _post_via_http(url: str, form: dict, files: dict, secret: str | None,
+                   timeout: int = 30) -> requests.Response:
+    """POST to a running Flask app over HTTP (the realistic path)."""
+    if secret:
+        sep = '&' if '?' in url else '?'
+        url = f'{url}{sep}secret={secret}'
+    return requests.post(url, data=form, files=files, timeout=timeout)
+
+
+def _post_via_test_client(form: dict, files: dict, *,
+                          mock_ai: bool,
+                          secret: str | None) -> tuple[int, str]:
+    """Hit the webhook through Flask's test client without spawning the
+    server. Useful when you want the AI mocked for fast offline iteration.
+    """
+    from app import create_app
+    application = create_app()
+    application.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+
+    test_files = {k: (io.BytesIO(v[1]), v[0], v[2]) for k, v in files.items()}
+    payload = {**form, **test_files}
+    url = '/webhooks/sendgrid/inbound-parse'
+    if secret:
+        url = f'{url}?secret={secret}'
+
+    with application.test_client() as client:
+        if mock_ai:
+            with patch(
+                'services.contact_extraction.generate_contact_extraction',
+                return_value=MOCK_AI_PAYLOAD,
+            ):
+                rv = client.post(url, data=payload,
+                                 content_type='multipart/form-data')
+        else:
+            rv = client.post(url, data=payload,
+                             content_type='multipart/form-data')
+        return rv.status_code, rv.get_data(as_text=True)
+
+
+def _print_result(message_id: int | None, login_email: str) -> None:
+    """Look up the just-created InboundMessage and pretty-print it."""
+    from app import create_app
+    from models import Contact, InboundMessage, User
+
+    application = create_app()
+    with application.app_context():
+        user = User.query.filter(User.email.ilike(login_email)).first()
+        if user is None:
+            return
+
+        msg = (InboundMessage.query
+               .filter_by(user_id=user.id)
+               .order_by(InboundMessage.id.desc())
+               .first())
+        if msg is None:
+            print('  (no InboundMessage row was written — '
+                  'likely the recipient lookup failed)')
+            return
+
+        contacts = []
+        for cid in (msg.created_contact_ids or []):
+            c = Contact.query.get(cid)
+            if c is not None:
+                contacts.append(c)
+
+        print('')
+        print(f'  InboundMessage  id={msg.id}')
+        print(f'    status        {msg.status}')
+        print(f'    source_kind   {msg.source_kind}')
+        if msg.plus_alias:
+            print(f'    plus_alias    {msg.plus_alias}')
+        if msg.ai_model:
+            print(f'    ai_model      {msg.ai_model}'
+                  f'  tokens_in={msg.ai_tokens_in}'
+                  f'  tokens_out={msg.ai_tokens_out}'
+                  f'  cost~{msg.ai_cost_cents}¢')
+        if msg.error_message:
+            print(f'    error         {msg.error_message}')
+        if contacts:
+            print(f'    created_contacts:')
+            for c in contacts:
+                print(f'      - id={c.id}  {c.first_name} {c.last_name}'
+                      f'  email={c.email or "—"}  phone={c.phone or "—"}')
+        elif msg.status == 'processed':
+            print('    (created_contact_ids set but rows not found)')
+        print('')
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('fixture', nargs='?', default='text',
+                        choices=list(FIXTURES) + ['who-am-i'],
+                        help='Which payload to send (default: text). '
+                             'Pass "who-am-i" to just print your inbox.')
+    parser.add_argument('--user', default=None,
+                        help='Email of the user to address. '
+                             'Defaults to the first user with an inbox.')
+    parser.add_argument('--plus', default=None,
+                        help='Plus-alias to append (e.g. buyers, sphere).')
+    parser.add_argument('--sender', default='you@example.com',
+                        help='From: address on the simulated email.')
+    parser.add_argument('--spam-score', type=float, default=0.0)
+    parser.add_argument('--base-url', default='http://127.0.0.1:5011',
+                        help='Where the dev server is listening.')
+    parser.add_argument('--secret', default=None,
+                        help='Override SENDGRID_INBOUND_WEBHOOK_SECRET.')
+    parser.add_argument('--mock-ai', action='store_true',
+                        help='Skip OpenAI; force a canned Sarah Chen contact.')
+    parser.add_argument('--in-process', action='store_true',
+                        help='Hit the webhook via Flask test client instead '
+                             'of HTTP. Required for --mock-ai. Useful when '
+                             'the dev server is not running.')
+    # Positional alias also for `who-am-i`.
+    parser.add_argument('--who-am-i', action='store_true',
+                        help='Print your inbox address and exit.')
+    parser.add_argument('--quiet', action='store_true')
+    args = parser.parse_args()
+
+    if args.quiet:
+        logging.getLogger().setLevel(logging.WARNING)
+
+    if args.fixture == 'who-am-i' or args.who_am_i:
+        recipient, login_email = _resolve_recipient(args.user)
+        print(f'  inbox address : {recipient}')
+        print(f'  login email   : {login_email}')
+        return 0
+
+    recipient, login_email = _resolve_recipient(args.user)
+    secret = args.secret or os.getenv('SENDGRID_INBOUND_WEBHOOK_SECRET')
+
+    form, files = _build_request(
+        args.fixture, recipient, sender=args.sender,
+        plus_alias=args.plus, spam_score=args.spam_score,
+    )
+
+    print('')
+    print(f'  fixture       : {args.fixture}')
+    print(f'  recipient     : {form["to"]}')
+    print(f'  sender        : {form["from"]}')
+    print(f'  attachments   : {form.get("attachments", "0")}')
+    print(f'  mock-ai       : {args.mock_ai}')
+    if args.in_process or args.mock_ai:
+        print('  transport     : in-process Flask test client')
+        if args.mock_ai and not args.in_process:
+            logger.info('--mock-ai implies --in-process. Switching transport.')
+        status, body = _post_via_test_client(form, files,
+                                             mock_ai=args.mock_ai,
+                                             secret=secret)
+    else:
+        url = f'{args.base_url.rstrip("/")}/webhooks/sendgrid/inbound-parse'
+        print(f'  transport     : HTTP POST → {url}')
+        try:
+            rv = _post_via_http(url, form, files, secret)
+        except requests.ConnectionError as e:
+            raise SystemExit(
+                f'Could not reach {url}. Is the dev server running?\n'
+                f'  set -a && source ./.env && set +a\n'
+                f'  python3 app.py\n\n'
+                f'Underlying error: {e}'
+            )
+        status, body = rv.status_code, rv.text
+    print(f'  http status   : {status}')
+
+    # Give the orchestrator a beat to finish writing rows when running
+    # against a live server.
+    if not args.in_process and not args.mock_ai:
+        time.sleep(0.5)
+
+    _print_result(None, login_email)
+
+    return 0 if status == 200 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import json
+import os
 import openai
 import logging
 from config import Config
@@ -391,6 +392,221 @@ def generate_vision_response(
     except Exception as legacy_error:
         logger.error(f"FATAL: All vision models failed. Error: {str(legacy_error)}")
         raise
+
+
+# =============================================================================
+# MAGIC INBOX CONTACT EXTRACTION (vCard / CSV / business card photo / signature)
+# =============================================================================
+
+# Single primary model for everything sent to the magic inbox: vCards, CSVs,
+# images, plain text. Vision-capable + cheap, with one safety-net fallback.
+# Override at runtime via INBOX_EXTRACTION_MODEL if the canonical model name
+# changes (the plan allows for the live name to be e.g. ``gpt-5-nano-2026-…``).
+INBOX_PRIMARY_MODEL = os.getenv('INBOX_EXTRACTION_MODEL', 'gpt-5.4-nano')
+INBOX_FALLBACK_MODEL = os.getenv('INBOX_EXTRACTION_FALLBACK_MODEL', 'gpt-5-mini')
+
+# Strict JSON schema we hold the model to. The orchestrator validates against
+# this shape before creating any contacts.
+CONTACT_EXTRACTION_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["contacts"],
+    "properties": {
+        "contacts": {
+            "type": "array",
+            "description": (
+                "Every distinct person referenced in the message. Empty if "
+                "no real person can be confidently identified."
+            ),
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "first_name", "last_name", "email", "phone",
+                    "street_address", "city", "state", "zip_code",
+                    "notes", "confidence",
+                ],
+                "properties": {
+                    "first_name": {"type": ["string", "null"]},
+                    "last_name": {"type": ["string", "null"]},
+                    "email": {"type": ["string", "null"]},
+                    "phone": {"type": ["string", "null"]},
+                    "street_address": {"type": ["string", "null"]},
+                    "city": {"type": ["string", "null"]},
+                    "state": {"type": ["string", "null"]},
+                    "zip_code": {"type": ["string", "null"]},
+                    "notes": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Brief context: company, title, where the contact "
+                            "came from. Keep under 280 chars."
+                        ),
+                    },
+                    "confidence": {
+                        "type": "string",
+                        "enum": ["high", "medium", "low"],
+                    },
+                },
+            },
+        }
+    },
+}
+
+CONTACT_EXTRACTION_SYSTEM_PROMPT = (
+    "You extract real-estate-CRM contacts from messy inbound material: vCards, "
+    "CSV rows, business-card photos, screenshots of LinkedIn profiles, email "
+    "signatures, and forwarded messages. "
+    "Return ONLY people the message clearly identifies as real human contacts. "
+    "Do NOT invent fields. If a value is missing, return null. "
+    "Use null (not empty string) for unknown fields. "
+    "Normalize phone numbers to digits only (no formatting); the caller will "
+    "format. Lowercase email addresses. Title-case names. "
+    "Set confidence='high' only when you have at least a full name plus one of "
+    "email or phone. Use 'medium' for partial business-card style data, 'low' "
+    "for ambiguous mentions. "
+    "Skip generic mailing-list footers, automated 'do-not-reply' senders, and "
+    "the recipient themselves."
+)
+
+
+def _build_inbox_user_content(text: str, image_blocks):
+    """Build the user message content array for the extraction call."""
+    user_content = [{
+        "type": "text",
+        "text": (
+            "Extract every real contact from the material below.\n\n"
+            "------ MESSAGE ------\n"
+            f"{text or '(no text body)'}\n"
+            "------ END MESSAGE ------"
+        ),
+    }]
+    for img_b64 in image_blocks or []:
+        user_content.append({
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/jpeg;base64,{img_b64}",
+                "detail": "auto",
+            },
+        })
+    return user_content
+
+
+def _call_inbox_extraction(client, model, text, image_blocks):
+    """One Chat Completions call with strict json_schema.
+
+    Returns ``(parsed_dict, usage)`` where ``usage`` exposes token counts so
+    the orchestrator can record observability data.
+    """
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": CONTACT_EXTRACTION_SYSTEM_PROMPT},
+            {"role": "user",
+             "content": _build_inbox_user_content(text, image_blocks)},
+        ],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "contact_extraction",
+                "schema": CONTACT_EXTRACTION_SCHEMA,
+                "strict": True,
+            },
+        },
+    )
+    raw = response.choices[0].message.content or '{}'
+    parsed = json.loads(raw)
+    return parsed, response.usage
+
+
+def generate_contact_extraction(
+    text: str,
+    image_blocks: list | None = None,
+    api_key: str = None,
+) -> dict:
+    """Extract structured contacts from a normalized inbound payload.
+
+    Single AI path — one model handles vCards, CSVs, photos, signatures.
+    Reliability comes from the strict json_schema, not from branching by
+    source kind.
+
+    Args:
+        text: Cleaned text body plus any text-attachment passthrough
+              (vcf/csv/txt). Already capped + HTML-stripped by the caller.
+        image_blocks: Optional list of base64-encoded JPEG images
+              (already downscaled and capped by the caller).
+        api_key: Optional API key override.
+
+    Returns:
+        Dict shaped like ``{"contacts": [...], "_meta": {...}}``. ``_meta``
+        carries the model used and token usage so the orchestrator can write
+        cost and audit info onto the InboundMessage row.
+    """
+    key = api_key or Config.OPENAI_API_KEY
+    if not key:
+        raise ValueError("OpenAI API key is not configured")
+
+    client = openai.OpenAI(api_key=key)
+
+    img_count = len(image_blocks or [])
+    text_len = len(text or '')
+
+    # ---- Primary: gpt-5.4-nano ------------------------------------------
+    try:
+        logger.info(
+            'Inbox extraction [1/2]: model=%s text_chars=%d images=%d',
+            INBOX_PRIMARY_MODEL, text_len, img_count,
+        )
+        parsed, usage = _call_inbox_extraction(
+            client, INBOX_PRIMARY_MODEL, text, image_blocks,
+        )
+        parsed['_meta'] = _usage_meta(INBOX_PRIMARY_MODEL, usage)
+        logger.info(
+            'Inbox extraction SUCCESS: model=%s contacts=%d',
+            INBOX_PRIMARY_MODEL, len(parsed.get('contacts') or []),
+        )
+        return parsed
+
+    except (openai.NotFoundError, openai.AuthenticationError,
+            openai.PermissionDeniedError, openai.RateLimitError,
+            json.JSONDecodeError) as e:
+        logger.warning(
+            'Inbox extraction primary failed (%s) — falling back. err=%s',
+            type(e).__name__, str(e),
+        )
+    except openai.APIError as e:
+        if not _should_fallback(e):
+            logger.error(
+                'Inbox extraction primary failed unrecoverably status=%s err=%s',
+                getattr(e, 'status_code', None), str(e),
+            )
+            raise
+        logger.warning(
+            'Inbox extraction primary APIError status=%s — falling back.',
+            getattr(e, 'status_code', None),
+        )
+
+    # ---- Fallback: gpt-5-mini -------------------------------------------
+    logger.info('Inbox extraction [2/2]: model=%s', INBOX_FALLBACK_MODEL)
+    parsed, usage = _call_inbox_extraction(
+        client, INBOX_FALLBACK_MODEL, text, image_blocks,
+    )
+    parsed['_meta'] = _usage_meta(INBOX_FALLBACK_MODEL, usage)
+    logger.info(
+        'Inbox extraction SUCCESS (fallback): model=%s contacts=%d',
+        INBOX_FALLBACK_MODEL, len(parsed.get('contacts') or []),
+    )
+    return parsed
+
+
+def _usage_meta(model: str, usage) -> dict:
+    """Pull token counts off an OpenAI usage object in a defensive way."""
+    tokens_in = getattr(usage, 'prompt_tokens', None) if usage else None
+    tokens_out = getattr(usage, 'completion_tokens', None) if usage else None
+    return {
+        'model': model,
+        'tokens_in': tokens_in,
+        'tokens_out': tokens_out,
+    }
 
 
 # =============================================================================

--- a/services/contact_extraction.py
+++ b/services/contact_extraction.py
@@ -1,0 +1,405 @@
+"""
+Magic Inbox orchestrator: take a normalized inbound payload, run the AI
+extraction, dedupe, create Contact rows, write status back to the
+InboundMessage row, and notify the user.
+
+Single AI path — vCards, CSVs, photos, signatures, all the same call.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import func
+
+from models import (
+    Contact,
+    ContactGroup,
+    InboundMessage,
+    User,
+    db,
+)
+from services.ai_service import (
+    INBOX_PRIMARY_MODEL,
+    generate_contact_extraction,
+)
+from services.inbound_payload import NormalizedInbound
+from services.notification_service import create_notification
+from services.sendgrid_outbound import (
+    make_undo_token,
+    send_inbox_receipt,
+)
+from utils import format_phone_number
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cost approximation — only used so we can store something useful on the row.
+# Real per-call cost lives in OpenAI's billing console.
+# ---------------------------------------------------------------------------
+# Prices in USD per 1M tokens (input, output). Update if pricing drifts.
+_MODEL_PRICING = {
+    'gpt-5.4-nano': (0.20, 1.25),
+    'gpt-5-nano': (0.20, 1.25),
+    'gpt-5-mini': (0.25, 2.00),
+    'gpt-5.1': (1.25, 10.00),
+}
+
+
+def _estimate_cost_cents(model: str | None,
+                         tokens_in: int | None,
+                         tokens_out: int | None) -> Decimal | None:
+    if not model or tokens_in is None or tokens_out is None:
+        return None
+    in_p, out_p = _MODEL_PRICING.get(model, _MODEL_PRICING.get(INBOX_PRIMARY_MODEL,
+                                                              (0.20, 1.25)))
+    cost_usd = (tokens_in / 1_000_000.0) * in_p + (tokens_out / 1_000_000.0) * out_p
+    return Decimal(str(round(cost_usd * 100, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Limits / helpers
+# ---------------------------------------------------------------------------
+
+def _org_can_add_more(org, count: int = 1) -> tuple[bool, str]:
+    """`tenant_service.org_can_add_contact` requires current_user — this
+    variant works in the webhook context where we have the org explicitly.
+    """
+    if org is None or org.max_contacts is None:
+        return True, ''
+    current_count = Contact.query.filter_by(organization_id=org.id).count()
+    if current_count + count > org.max_contacts:
+        return False, (
+            f'Contact limit reached ({org.max_contacts}). '
+            'Upgrade to Pro for unlimited.'
+        )
+    return True, ''
+
+
+def _normalize_phone(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    return format_phone_number(raw)
+
+
+def _normalize_email(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    cleaned = str(raw).strip().lower()
+    return cleaned or None
+
+
+def _title_case_name(raw: str | None) -> str:
+    if not raw:
+        return ''
+    return ' '.join(part.capitalize() for part in str(raw).strip().split())
+
+
+def _existing_contact_for(user_id: int, *, email: str | None, phone: str | None,
+                          first_name: str, last_name: str) -> Contact | None:
+    """Mirrors the dedupe rules from `routes/contacts.py` lines 657-688."""
+    if email:
+        dup = (Contact.query
+               .filter(Contact.user_id == user_id)
+               .filter(func.lower(Contact.email) == email)
+               .first())
+        if dup:
+            return dup
+    if phone:
+        dup = (Contact.query
+               .filter(Contact.user_id == user_id, Contact.phone == phone)
+               .first())
+        if dup:
+            return dup
+    if not email and not phone and (first_name or last_name):
+        dup = (Contact.query
+               .filter(Contact.user_id == user_id)
+               .filter(func.lower(Contact.first_name) == first_name.lower())
+               .filter(func.lower(Contact.last_name) == last_name.lower())
+               .first())
+        if dup:
+            return dup
+    return None
+
+
+def _resolve_group_for_alias(org_id: int, alias: str | None) -> ContactGroup | None:
+    """Map a plus-alias (`investors` from `you-token+investors@…`) onto an
+    existing ContactGroup in the user's org, if one matches by name (case
+    insensitive). Anything fancier (auto-create groups, etc.) is v2.
+    """
+    if not alias:
+        return None
+    return (ContactGroup.query
+            .filter(ContactGroup.organization_id == org_id)
+            .filter(func.lower(ContactGroup.name) == alias.lower())
+            .first())
+
+
+def _build_notes(raw_notes: str | None,
+                 sender_email: str | None,
+                 source_kind: str) -> str | None:
+    pieces = []
+    if raw_notes:
+        pieces.append(str(raw_notes).strip())
+    provenance_bits = []
+    if sender_email:
+        provenance_bits.append(f'forwarded from {sender_email}')
+    provenance_bits.append(f'via Magic Inbox ({source_kind})')
+    pieces.append('Added ' + ', '.join(provenance_bits) + '.')
+    notes = '\n\n'.join(p for p in pieces if p)
+    return notes[:2000] if notes else None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def process_inbound(user: User, message: InboundMessage,
+                    bundle: NormalizedInbound) -> dict:
+    """Process a normalized inbound payload end-to-end.
+
+    Updates *message* in place with status, ai cost, and created contact
+    ids, then commits. Always returns a small dict summarising what happened
+    so the webhook can log a one-liner.
+
+    Returns shape::
+
+        {
+          'created_contacts': [Contact, ...],
+          'status': 'processed' | 'over_limit' | 'failed' | 'rejected',
+          'reason': '<human-readable, or empty>',
+        }
+    """
+    org = user.organization
+    if org is None:
+        message.status = 'failed'
+        message.error_message = 'User has no organization'
+        message.processed_at = datetime.utcnow()
+        db.session.commit()
+        return {'created_contacts': [], 'status': 'failed',
+                'reason': 'no organization'}
+
+    # --- Empty payload guard -------------------------------------------
+    if not bundle.cleaned_text and not bundle.image_blocks:
+        message.status = 'rejected'
+        message.error_message = 'Empty payload'
+        message.processed_at = datetime.utcnow()
+        db.session.commit()
+        return {'created_contacts': [], 'status': 'rejected',
+                'reason': 'empty payload'}
+
+    # --- AI extraction --------------------------------------------------
+    try:
+        result = generate_contact_extraction(
+            text=bundle.cleaned_text,
+            image_blocks=bundle.image_blocks,
+        )
+    except Exception as e:
+        logger.exception('Magic Inbox AI extraction failed inbound_id=%s', message.id)
+        message.status = 'failed'
+        message.error_message = f'AI extraction failed: {e}'[:1000]
+        message.processed_at = datetime.utcnow()
+        db.session.commit()
+        return {'created_contacts': [], 'status': 'failed',
+                'reason': 'AI extraction failed'}
+
+    meta = result.get('_meta') or {}
+    ai_model = meta.get('model') or INBOX_PRIMARY_MODEL
+    tokens_in = meta.get('tokens_in')
+    tokens_out = meta.get('tokens_out')
+
+    message.ai_model = ai_model
+    message.ai_tokens_in = tokens_in
+    message.ai_tokens_out = tokens_out
+    message.ai_cost_cents = _estimate_cost_cents(ai_model, tokens_in, tokens_out)
+
+    raw_contacts = result.get('contacts') or []
+    if not isinstance(raw_contacts, list):
+        raw_contacts = []
+
+    # --- Filter / build candidates -------------------------------------
+    candidates = []
+    for entry in raw_contacts:
+        if not isinstance(entry, dict):
+            continue
+        confidence = (entry.get('confidence') or 'low').lower()
+
+        first = _title_case_name(entry.get('first_name'))
+        last = _title_case_name(entry.get('last_name'))
+        email = _normalize_email(entry.get('email'))
+        phone = _normalize_phone(entry.get('phone'))
+
+        # Drop garbage rows: need a name AND at least one of email/phone, OR
+        # 'high'/'medium' confidence with a full name.
+        has_name = bool(first or last)
+        has_signal = bool(email or phone)
+        if not has_name:
+            continue
+        if not has_signal and confidence == 'low':
+            continue
+
+        # Drop self-references (the user forwarded their own signature).
+        if email and user.email and email == user.email.lower():
+            continue
+
+        candidates.append({
+            'first_name': first,
+            'last_name': last,
+            'email': email,
+            'phone': phone,
+            'street_address': (entry.get('street_address') or '').strip() or None,
+            'city': (entry.get('city') or '').strip() or None,
+            'state': (entry.get('state') or '').strip() or None,
+            'zip_code': (entry.get('zip_code') or '').strip() or None,
+            'notes': entry.get('notes'),
+        })
+
+    # --- Free-tier limit check (per user_id is the contact owner) ------
+    allowed, limit_reason = _org_can_add_more(org, count=len(candidates))
+    if not allowed:
+        message.status = 'over_limit'
+        message.error_message = limit_reason
+        message.processed_at = datetime.utcnow()
+        db.session.commit()
+        return {'created_contacts': [], 'status': 'over_limit',
+                'reason': limit_reason}
+
+    # --- Dedupe + create -----------------------------------------------
+    group = _resolve_group_for_alias(org.id, bundle.plus_alias)
+    created: list[Contact] = []
+    skipped_dupes = 0
+
+    for c in candidates:
+        existing = _existing_contact_for(
+            user.id, email=c['email'], phone=c['phone'],
+            first_name=c['first_name'], last_name=c['last_name'],
+        )
+        if existing is not None:
+            skipped_dupes += 1
+            continue
+
+        contact = Contact(
+            organization_id=org.id,
+            user_id=user.id,
+            created_by_id=user.id,
+            first_name=c['first_name'] or '',
+            last_name=c['last_name'] or '',
+            email=c['email'],
+            phone=c['phone'],
+            street_address=c['street_address'],
+            city=c['city'],
+            state=c['state'],
+            zip_code=c['zip_code'],
+            notes=_build_notes(c['notes'],
+                               sender_email=message.sender_email,
+                               source_kind=bundle.source_kind),
+        )
+        if group is not None:
+            contact.groups.append(group)
+        db.session.add(contact)
+        created.append(contact)
+
+    if created:
+        try:
+            db.session.commit()
+        except Exception:
+            logger.exception('Magic Inbox commit failed inbound_id=%s', message.id)
+            db.session.rollback()
+            message.status = 'failed'
+            message.error_message = 'Database error while saving contacts'
+            message.processed_at = datetime.utcnow()
+            db.session.commit()
+            return {'created_contacts': [], 'status': 'failed',
+                    'reason': 'db error'}
+
+    message.created_contact_ids = [c.id for c in created]
+    message.status = 'processed' if created else 'rejected'
+    message.error_message = (None if created
+                             else f'No new contacts (dupes={skipped_dupes})')
+    message.processed_at = datetime.utcnow()
+    db.session.commit()
+
+    # --- Side effects: notification + receipt email --------------------
+    if created:
+        _send_in_app_notification(user, created)
+        _send_receipt_email(
+            user, message, created, skipped_count=skipped_dupes)
+
+    logger.info(
+        'Magic Inbox processed inbound_id=%s created=%d skipped_dupes=%d kind=%s',
+        message.id, len(created), skipped_dupes, bundle.source_kind,
+    )
+
+    return {
+        'created_contacts': created,
+        'status': message.status,
+        'reason': message.error_message or '',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Side effects (best-effort — never block the webhook)
+# ---------------------------------------------------------------------------
+
+def _send_in_app_notification(user: User, contacts: list[Contact]) -> None:
+    try:
+        from flask import url_for
+        if len(contacts) == 1:
+            c = contacts[0]
+            name = f'{c.first_name} {c.last_name}'.strip() or 'a new contact'
+            title = f'Saved {name} to your CRM'
+            try:
+                action_url = url_for('contacts.view_contact', contact_id=c.id)
+            except Exception:
+                action_url = '/contacts'
+        else:
+            title = f'Saved {len(contacts)} contacts to your CRM'
+            action_url = '/contacts'
+
+        create_notification(
+            user_id=user.id,
+            organization_id=user.organization_id,
+            category='magic_inbox',
+            title=title,
+            body='Forwarded via your magic inbox.',
+            icon='fa-paper-plane',
+            action_url=action_url,
+        )
+    except Exception:
+        logger.exception(
+            'Failed to write magic inbox notification user_id=%s', user.id,
+        )
+
+
+def _send_receipt_email(user: User, message: InboundMessage,
+                        contacts: list[Contact],
+                        skipped_count: int = 0) -> None:
+    """Reply-allowlist: only email back to the user themselves to prevent
+    backscatter when someone else forwards into the user's inbox.
+    """
+    try:
+        sender = (message.sender_email or '').lower().strip()
+        if sender and sender != (user.email or '').lower().strip():
+            logger.info(
+                'Magic Inbox: suppressing receipt to %s (forwarded by %s)',
+                user.email, sender,
+            )
+            return
+        token = make_undo_token(message.id)
+        send_inbox_receipt(
+            user, contacts,
+            undo_token=token,
+            inbound_recipient=message.recipient_address,
+            sender_email=message.sender_email,
+            source_kind=message.source_kind,
+            source_subject=message.subject,
+            skipped_count=skipped_count,
+            sent_at=message.created_at,
+        )
+    except Exception:
+        logger.exception(
+            'Failed to send magic inbox receipt user_id=%s inbound_id=%s',
+            user.id, message.id,
+        )

--- a/services/inbound_payload.py
+++ b/services/inbound_payload.py
@@ -1,0 +1,342 @@
+"""
+Normalize SendGrid Inbound Parse multipart payloads into an AI-ready bundle.
+
+Pure function — no DB, no HTTP, no external services. Easy to unit-test
+exhaustively against captured SendGrid payloads.
+
+The output is consumed by `services.ai_service.generate_contact_extraction`
+which makes a single AI call regardless of source kind.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import bleach
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cost ceilings — single source of truth for what the AI is allowed to see.
+# ---------------------------------------------------------------------------
+
+MAX_TEXT_BYTES = 16 * 1024            # 16 KB after HTML stripping
+MAX_IMAGES = 5                        # First 5 image attachments only
+IMAGE_MAX_LONG_EDGE = 1024            # px, downscale before base64
+MAX_CSV_ROWS = 500                    # Hard stop in MVP — bigger → CSV importer
+MAX_VCARD_BYTES = 64 * 1024           # vCard files larger than this are unusual
+
+VCARD_MIMES = {'text/vcard', 'text/x-vcard', 'text/directory'}
+CSV_MIMES = {'text/csv', 'application/csv',
+             'application/vnd.ms-excel'}  # Outlook exports as ms-excel sometimes
+TEXT_MIMES = {'text/plain'}
+IMAGE_MIMES = {'image/png', 'image/jpeg', 'image/jpg',
+               'image/heic', 'image/heif', 'image/webp', 'image/gif'}
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NormalizedInbound:
+    """Result of normalizing an inbound SendGrid payload.
+
+    `cleaned_text` is everything textual concatenated together (body + vcf +
+    csv + txt attachments). `image_blocks` are base64-encoded JPEGs sized for
+    the AI vision endpoint. `source_kind` is for analytics only — the AI path
+    is identical regardless of value.
+    """
+    cleaned_text: str = ''
+    image_blocks: list[str] = field(default_factory=list)
+    source_kind: str = 'text'
+    plus_alias: str | None = None
+    truncated_text: bool = False
+    skipped_images: int = 0
+    skipped_csv_rows: int = 0
+    over_limit_csv: bool = False
+    attachment_summary: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def normalize_sendgrid_payload(form: dict, files: dict | None = None,
+                               *, plus_alias: str | None = None
+                               ) -> NormalizedInbound:
+    """Normalize a SendGrid Inbound Parse POST into something the AI can chew.
+
+    Args:
+        form: ``request.form`` from a Parse webhook (text, html, subject,
+              from, envelope, attachment-info, etc.). Pass a plain ``dict``
+              or any mapping.
+        files: ``request.files`` mapping. SendGrid sends attachments as
+              ``attachment1``, ``attachment2``, …; we walk all of them.
+        plus_alias: Optional plus-alias parsed from the recipient address
+              (e.g. ``investors`` from ``you-token+investors@…``). Stored on
+              the result so downstream callers can map it to a contact group.
+
+    Returns:
+        A ``NormalizedInbound`` ready to hand to
+        ``generate_contact_extraction``.
+    """
+    files = files or {}
+
+    text_chunks: list[str] = []
+    image_blocks: list[str] = []
+    skipped_images = 0
+    skipped_csv_rows = 0
+    over_limit_csv = False
+    attachment_kinds: set[str] = set()
+    attachment_summary: list[dict] = []
+
+    # --- Subject + body --------------------------------------------------
+    subject = (form.get('subject') or '').strip()
+    if subject:
+        text_chunks.append(f'SUBJECT: {subject}')
+
+    sender = (form.get('from') or '').strip()
+    if sender:
+        text_chunks.append(f'FROM: {sender}')
+
+    body_text = (form.get('text') or '').strip()
+    body_html = (form.get('html') or '').strip()
+    if not body_text and body_html:
+        body_text = _strip_html(body_html)
+
+    if body_text:
+        text_chunks.append('BODY:\n' + body_text)
+
+    # --- Attachments -----------------------------------------------------
+    for filename, mime, raw_bytes in _iter_attachments(form, files):
+        mime = (mime or '').lower()
+        kind = _classify(mime, filename)
+        attachment_summary.append({
+            'filename': filename or '(unnamed)',
+            'mime': mime or 'unknown',
+            'kind': kind,
+            'bytes': len(raw_bytes),
+        })
+
+        if kind == 'vcard':
+            attachment_kinds.add('vcard')
+            text = _decode_text(raw_bytes[:MAX_VCARD_BYTES])
+            if text:
+                text_chunks.append(
+                    f'ATTACHMENT vCard ({filename or "card.vcf"}):\n{text}'
+                )
+
+        elif kind == 'csv':
+            attachment_kinds.add('csv')
+            text, rows_total, rows_kept, over = _truncate_csv(raw_bytes)
+            if rows_total > MAX_CSV_ROWS:
+                over_limit_csv = True
+                skipped_csv_rows += max(0, rows_total - rows_kept)
+            if text:
+                label = f'ATTACHMENT CSV ({filename or "contacts.csv"})'
+                if over:
+                    label += (f' — TRUNCATED to first {MAX_CSV_ROWS} rows '
+                              f'of {rows_total}')
+                text_chunks.append(f'{label}:\n{text}')
+
+        elif kind == 'text':
+            attachment_kinds.add('text')
+            text = _decode_text(raw_bytes[:MAX_TEXT_BYTES])
+            if text:
+                text_chunks.append(
+                    f'ATTACHMENT text ({filename or "note.txt"}):\n{text}'
+                )
+
+        elif kind == 'image':
+            attachment_kinds.add('image')
+            if len(image_blocks) >= MAX_IMAGES:
+                skipped_images += 1
+                continue
+            block = _image_to_base64_jpeg(raw_bytes)
+            if block:
+                image_blocks.append(block)
+            else:
+                skipped_images += 1
+
+        else:
+            # Unknown attachment type — skip silently. The AI gets the body
+            # and any other recognized attachments; we don't want to feed
+            # binary garbage to it.
+            continue
+
+    cleaned_text = '\n\n'.join(t for t in text_chunks if t)
+    truncated = False
+    if len(cleaned_text.encode('utf-8')) > MAX_TEXT_BYTES:
+        cleaned_text = _truncate_text(cleaned_text, MAX_TEXT_BYTES)
+        truncated = True
+
+    return NormalizedInbound(
+        cleaned_text=cleaned_text,
+        image_blocks=image_blocks,
+        source_kind=_summarize_kind(attachment_kinds, has_text=bool(body_text),
+                                    has_image=bool(image_blocks)),
+        plus_alias=plus_alias,
+        truncated_text=truncated,
+        skipped_images=skipped_images,
+        skipped_csv_rows=skipped_csv_rows,
+        over_limit_csv=over_limit_csv,
+        attachment_summary=attachment_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _iter_attachments(form, files) -> Iterable[tuple[str, str, bytes]]:
+    """Yield ``(filename, mime, bytes)`` for each attachment.
+
+    SendGrid Inbound Parse sends attachments as ``attachment1``,
+    ``attachment2``, etc. with metadata in ``attachment-info``. This
+    iterates over both Werkzeug FileStorage uploads and any inline parts.
+    """
+    for key in sorted(files.keys()):
+        if not key.lower().startswith('attachment'):
+            continue
+        f = files[key]
+        if not f:
+            continue
+        try:
+            data = f.read()
+        except Exception:
+            logger.exception('Failed reading attachment %s', key)
+            continue
+        if not data:
+            continue
+        yield (
+            getattr(f, 'filename', None) or '',
+            getattr(f, 'mimetype', None) or getattr(f, 'content_type', None) or '',
+            data,
+        )
+
+
+def _classify(mime: str, filename: str) -> str:
+    name = (filename or '').lower()
+    if mime in VCARD_MIMES or name.endswith('.vcf'):
+        return 'vcard'
+    if mime in CSV_MIMES or name.endswith('.csv'):
+        return 'csv'
+    if mime in TEXT_MIMES or name.endswith('.txt'):
+        return 'text'
+    if mime in IMAGE_MIMES or any(name.endswith(ext) for ext in (
+            '.png', '.jpg', '.jpeg', '.heic', '.heif', '.webp', '.gif')):
+        return 'image'
+    return 'other'
+
+
+def _decode_text(data: bytes) -> str:
+    """Decode bytes as UTF-8 / latin-1 with a soft fallback."""
+    if not data:
+        return ''
+    for enc in ('utf-8', 'utf-8-sig', 'latin-1'):
+        try:
+            return data.decode(enc).strip()
+        except UnicodeDecodeError:
+            continue
+    return data.decode('utf-8', errors='replace').strip()
+
+
+def _strip_html(html: str) -> str:
+    """Strip HTML to plain text via bleach + whitespace squashing."""
+    if not html:
+        return ''
+    cleaned = bleach.clean(html, tags=[], strip=True)
+    cleaned = re.sub(r'\s+', ' ', cleaned)
+    return cleaned.strip()
+
+
+def _truncate_text(text: str, max_bytes: int) -> str:
+    """Hard-truncate text to *max_bytes* of UTF-8."""
+    encoded = text.encode('utf-8')
+    if len(encoded) <= max_bytes:
+        return text
+    cut = encoded[:max_bytes]
+    return cut.decode('utf-8', errors='ignore') + '\n…(truncated)'
+
+
+def _truncate_csv(data: bytes) -> tuple[str, int, int, bool]:
+    """Cap a CSV at MAX_CSV_ROWS data rows.
+
+    Returns ``(text, total_rows_seen, rows_kept, was_truncated)``. The header
+    row is always included so the AI keeps the column context.
+    """
+    text = _decode_text(data)
+    if not text:
+        return '', 0, 0, False
+
+    lines = text.splitlines()
+    if not lines:
+        return '', 0, 0, False
+
+    header = lines[0]
+    body = lines[1:]
+    total = len(body)
+    keep = body[:MAX_CSV_ROWS]
+    truncated = total > MAX_CSV_ROWS
+
+    out = '\n'.join([header, *keep])
+    return out, total, len(keep), truncated
+
+
+def _image_to_base64_jpeg(data: bytes) -> str | None:
+    """Downscale and re-encode an image to JPEG/base64 for the vision model.
+
+    Returns None if the image can't be loaded (corrupted, weird format).
+    HEIC support depends on the runtime; we try and silently skip on failure.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        logger.warning('Pillow not installed — skipping image attachment.')
+        return None
+
+    try:
+        img = Image.open(io.BytesIO(data))
+        img.load()
+    except Exception as e:
+        logger.info('Could not decode inbound image (%s) — skipping.', e)
+        return None
+
+    # Convert to RGB so JPEG encoding never fails on RGBA/CMYK/etc.
+    if img.mode not in ('RGB', 'L'):
+        img = img.convert('RGB')
+
+    # Downscale preserving aspect ratio.
+    long_edge = max(img.size)
+    if long_edge > IMAGE_MAX_LONG_EDGE:
+        scale = IMAGE_MAX_LONG_EDGE / long_edge
+        new_size = (int(img.size[0] * scale), int(img.size[1] * scale))
+        try:
+            img = img.resize(new_size, Image.LANCZOS)
+        except AttributeError:
+            # Pillow >= 10 renamed LANCZOS to Resampling.LANCZOS
+            img = img.resize(new_size, Image.Resampling.LANCZOS)
+
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG', quality=82, optimize=True)
+    return base64.b64encode(buf.getvalue()).decode('ascii')
+
+
+def _summarize_kind(kinds: set[str], *, has_text: bool, has_image: bool) -> str:
+    """Pick one of vcard/csv/image/text/mixed for analytics on InboundMessage."""
+    distinct = set(kinds)
+    if has_image:
+        distinct.add('image')
+    if has_text and not distinct:
+        return 'text'
+    if not distinct:
+        return 'text'
+    if len(distinct) == 1:
+        return next(iter(distinct))
+    return 'mixed'

--- a/services/inbox_provisioning.py
+++ b/services/inbox_provisioning.py
@@ -1,0 +1,184 @@
+"""
+Magic Inbox provisioning.
+
+Each user gets a unique forwarding address of the form
+    <slug>-<token>@<INBOUND_EMAIL_DOMAIN>
+
+The 8-char base32 token is the auth — anyone with the address can post,
+which is the entire point. Slug is just there to make the address feel
+human ("oh that's mine") rather than to gate access.
+"""
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import string
+import unicodedata
+
+from flask import current_app
+
+from models import db, User
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_DOMAIN = 'inbox.origentechnolog.com'
+TOKEN_LENGTH = 8
+# Crockford-ish base32 minus visually ambiguous chars (0/O, 1/I/l). Lowercase
+# so the address is comfortable to read in the wild.
+TOKEN_ALPHABET = 'abcdefghjkmnpqrstuvwxyz23456789'
+SLUG_MAX = 40
+
+# Slugs that would look weird or land us in the middle of a system address.
+RESERVED_SLUGS = {
+    'admin', 'support', 'help', 'info', 'noreply', 'no-reply',
+    'postmaster', 'abuse', 'security', 'hello', 'inbox', 'mail',
+    'mailer-daemon', 'system', 'root', 'webmaster', 'origen',
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def get_inbox_domain() -> str:
+    """Return the configured inbox subdomain (env-overridable)."""
+    return os.getenv('INBOUND_EMAIL_DOMAIN') or DEFAULT_DOMAIN
+
+
+def slugify_for_inbox(first_name: str | None, last_name: str | None,
+                      fallback: str | None = None) -> str:
+    """Build a human-readable slug like ``chris.nichols``.
+
+    Falls back to *fallback* (typically the username or email local-part)
+    if the name is empty or strips to nothing useful.
+    """
+    parts = [(first_name or '').strip(), (last_name or '').strip()]
+    raw = '.'.join(p for p in parts if p)
+    if not raw and fallback:
+        raw = fallback
+    return _normalize_slug(raw or 'user')
+
+
+def _normalize_slug(text: str) -> str:
+    text = unicodedata.normalize('NFKD', text)
+    text = text.encode('ascii', 'ignore').decode('ascii').lower()
+    # Replace any run of non-alphanumeric characters with a single dot so
+    # "Mary-Jane O'Brien" → "mary.jane.obrien" — readable, RFC-safe.
+    text = re.sub(r'[^a-z0-9]+', '.', text).strip('.')
+    text = re.sub(r'\.{2,}', '.', text) or 'user'
+    text = text[:SLUG_MAX].strip('.')
+    if text in RESERVED_SLUGS or not text:
+        text = f'{text or "user"}.user'.strip('.')
+    return text
+
+
+def generate_token() -> str:
+    """8 chars of base32-ish entropy (~40 bits)."""
+    return ''.join(secrets.choice(TOKEN_ALPHABET) for _ in range(TOKEN_LENGTH))
+
+
+def build_address(slug: str, token: str, domain: str | None = None) -> str:
+    return f'{slug}-{token}@{domain or get_inbox_domain()}'
+
+
+def parse_recipient(address: str) -> tuple[str | None, str | None, str | None]:
+    """Split an inbound recipient into (slug, token, plus_alias).
+
+    Returns (None, None, None) if it doesn't look like one of our addresses.
+    """
+    if not address or '@' not in address:
+        return None, None, None
+    local, _, domain = address.lower().partition('@')
+    if domain != get_inbox_domain().lower():
+        return None, None, None
+
+    plus_alias = None
+    if '+' in local:
+        local, _, plus_alias = local.partition('+')
+        plus_alias = plus_alias or None
+
+    if '-' not in local:
+        return None, None, None
+    slug, _, token = local.rpartition('-')
+    if not slug or len(token) != TOKEN_LENGTH:
+        return None, None, None
+    if not all(c in TOKEN_ALPHABET for c in token):
+        return None, None, None
+    return slug, token, plus_alias
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+def provision_inbox_address(user: User, *, commit: bool = True) -> User:
+    """Generate and assign a unique inbox address for *user*.
+
+    Idempotent — if the user already has an address, returns the user
+    unchanged. Caller is responsible for handling commit failures.
+    """
+    if user.inbox_address and user.inbox_token:
+        return user
+
+    fallback = (user.username or
+                (user.email.split('@')[0] if user.email else None))
+    base_slug = slugify_for_inbox(user.first_name, user.last_name,
+                                  fallback=fallback)
+    domain = get_inbox_domain()
+
+    # The token alone is sufficiently unique. We retry on the rare slug+token
+    # collision so the address column's UNIQUE constraint can stay the source
+    # of truth.
+    for _ in range(8):
+        token = generate_token()
+        address = build_address(base_slug, token, domain)
+        existing = User.query.filter(
+            (User.inbox_token == token) | (User.inbox_address == address)
+        ).first()
+        if existing is None:
+            user.inbox_token = token
+            user.inbox_address = address
+            if commit:
+                db.session.commit()
+            return user
+
+    raise RuntimeError(
+        f'Could not allocate a unique inbox token for user {user.id} '
+        f'after 8 attempts. Check the inbox token alphabet/length.'
+    )
+
+
+def rotate_inbox_address(user: User, *, commit: bool = True) -> User:
+    """Re-issue the token suffix while keeping the slug.
+
+    Use sparingly — anyone who saved the old address (e.g. on their phone
+    as "Origen Inbox") will need the new one.
+    """
+    user.inbox_token = None
+    user.inbox_address = None
+    return provision_inbox_address(user, commit=commit)
+
+
+def ensure_inbox_for(user: User) -> User:
+    """Lazy provisioning safety net used by the request hook.
+
+    Wraps any failure so a missing inbox can never break a normal request.
+    """
+    if not user or user.inbox_address:
+        return user
+    try:
+        return provision_inbox_address(user)
+    except Exception:
+        current_app.logger.exception(
+            'Failed to lazily provision inbox address for user_id=%s',
+            getattr(user, 'id', None),
+        )
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+        return user

--- a/services/sendgrid_outbound.py
+++ b/services/sendgrid_outbound.py
@@ -1,0 +1,572 @@
+"""
+Outbound transactional sends for the Magic Inbox feature.
+
+Why a separate module from `services/sendgrid_service.py`? That file is the
+SendGrid template-sync admin tool. Magic Inbox sends are dynamic, plain
+HTML, content-driven, and triggered from the inbound webhook. Keeping them
+separate avoids overloading either module.
+
+All three helpers are best-effort. They never raise into the webhook —
+inbound parsing must keep returning 200 to SendGrid even if our reply send
+breaks.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Iterable
+
+from flask import current_app, url_for
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Email, Mail, To
+
+from services.inbox_provisioning import get_inbox_domain
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+DEFAULT_REPLY_FROM = 'info@origentechnolog.com'
+DEFAULT_REPLY_NAME = 'Origen Inbox'
+UNDO_TOKEN_MAX_AGE = 24 * 3600  # 24h, per the plan
+DEFAULT_WELCOME_TEMPLATE_ID = 'd-d89070c074554464a728867471e173e1'
+DEFAULT_RECEIPT_TEMPLATE_ID = 'd-f3ef49fcfb80406ab22ec2d0bf87c0e7'
+
+
+def _reply_from() -> str:
+    return os.getenv('INBOUND_REPLY_FROM') or DEFAULT_REPLY_FROM
+
+
+def _welcome_template_id() -> str:
+    return (os.getenv('SENDGRID_INBOX_WELCOME_TEMPLATE_ID')
+            or DEFAULT_WELCOME_TEMPLATE_ID)
+
+
+def _receipt_template_id() -> str:
+    return (os.getenv('SENDGRID_INBOX_RECEIPT_TEMPLATE_ID')
+            or DEFAULT_RECEIPT_TEMPLATE_ID)
+
+
+def _sendgrid_api_key() -> str | None:
+    return (os.getenv('SENDGRID_API_KEY')
+            or current_app.config.get('SENDGRID_API_KEY'))
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    """itsdangerous serializer keyed off the Flask SECRET_KEY."""
+    return URLSafeTimedSerializer(
+        current_app.config['SECRET_KEY'],
+        salt='magic-inbox-undo-v1',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Undo token
+# ---------------------------------------------------------------------------
+
+def make_undo_token(inbound_message_id: int, contact_id: int | None = None) -> str:
+    payload = {'inbound_id': int(inbound_message_id)}
+    if contact_id is not None:
+        payload['contact_id'] = int(contact_id)
+    return _serializer().dumps(payload)
+
+
+def parse_undo_token(token: str) -> dict | None:
+    """Return the signed undo payload if valid, else None.
+
+    Payload shape:
+      {"inbound_id": 123}                  -> undo whole inbound batch
+      {"inbound_id": 123, "contact_id": 7} -> undo one contact from the batch
+    """
+    try:
+        payload = _serializer().loads(token, max_age=UNDO_TOKEN_MAX_AGE)
+    except SignatureExpired:
+        logger.info('Magic Inbox undo token expired.')
+        return None
+    except BadSignature:
+        logger.info('Magic Inbox undo token failed signature check.')
+        return None
+    if not isinstance(payload, dict) or 'inbound_id' not in payload:
+        return None
+    try:
+        parsed = {'inbound_id': int(payload['inbound_id'])}
+        if payload.get('contact_id') is not None:
+            parsed['contact_id'] = int(payload['contact_id'])
+        return parsed
+    except (TypeError, ValueError):
+        return None
+
+
+def verify_undo_token(token: str) -> int | None:
+    """Return the InboundMessage id if the token is valid, else None.
+
+    Kept for existing tests and callers that only care about the batch id.
+    Use ``parse_undo_token`` when the caller needs per-contact undo.
+    """
+    payload = parse_undo_token(token)
+    return payload['inbound_id'] if payload else None
+
+
+# ---------------------------------------------------------------------------
+# Send helpers
+# ---------------------------------------------------------------------------
+
+def _send_html(to_email: str, subject: str, html: str,
+               *, reply_to: str | None = None) -> bool:
+    """Wrap the SendGrid call and swallow errors (logged) so callers stay safe."""
+    api_key = _sendgrid_api_key()
+    if not api_key:
+        logger.warning('SENDGRID_API_KEY missing — magic inbox email skipped.')
+        return False
+
+    try:
+        message = Mail(
+            from_email=Email(_reply_from(), DEFAULT_REPLY_NAME),
+            to_emails=To(to_email),
+            subject=subject,
+            html_content=html,
+        )
+        if reply_to:
+            message.reply_to = Email(reply_to)
+        response = SendGridAPIClient(api_key).send(message)
+        ok = response.status_code in (200, 201, 202)
+        if not ok:
+            logger.warning(
+                'Magic Inbox SendGrid non-2xx status=%s body=%r',
+                response.status_code, getattr(response, 'body', None),
+            )
+        return ok
+    except Exception:
+        logger.exception('Magic Inbox SendGrid send failed to=%s', to_email)
+        return False
+
+
+def _send_template(to_email: str, template_id: str, data: dict,
+                   *, subject: str | None = None,
+                   reply_to: str | None = None) -> bool:
+    """Send a SendGrid Dynamic Template with dynamic_template_data."""
+    api_key = _sendgrid_api_key()
+    if not api_key:
+        logger.warning('SENDGRID_API_KEY missing — magic inbox email skipped.')
+        return False
+    if not template_id:
+        return False
+
+    try:
+        message = Mail(
+            from_email=Email(_reply_from(), DEFAULT_REPLY_NAME),
+            to_emails=To(to_email),
+            subject=subject or '',
+        )
+        message.template_id = template_id
+        message.dynamic_template_data = data
+        if reply_to:
+            message.reply_to = Email(reply_to)
+        response = SendGridAPIClient(api_key).send(message)
+        ok = response.status_code in (200, 201, 202)
+        if not ok:
+            logger.warning(
+                'Magic Inbox SendGrid template non-2xx template_id=%s '
+                'status=%s body=%r',
+                template_id, response.status_code, getattr(response, 'body', None),
+            )
+        return ok
+    except Exception:
+        logger.exception(
+            'Magic Inbox SendGrid template send failed template_id=%s to=%s',
+            template_id, to_email,
+        )
+        return False
+
+
+def _safe_url(endpoint: str, **values) -> str:
+    """url_for that gracefully degrades when there's no request context."""
+    try:
+        return url_for(endpoint, _external=True, **values)
+    except Exception:
+        # Background contexts may not have SERVER_NAME set; fall back to a
+        # relative URL so the link is at least useful inside the app.
+        try:
+            return url_for(endpoint, **values)
+        except Exception:
+            return '#'
+
+
+# ---------------------------------------------------------------------------
+# 1) Receipt — "Saved Sarah Chen to your CRM"
+# ---------------------------------------------------------------------------
+
+def send_inbox_receipt(user, contacts: Iterable, *, undo_token: str | None,
+                       inbound_recipient: str | None = None,
+                       sender_email: str | None = None,
+                       source_kind: str | None = None,
+                       source_subject: str | None = None,
+                       skipped_count: int = 0,
+                       sent_at: datetime | None = None) -> bool:
+    """Send the per-message receipt with per-contact view + undo links."""
+    if not user or not user.email:
+        return False
+    contacts = list(contacts or [])
+    if not contacts:
+        return False
+
+    if len(contacts) == 1:
+        c = contacts[0]
+        name = _display_name(c) or 'a new contact'
+        subject = f'Saved {name} to your CRM'
+        intro = f'Saved <strong>{_html(name)}</strong> to your CRM.'
+    else:
+        subject = f'Saved {len(contacts)} contacts to your CRM'
+        intro = f'Saved <strong>{len(contacts)} contacts</strong> to your CRM.'
+
+    inbound_id = verify_undo_token(undo_token or '') if undo_token else None
+
+    template_data = _receipt_template_data(
+        contacts,
+        inbound_id=inbound_id,
+        subject=subject,
+        inbound_recipient=inbound_recipient or user.inbox_address or '',
+        sender_email=sender_email or user.email or '',
+        source_kind=source_kind or '',
+        source_subject=source_subject or '',
+        skipped_count=skipped_count,
+        sent_at=sent_at,
+    )
+    if _send_template(
+        user.email,
+        _receipt_template_id(),
+        template_data,
+        subject=subject,
+    ):
+        return True
+
+    rows_html = '\n'.join(
+        _contact_row_html(c, inbound_id=inbound_id) for c in contacts
+    )
+
+    view_url = (_safe_url('main.contacts') if len(contacts) > 1
+                else _safe_url('contacts.view_contact',
+                               contact_id=contacts[0].id))
+
+    actions_html = (
+        f'<a class="btn-primary" href="{view_url}">'
+        f'{"View contacts" if len(contacts) > 1 else "View contact"}</a>'
+    )
+
+    inbox_addr = inbound_recipient or user.inbox_address or ''
+    footer = (f'<p style="margin-top:24px;font-size:12px;color:#94a3b8">'
+              f'Sent to <a style="color:#94a3b8" href="mailto:{_html(inbox_addr)}">'
+              f'{_html(inbox_addr)}</a> — your magic inbox.</p>'
+              if inbox_addr else '')
+
+    html = _wrap_html(
+        title='Saved to your CRM',
+        body=f"""
+            <h1 style="margin:0 0 16px;font-size:20px;color:#0f172a">{intro}</h1>
+            <table role="presentation" cellpadding="0" cellspacing="0"
+                   style="width:100%;border-collapse:collapse;margin:16px 0">
+                {rows_html}
+            </table>
+            <p style="margin:24px 0 0">{actions_html}</p>
+            {footer}
+        """,
+    )
+    return _send_html(user.email, subject, html)
+
+
+def _receipt_template_data(contacts: list, *, inbound_id: int | None,
+                           subject: str, inbound_recipient: str,
+                           sender_email: str, source_kind: str,
+                           source_subject: str, skipped_count: int = 0,
+                           sent_at: datetime | None = None) -> dict:
+    count = len(contacts)
+    return {
+        'subject': subject,
+        'headline': subject + '.',
+        'count': count,
+        'count_label': f'{count} new contact' + ('' if count == 1 else 's'),
+        'saved_pronoun': 'it' if count == 1 else 'them',
+        'sent_at': _format_email_time(sent_at),
+        'sender_email': sender_email or '',
+        'contacts': [
+            _contact_template_data(c, inbound_id=inbound_id)
+            for c in contacts
+        ],
+        'contacts_url': _safe_url('main.contacts'),
+        'inbox_url': _safe_url('inbound_email.inbox_home'),
+        'source_kind': _source_kind_label(source_kind),
+        'source_subject': source_subject or '',
+        'has_skipped': skipped_count > 0,
+        'skipped_count': skipped_count,
+        'skipped_label': (
+            f'{skipped_count} entr' + ('y' if skipped_count == 1 else 'ies')
+            if skipped_count else ''
+        ),
+        'inbox_address': inbound_recipient or '',
+        'inbound_domain': get_inbox_domain(),
+        'year': str(datetime.utcnow().year),
+    }
+
+
+def _contact_template_data(c, *, inbound_id: int | None = None) -> dict:
+    name = _display_name(c) or '(no name)'
+    group_names = [
+        getattr(g, 'name', '') for g in (getattr(c, 'groups', None) or [])
+        if getattr(g, 'name', '')
+    ]
+    view_url = _safe_url('contacts.view_contact', contact_id=c.id)
+    undo_url = ''
+    if inbound_id:
+        undo_url = _safe_url(
+            'inbound_email.undo',
+            token=make_undo_token(inbound_id, contact_id=c.id),
+        )
+    return {
+        'id': c.id,
+        'name': name,
+        'initials': _initials(name),
+        'email': getattr(c, 'email', None) or '',
+        'phone': getattr(c, 'phone', None) or '',
+        'title': '',
+        'company': '',
+        'view_url': view_url,
+        'undo_url': undo_url,
+        'is_duplicate_merged': False,
+        'group_name': group_names[0] if group_names else '',
+    }
+
+
+def _contact_row_html(c, *, inbound_id: int | None = None) -> str:
+    name = _display_name(c) or '(no name)'
+    bits = [name]
+    if getattr(c, 'email', None):
+        bits.append(c.email)
+    if getattr(c, 'phone', None):
+        bits.append(c.phone)
+    view_url = _safe_url('contacts.view_contact', contact_id=c.id)
+    undo_url = ''
+    if inbound_id:
+        undo_url = _safe_url(
+            'inbound_email.undo',
+            token=make_undo_token(inbound_id, contact_id=c.id),
+        )
+    actions = (
+        f'<div style="margin-top:8px">'
+        f'<a href="{view_url}" style="color:#ea580c;font-weight:600;'
+        f'text-decoration:none">View</a>'
+        + (f' <span style="color:#cbd5e1">·</span> '
+           f'<a href="{undo_url}" style="color:#64748b;font-weight:600;'
+           f'text-decoration:none">Undo</a>' if undo_url else '')
+        + '</div>'
+    )
+    return (
+        '<tr><td style="padding:8px 0;border-bottom:1px solid #e2e8f0;'
+        'font-size:14px;color:#0f172a">'
+        f'<strong>{_html(name)}</strong>'
+        f'<div style="color:#64748b;font-size:13px">{_html(" · ".join(bits[1:]) or "—")}</div>'
+        f'{actions}'
+        '</td></tr>'
+    )
+
+
+def _display_name(c) -> str:
+    first = (getattr(c, 'first_name', '') or '').strip()
+    last = (getattr(c, 'last_name', '') or '').strip()
+    return ' '.join(p for p in (first, last) if p)
+
+
+def _initials(name: str) -> str:
+    parts = [p for p in (name or '').replace('-', ' ').split() if p]
+    if not parts:
+        return '?'
+    if len(parts) == 1:
+        return parts[0][:2].upper()
+    return (parts[0][0] + parts[-1][0]).upper()
+
+
+def _source_kind_label(source_kind: str | None) -> str:
+    value = (source_kind or '').strip().lower()
+    labels = {
+        'csv': 'CSV',
+        'vcard': 'vCard',
+        'image': 'Image',
+        'text': 'Email',
+        'mixed': 'Mixed',
+    }
+    return labels.get(value, value.title() if value else 'Magic Inbox')
+
+
+def _format_email_time(value: datetime | None) -> str:
+    when = value or datetime.utcnow()
+    try:
+        return when.strftime('%b %-d at %-I:%M %p')
+    except ValueError:
+        # Windows does not support %-d / %-I.
+        return when.strftime('%b %d at %I:%M %p').replace(' 0', ' ')
+
+
+# ---------------------------------------------------------------------------
+# 2) Welcome — sent at signup and from the backfill announcement
+# ---------------------------------------------------------------------------
+
+def send_inbox_welcome(user) -> bool:
+    if not user or not user.email or not user.inbox_address:
+        return False
+
+    inbox_url = _safe_url('inbound_email.inbox_home')
+    vcard_url = _safe_url('inbound_email.download_vcard')
+
+    subject = 'Stop typing contacts by hand'
+    template_data = _welcome_template_data(
+        inbox_address=user.inbox_address,
+        vcard_url=vcard_url,
+        inbox_url=inbox_url,
+    )
+    if _send_template(
+        user.email,
+        _welcome_template_id(),
+        template_data,
+        subject=subject,
+    ):
+        return True
+
+    html = _wrap_html(
+        title='Your Magic Inbox is ready',
+        body=f"""
+            <h1 style="margin:0 0 12px;font-size:22px;color:#0f172a">
+                Your Magic Inbox is ready.
+            </h1>
+            <p style="margin:0 0 16px;color:#475569;font-size:15px">
+                This is the fastest way to get contacts into Origen.
+                Forward an email, business card photo, vCard, CSV, or messy
+                email signature to this private address:
+            </p>
+            <p style="margin:0 0 24px">
+                <code style="display:inline-block;background:#f1f5f9;padding:10px 14px;
+                       border-radius:8px;font-size:15px;color:#0f172a;
+                       border:1px solid #e2e8f0;font-family:'SF Mono',Menlo,monospace">
+                    {_html(user.inbox_address)}
+                </code>
+            </p>
+            <p style="margin:0 0 16px;color:#475569;font-size:15px">
+                Origen reads the details, creates the contact, and sends you a
+                reply with a View link and an Undo link. No spreadsheet cleanup.
+                No copy and paste. No "I'll add it later."
+            </p>
+            <div style="margin:22px 0;padding:16px;border:1px solid #fed7aa;
+                        border-radius:12px;background:#fff7ed;color:#7c2d12;
+                        font-size:14px;line-height:1.5">
+                <strong>Do this now:</strong> save the address as
+                <strong>Origen Inbox</strong> in your phone. Next time someone
+                hands you a card, take a picture and share it to that contact.
+            </div>
+            <p style="margin:0 0 16px;color:#475569;font-size:15px">
+                Great things to send here:
+            </p>
+            <ul style="margin:0 0 22px 20px;padding:0;color:#475569;
+                       font-size:15px;line-height:1.6">
+                <li>Photos of business cards</li>
+                <li>Forwarded intros and lead emails</li>
+                <li>Email signatures from buyers, sellers, lenders, and vendors</li>
+                <li>Small CSVs or vCards from events</li>
+            </ul>
+            <p style="margin:24px 0 0">
+                <a class="btn-primary"
+                   href="{vcard_url}">Save Origen Inbox</a>
+                <a class="btn-secondary" href="{inbox_url}">Open Magic Inbox</a>
+            </p>
+            <p style="margin:24px 0 0;font-size:12px;color:#94a3b8">
+                This address is private to your account. If it ever gets shared
+                too widely, you can rotate it from your profile.
+            </p>
+        """,
+    )
+    return _send_html(user.email, subject, html)
+
+
+def _welcome_template_data(*, inbox_address: str, vcard_url: str,
+                           inbox_url: str) -> dict:
+    return {
+        'inbox_address': inbox_address,
+        'vcard_url': vcard_url,
+        'inbox_url': inbox_url,
+        'inbound_domain': get_inbox_domain(),
+        'year': str(datetime.utcnow().year),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3) Over-limit / rejected
+# ---------------------------------------------------------------------------
+
+def send_over_limit_notice(user, *, reason: str) -> bool:
+    if not user or not user.email:
+        return False
+    subject = "Couldn't save the message you forwarded"
+    html = _wrap_html(
+        title="We couldn't save that one",
+        body=f"""
+            <h1 style="margin:0 0 12px;font-size:20px;color:#0f172a">
+                We couldn't save the contact you forwarded.
+            </h1>
+            <p style="margin:0 0 16px;color:#475569;font-size:15px">
+                {_html(reason)}
+            </p>
+            <p style="margin:24px 0 0">
+                <a class="btn-primary" href="{_safe_url('main.contacts')}">
+                    Open Contacts
+                </a>
+            </p>
+        """,
+    )
+    return _send_html(user.email, subject, html)
+
+
+# ---------------------------------------------------------------------------
+# HTML scaffolding
+# ---------------------------------------------------------------------------
+
+def _wrap_html(title: str, body: str) -> str:
+    """Minimal email shell. Inline styles only; no external CSS."""
+    year = datetime.utcnow().year
+    domain = get_inbox_domain()
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>{_html(title)}</title>
+<style>
+  body {{ margin:0; background:#f8fafc; font-family: -apple-system, BlinkMacSystemFont,
+          "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; color:#0f172a; }}
+  .wrap {{ max-width: 560px; margin: 0 auto; padding: 32px 16px; }}
+  .card {{ background:#ffffff; border:1px solid #e2e8f0; border-radius:14px;
+           padding:28px; }}
+  a.btn-primary {{ display:inline-block; background:#ea580c; color:#ffffff !important;
+        text-decoration:none; padding:10px 16px; border-radius:8px;
+        font-weight:600; font-size:14px; margin-right:8px; }}
+  a.btn-secondary {{ display:inline-block; background:#f1f5f9; color:#0f172a !important;
+        text-decoration:none; padding:10px 16px; border-radius:8px;
+        font-weight:600; font-size:14px; }}
+  code {{ font-family: "SF Mono", Menlo, Consolas, monospace; }}
+  .footer {{ text-align:center; color:#94a3b8; font-size:12px; margin-top:18px; }}
+</style></head>
+<body>
+  <div class="wrap">
+    <div class="card">{body}</div>
+    <div class="footer">Origen TechnolOG · {domain} · &copy; {year}</div>
+  </div>
+</body></html>"""
+
+
+def _html(value) -> str:
+    """Tiny HTML-escape helper (avoids pulling in jinja in this module)."""
+    if value is None:
+        return ''
+    return (str(value)
+            .replace('&', '&amp;')
+            .replace('<', '&lt;')
+            .replace('>', '&gt;')
+            .replace('"', '&quot;')
+            .replace("'", '&#39;'))

--- a/templates/auth/user_profile.html
+++ b/templates/auth/user_profile.html
@@ -472,6 +472,101 @@
                 </a>
                 {% endif %}
 
+                <!-- Magic Inbox Card -->
+                {% if not is_admin_edit and user.inbox_address %}
+                <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2"
+                     data-controller="copy">
+                    <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-orange-400 to-orange-600 flex items-center justify-center">
+                                <i class="fas fa-paper-plane text-white text-sm"></i>
+                            </div>
+                            <div class="flex-1 min-w-0">
+                                <h2 class="text-base font-semibold text-slate-800">Magic Inbox</h2>
+                                <p class="text-xs text-slate-500 mt-0.5">Forward emails or photos here to auto-create contacts</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="p-5 space-y-3">
+                        <label class="form-label">Your private address</label>
+                        <div class="flex flex-col gap-2 sm:flex-row sm:items-stretch">
+                            <input type="text" readonly
+                                   value="{{ user.inbox_address }}"
+                                   data-copy-target="source"
+                                   class="premium-input flex-1 font-mono text-sm"
+                                   aria-label="Your magic inbox address">
+                            <button type="button"
+                                    data-action="copy#copy"
+                                    data-copy-target="button"
+                                    data-copy-default-text="Copy"
+                                    data-copy-success-text="Copied"
+                                    class="crm-btn crm-btn-secondary whitespace-nowrap">
+                                <i class="fas fa-copy text-xs"></i>
+                                <span data-copy-target="label">Copy</span>
+                            </button>
+                        </div>
+
+                        <div class="flex flex-wrap items-center gap-2 pt-2">
+                            <a href="{{ url_for('inbound_email.inbox_home') }}"
+                               class="crm-btn crm-btn-primary">
+                                <i class="fas fa-arrow-right text-xs"></i>
+                                Open Magic Inbox
+                            </a>
+                            <a href="{{ url_for('inbound_email.download_vcard') }}"
+                               class="crm-btn crm-btn-secondary">
+                                <i class="fas fa-mobile-alt text-xs"></i>
+                                Save to phone
+                            </a>
+                            <form method="POST"
+                                  action="{{ url_for('inbound_email.rotate') }}"
+                                  class="inline"
+                                  onsubmit="return confirm('Rotate your address? The old one stops working immediately.');">
+                                <input type="hidden" name="csrf_token"
+                                       value="{{ csrf_token() if csrf_token is defined else '' }}">
+                                <button type="submit" class="crm-btn crm-btn-subtle">
+                                    <i class="fas fa-sync-alt text-xs"></i>
+                                    Rotate
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <script>
+                (function () {
+                    document.querySelectorAll('[data-controller="copy"]').forEach(function (root) {
+                        if (root.dataset.copyBound) return;
+                        root.dataset.copyBound = '1';
+                        var source = root.querySelector('[data-copy-target="source"]');
+                        var label = root.querySelector('[data-copy-target="label"]');
+                        var btn = root.querySelector('[data-copy-target="button"]');
+                        if (!source) return;
+                        root.querySelectorAll('[data-action~="copy#copy"]').forEach(function (el) {
+                            el.addEventListener('click', function (e) {
+                                e.preventDefault();
+                                var text = source.value || source.textContent || '';
+                                if (!text) return;
+                                var done = function () {
+                                    var defaultText = (btn && btn.dataset.copyDefaultText) || 'Copy';
+                                    var successText = (btn && btn.dataset.copySuccessText) || 'Copied';
+                                    if (label) {
+                                        label.textContent = successText;
+                                        setTimeout(function () { label.textContent = defaultText; }, 1500);
+                                    }
+                                };
+                                if (navigator.clipboard && navigator.clipboard.writeText) {
+                                    navigator.clipboard.writeText(text).then(done).catch(function () {
+                                        source.select(); document.execCommand('copy'); done();
+                                    });
+                                } else {
+                                    source.select(); document.execCommand('copy'); done();
+                                }
+                            });
+                        });
+                    });
+                })();
+                </script>
+                {% endif %}
+
                 <!-- Quick Stats Card -->
                 <div class="bg-white rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200 overflow-hidden premium-card animate-fade-in-up-delay-2">
                     <div class="p-5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white">

--- a/templates/base.html
+++ b/templates/base.html
@@ -1155,6 +1155,11 @@
                     <i class="fas fa-address-book w-6 mr-3"></i>
                     Contacts
                 </a>
+                <a href="{{ url_for('inbound_email.inbox_home') }}"
+                    class="flex items-center px-6 py-3 text-white hover:bg-slate-800 {% if request.endpoint and request.endpoint.startswith('inbound_email.') %}bg-slate-800 border-l-4 border-orange-500{% endif %}">
+                    <i class="fas fa-paper-plane w-6 mr-3"></i>
+                    Magic Inbox
+                </a>
                 {% if current_user.role == 'admin' and org_has_feature('TRANSACTIONS') %}
                 <a href="{{ url_for('transactions.list_transactions') }}"
                     class="flex items-center px-6 py-3 text-white hover:bg-slate-800 {% if request.endpoint and request.endpoint.startswith('transactions.') %}bg-slate-800 border-l-4 border-orange-500{% endif %}">
@@ -1277,6 +1282,12 @@
                    class="crm-nav-link {% if request.endpoint == 'main.contacts' or (request.endpoint and request.endpoint.startswith('contacts.')) %}is-active{% endif %}">
                     <i class="fas fa-address-book"></i>
                     <span>Contacts</span>
+                </a>
+
+                <a href="{{ url_for('inbound_email.inbox_home') }}"
+                   class="crm-nav-link {% if request.endpoint and request.endpoint.startswith('inbound_email.') %}is-active{% endif %}">
+                    <i class="fas fa-paper-plane"></i>
+                    <span>Magic Inbox</span>
                 </a>
 
                 {% if can_access_transactions(current_user) %}

--- a/templates/contacts/list.html
+++ b/templates/contacts/list.html
@@ -343,7 +343,11 @@
             </table>
         </div>
         {% else %}
-        {% call empty_state('No contacts yet', 'Import a CSV or add your first contact to get started.', 'fa-address-book') %}
+        {% call empty_state('No contacts yet', 'Add your first contact, import a CSV, or forward an email to your Magic Inbox &mdash; we\'ll save the contact for you.', 'fa-address-book') %}
+            <a href="{{ url_for('inbound_email.inbox_home') }}" class="crm-btn crm-btn-secondary">
+                <i class="fas fa-paper-plane text-xs"></i>
+                Use Magic Inbox
+            </a>
             <button type="button"
                     class="crm-btn crm-btn-secondary"
                     data-action="contacts-page#openImportDialog">
@@ -353,6 +357,14 @@
                 Create contact
             </a>
         {% endcall %}
+        {% if current_user.inbox_address %}
+        <div class="mt-3 flex flex-col items-center text-center">
+            <p class="text-xs text-slate-500">Your private address:</p>
+            <code class="mt-1 inline-flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-xs text-slate-700">
+                {{ current_user.inbox_address }}
+            </code>
+        </div>
+        {% endif %}
         {% endif %}
 
         <div class="mt-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -48,6 +48,97 @@
         </div>
         {% endif %}
 
+        {% if current_user.inbox_address and not current_user.has_seen_inbox_onboarding %}
+        <section class="crm-surface mb-6" data-controller="inbox-onboarding">
+            <div class="crm-surface-body">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                    <div class="flex items-start gap-4 min-w-0">
+                        <div class="crm-icon-block shrink-0">
+                            <i class="fas fa-paper-plane text-sm text-orange-600"></i>
+                        </div>
+                        <div class="min-w-0">
+                            <div class="crm-section-kicker">New: Magic Inbox</div>
+                            <h2 class="mt-1 text-base font-semibold text-slate-900">
+                                Forward emails or photos &mdash; we save the contact for you.
+                            </h2>
+                            <p class="mt-1 text-sm text-slate-500">
+                                Send a business card, screenshot, vCard, or any email to this private address. The contact lands in your CRM automatically.
+                            </p>
+                            <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center"
+                                 data-controller="copy">
+                                <input type="text" readonly
+                                       value="{{ current_user.inbox_address }}"
+                                       data-copy-target="source"
+                                       class="crm-input flex-1 font-mono text-xs sm:text-sm tracking-tight"
+                                       aria-label="Your magic inbox address">
+                                <button type="button"
+                                        data-action="copy#copy"
+                                        data-copy-target="button"
+                                        data-copy-default-text="Copy"
+                                        data-copy-success-text="Copied"
+                                        class="crm-btn crm-btn-secondary whitespace-nowrap">
+                                    <i class="fas fa-copy text-xs"></i>
+                                    <span data-copy-target="label">Copy</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2 shrink-0">
+                        <a href="{{ url_for('inbound_email.inbox_home') }}"
+                           class="crm-btn crm-btn-primary">
+                            <i class="fas fa-arrow-right text-xs"></i>
+                            Set it up
+                        </a>
+                        <form method="POST"
+                              action="{{ url_for('inbound_email.dismiss_onboarding') }}"
+                              class="inline">
+                            <input type="hidden" name="csrf_token"
+                                   value="{{ csrf_token() if csrf_token is defined else '' }}">
+                            <button type="submit" class="crm-btn crm-btn-subtle">
+                                Dismiss
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <script>
+        (function () {
+            // Reuse the same lightweight copy wiring the /inbox page uses.
+            document.querySelectorAll('[data-controller="copy"]').forEach(function (root) {
+                if (root.dataset.copyBound) return;
+                root.dataset.copyBound = '1';
+                var source = root.querySelector('[data-copy-target="source"]');
+                var label = root.querySelector('[data-copy-target="label"]');
+                var btn = root.querySelector('[data-copy-target="button"]');
+                if (!source) return;
+                root.querySelectorAll('[data-action~="copy#copy"]').forEach(function (el) {
+                    el.addEventListener('click', function (e) {
+                        e.preventDefault();
+                        var text = source.value || source.textContent || '';
+                        if (!text) return;
+                        var done = function () {
+                            var defaultText = (btn && btn.dataset.copyDefaultText) || 'Copy';
+                            var successText = (btn && btn.dataset.copySuccessText) || 'Copied';
+                            if (label) {
+                                label.textContent = successText;
+                                setTimeout(function () { label.textContent = defaultText; }, 1500);
+                            }
+                        };
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            navigator.clipboard.writeText(text).then(done).catch(function () {
+                                source.select(); document.execCommand('copy'); done();
+                            });
+                        } else {
+                            source.select(); document.execCommand('copy'); done();
+                        }
+                    });
+                });
+            });
+        })();
+        </script>
+        {% endif %}
+
         <section class="crm-surface crm-mi mb-6"
                  data-controller="market-insights"
                  data-market-insights-default-slug-value="mont-belvieu"

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -1,0 +1,289 @@
+{% extends "base.html" %}
+{% from "components/ui.html" import page_header, empty_state %}
+
+{% block title %}Magic Inbox{% endblock %}
+
+{% block content %}
+<div class="crm-page">
+  <div class="crm-page__inner max-w-6xl">
+
+    {% call page_header(
+        'Magic Inbox',
+        'Forward any email, vCard, CSV, or business card photo to your private address. New contacts land in your CRM automatically.',
+        'Inbox') %}
+      <a href="{{ url_for('main.contacts') }}"
+         class="crm-btn crm-btn-secondary">
+        <i class="fas fa-address-book text-xs"></i>
+        Open Contacts
+      </a>
+    {% endcall %}
+
+    {# ───────── Address card ───────── #}
+    <section class="crm-surface mb-6">
+      <div class="grid grid-cols-1 gap-0 md:grid-cols-[1fr_auto]">
+
+        <div class="px-5 py-5 md:px-6 md:py-6">
+          <div class="crm-section-kicker">Your private address</div>
+          <h2 class="mt-1 crm-section-title">Send anything here</h2>
+          <p class="mt-1 crm-section-description">
+            Treat this like a contact in your phone. Forward emails, share
+            business card photos, AirDrop a vCard — we extract the contact
+            and save it to your CRM.
+          </p>
+
+          <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-stretch"
+               data-controller="copy">
+            <div class="relative flex-1">
+              <input
+                type="text"
+                readonly
+                value="{{ inbox_address }}"
+                data-copy-target="source"
+                class="crm-input w-full pr-12 font-mono text-sm tracking-tight text-slate-900"
+                aria-label="Your magic inbox address">
+              <button
+                type="button"
+                data-action="copy#copy"
+                class="absolute inset-y-0 right-0 inline-flex items-center px-3 text-slate-400 hover:text-slate-700"
+                aria-label="Copy address">
+                <i class="fas fa-copy text-sm"></i>
+              </button>
+            </div>
+            <button
+              type="button"
+              data-action="copy#copy"
+              class="crm-btn crm-btn-primary whitespace-nowrap"
+              data-copy-target="button"
+              data-copy-default-text="Copy"
+              data-copy-success-text="Copied">
+              <i class="fas fa-copy text-xs"></i>
+              <span data-copy-target="label">Copy</span>
+            </button>
+          </div>
+
+          <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <a href="mailto:{{ inbox_address }}"
+               class="crm-btn crm-btn-secondary justify-start">
+              <i class="fas fa-envelope text-xs text-slate-500"></i>
+              Send a test email
+            </a>
+            <a href="{{ url_for('inbound_email.download_vcard') }}"
+               class="crm-btn crm-btn-secondary justify-start">
+              <i class="fas fa-mobile-alt text-xs text-slate-500"></i>
+              Save to phone contacts
+            </a>
+            <form method="POST"
+                  action="{{ url_for('inbound_email.rotate') }}"
+                  onsubmit="return confirm('Rotate your address? The old one will stop working immediately.');">
+              <input type="hidden" name="csrf_token"
+                     value="{{ csrf_token() if csrf_token is defined else '' }}">
+              <button type="submit"
+                      class="crm-btn crm-btn-subtle w-full justify-start">
+                <i class="fas fa-sync-alt text-xs text-slate-500"></i>
+                Rotate address
+              </button>
+            </form>
+          </div>
+
+          <p class="mt-3 text-xs text-slate-500">
+            Tip: add <span class="font-mono text-slate-700">+leads</span>,
+            <span class="font-mono text-slate-700">+sphere</span>, or any tag
+            before the <span class="font-mono">@</span> to drop new contacts
+            into a matching group.
+          </p>
+        </div>
+
+        <div class="hidden border-t border-slate-200 md:block md:border-l md:border-t-0">
+          <div class="flex h-full flex-col items-center justify-center px-6 py-6">
+            <div class="rounded-md border border-slate-200 bg-white p-3">
+              {{ qr_svg }}
+            </div>
+            <p class="mt-2 text-xs text-slate-500">Scan with your phone</p>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    {# ───────── How it works ───────── #}
+    <section class="crm-surface mb-6">
+      <div class="crm-surface-header">
+        <div>
+          <div class="crm-section-kicker">How it works</div>
+          <h2 class="mt-1 crm-section-title">Three ways to use it</h2>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 divide-y divide-slate-100 md:grid-cols-3 md:divide-x md:divide-y-0">
+        <div class="px-5 py-5">
+          <div class="crm-icon-block">
+            <i class="fas fa-share-square text-sm"></i>
+          </div>
+          <h3 class="mt-3 text-sm font-semibold text-slate-900">
+            Forward an email
+          </h3>
+          <p class="mt-1 text-sm text-slate-600">
+            Got a lead in your inbox? Forward the message to your address.
+            We'll pull the name, phone, email, and notes from the signature
+            and the body.
+          </p>
+        </div>
+
+        <div class="px-5 py-5">
+          <div class="crm-icon-block">
+            <i class="fas fa-camera text-sm"></i>
+          </div>
+          <h3 class="mt-3 text-sm font-semibold text-slate-900">
+            Snap a business card
+          </h3>
+          <p class="mt-1 text-sm text-slate-600">
+            From your phone's photo app, share the picture to "Origen Inbox".
+            Up to five cards per email — we read each one and create the
+            contact.
+          </p>
+        </div>
+
+        <div class="px-5 py-5">
+          <div class="crm-icon-block">
+            <i class="fas fa-file-import text-sm"></i>
+          </div>
+          <h3 class="mt-3 text-sm font-semibold text-slate-900">
+            Send a vCard or CSV
+          </h3>
+          <p class="mt-1 text-sm text-slate-600">
+            Attach a <span class="font-mono">.vcf</span> from your phone or a
+            <span class="font-mono">.csv</span> export from another tool.
+            We'll dedupe against your existing contacts before saving.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    {# ───────── Recent activity ───────── #}
+    <section class="crm-surface">
+      <div class="crm-surface-header">
+        <div>
+          <div class="crm-section-kicker">Recent activity</div>
+          <h2 class="mt-1 crm-section-title">Last 20 messages</h2>
+        </div>
+        {% if total_inbound %}
+        <span class="crm-badge">{{ total_inbound }} total</span>
+        {% endif %}
+      </div>
+
+      {% if not activity %}
+        {% call empty_state(
+            'Nothing here yet',
+            'Send your first email or photo to your address above. New contacts will appear here as they are created.',
+            'fa-paper-plane') %}
+          <a href="mailto:{{ inbox_address }}" class="crm-btn crm-btn-primary">
+            <i class="fas fa-envelope text-xs"></i>
+            Send a test email
+          </a>
+        {% endcall %}
+      {% else %}
+      <ul class="divide-y divide-slate-100">
+        {% for item in activity %}
+        {% set m = item.message %}
+        <li class="px-5 py-4">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-2 text-sm">
+                <span class="font-medium text-slate-900 truncate">
+                  {{ m.subject or '(no subject)' }}
+                </span>
+                {% if m.plus_alias %}
+                <span class="crm-badge crm-badge-accent">+{{ m.plus_alias }}</span>
+                {% endif %}
+                {% if m.status == 'processed' %}
+                <span class="crm-badge crm-badge-success">
+                  <i class="fas fa-check text-[10px] mr-1"></i>Saved
+                </span>
+                {% elif m.status == 'over_limit' %}
+                <span class="crm-badge crm-badge-warning">Over limit</span>
+                {% elif m.status == 'failed' %}
+                <span class="crm-badge crm-badge-warning">Failed</span>
+                {% elif m.status == 'rejected' %}
+                <span class="crm-badge">No new contacts</span>
+                {% elif m.status == 'received' %}
+                <span class="crm-badge">Processing</span>
+                {% endif %}
+                <span class="crm-badge">{{ m.source_kind|capitalize }}</span>
+              </div>
+              <p class="mt-1 text-xs text-slate-500">
+                {% if m.sender_email %}from {{ m.sender_email }} ·{% endif %}
+                {{ m.created_at.strftime('%b %d, %Y · %I:%M %p') }}
+                {% if m.error_message %}
+                · <span class="text-amber-700">{{ m.error_message }}</span>
+                {% endif %}
+              </p>
+
+              {% if item.contacts %}
+              <div class="mt-2 flex flex-wrap items-center gap-2">
+                {% for c in item.contacts %}
+                <a href="{{ url_for('contacts.view_contact', contact_id=c.id) }}"
+                   class="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-700 hover:bg-slate-100">
+                  <i class="fas fa-user text-[10px] text-slate-400"></i>
+                  {{ (c.first_name or '') ~ ' ' ~ (c.last_name or '') }}
+                </a>
+                {% endfor %}
+              </div>
+              {% endif %}
+            </div>
+
+            {% if item.contacts and item.contacts|length == 1 %}
+            <div class="flex items-center gap-2 sm:pt-1">
+              <a href="{{ url_for('contacts.view_contact', contact_id=item.contacts[0].id) }}"
+                 class="crm-btn crm-btn-secondary">
+                <i class="fas fa-arrow-right text-xs"></i>
+                View
+              </a>
+            </div>
+            {% endif %}
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </section>
+
+  </div>
+</div>
+
+<script>
+(function () {
+  // Minimal copy-to-clipboard wiring (no Stimulus dependency required).
+  // Buttons can use either the wrapping data-controller="copy" pattern or
+  // be standalone within the same parent.
+  document.querySelectorAll('[data-controller="copy"]').forEach(function (root) {
+    var source = root.querySelector('[data-copy-target="source"]');
+    var label = root.querySelector('[data-copy-target="label"]');
+    var btn = root.querySelector('[data-copy-target="button"]');
+    if (!source) return;
+
+    root.querySelectorAll('[data-action~="copy#copy"]').forEach(function (el) {
+      el.addEventListener('click', function (e) {
+        e.preventDefault();
+        var text = source.value || source.textContent || '';
+        if (!text) return;
+        var done = function () {
+          var defaultText = (btn && btn.dataset.copyDefaultText) || 'Copy';
+          var successText = (btn && btn.dataset.copySuccessText) || 'Copied';
+          if (label) {
+            label.textContent = successText;
+            setTimeout(function () { label.textContent = defaultText; }, 1500);
+          }
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            source.select(); document.execCommand('copy'); done();
+          });
+        } else {
+          source.select(); document.execCommand('copy'); done();
+        }
+      });
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -1,0 +1,1009 @@
+"""
+Magic Inbox unit + integration tests.
+
+Covers:
+- Address provisioning, slug normalization, plus-alias parsing
+- Undo token round-trip + tamper resistance
+- SendGrid payload normalizer (text bodies, HTML stripping, vCards, CSVs,
+  truncation, image classification)
+- Contact extraction orchestrator: dedupe, group resolution from plus alias,
+  free-tier limits, self-reference suppression, rejected-when-empty
+- /inbox UI route (logged-in render)
+- Webhook end-to-end via Flask test client (AI mocked)
+
+Heavy paths (real OpenAI, real SendGrid) are mocked. All DB writes happen
+against the shared SQLite test database from `tests/conftest.py`.
+"""
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import inspect
+
+from models import (
+    Contact,
+    ContactGroup,
+    InboundMessage,
+    User,
+    db,
+)
+from services.inbound_payload import (
+    MAX_CSV_ROWS,
+    NormalizedInbound,
+    normalize_sendgrid_payload,
+)
+from services.inbox_provisioning import (
+    build_address,
+    generate_token,
+    get_inbox_domain,
+    parse_recipient,
+    provision_inbox_address,
+    rotate_inbox_address,
+    slugify_for_inbox,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _user(seed, key='owner_a') -> User:
+    return User.query.get(seed[key])
+
+
+def _ensure_inbox(seed, key='owner_a') -> User:
+    """Provision an inbox for the seed user if missing."""
+    u = _user(seed, key)
+    if not u.inbox_address:
+        provision_inbox_address(u)
+    return u
+
+
+@pytest.fixture(autouse=True)
+def _scrub_inbox_writes(app, seed):
+    """The orchestrator commits via ``db.session.commit()``, so the
+    project-wide ``_rollback_after_test`` fixture in ``conftest.py`` cannot
+    undo what these tests create. Without an explicit scrub, ``Contact`` and
+    ``InboundMessage`` rows would leak across tests, breaking unique
+    constraints and the seed-state assumptions of unrelated test files
+    (e.g. ``test_market_insights``, ``test_admin``)."""
+    yield
+    seed_contact_ids = {seed[k] for k in seed
+                        if isinstance(k, str) and k.startswith('contact_')}
+    with app.app_context():
+        db.session.rollback()
+        tables = set(inspect(db.engine).get_table_names())
+        if 'inbound_messages' in tables:
+            InboundMessage.query.delete(synchronize_session=False)
+        if 'contact' in tables:
+            Contact.query.filter(
+                ~Contact.id.in_(seed_contact_ids)
+            ).delete(synchronize_session=False)
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Slug + token + address shape
+# ---------------------------------------------------------------------------
+
+class TestSlugAndToken:
+    def test_slugify_basic(self):
+        assert slugify_for_inbox('Chris', 'Nichols') == 'chris.nichols'
+
+    def test_slugify_strips_punctuation(self):
+        # Each run of non-alphanumeric collapses into one '.'.
+        assert slugify_for_inbox("Mary-Jane", "O'Brien") == 'mary.jane.o.brien'
+
+    def test_slugify_unicode_collapses_to_ascii(self):
+        assert slugify_for_inbox('Renée', 'Zellweger') == 'renee.zellweger'
+
+    def test_slugify_empty_uses_fallback(self):
+        assert slugify_for_inbox('', '', fallback='alice@x.com') == 'alice.x.com'
+
+    def test_slugify_completely_empty_yields_user(self):
+        assert slugify_for_inbox(None, None) == 'user'
+
+    def test_slugify_reserved_appends_user(self):
+        # 'admin' is in RESERVED_SLUGS — must not collide with system mailbox.
+        out = slugify_for_inbox('admin', '')
+        assert out.endswith('.user')
+
+    def test_token_alphabet_and_length(self):
+        for _ in range(50):
+            t = generate_token()
+            assert len(t) == 8
+            assert all(c in 'abcdefghjkmnpqrstuvwxyz23456789' for c in t)
+            # Visually-ambiguous chars excluded.
+            assert '0' not in t and '1' not in t and 'o' not in t and 'l' not in t
+
+
+# ---------------------------------------------------------------------------
+# Provisioning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures('app')
+class TestProvisioning:
+    def test_provisioning_is_idempotent(self, app, seed):
+        with app.app_context():
+            u = _user(seed, 'owner_a')
+            u.inbox_address = None
+            u.inbox_token = None
+            db.session.commit()
+
+            provision_inbox_address(u)
+            first_address = u.inbox_address
+
+            provision_inbox_address(u)
+            assert u.inbox_address == first_address
+
+    def test_address_format(self, app, seed):
+        with app.app_context():
+            u = _ensure_inbox(seed, 'agent_a')
+            slug, _, domain = u.inbox_address.partition('@')
+            assert domain == get_inbox_domain()
+            assert '-' in slug
+            local_slug, _, token = slug.rpartition('-')
+            assert local_slug
+            assert len(token) == 8
+
+    def test_two_users_get_distinct_tokens(self, app, seed):
+        with app.app_context():
+            a = _ensure_inbox(seed, 'owner_a')
+            b = _ensure_inbox(seed, 'agent_a')
+            assert a.inbox_token != b.inbox_token
+            assert a.inbox_address != b.inbox_address
+
+    def test_rotate_changes_token(self, app, seed):
+        with app.app_context():
+            u = _ensure_inbox(seed, 'owner_b')
+            old_token = u.inbox_token
+            old_address = u.inbox_address
+
+            rotate_inbox_address(u)
+            assert u.inbox_token != old_token
+            assert u.inbox_address != old_address
+
+
+# ---------------------------------------------------------------------------
+# parse_recipient
+# ---------------------------------------------------------------------------
+
+class TestParseRecipient:
+    def test_parses_valid_address(self):
+        addr = build_address('chris.nichols', 'abcd2345')
+        slug, token, alias = parse_recipient(addr)
+        assert slug == 'chris.nichols'
+        assert token == 'abcd2345'
+        assert alias is None
+
+    def test_parses_plus_alias(self):
+        addr = f'chris.nichols-abcd2345+leads@{get_inbox_domain()}'
+        slug, token, alias = parse_recipient(addr)
+        assert slug == 'chris.nichols'
+        assert token == 'abcd2345'
+        assert alias == 'leads'
+
+    def test_rejects_wrong_domain(self):
+        addr = 'chris.nichols-abcd2345@example.com'
+        assert parse_recipient(addr) == (None, None, None)
+
+    def test_rejects_no_dash(self):
+        addr = f'chrisnichols@{get_inbox_domain()}'
+        assert parse_recipient(addr) == (None, None, None)
+
+    def test_rejects_short_token(self):
+        addr = f'chris.nichols-short@{get_inbox_domain()}'
+        assert parse_recipient(addr) == (None, None, None)
+
+    def test_rejects_invalid_token_chars(self):
+        addr = f'chris.nichols-AAAA1111@{get_inbox_domain()}'
+        # Uppercase 'A' is in alphabet (lowercase only); '1' is not.
+        slug, token, alias = parse_recipient(addr)
+        assert slug is None and token is None
+
+    def test_lowercases_address(self):
+        addr = f'Chris.Nichols-Abcd2345@{get_inbox_domain().upper()}'
+        slug, token, _ = parse_recipient(addr)
+        assert slug == 'chris.nichols'
+        assert token == 'abcd2345'
+
+
+# ---------------------------------------------------------------------------
+# Undo token
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures('app')
+class TestUndoToken:
+    def test_round_trip(self, app):
+        from services.sendgrid_outbound import (
+            make_undo_token, parse_undo_token, verify_undo_token,
+        )
+        with app.app_context():
+            tok = make_undo_token(42)
+            assert verify_undo_token(tok) == 42
+            assert parse_undo_token(tok) == {'inbound_id': 42}
+
+    def test_contact_specific_token(self, app):
+        from services.sendgrid_outbound import (
+            make_undo_token, parse_undo_token, verify_undo_token,
+        )
+        with app.app_context():
+            tok = make_undo_token(42, contact_id=7)
+            assert verify_undo_token(tok) == 42
+            assert parse_undo_token(tok) == {
+                'inbound_id': 42,
+                'contact_id': 7,
+            }
+
+    def test_tampered_token_rejected(self, app):
+        from services.sendgrid_outbound import (
+            make_undo_token, verify_undo_token,
+        )
+        with app.app_context():
+            tok = make_undo_token(42)
+            assert verify_undo_token(tok + 'x') is None
+
+    def test_garbage_token_rejected(self, app):
+        from services.sendgrid_outbound import verify_undo_token
+        with app.app_context():
+            assert verify_undo_token('not-a-token') is None
+            assert verify_undo_token('') is None
+
+
+class TestSendGridTemplateData:
+    def test_welcome_uses_dynamic_template_when_configured(self, app, seed):
+        from services.sendgrid_outbound import send_inbox_welcome
+
+        with app.app_context(), app.test_request_context('/'):
+            user = _ensure_inbox(seed, 'owner_a')
+            with patch('services.sendgrid_outbound._send_template',
+                       return_value=True) as send_template, \
+                    patch('services.sendgrid_outbound._send_html') as send_html:
+                assert send_inbox_welcome(user) is True
+
+            send_template.assert_called_once()
+            _, template_id, data = send_template.call_args.args[:3]
+            assert template_id == 'd-d89070c074554464a728867471e173e1'
+            assert data['inbox_address'] == user.inbox_address
+            assert data['inbound_domain'] == get_inbox_domain()
+            assert data['vcard_url'].endswith('/inbox/vcard')
+            assert data['inbox_url'].endswith('/inbox')
+            send_html.assert_not_called()
+
+    def test_receipt_data_has_per_contact_view_and_undo_urls(
+            self, app, seed):
+        from services.sendgrid_outbound import _receipt_template_data
+
+        with app.app_context(), app.test_request_context('/'):
+            user = _ensure_inbox(seed, 'owner_a')
+            c1 = Contact(
+                user_id=user.id,
+                organization_id=user.organization_id,
+                created_by_id=user.id,
+                first_name='Janet',
+                last_name='Hill',
+                email='janet.hill@example.com',
+            )
+            c2 = Contact(
+                user_id=user.id,
+                organization_id=user.organization_id,
+                created_by_id=user.id,
+                first_name='Daniel',
+                last_name='Reyes',
+                email='dreyes@example.com',
+            )
+            db.session.add_all([c1, c2])
+            db.session.flush()
+
+            data = _receipt_template_data(
+                [c1, c2],
+                inbound_id=99,
+                subject='Saved 2 contacts to your CRM',
+                inbound_recipient=user.inbox_address,
+                sender_email=user.email,
+                source_kind='csv',
+                source_subject='Weekend leads',
+                skipped_count=1,
+            )
+
+            assert data['count_label'] == '2 new contacts'
+            assert data['saved_pronoun'] == 'them'
+            assert data['source_kind'] == 'CSV'
+            assert data['skipped_label'] == '1 entry'
+            assert data['contacts_url'].endswith('/contacts')
+            assert data['inbox_url'].endswith('/inbox')
+            assert len(data['contacts']) == 2
+            for row in data['contacts']:
+                assert row['view_url'].endswith(f"/contact/{row['id']}")
+                assert '/inbox/undo/' in row['undo_url']
+
+
+# ---------------------------------------------------------------------------
+# Payload normalizer
+# ---------------------------------------------------------------------------
+
+class _FakeFile:
+    """Minimal stand-in for werkzeug FileStorage."""
+
+    def __init__(self, filename, mimetype, data):
+        self.filename = filename
+        self.mimetype = mimetype
+        self._data = data
+
+    def read(self):
+        return self._data
+
+
+class TestNormalizer:
+    def test_empty_payload(self):
+        bundle = normalize_sendgrid_payload({}, {})
+        assert isinstance(bundle, NormalizedInbound)
+        assert bundle.cleaned_text == ''
+        assert bundle.image_blocks == []
+        assert bundle.source_kind == 'text'
+
+    def test_text_only(self):
+        form = {
+            'subject': 'Quick intro',
+            'from': 'Sarah Chen <sarah@example.com>',
+            'text': 'Adding a new client. 555-123-9999',
+        }
+        bundle = normalize_sendgrid_payload(form, {})
+        assert 'SUBJECT: Quick intro' in bundle.cleaned_text
+        assert 'FROM: Sarah Chen' in bundle.cleaned_text
+        assert '555-123-9999' in bundle.cleaned_text
+        assert bundle.image_blocks == []
+        assert bundle.source_kind == 'text'
+
+    def test_html_stripped_when_no_text(self):
+        form = {
+            'subject': 'X',
+            'html': '<p>Hello <b>Sarah</b></p><div>email: sarah@x.com</div>',
+        }
+        bundle = normalize_sendgrid_payload(form, {})
+        # Tags gone, content kept, whitespace squashed.
+        assert '<p>' not in bundle.cleaned_text
+        assert 'Hello Sarah' in bundle.cleaned_text
+        assert 'sarah@x.com' in bundle.cleaned_text
+
+    def test_vcard_attachment_passthrough(self):
+        vcf = (b'BEGIN:VCARD\r\nVERSION:3.0\r\n'
+               b'FN:Sarah Chen\r\nEMAIL:sarah@example.com\r\nEND:VCARD\r\n')
+        files = {'attachment1': _FakeFile('sarah.vcf', 'text/vcard', vcf)}
+        bundle = normalize_sendgrid_payload({}, files)
+        assert 'BEGIN:VCARD' in bundle.cleaned_text
+        assert 'sarah@example.com' in bundle.cleaned_text
+        assert bundle.source_kind == 'vcard'
+
+    def test_csv_truncated_above_limit(self):
+        rows = ['name,email']
+        rows += [f'Person {i},p{i}@x.com' for i in range(MAX_CSV_ROWS + 50)]
+        csv_bytes = '\n'.join(rows).encode('utf-8')
+        files = {'attachment1': _FakeFile('big.csv', 'text/csv', csv_bytes)}
+        bundle = normalize_sendgrid_payload({}, files)
+        assert bundle.over_limit_csv is True
+        assert bundle.skipped_csv_rows >= 50
+        assert 'TRUNCATED' in bundle.cleaned_text
+        assert bundle.source_kind == 'csv'
+
+    def test_unknown_attachment_type_skipped(self):
+        files = {'attachment1': _FakeFile(
+            'mystery.bin', 'application/octet-stream', b'\x00\x01\x02')}
+        bundle = normalize_sendgrid_payload({}, files)
+        assert bundle.cleaned_text == ''
+        assert bundle.image_blocks == []
+
+    def test_image_attachment_classified(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip('Pillow not installed')
+
+        # Build a real 64x64 PNG so the normalizer can decode it.
+        img = Image.new('RGB', (64, 64), color=(220, 80, 80))
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+        files = {'attachment1': _FakeFile(
+            'card.png', 'image/png', buf.getvalue())}
+        bundle = normalize_sendgrid_payload({}, files)
+        assert len(bundle.image_blocks) == 1
+        assert bundle.source_kind == 'image'
+
+    def test_extra_images_above_limit_skipped(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip('Pillow not installed')
+
+        img = Image.new('RGB', (32, 32), color='blue')
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+        png = buf.getvalue()
+
+        files = {f'attachment{i}': _FakeFile(f'i{i}.png', 'image/png', png)
+                 for i in range(1, 8)}
+        bundle = normalize_sendgrid_payload({}, files)
+        assert len(bundle.image_blocks) == 5
+        assert bundle.skipped_images == 2
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (process_inbound) — AI is mocked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures('app')
+class TestOrchestrator:
+    def _bundle(self, text='SUBJECT: hi', images=None,
+                kind='text', plus_alias=None):
+        return NormalizedInbound(
+            cleaned_text=text,
+            image_blocks=images or [],
+            source_kind=kind,
+            plus_alias=plus_alias,
+        )
+
+    def _new_message(self, user, plus_alias=None):
+        m = InboundMessage(
+            organization_id=user.organization_id,
+            user_id=user.id,
+            recipient_address=user.inbox_address,
+            sender_email=user.email,
+            subject='Test',
+            plus_alias=plus_alias,
+            source_kind='text',
+            status='received',
+        )
+        db.session.add(m)
+        db.session.commit()
+        return m
+
+    def test_creates_new_contact(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            msg = self._new_message(user)
+            ai_payload = {
+                'contacts': [{
+                    'first_name': 'Sarah', 'last_name': 'Chen',
+                    'email': 'sarah.chen@example.com', 'phone': '555-123-9999',
+                    'street_address': None, 'city': None,
+                    'state': None, 'zip_code': None,
+                    'notes': 'Met at open house', 'confidence': 'high',
+                }],
+                '_meta': {'model': 'gpt-5.4-nano',
+                          'tokens_in': 100, 'tokens_out': 30},
+            }
+            with patch('services.contact_extraction.generate_contact_extraction',
+                       return_value=ai_payload):
+                result = process_inbound(user, msg, self._bundle())
+
+            assert result['status'] == 'processed'
+            assert len(result['created_contacts']) == 1
+            c = result['created_contacts'][0]
+            assert c.first_name == 'Sarah'
+            assert c.email == 'sarah.chen@example.com'
+            db.session.refresh(msg)
+            assert msg.status == 'processed'
+            assert msg.created_contact_ids == [c.id]
+            assert msg.ai_model == 'gpt-5.4-nano'
+            assert msg.ai_tokens_in == 100
+            # Cost should be a positive Decimal.
+            assert msg.ai_cost_cents is not None
+            assert float(msg.ai_cost_cents) > 0
+
+    def test_dedupes_against_existing_email(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            existing = Contact.query.get(seed['contact_a'])  # jane@test.com
+            msg = self._new_message(user)
+            ai_payload = {
+                'contacts': [{
+                    'first_name': 'Jane', 'last_name': 'Doe',
+                    'email': existing.email, 'phone': None,
+                    'street_address': None, 'city': None,
+                    'state': None, 'zip_code': None,
+                    'notes': None, 'confidence': 'high',
+                }],
+                '_meta': {'model': 'gpt-5.4-nano',
+                          'tokens_in': 10, 'tokens_out': 5},
+            }
+            with patch('services.contact_extraction.generate_contact_extraction',
+                       return_value=ai_payload):
+                result = process_inbound(user, msg, self._bundle())
+
+            assert result['created_contacts'] == []
+            db.session.refresh(msg)
+            assert msg.status == 'rejected'
+            assert 'dupes=1' in (msg.error_message or '')
+
+    def test_drops_self_reference(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            msg = self._new_message(user)
+            ai_payload = {
+                'contacts': [{
+                    'first_name': 'Alice', 'last_name': 'Owner',
+                    'email': user.email, 'phone': None,
+                    'street_address': None, 'city': None,
+                    'state': None, 'zip_code': None,
+                    'notes': None, 'confidence': 'high',
+                }],
+                '_meta': {'model': 'gpt-5.4-nano',
+                          'tokens_in': 10, 'tokens_out': 5},
+            }
+            with patch('services.contact_extraction.generate_contact_extraction',
+                       return_value=ai_payload):
+                result = process_inbound(user, msg, self._bundle())
+
+            assert result['created_contacts'] == []
+            db.session.refresh(msg)
+            assert msg.status == 'rejected'
+
+    def test_resolves_group_via_plus_alias(self, app, seed):
+        """Self-contained: provision our own group rather than relying on the
+        seeded `Buyers` group, which other test files (e.g. test_admin) may
+        have renamed in earlier tests in the same session."""
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            target = ContactGroup(
+                name='InboxAliasGroup',
+                organization_id=user.organization_id,
+                category='custom',
+                sort_order=99,
+            )
+            db.session.add(target)
+            db.session.commit()
+
+            try:
+                msg = self._new_message(user, plus_alias='inboxaliasgroup')
+                ai_payload = {
+                    'contacts': [{
+                        'first_name': 'New', 'last_name': 'Lead',
+                        'email': 'newlead@example.com', 'phone': None,
+                        'street_address': None, 'city': None,
+                        'state': None, 'zip_code': None,
+                        'notes': None, 'confidence': 'high',
+                    }],
+                    '_meta': {'model': 'gpt-5.4-nano',
+                              'tokens_in': 10, 'tokens_out': 5},
+                }
+                with patch(
+                    'services.contact_extraction.generate_contact_extraction',
+                    return_value=ai_payload,
+                ):
+                    result = process_inbound(
+                        user, msg,
+                        self._bundle(plus_alias='inboxaliasgroup'))
+
+                assert len(result['created_contacts']) == 1
+                c = result['created_contacts'][0]
+                assert target in c.groups
+            finally:
+                db.session.delete(target)
+                db.session.commit()
+
+    def test_rejects_empty_payload(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            msg = self._new_message(user)
+            bundle = NormalizedInbound(cleaned_text='', image_blocks=[])
+            result = process_inbound(user, msg, bundle)
+            assert result['status'] == 'rejected'
+            db.session.refresh(msg)
+            assert msg.status == 'rejected'
+
+    def test_low_confidence_no_signal_dropped(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            msg = self._new_message(user)
+            ai_payload = {
+                'contacts': [{
+                    'first_name': 'Maybe', 'last_name': 'Someone',
+                    'email': None, 'phone': None,
+                    'street_address': None, 'city': None,
+                    'state': None, 'zip_code': None,
+                    'notes': None, 'confidence': 'low',
+                }],
+                '_meta': {'model': 'gpt-5.4-nano',
+                          'tokens_in': 10, 'tokens_out': 5},
+            }
+            with patch('services.contact_extraction.generate_contact_extraction',
+                       return_value=ai_payload):
+                result = process_inbound(user, msg, self._bundle())
+            assert result['created_contacts'] == []
+
+
+# ---------------------------------------------------------------------------
+# /inbox UI
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures('app')
+class TestInboxRoute:
+    def test_logged_out_redirects(self, client):
+        rv = client.get('/inbox', follow_redirects=False)
+        assert rv.status_code in (301, 302)
+
+    def test_logged_in_renders_address(self, app, seed, owner_a_client):
+        with app.app_context():
+            _ensure_inbox(seed, 'owner_a')
+            user = _user(seed, 'owner_a')
+            address = user.inbox_address
+
+        rv = owner_a_client.get('/inbox')
+        assert rv.status_code == 200
+        body = rv.data.decode('utf-8')
+        assert address in body
+        assert 'Magic Inbox' in body
+
+    def test_vcard_download(self, app, seed, owner_a_client):
+        with app.app_context():
+            _ensure_inbox(seed, 'owner_a')
+        rv = owner_a_client.get('/inbox/vcard')
+        assert rv.status_code == 200
+        assert rv.mimetype == 'text/vcard'
+        body = rv.data.decode('utf-8')
+        assert 'BEGIN:VCARD' in body
+        assert 'Origen Inbox' in body
+
+    def test_dismiss_onboarding_persists(self, app, seed, owner_a_client):
+        with app.app_context():
+            user = _user(seed, 'owner_a')
+            user.has_seen_inbox_onboarding = False
+            db.session.commit()
+
+        rv = owner_a_client.post('/inbox/dismiss-onboarding',
+                                 follow_redirects=False)
+        assert rv.status_code in (200, 204, 302)
+
+        with app.app_context():
+            user = _user(seed, 'owner_a')
+            assert user.has_seen_inbox_onboarding is True
+
+
+@pytest.mark.usefixtures('app')
+class TestUndoRoute:
+    def _make_inbound_with_contacts(self, seed):
+        user = _ensure_inbox(seed, 'owner_a')
+        c1 = Contact(
+            user_id=user.id,
+            organization_id=user.organization_id,
+            created_by_id=user.id,
+            first_name='Undo',
+            last_name='One',
+            email='undo.one@example.com',
+        )
+        c2 = Contact(
+            user_id=user.id,
+            organization_id=user.organization_id,
+            created_by_id=user.id,
+            first_name='Keep',
+            last_name='Two',
+            email='keep.two@example.com',
+        )
+        db.session.add_all([c1, c2])
+        db.session.flush()
+        msg = InboundMessage(
+            organization_id=user.organization_id,
+            user_id=user.id,
+            recipient_address=user.inbox_address,
+            sender_email=user.email,
+            subject='Undo route test',
+            source_kind='text',
+            status='processed',
+            created_contact_ids=[c1.id, c2.id],
+        )
+        db.session.add(msg)
+        db.session.commit()
+        return msg.id, c1.id, c2.id
+
+    def test_contact_specific_undo_only_removes_one_contact(
+            self, app, seed, client):
+        from services.sendgrid_outbound import make_undo_token
+
+        with app.app_context():
+            inbound_id, remove_id, keep_id = self._make_inbound_with_contacts(
+                seed)
+            token = make_undo_token(inbound_id, contact_id=remove_id)
+
+        rv = client.get(f'/inbox/undo/{token}', follow_redirects=False)
+        assert rv.status_code in (301, 302)
+
+        with app.app_context():
+            msg = InboundMessage.query.get(inbound_id)
+            assert Contact.query.get(remove_id) is None
+            assert Contact.query.get(keep_id) is not None
+            assert msg.status == 'processed'
+            assert msg.created_contact_ids == [keep_id]
+
+    def test_batch_undo_still_removes_all_contacts(self, app, seed, client):
+        from services.sendgrid_outbound import make_undo_token
+
+        with app.app_context():
+            inbound_id, remove_id, keep_id = self._make_inbound_with_contacts(
+                seed)
+            token = make_undo_token(inbound_id)
+
+        rv = client.get(f'/inbox/undo/{token}', follow_redirects=False)
+        assert rv.status_code in (301, 302)
+
+        with app.app_context():
+            msg = InboundMessage.query.get(inbound_id)
+            assert Contact.query.get(remove_id) is None
+            assert Contact.query.get(keep_id) is None
+            assert msg.status == 'rejected'
+            assert msg.created_contact_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Webhook end-to-end (signature off, AI mocked)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.usefixtures('app')
+class TestWebhook:
+    @pytest.fixture(autouse=True)
+    def _no_inbox_secrets(self, monkeypatch):
+        """These tests exercise non-auth behavior. Ensure the shared-secret
+        and public-key env vars are unset so the webhook accepts requests
+        even when the developer ran tests after `source .env`."""
+        monkeypatch.delenv('SENDGRID_INBOUND_WEBHOOK_SECRET', raising=False)
+        monkeypatch.delenv('SENDGRID_INBOUND_PUBLIC_KEY', raising=False)
+
+    def _post(self, client, recipient, **extra):
+        form = {
+            'to': recipient,
+            'from': 'sender@example.com',
+            'subject': 'Forwarded contact',
+            'text': 'Hi! Adding Sarah Chen, sarah@example.com, 555-123-9999.',
+            'envelope': json.dumps({'to': [recipient],
+                                    'from': 'sender@example.com'}),
+            'spam_score': '0.0',
+        }
+        form.update(extra)
+        return client.post('/webhooks/sendgrid/inbound-parse', data=form)
+
+    def test_unknown_recipient_returns_200(self, client):
+        rv = self._post(
+            client, f'unknown-aaaa2345@{get_inbox_domain()}')
+        assert rv.status_code == 200
+
+    def test_high_spam_score_dropped(self, app, seed, client):
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        rv = self._post(client, recipient, spam_score='9.5')
+        assert rv.status_code == 200
+        with app.app_context():
+            # Webhook should still record nothing AI-processed for spam drops.
+            count = (InboundMessage.query
+                     .filter_by(user_id=seed['agent_a'])
+                     .count())
+            # Spam is dropped before persisting any row.
+            assert count == 0
+
+    def test_happy_path_creates_contact(self, app, seed, client):
+        from services.ai_service import INBOX_PRIMARY_MODEL  # noqa: F401
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        ai_payload = {
+            'contacts': [{
+                'first_name': 'Sarah', 'last_name': 'Chen',
+                'email': 'sarah.webhook@example.com', 'phone': '555-321-7777',
+                'street_address': None, 'city': None,
+                'state': None, 'zip_code': None,
+                'notes': 'From webhook test', 'confidence': 'high',
+            }],
+            '_meta': {'model': 'gpt-5.4-nano',
+                      'tokens_in': 100, 'tokens_out': 25},
+        }
+
+        with patch('services.contact_extraction.generate_contact_extraction',
+                   return_value=ai_payload):
+            rv = self._post(client, recipient)
+
+        assert rv.status_code == 200
+        with app.app_context():
+            created = (Contact.query
+                       .filter_by(email='sarah.webhook@example.com')
+                       .all())
+            assert len(created) == 1
+            inbound = (InboundMessage.query
+                       .filter_by(user_id=seed['agent_a'])
+                       .order_by(InboundMessage.id.desc())
+                       .first())
+            assert inbound is not None
+            assert inbound.status == 'processed'
+            assert created[0].id in (inbound.created_contact_ids or [])
+
+    def test_ai_failure_marks_failed_but_returns_200(self, app, seed, client):
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        with patch('services.contact_extraction.generate_contact_extraction',
+                   side_effect=RuntimeError('boom')):
+            rv = self._post(client, recipient)
+
+        assert rv.status_code == 200
+        with app.app_context():
+            inbound = (InboundMessage.query
+                       .filter_by(user_id=seed['agent_a'])
+                       .order_by(InboundMessage.id.desc())
+                       .first())
+            assert inbound is not None
+            assert inbound.status == 'failed'
+            assert 'boom' in (inbound.error_message or '')
+
+
+# ---------------------------------------------------------------------------
+# Webhook authentication (shared secret + public key fallbacks)
+# ---------------------------------------------------------------------------
+
+class TestWebhookAuth:
+    """Shared-secret auth is the realistic path for SendGrid Inbound Parse,
+    which doesn't natively sign requests. We accept the secret either as a
+    ``?secret=`` query param (what SendGrid configures) or an
+    ``X-Inbound-Secret`` header (for reverse proxies)."""
+
+    SECRET = 'super-secret-token-abc123'
+
+    def _post(self, client, recipient, *, url_secret=None, header_secret=None):
+        url = '/webhooks/sendgrid/inbound-parse'
+        if url_secret is not None:
+            url = f'{url}?secret={url_secret}'
+        headers = {}
+        if header_secret is not None:
+            headers['X-Inbound-Secret'] = header_secret
+        form = {
+            'to': recipient,
+            'from': 'sender@example.com',
+            'subject': 'Auth probe',
+            'text': 'Sarah Chen, sarah@example.com, 555-123-9999.',
+            'envelope': json.dumps({'to': [recipient],
+                                    'from': 'sender@example.com'}),
+            'spam_score': '0.0',
+        }
+        return client.post(url, data=form, headers=headers)
+
+    def test_missing_secret_when_required_drops_silently(
+            self, app, seed, client, monkeypatch):
+        """When the secret is configured but the request omits it, we still
+        return 200 (SendGrid won't retry on 4xx anyway) but the message must
+        not be persisted or processed."""
+        monkeypatch.setenv('SENDGRID_INBOUND_WEBHOOK_SECRET', self.SECRET)
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+            before = InboundMessage.query.filter_by(
+                user_id=seed['agent_a']).count()
+
+        with patch('services.contact_extraction.generate_contact_extraction'
+                   ) as ai:
+            rv = self._post(client, recipient)
+
+        assert rv.status_code == 200
+        ai.assert_not_called()
+        with app.app_context():
+            after = InboundMessage.query.filter_by(
+                user_id=seed['agent_a']).count()
+            assert after == before, (
+                'Auth-failed webhook hit must not persist an InboundMessage')
+
+    def test_wrong_secret_dropped(self, app, seed, client, monkeypatch):
+        monkeypatch.setenv('SENDGRID_INBOUND_WEBHOOK_SECRET', self.SECRET)
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+            before = InboundMessage.query.filter_by(
+                user_id=seed['agent_a']).count()
+
+        with patch('services.contact_extraction.generate_contact_extraction'
+                   ) as ai:
+            rv = self._post(client, recipient, url_secret='not-the-secret')
+
+        assert rv.status_code == 200
+        ai.assert_not_called()
+        with app.app_context():
+            after = InboundMessage.query.filter_by(
+                user_id=seed['agent_a']).count()
+            assert after == before
+
+    def test_secret_via_query_param_accepted(
+            self, app, seed, client, monkeypatch):
+        monkeypatch.setenv('SENDGRID_INBOUND_WEBHOOK_SECRET', self.SECRET)
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        ai_payload = {
+            'contacts': [{
+                'first_name': 'Auth', 'last_name': 'OkQuery',
+                'email': 'auth.okquery@example.com', 'phone': '555-000-1111',
+                'street_address': None, 'city': None, 'state': None,
+                'zip_code': None, 'notes': '', 'confidence': 'high',
+            }],
+            '_meta': {'model': 'gpt-5.4-nano',
+                      'tokens_in': 50, 'tokens_out': 10},
+        }
+        with patch('services.contact_extraction.generate_contact_extraction',
+                   return_value=ai_payload):
+            rv = self._post(client, recipient, url_secret=self.SECRET)
+
+        assert rv.status_code == 200
+        with app.app_context():
+            assert Contact.query.filter_by(
+                email='auth.okquery@example.com').count() == 1
+
+    def test_secret_via_header_accepted(
+            self, app, seed, client, monkeypatch):
+        """Lets a reverse proxy strip the ?secret= from the URL and forward it
+        as a header instead."""
+        monkeypatch.setenv('SENDGRID_INBOUND_WEBHOOK_SECRET', self.SECRET)
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        ai_payload = {
+            'contacts': [{
+                'first_name': 'Auth', 'last_name': 'OkHeader',
+                'email': 'auth.okheader@example.com', 'phone': '555-000-2222',
+                'street_address': None, 'city': None, 'state': None,
+                'zip_code': None, 'notes': '', 'confidence': 'high',
+            }],
+            '_meta': {'model': 'gpt-5.4-nano',
+                      'tokens_in': 50, 'tokens_out': 10},
+        }
+        with patch('services.contact_extraction.generate_contact_extraction',
+                   return_value=ai_payload):
+            rv = self._post(client, recipient, header_secret=self.SECRET)
+
+        assert rv.status_code == 200
+        with app.app_context():
+            assert Contact.query.filter_by(
+                email='auth.okheader@example.com').count() == 1
+
+    def test_no_secret_configured_accepts_unverified(
+            self, app, seed, client, monkeypatch):
+        """Backwards compat: in dev with neither env var set, requests are
+        accepted with a warning so devs can iterate without ngrok."""
+        monkeypatch.delenv('SENDGRID_INBOUND_WEBHOOK_SECRET', raising=False)
+        monkeypatch.delenv('SENDGRID_INBOUND_PUBLIC_KEY', raising=False)
+        with app.app_context():
+            user = _ensure_inbox(seed, 'agent_a')
+            recipient = user.inbox_address
+
+        ai_payload = {
+            'contacts': [{
+                'first_name': 'Dev', 'last_name': 'Noauth',
+                'email': 'dev.noauth@example.com', 'phone': '555-000-3333',
+                'street_address': None, 'city': None, 'state': None,
+                'zip_code': None, 'notes': '', 'confidence': 'high',
+            }],
+            '_meta': {'model': 'gpt-5.4-nano',
+                      'tokens_in': 50, 'tokens_out': 10},
+        }
+        with patch('services.contact_extraction.generate_contact_extraction',
+                   return_value=ai_payload):
+            rv = self._post(client, recipient)
+
+        assert rv.status_code == 200
+        with app.app_context():
+            assert Contact.query.filter_by(
+                email='dev.noauth@example.com').count() == 1


### PR DESCRIPTION
## Summary
- Add Magic Inbox forwarding addresses, SendGrid Inbound Parse webhook handling, AI contact extraction, dedupe, per-contact undo, and receipt/welcome emails through SendGrid Dynamic Templates.
- Surface the Magic Inbox across onboarding, sidebar navigation, dashboard, contacts empty state, profile, and a dedicated `/inbox` page with QR/vCard support and activity history.
- Add migration, local simulator, backfill script, operator runbook, and focused Magic Inbox test coverage.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`53 passed`)
- [x] Linter diagnostics on touched Magic Inbox files show no errors
- [x] Local HTTP simulator exercised real AI flow: webhook -> Supabase archive -> OpenAI extraction -> contacts -> notifications -> SendGrid receipt path
- [ ] Full `python3 -m pytest -q` currently fails because of an existing/shared test DB isolation issue (`sqlite3.OperationalError: no such table: user` after test DB teardown/order interaction). Focused Magic Inbox suite is green.

## Operator notes
- Railway/prod needs `INBOUND_REPLY_FROM=info@origentechnolog.com`, `SENDGRID_INBOX_WELCOME_TEMPLATE_ID`, `SENDGRID_INBOX_RECEIPT_TEMPLATE_ID`, `SENDGRID_INBOUND_WEBHOOK_SECRET`, and `INBOUND_EMAIL_DOMAIN` set before end-to-end production testing.
- SendGrid Inbound Parse destination should include `?secret=<SENDGRID_INBOUND_WEBHOOK_SECRET>`.

Made with [Cursor](https://cursor.com)