### PR TITLE
fix: parse raw Magic Inbox email payloads

### DIFF
--- a/scripts/backfill_inbox_addresses.py
+++ b/scripts/backfill_inbox_addresses.py
@@ -3,7 +3,7 @@ Backfill Magic Inbox addresses for all existing users.
 
 By default this script does a dry run that reports how many users still
 need provisioning. Pass ``--commit`` to actually allocate addresses, and
-``--announce`` to send the welcome/announcement email at the same time.
+``--send-welcome`` to send the welcome/announcement email at the same time.
 
 Usage:
     # Show how many users still need an address (no writes).
@@ -13,17 +13,19 @@ Usage:
     python3 scripts/backfill_inbox_addresses.py --commit
 
     # Provision + send the announcement to every user that just got one.
-    python3 scripts/backfill_inbox_addresses.py --commit --announce
+    python3 scripts/backfill_inbox_addresses.py --commit --send-welcome \
+        --base-url https://www.origentechnolog.com
 
     # Re-send the announcement to users who already had an address
     # (useful for a one-off relaunch email — pair with --commit).
-    python3 scripts/backfill_inbox_addresses.py --commit --announce \
-        --include-existing
+    python3 scripts/backfill_inbox_addresses.py --commit --send-welcome \
+        --include-existing --base-url https://www.origentechnolog.com
 
 Safety:
 - The provisioning loop commits per user, so a single bad row does not
   poison the rest of the run.
