### PR TITLE
feat: add account welcome email template

### DIFF
--- a/email_templates/magic_link_account_welcome.html
+++ b/email_templates/magic_link_account_welcome.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<title>Your Magic Inbox is live</title>
+<title>Welcome to Origen</title>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap" rel="stylesheet">
 <style>
   body, table, td, p, a, li { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
@@ -14,7 +14,7 @@
   @media only screen and (max-width: 600px) {
     .container { width: 100% !important; }
     .pad-lg { padding: 32px 24px !important; }
-    .hero-title { font-size: 38px !important; }
+    .hero-title { font-size: 36px !important; }
     .hero-pad { padding: 40px 28px 36px !important; }
     .stack-cell { display: block !important; width: 100% !important; padding: 0 0 12px 0 !important; }
   }
@@ -23,7 +23,7 @@
 <body style="margin:0; padding:0; background:#f0f4f8;">
 
 <div style="display:none; max-height:0; overflow:hidden;">
-  Forward a business card. Get a contact back. Your private Magic Inbox is ready.
+  Welcome to Origen. Start by saving your Magic Inbox and adding your first contacts.
 </div>
 
 <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f0f4f8;">
@@ -39,40 +39,48 @@
           <span style="color:#102a43;">Origen Technol</span><span style="color:#f97316;">OG</span>
         </td>
         <td align="right" style="font-family:'DM Sans',sans-serif; font-size:11px; font-weight:600; color:#94a3b8; letter-spacing:1.2px; text-transform:uppercase;">
-          New &middot; Magic Inbox
+          Welcome
         </td>
       </tr>
     </table>
   </td></tr>
 
   <!-- ===== Hero ===== -->
-  <tr><td class="hero-pad" style="background:linear-gradient(160deg,#0b1b2b 0%,#102a43 55%,#1a3a5c 100%); padding:56px 48px 52px; position:relative;">
-    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
-      <tr><td>
-        <p style="margin:0 0 18px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#f97316; letter-spacing:2.4px; text-transform:uppercase;">
-          ✦ &nbsp;Introducing Magic Inbox
-        </p>
-        <h1 class="hero-title" style="margin:0 0 18px 0; font-family:'Fraunces','DM Sans',serif; font-size:46px; line-height:1.05; font-weight:500; color:#ffffff; letter-spacing:-0.5px;">
-          Forward&nbsp;anything.<br>
-          <em style="font-style:italic; color:#f97316; font-weight:500;">Get a contact back.</em>
-        </h1>
-        <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:16px; line-height:1.6; color:#a8c3df; max-width:440px;">
-          Photos of business cards. Forwarded intros. Messy email signatures. CSVs from the conference.
-          Send any of it to one private address &mdash; we'll handle the typing.
-        </p>
-      </td></tr>
-    </table>
+  <tr><td class="hero-pad" style="background:linear-gradient(160deg,#0b1b2b 0%,#102a43 55%,#1a3a5c 100%); padding:56px 48px 52px;">
+    <p style="margin:0 0 18px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#f97316; letter-spacing:2.4px; text-transform:uppercase;">
+      Welcome to Origen
+    </p>
+    <h1 class="hero-title" style="margin:0 0 18px 0; font-family:'Fraunces','DM Sans',serif; font-size:44px; line-height:1.06; font-weight:500; color:#ffffff; letter-spacing:-0.5px;">
+      Your CRM is ready.<br>
+      <em style="font-style:italic; color:#f97316; font-weight:500;">Start with contacts.</em>
+    </h1>
+    <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:16px; line-height:1.6; color:#a8c3df; max-width:448px;">
+      Thanks for joining Origen. You do not need to set up everything today.
+      Save your Magic Inbox, send it a few contacts, and let the CRM start filling in.
+    </p>
   </td></tr>
 
-  <!-- ===== The Address (the hero asset) ===== -->
+  <!-- ===== Personal note ===== -->
   <tr><td style="padding:36px 48px 8px; background:#ffffff;">
+    <p style="margin:0 0 16px 0; font-family:'DM Sans',sans-serif; font-size:16px; color:#334e68; line-height:1.65;">
+      Hi {{first_name}},
+    </p>
+    <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:15px; color:#334e68; line-height:1.7;">
+      Origen is built to help you keep up with the real work: contacts,
+      follow-up, transactions, notes, documents, and the small details that
+      are easy to lose when the day gets busy.
+    </p>
+  </td></tr>
+
+  <!-- ===== Magic Inbox address ===== -->
+  <tr><td style="padding:28px 48px 8px; background:#ffffff;">
     <p style="margin:0 0 12px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#627d98; letter-spacing:1.6px; text-transform:uppercase;">
-      Your private address
+      First, save your Magic Inbox
     </p>
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f8fafc; border:1px solid #dbe4ee; border-radius:12px;">
       <tr><td style="padding:16px 18px;">
         <p style="margin:0 0 6px 0; font-family:'DM Sans',sans-serif; font-size:10px; font-weight:700; color:#f97316; letter-spacing:1.3px; text-transform:uppercase;">
-          Magic Inbox address
+          Your private contact import address
         </p>
         <p style="margin:0; font-family:'SF Mono','JetBrains Mono',Menlo,Consolas,monospace; font-size:12px; line-height:1.45; color:#102a43; word-break:break-all; overflow-wrap:anywhere; letter-spacing:-0.35px;">
           <a href="mailto:{{inbox_address}}" style="color:#102a43 !important; text-decoration:none !important;">{{inbox_address}}</a>
@@ -80,7 +88,7 @@
       </td></tr>
     </table>
     <p style="margin:10px 0 0 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#94a3b8; line-height:1.5;">
-      Private to your account. Rotate anytime from your profile.
+      Forward emails, signatures, business card photos, vCards, and small CSVs here.
     </p>
   </td></tr>
 
@@ -90,22 +98,22 @@
       <tr>
         <td class="stack-cell" valign="top" style="padding-right:8px;">
           <a href="{{vcard_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:linear-gradient(135deg,#f97316 0%,#ea580c 100%); color:#ffffff; font-size:15px; font-weight:600; text-decoration:none; padding:15px 16px; border-radius:10px; box-shadow:0 8px 22px rgba(249,115,22,0.32);">
-            Add to my phone contacts &nbsp;↓
+            Save Magic Inbox
           </a>
         </td>
         <td class="stack-cell" valign="top" style="padding-left:8px;">
-          <a href="{{inbox_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:#ffffff; color:#102a43; font-size:15px; font-weight:600; text-decoration:none; padding:13px 16px; border-radius:10px; border:1.5px solid #e2e8f0;">
-            Open Magic Inbox
+          <a href="{{dashboard_url}}" style="display:block; text-align:center; font-family:'DM Sans',sans-serif; background:#ffffff; color:#102a43; font-size:15px; font-weight:600; text-decoration:none; padding:13px 16px; border-radius:10px; border:1.5px solid #e2e8f0;">
+            Open Origen
           </a>
         </td>
       </tr>
     </table>
   </td></tr>
 
-  <!-- ===== Three-step story ===== -->
+  <!-- ===== Getting started ===== -->
   <tr><td class="pad-lg" style="padding:44px 48px 32px; background:#ffffff;">
     <p style="margin:0 0 22px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#627d98; letter-spacing:1.6px; text-transform:uppercase;">
-      How it works
+      A simple way to start
     </p>
 
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
@@ -115,9 +123,9 @@
             <tr>
               <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">01</td>
               <td valign="top">
-                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">Forward, share, or snap.</p>
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">Save Magic Inbox to your phone.</p>
                 <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
-                  An email signature, a vCard, a photo of a business card &mdash; whatever's in front of you.
+                  Add it as a contact named Origen Inbox. Next time you meet someone, share the card, screenshot, or email right to it.
                 </p>
               </td>
             </tr>
@@ -130,9 +138,9 @@
             <tr>
               <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">02</td>
               <td valign="top">
-                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">We read between the lines.</p>
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">Send in five contacts.</p>
                 <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
-                  Name, role, company, phone, email, address. Deduped against your contacts. No copy-paste.
+                  Use a business card photo, a forwarded intro, an email signature, a vCard, or a small CSV. Origen reads it and saves the contact.
                 </p>
               </td>
             </tr>
@@ -145,9 +153,9 @@
             <tr>
               <td valign="top" width="44" style="font-family:'Fraunces',serif; font-size:28px; font-weight:500; color:#f97316; line-height:1; padding-top:2px;">03</td>
               <td valign="top">
-                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">A reply lands in your inbox.</p>
+                <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#102a43;">Work from the dashboard.</p>
                 <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14px; color:#627d98; line-height:1.6;">
-                  With a <strong style="color:#102a43;">View</strong> link and a 24-hour <strong style="color:#102a43;">Undo</strong>. Mistakes happen. We've got you.
+                  Add follow-up tasks, keep notes, and move active deals forward. Start small. The system gets more useful as your contacts come in.
                 </p>
               </td>
             </tr>
@@ -157,31 +165,32 @@
     </table>
   </td></tr>
 
-  <!-- ===== Pro tip callout ===== -->
+  <!-- ===== Quick links ===== -->
   <tr><td style="padding:0 48px 40px; background:#ffffff;">
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#fff7ed; border-radius:14px;">
       <tr><td style="padding:22px 24px;">
-        <p style="margin:0 0 6px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#c2410c; letter-spacing:1.4px; text-transform:uppercase;">
-          ★ &nbsp;Pro tip
+        <p style="margin:0 0 10px 0; font-family:'DM Sans',sans-serif; font-size:11px; font-weight:700; color:#c2410c; letter-spacing:1.4px; text-transform:uppercase;">
+          Good first clicks
         </p>
-        <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14.5px; color:#7c2d12; line-height:1.6;">
-          Save the address as <strong>&ldquo;Origen Inbox&rdquo;</strong> in your phone contacts.
-          Next handshake at an open house, snap the card, share it to that contact &mdash; done before you walk to your car.
+        <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:14.5px; color:#7c2d12; line-height:1.7;">
+          Open <a href="{{contacts_url}}" style="color:#7c2d12; font-weight:700;">Contacts</a> to review what you have added.
+          Open <a href="{{inbox_url}}" style="color:#7c2d12; font-weight:700;">Magic Inbox</a> to copy your address, save the QR contact, or see recent activity.
         </p>
       </td></tr>
     </table>
   </td></tr>
 
-  <!-- ===== Power-user line ===== -->
+  <!-- ===== Human note ===== -->
   <tr><td style="padding:0 48px 40px; background:#ffffff;">
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
       <tr>
         <td style="border-top:1px dashed #cbd5e1; padding-top:22px;">
-          <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.7;">
-            <strong style="color:#102a43;">Power move:</strong>
-            append <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+buyers</code>
-            or <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+sellers</code>
-            before the @ to drop new contacts straight into the right group.
+          <p style="margin:0 0 12px 0; font-family:'DM Sans',sans-serif; font-size:13.5px; color:#627d98; line-height:1.7;">
+            One honest recommendation: do not start by cleaning every old spreadsheet.
+            Send in the contacts you are working right now. That is where Origen will help fastest.
+          </p>
+          <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13.5px; color:#627d98; line-height:1.7;">
+            Glad you are here.
           </p>
         </td>
       </tr>
@@ -196,14 +205,11 @@
     <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#829ab1;">
       The Real Estate CRM Built for Serious Agents
     </p>
-    <p style="margin:0 0 14px 0; font-family:'DM Sans',sans-serif; font-size:12px; color:#cbd5e1; letter-spacing:8px;">
-      • • •
-    </p>
     <p style="margin:0 0 4px 0; font-family:'DM Sans',sans-serif; font-size:11px; color:#9fb3c8;">
-      Sent to you because you have a Magic Inbox at {{inbound_domain}}
+      Sent to you because you created an Origen account.
     </p>
     <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:11px; color:#9fb3c8;">
-      © {{year}} Origen TechnolOG. All rights reserved.
+      &copy; {{year}} Origen TechnolOG. All rights reserved.
     </p>
   </td></tr>
 
@@ -217,9 +223,11 @@
 
 <!-- test data -->
 {
-    "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
-    "vcard_url": "https://app.origentechnolog.com/inbox/vcard",
-    "inbox_url": "https://app.origentechnolog.com/inbox",
-    "inbound_domain": "inbox.origentechnolog.com",
-    "year": "2026"
-  }
+  "first_name": "Chris",
+  "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
+  "vcard_url": "https://app.origentechnolog.com/inbox/vcard",
+  "dashboard_url": "https://app.origentechnolog.com/dashboard",
+  "contacts_url": "https://app.origentechnolog.com/contacts",
+  "inbox_url": "https://app.origentechnolog.com/inbox",
+  "year": "2026"
+}

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -164,12 +164,12 @@ def register():
             )
 
         try:
-            from services.sendgrid_outbound import send_inbox_welcome
+            from services.sendgrid_outbound import send_account_welcome
             if user.inbox_address:
-                send_inbox_welcome(user)
+                send_account_welcome(user)
         except Exception:
             current_app.logger.exception(
-                'Failed to send magic inbox welcome email user_id=%s',
+                'Failed to send account welcome email user_id=%s',
                 user.id,
             )
 
@@ -365,12 +365,12 @@ def complete_invite(token):
         )
 
     try:
-        from services.sendgrid_outbound import send_inbox_welcome
+        from services.sendgrid_outbound import send_account_welcome
         if user.inbox_address:
-            send_inbox_welcome(user)
+            send_account_welcome(user)
     except Exception:
         current_app.logger.exception(
-            'Failed to send magic inbox welcome email user_id=%s', user.id,
+            'Failed to send account welcome email user_id=%s', user.id,
         )
 
     login_user(user)

--- a/services/sendgrid_outbound.py
+++ b/services/sendgrid_outbound.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_REPLY_FROM = 'info@origentechnolog.com'
 DEFAULT_REPLY_NAME = 'Origen Inbox'
 UNDO_TOKEN_MAX_AGE = 24 * 3600  # 24h, per the plan
+DEFAULT_ACCOUNT_WELCOME_TEMPLATE_ID = 'd-8ca289d2b7fa4778a8c4b3d10992aab5'
 DEFAULT_WELCOME_TEMPLATE_ID = 'd-d89070c074554464a728867471e173e1'
 DEFAULT_RECEIPT_TEMPLATE_ID = 'd-f3ef49fcfb80406ab22ec2d0bf87c0e7'
 
