### PR TITLE
feat: make Magic Inbox QR save contact

### DIFF
--- a/routes/inbound_email.py
+++ b/routes/inbound_email.py
@@ -275,7 +275,7 @@ def inbox_home():
                         .all())
         activity.append({'message': m, 'contacts': contacts})
 
-    qr_svg = _qr_svg_markup(f'mailto:{current_user.inbox_address}'
+    qr_svg = _qr_svg_markup(_inbox_vcard(current_user.inbox_address)
                             if current_user.inbox_address else '')
 
     return render_template(
@@ -290,7 +290,7 @@ def inbox_home():
 
 
 def _qr_svg_markup(payload: str) -> Markup:
-    """Render an inline SVG QR pointing at ``payload`` (typically ``mailto:``).
+    """Render an inline SVG QR pointing at ``payload``.
 
     Falls back to an empty string if ``segno`` is unavailable so the page
     still renders without the QR.
@@ -324,7 +324,18 @@ def download_vcard():
               'info')
         return redirect(url_for('inbound_email.inbox_home'))
 
-    vcf = (
+    vcf = _inbox_vcard(address)
+    return send_file(
+        BytesIO(vcf.encode('utf-8')),
+        mimetype='text/vcard',
+        as_attachment=True,
+        download_name='origen-inbox.vcf',
+    )
+
+
+def _inbox_vcard(address: str) -> str:
+    """Build the contact card used by both QR and vCard download."""
+    return (
         'BEGIN:VCARD\r\n'
         'VERSION:3.0\r\n'
         'PRODID:-//OrigenTechnolOG//Magic Inbox//EN\r\n'
@@ -335,12 +346,6 @@ def download_vcard():
         'NOTE:Forward emails or share photos to this contact and they '
         'land in your CRM automatically.\r\n'
         'END:VCARD\r\n'
-    )
-    return send_file(
-        BytesIO(vcf.encode('utf-8')),
-        mimetype='text/vcard',
-        as_attachment=True,
-        download_name='origen-inbox.vcf',
     )
 
 

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -98,7 +98,7 @@
             <div class="rounded-md border border-slate-200 bg-white p-3">
               {{ qr_svg }}
             </div>
-            <p class="mt-2 text-xs text-slate-500">Scan with your phone</p>
+            <p class="mt-2 text-xs text-slate-500">Scan to save this contact</p>
           </div>
         </div>
 

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -694,6 +694,28 @@ class TestInboxRoute:
         assert address in body
         assert 'Magic Inbox' in body
 
+    def test_qr_payload_is_contact_vcard(self, app, seed, owner_a_client):
+        with app.app_context():
+            _ensure_inbox(seed, 'owner_a')
+            user = _user(seed, 'owner_a')
+            address = user.inbox_address
+
+        captured = {}
+
+        def _capture_qr(payload):
+            captured['payload'] = payload
+            return ''
+
+        with patch('routes.inbound_email._qr_svg_markup',
+                   side_effect=_capture_qr):
+            rv = owner_a_client.get('/inbox')
+
+        assert rv.status_code == 200
+        assert captured['payload'].startswith('BEGIN:VCARD')
+        assert 'FN:Origen Inbox' in captured['payload']
+        assert f'EMAIL;TYPE=INTERNET;TYPE=PREF:{address}' in captured['payload']
+        assert not captured['payload'].startswith('mailto:')
+
     def test_vcard_download(self, app, seed, owner_a_client):
         with app.app_context():
             _ensure_inbox(seed, 'owner_a')


### PR DESCRIPTION
## Summary
- Encode the Magic Inbox QR as a vCard contact instead of a `mailto:` link, so scanning it prompts users to save `Origen Inbox` to their phone contacts.
- Reuse the same vCard builder for both the QR payload and `/inbox/vcard` download.
- Update the inbox UI hint to `Scan to save this contact`.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`57 passed`)
- [x] Linter diagnostics on touched files show no errors

Made with [Cursor](https://cursor.com)