### PR TITLE
fix: handle large Magic Inbox webhook payloads

### DIFF
--- a/routes/inbound_email.py
+++ b/routes/inbound_email.py
@@ -30,6 +30,7 @@ from flask import (
 from flask_login import current_user, login_required
 from markupsafe import Markup
 from sqlalchemy import text
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from models import Contact, InboundMessage, User, db
 from services.contact_extraction import process_inbound
@@ -53,6 +54,12 @@ inbound_bp = Blueprint('inbound_email', __name__)
 PER_USER_DAILY_LIMIT = 200
 PER_ORG_DAILY_LIMIT = 1000
 RAW_RETENTION_BUCKET = os.getenv('INBOUND_RAW_BUCKET', 'inbound-email-raw')
+INBOUND_MAX_CONTENT_LENGTH = int(
+    os.getenv('INBOUND_MAX_CONTENT_MB', '25')
+) * 1024 * 1024
+INBOUND_MAX_FORM_MEMORY_SIZE = int(
+    os.getenv('INBOUND_MAX_FORM_MEMORY_MB', '8')
+) * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +71,8 @@ def sendgrid_inbound_parse():
     """SendGrid Inbound Parse handler. Always returns 200."""
     org_context_set = False
     try:
+        _raise_inbound_parse_limits()
+
         if not _verify_signature(request):
             logger.warning('Magic Inbox: webhook signature invalid — dropping.')
             return ('ok', 200)
@@ -148,6 +157,16 @@ def sendgrid_inbound_parse():
         process_inbound(user, message, bundle)
         return ('ok', 200)
 
+    except RequestEntityTooLarge:
+        logger.warning(
+            'Magic Inbox: inbound payload exceeded parser limit '
+            '(content_length=%s max_content_length=%s '
+            'max_form_memory_size=%s).',
+            request.content_length,
+            INBOUND_MAX_CONTENT_LENGTH,
+            INBOUND_MAX_FORM_MEMORY_SIZE,
+        )
+        return ('ok', 200)
     except Exception:
         logger.exception('Magic Inbox: unhandled error in inbound webhook.')
         try:
@@ -352,6 +371,12 @@ def rotate():
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _raise_inbound_parse_limits() -> None:
+    """Allow realistic SendGrid Parse payloads without lifting app-wide caps."""
+    request.max_content_length = INBOUND_MAX_CONTENT_LENGTH
+    request.max_form_memory_size = INBOUND_MAX_FORM_MEMORY_SIZE
+
+
 def _set_webhook_org_context(org_id: int) -> bool:
     """Set RLS org context for the whole DB connection during this webhook.
 
@@ -411,20 +436,24 @@ def _verify_signature(req) -> bool:
         SENDGRID_INBOUND_PUBLIC_KEY       →  signed event webhook check
         (neither set)                     →  accept with a warning
     """
-    secret = os.getenv('SENDGRID_INBOUND_WEBHOOK_SECRET')
+    secret = (os.getenv('SENDGRID_INBOUND_WEBHOOK_SECRET') or '').strip()
     if secret:
-        provided = (req.args.get('secret')
-                    or req.headers.get('X-Inbound-Secret')
-                    or '')
-        if not _consteq(provided.strip(), secret.strip()):
+        provided_query = req.args.get('secret') or ''
+        provided_header = req.headers.get('X-Inbound-Secret') or ''
+        provided = (provided_query or provided_header).strip()
+        if not _consteq(provided, secret):
+            source = ('query' if provided_query else
+                      'header' if provided_header else
+                      'missing')
             logger.warning(
-                'Magic Inbox: shared-secret check failed (provided_len=%d).',
-                len(provided or ''),
+                'Magic Inbox: shared-secret check failed '
+                '(source=%s provided_len=%d expected_len=%d).',
+                source, len(provided), len(secret),
             )
             return False
         return True
 
-    pub_key = os.getenv('SENDGRID_INBOUND_PUBLIC_KEY')
+    pub_key = (os.getenv('SENDGRID_INBOUND_PUBLIC_KEY') or '').strip()
     if pub_key:
         sig = (req.headers.get('X-Twilio-Email-Event-Webhook-Signature')
                or req.headers.get('X-Sendgrid-Signature'))

--- a/services/sendgrid_outbound.py
+++ b/services/sendgrid_outbound.py
@@ -38,23 +38,45 @@ DEFAULT_WELCOME_TEMPLATE_ID = 'd-d89070c074554464a728867471e173e1'
 DEFAULT_RECEIPT_TEMPLATE_ID = 'd-f3ef49fcfb80406ab22ec2d0bf87c0e7'
 
 
+def _env_value(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
 def _reply_from() -> str:
-    return os.getenv('INBOUND_REPLY_FROM') or DEFAULT_REPLY_FROM
+    return _env_value('INBOUND_REPLY_FROM') or DEFAULT_REPLY_FROM
 
 
 def _welcome_template_id() -> str:
-    return (os.getenv('SENDGRID_INBOX_WELCOME_TEMPLATE_ID')
+    return (_env_value('SENDGRID_INBOX_WELCOME_TEMPLATE_ID')
             or DEFAULT_WELCOME_TEMPLATE_ID)
 
 
 def _receipt_template_id() -> str:
-    return (os.getenv('SENDGRID_INBOX_RECEIPT_TEMPLATE_ID')
+    return (_env_value('SENDGRID_INBOX_RECEIPT_TEMPLATE_ID')
             or DEFAULT_RECEIPT_TEMPLATE_ID)
 
 
 def _sendgrid_api_key() -> str | None:
-    return (os.getenv('SENDGRID_API_KEY')
+    return (_env_value('SENDGRID_API_KEY')
             or current_app.config.get('SENDGRID_API_KEY'))
+
+
+def _sendgrid_error_body(exc: Exception):
+    body = getattr(exc, 'body', None)
+    if body is None:
+        body = getattr(exc, 'response_body', None)
+    if isinstance(body, bytes):
+        return body.decode('utf-8', 'replace')
+    return body
+
+
+def _sendgrid_error_status(exc: Exception):
+    return (getattr(exc, 'status_code', None)
+            or getattr(exc, 'code', None))
 
 
 def _serializer() -> URLSafeTimedSerializer:
@@ -141,8 +163,14 @@ def _send_html(to_email: str, subject: str, html: str,
                 response.status_code, getattr(response, 'body', None),
             )
         return ok
-    except Exception:
-        logger.exception('Magic Inbox SendGrid send failed to=%s', to_email)
+    except Exception as exc:
+        logger.exception(
+            'Magic Inbox SendGrid send failed to=%s from=%s status=%s body=%r',
+            to_email,
+            _reply_from(),
+            _sendgrid_error_status(exc),
+            _sendgrid_error_body(exc),
+        )
         return False
 
 
@@ -176,10 +204,15 @@ def _send_template(to_email: str, template_id: str, data: dict,
                 template_id, response.status_code, getattr(response, 'body', None),
             )
         return ok
-    except Exception:
+    except Exception as exc:
         logger.exception(
-            'Magic Inbox SendGrid template send failed template_id=%s to=%s',
-            template_id, to_email,
+            'Magic Inbox SendGrid template send failed template_id=%s '
+            'to=%s from=%s status=%s body=%r',
+            template_id,
+            to_email,
+            _reply_from(),
+            _sendgrid_error_status(exc),
+            _sendgrid_error_body(exc),
         )
         return False
 

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import inspect
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from models import (
     Contact,
@@ -850,6 +851,14 @@ class TestWebhook:
             assert inbound is not None
             assert inbound.status == 'failed'
             assert 'boom' in (inbound.error_message or '')
+
+    def test_oversized_payload_returns_200(self, client):
+        with patch('routes.inbound_email._resolve_recipient',
+                   side_effect=RequestEntityTooLarge()):
+            rv = self._post(
+                client, f'big-file-aaaa2345@{get_inbox_domain()}')
+
+        assert rv.status_code == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Raise request parsing limits only for the SendGrid Inbound Parse webhook so normal emails with attachments can reach Magic Inbox normalization.
- Return `200` with a clean warning when a payload still exceeds the bounded webhook limit, avoiding SendGrid retry storms.
- Trim Magic Inbox email env values and log safe SendGrid diagnostics for sender/template failures.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`54 passed`)
- [x] Linter diagnostics on touched files show no errors

Made with [Cursor](https://cursor.com)