@@ -53,6 +54,11 @@ def _reply_from() -> str:
 def _welcome_template_id() -> str:
     return (_env_value('SENDGRID_INBOX_WELCOME_TEMPLATE_ID')
             or DEFAULT_WELCOME_TEMPLATE_ID)
+
+
+def _account_welcome_template_id() -> str:
+    return (_env_value('SENDGRID_ACCOUNT_WELCOME_TEMPLATE_ID')
+            or DEFAULT_ACCOUNT_WELCOME_TEMPLATE_ID)
 
 
 def _receipt_template_id() -> str:
@@ -444,8 +450,66 @@ def _format_email_time(value: datetime | None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 2) Welcome — sent at signup and from the backfill announcement
+# 2) Welcome emails
 # ---------------------------------------------------------------------------
+
+def send_account_welcome(user) -> bool:
+    """Send the general new-account welcome email.
+
+    This is used for brand-new registrations and completed invites. The older
+    Magic Inbox feature email stays available through ``send_inbox_welcome``
+    for backfills and release announcements to existing users.
+    """
+    if not user or not user.email or not user.inbox_address:
+        return False
+
+    dashboard_url = _safe_url('main.dashboard')
+    contacts_url = _safe_url('main.contacts')
+    inbox_url = _safe_url('inbound_email.inbox_home')
+    vcard_url = _safe_url('inbound_email.download_vcard')
+
+    subject = 'Welcome to Origen'
+    template_data = _account_welcome_template_data(
+        first_name=(getattr(user, 'first_name', None) or 'there').strip(),
+        inbox_address=user.inbox_address,
+        vcard_url=vcard_url,
+        dashboard_url=dashboard_url,
+        contacts_url=contacts_url,
+        inbox_url=inbox_url,
+    )
+    if _send_template(
+        user.email,
+        _account_welcome_template_id(),
+        template_data,
+        subject=subject,
+    ):
+        return True
+
+    html = _wrap_html(
+        title='Welcome to Origen',
+        body=f"""
+            <h1 style="margin:0 0 12px;font-size:22px;color:#0f172a">
+                Welcome to Origen.
+            </h1>
+            <p style="margin:0 0 16px;color:#475569;font-size:15px">
+                Your CRM is ready. Start by saving your Magic Inbox and sending
+                in a few contacts you are working right now.
+            </p>
+            <p style="margin:0 0 24px">
+                <code style="display:inline-block;background:#f1f5f9;padding:10px 14px;
+                       border-radius:8px;font-size:13px;color:#0f172a;
+                       border:1px solid #e2e8f0;font-family:'SF Mono',Menlo,monospace">
+                    {_html(user.inbox_address)}
+                </code>
+            </p>
+            <p style="margin:24px 0 0">
+                <a class="btn-primary" href="{vcard_url}">Save Magic Inbox</a>
+                <a class="btn-secondary" href="{dashboard_url}">Open Origen</a>
+            </p>
+        """,
+    )
+    return _send_html(user.email, subject, html)
+
 
 def send_inbox_welcome(user) -> bool:
     if not user or not user.email or not user.inbox_address:
@@ -520,6 +584,20 @@ def send_inbox_welcome(user) -> bool:
         """,
     )
     return _send_html(user.email, subject, html)
+
+
+def _account_welcome_template_data(*, first_name: str, inbox_address: str,
+                                   vcard_url: str, dashboard_url: str,
+                                   contacts_url: str, inbox_url: str) -> dict:
+    return {
+        'first_name': first_name or 'there',
+        'inbox_address': inbox_address,
+        'vcard_url': vcard_url,
+        'dashboard_url': dashboard_url,
+        'contacts_url': contacts_url,
+        'inbox_url': inbox_url,
+        'year': str(datetime.utcnow().year),
+    }
 
 
 def _welcome_template_data(*, inbox_address: str, vcard_url: str,

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -256,6 +256,28 @@ class TestUndoToken:
 
 
 class TestSendGridTemplateData:
+    def test_account_welcome_uses_dynamic_template_when_configured(
+            self, app, seed):
+        from services.sendgrid_outbound import send_account_welcome
+
+        with app.app_context(), app.test_request_context('/'):
+            user = _ensure_inbox(seed, 'owner_a')
+            with patch('services.sendgrid_outbound._send_template',
+                       return_value=True) as send_template, \
+                    patch('services.sendgrid_outbound._send_html') as send_html:
+                assert send_account_welcome(user) is True
+
+            send_template.assert_called_once()
+            _, template_id, data = send_template.call_args.args[:3]
+            assert template_id == 'd-8ca289d2b7fa4778a8c4b3d10992aab5'
+            assert data['first_name'] == user.first_name
+            assert data['inbox_address'] == user.inbox_address
+            assert data['vcard_url'].endswith('/inbox/vcard')
+            assert data['dashboard_url'].endswith('/dashboard')
+            assert data['contacts_url'].endswith('/contacts')
+            assert data['inbox_url'].endswith('/inbox')
+            send_html.assert_not_called()
+
     def test_welcome_uses_dynamic_template_when_configured(self, app, seed):
         from services.sendgrid_outbound import send_inbox_welcome
 


### PR DESCRIPTION
## Summary
- Add a new SendGrid-ready account welcome email template that introduces Origen and makes Magic Inbox the primary first action.
- Wire registrations and completed invites to `send_account_welcome()` using `SENDGRID_ACCOUNT_WELCOME_TEMPLATE_ID`.
- Keep `send_inbox_welcome()` and `SENDGRID_INBOX_WELCOME_TEMPLATE_ID` for existing-user feature announcements/backfill.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`58 passed`)
- [x] Linter diagnostics checked; only intentional Outlook `mso-table-*` email CSS warnings appear

## Env
Set this in Railway:
`SENDGRID_ACCOUNT_WELCOME_TEMPLATE_ID=d-8ca289d2b7fa4778a8c4b3d10992aab5`

Made with [Cursor](https://cursor.com)