-- ``--announce`` is best-effort. SendGrid failures are logged and the
+- No emails are sent during dry runs, even with ``--send-welcome``.
+- ``--send-welcome`` is best-effort. SendGrid failures are logged and the
   script keeps going. Re-running with the same flags is safe.
 """
 from __future__ import annotations
@@ -32,6 +34,8 @@ import argparse
 import logging
 import os
 import sys
+import time
+from contextlib import nullcontext
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -57,32 +61,74 @@ def _eligible_users(include_existing: bool):
     return q.order_by(User.id.asc()).all()
 
 
+def _normalize_base_url(value: str | None) -> str | None:
+    value = (value or '').strip().rstrip('/')
+    if not value:
+        return None
+    if not value.startswith(('http://', 'https://')):
+        value = f'https://{value}'
+    return value
+
+
+def _default_base_url() -> str | None:
+    # Prefer explicit app URL envs, then Railway's public domain if present.
+    for name in ('APP_BASE_URL', 'PUBLIC_APP_URL', 'BASE_URL',
+                 'RAILWAY_PUBLIC_DOMAIN'):
+        base_url = _normalize_base_url(os.getenv(name))
+        if base_url:
+            return base_url
+    return None
+
+
+def _request_context(base_url: str | None):
+    if not base_url:
+        return nullcontext()
+    return app.test_request_context('/', base_url=base_url)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--commit', action='store_true',
                         help='Actually write to the database. '
                              'Default is dry-run.')
-    parser.add_argument('--announce', action='store_true',
-                        help='Send send_inbox_welcome() to each affected user.')
+    parser.add_argument('--send-welcome', '--announce',
+                        dest='send_welcome', action='store_true',
+                        help='Send send_inbox_welcome() to each affected user. '
+                             'Never sends during dry runs.')
     parser.add_argument('--include-existing', action='store_true',
                         help='Also process users that already have an address. '
                              'Useful for re-sending the announcement.')
     parser.add_argument('--limit', type=int, default=0,
                         help='Stop after N users (0 = no limit).')
+    parser.add_argument('--base-url', default=_default_base_url(),
+                        help='Public app URL used for email links, e.g. '
+                             'https://www.origentechnolog.com. Required when '
+                             'sending welcome emails unless APP_BASE_URL, '
+                             'PUBLIC_APP_URL, BASE_URL, or '
+                             'RAILWAY_PUBLIC_DOMAIN is set.')
+    parser.add_argument('--sleep', type=float, default=0.0,
+                        help='Seconds to pause between welcome emails.')
     args = parser.parse_args()
+    args.base_url = _normalize_base_url(args.base_url)
+
+    if args.send_welcome and args.commit and not args.base_url:
+        parser.error('--send-welcome requires --base-url or an app URL env var')
 
     with app.app_context():
         users = _eligible_users(args.include_existing)
         if args.limit:
             users = users[: args.limit]
 
-        logger.info('Found %d users to process (commit=%s, announce=%s, '
-                    'include_existing=%s).',
-                    len(users), args.commit, args.announce,
-                    args.include_existing)
+        logger.info(
+            'Found %d users to process (commit=%s, send_welcome=%s, '
+            'include_existing=%s, base_url=%s).',
+            len(users), args.commit, args.send_welcome,
+            args.include_existing, args.base_url or 'none',
+        )
 
         provisioned = 0
         skipped = 0
+        would_email = 0
         emailed = 0
         failed_provision = 0
         failed_email = 0
@@ -95,6 +141,10 @@ def main() -> int:
                     logger.info('  [dry-run] would provision user_id=%s '
                                 'email=%s', u.id, u.email)
                     provisioned += 1
+                    if args.send_welcome and u.email:
+                        logger.info('  [dry-run] would email user_id=%s '
+                                    'email=%s', u.id, u.email)
+                        would_email += 1
                     continue
                 try:
                     provision_inbox_address(u, commit=False)
@@ -109,24 +159,37 @@ def main() -> int:
                     continue
             else:
                 skipped += 1
+                if args.send_welcome and not args.commit and u.email:
+                    logger.info('  [dry-run] would email existing user_id=%s '
+                                'email=%s', u.id, u.email)
+                    would_email += 1
 
-            if args.announce and (args.commit or had_address):
+            if args.send_welcome and args.commit:
                 try:
-                    send_inbox_welcome(u)
-                    emailed += 1
+                    with _request_context(args.base_url):
+                        if send_inbox_welcome(u):
+                            emailed += 1
+                        else:
+                            failed_email += 1
+                            logger.warning(
+                                '  announcement email returned false '
+                                'user_id=%s email=%s', u.id, u.email)
                 except Exception:
                     failed_email += 1
                     logger.exception('  failed announcement email user_id=%s',
                                      u.id)
+                if args.sleep > 0:
+                    time.sleep(args.sleep)
 
         logger.info(
-            'Done. provisioned=%d skipped(existing)=%d emailed=%d '
+            'Done. provisioned=%d skipped(existing)=%d would_email=%d emailed=%d '
             'errors(provision)=%d errors(email)=%d',
-            provisioned, skipped, emailed, failed_provision, failed_email,
+            provisioned, skipped, would_email, emailed,
+            failed_provision, failed_email,
         )
 
         if not args.commit:
-            logger.warning('Dry run only. Re-run with --commit to apply.')
+            logger.warning('Dry run only. No database writes or emails were sent.')
 
     return 0
 

--- a/services/inbound_payload.py
+++ b/services/inbound_payload.py
@@ -10,9 +10,11 @@ which makes a single AI call regardless of source kind.
 from __future__ import annotations
 
 import base64
+import email
 import io
 import logging
 import re
+from email import policy
 from dataclasses import dataclass, field
 from typing import Iterable
 
@@ -113,8 +115,18 @@ def normalize_sendgrid_payload(form: dict, files: dict | None = None,
     if body_text:
         text_chunks.append('BODY:\n' + body_text)
 
+    raw_body_chunks, raw_attachments = _extract_raw_email_parts(
+        form.get('email') or ''
+    )
+    for chunk in raw_body_chunks:
+        text_chunks.append(chunk)
+    has_body_text = bool(body_text or raw_body_chunks)
+
     # --- Attachments -----------------------------------------------------
-    for filename, mime, raw_bytes in _iter_attachments(form, files):
+    for filename, mime, raw_bytes in [
+        *_iter_attachments(form, files),
+        *raw_attachments,
+    ]:
         mime = (mime or '').lower()
         kind = _classify(mime, filename)
         attachment_summary.append({
@@ -179,7 +191,7 @@ def normalize_sendgrid_payload(form: dict, files: dict | None = None,
     return NormalizedInbound(
         cleaned_text=cleaned_text,
         image_blocks=image_blocks,
-        source_kind=_summarize_kind(attachment_kinds, has_text=bool(body_text),
+        source_kind=_summarize_kind(attachment_kinds, has_text=has_body_text,
                                     has_image=bool(image_blocks)),
         plus_alias=plus_alias,
         truncated_text=truncated,
@@ -219,6 +231,69 @@ def _iter_attachments(form, files) -> Iterable[tuple[str, str, bytes]]:
             getattr(f, 'mimetype', None) or getattr(f, 'content_type', None) or '',
             data,
         )
+
+
+def _extract_raw_email_parts(raw_email: str) -> tuple[list[str],
+                                                     list[tuple[str, str, bytes]]]:
+    """Extract body text + attachments from SendGrid's raw ``email`` field.
+
+    SendGrid Inbound Parse can send either parsed ``attachmentN`` files or the
+    full original MIME message in the ``email`` form field. Large Gmail/iOS
+    photo shares often arrive as raw MIME only, so we parse it here and feed
+    the same cost-limited normalizer path.
+    """
+    raw_email = raw_email or ''
+    if not raw_email:
+        return [], []
+
+    try:
+        msg = email.message_from_string(raw_email, policy=policy.default)
+    except Exception:
+        logger.exception('Failed parsing raw inbound email MIME.')
+        return [], []
+
+    body_chunks: list[str] = []
+    attachments: list[tuple[str, str, bytes]] = []
+    parts = list(msg.walk()) if msg.is_multipart() else [msg]
+
+    for part in parts:
+        if part.is_multipart():
+            continue
+
+        mime = (part.get_content_type() or '').lower()
+        disposition = (part.get_content_disposition() or '').lower()
+        filename = part.get_filename() or ''
+
+        try:
+            payload = part.get_payload(decode=True)
+        except Exception:
+            payload = None
+
+        if payload is None:
+            try:
+                content = part.get_content()
+                payload = (content.encode('utf-8')
+                           if isinstance(content, str) else b'')
+            except Exception:
+                payload = b''
+
+        if not payload:
+            continue
+
+        is_body = disposition != 'attachment' and mime in {
+            'text/plain', 'text/html',
+        }
+        if is_body:
+            text = (_strip_html(_decode_text(payload[:MAX_TEXT_BYTES]))
+                    if mime == 'text/html'
+                    else _decode_text(payload[:MAX_TEXT_BYTES]))
+            if text:
+                body_chunks.append(f'RAW EMAIL BODY:\n{text}')
+            continue
+
+        attachments.append((filename, mime, payload))
+
+    return body_chunks, attachments
 
 
 def _classify(mime: str, filename: str) -> str:

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import io
 import json
+from email.message import EmailMessage
 from unittest.mock import patch
 
 import pytest
@@ -410,6 +411,31 @@ class TestNormalizer:
         files = {'attachment1': _FakeFile(
             'card.png', 'image/png', buf.getvalue())}
         bundle = normalize_sendgrid_payload({}, files)
+        assert len(bundle.image_blocks) == 1
+        assert bundle.source_kind == 'image'
+
+    def test_raw_email_field_image_classified(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip('Pillow not installed')
+
+        img = Image.new('RGB', (64, 64), color=(80, 120, 220))
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+
+        msg = EmailMessage()
+        msg['Subject'] = 'Contact screenshot'
+        msg.set_content('See attached contact card.')
+        msg.add_attachment(
+            buf.getvalue(),
+            maintype='image',
+            subtype='png',
+            filename='contact-card.png',
+        )
+
+        bundle = normalize_sendgrid_payload({'email': msg.as_string()}, {})
+        assert 'See attached contact card' in bundle.cleaned_text
         assert len(bundle.image_blocks) == 1
         assert bundle.source_kind == 'image'
 

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -391,6 +391,24 @@ class TestNormalizer:
         assert 'TRUNCATED' in bundle.cleaned_text
         assert bundle.source_kind == 'csv'
 
+    def test_raw_email_field_csv_attachment(self):
+        csv_bytes = b'name,email,phone\nJames Aikens,james@example.com,6038121777\n'
+        msg = EmailMessage()
+        msg['Subject'] = 'CSV contacts'
+        msg.set_content('Import these contacts.')
+        msg.add_attachment(
+            csv_bytes,
+            maintype='text',
+            subtype='csv',
+            filename='contacts.csv',
+        )
+
+        bundle = normalize_sendgrid_payload({'email': msg.as_string()}, {})
+        assert 'ATTACHMENT CSV (contacts.csv)' in bundle.cleaned_text
+        assert 'James Aikens' in bundle.cleaned_text
+        assert 'james@example.com' in bundle.cleaned_text
+        assert bundle.source_kind == 'csv'
+
     def test_unknown_attachment_type_skipped(self):
         files = {'attachment1': _FakeFile(
             'mystery.bin', 'application/octet-stream', b'\x00\x01\x02')}


### PR DESCRIPTION
## Summary
- Parse SendGrid's raw `email` MIME field so Gmail/iOS image shares still feed images into the Magic Inbox AI path when SendGrid does not provide parsed `attachmentN` files.
- Verified the archived production payload now normalizes to one image attachment (`IMG_0088.png`) instead of text-only.
- Harden the Magic Inbox backfill script so dry runs never send email and welcome emails require a real production base URL.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`55 passed`)
- [x] Linter diagnostics on touched files show no errors
- [x] Validated archived production payload: `image_blocks=1`, `source_kind=image`

Made with [Cursor](https://cursor.com)