### PR TITLE
feat: improve Magic Inbox email actions

### DIFF
--- a/documentation/magic_inbox.md
+++ b/documentation/magic_inbox.md
@@ -197,6 +197,11 @@ Known-good local smoke result on 2026-04-25:
 - `plus_alias` is optional. `+buyers` will drop the new contact into the
   user's `Buyers` ContactGroup (case-insensitive name match within their
   org). Unmatched aliases are recorded but otherwise ignored.
+- The sender can also type a group instruction in the email body, such as
+  `Group: Buyers` or `add these to Sphere`. The AI extracts the requested
+  group name, and the app attaches contacts only when that group already
+  exists in the user's org. Unmatched names are ignored so typos do not
+  create new groups.
 
 ---
 

--- a/email_templates/magic_link_inbox.html
+++ b/email_templates/magic_link_inbox.html
@@ -179,9 +179,9 @@
         <td style="border-top:1px dashed #cbd5e1; padding-top:22px;">
           <p style="margin:0; font-family:'DM Sans',sans-serif; font-size:13px; color:#627d98; line-height:1.7;">
             <strong style="color:#102a43;">Power move:</strong>
-            append <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+buyers</code>
-            or <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+sellers</code>
-            before the @ to drop new contacts straight into the right group.
+            write <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">Group: Buyers</code>
+            in the email body, or append <code style="font-family:'SF Mono',Menlo,monospace; background:#f1f5f9; padding:2px 6px; border-radius:4px; font-size:12px; color:#0f172a;">+buyers</code>
+            before the @, to drop new contacts straight into the right group.
           </p>
         </td>
       </tr>

--- a/routes/inbound_email.py
+++ b/routes/inbound_email.py
@@ -39,7 +39,7 @@ from services.inbox_provisioning import (
     ensure_inbox_for, get_inbox_domain, parse_recipient, rotate_inbox_address,
 )
 from services.sendgrid_outbound import (
-    parse_undo_token, send_over_limit_notice,
+    parse_undo_token, parse_vcard_token, send_over_limit_notice,
 )
 
 logger = logging.getLogger(__name__)
@@ -325,6 +325,31 @@ def download_vcard():
         return redirect(url_for('inbound_email.inbox_home'))
 
     vcf = _inbox_vcard(address)
+    return send_file(
+        BytesIO(vcf.encode('utf-8')),
+        mimetype='text/vcard',
+        as_attachment=True,
+        download_name='origen-inbox.vcf',
+    )
+
+
+@inbound_bp.route('/inbox/vcard/<token>')
+def public_vcard(token):
+    """Public signed vCard link used by welcome emails.
+
+    The token is tied to the user's current inbox address, so old links stop
+    working after the user rotates their Magic Inbox address.
+    """
+    payload = parse_vcard_token(token)
+    if not payload:
+        abort(404)
+
+    user = User.query.get(payload['user_id'])
+    if (not user or not user.inbox_address or
+            user.inbox_address != payload['inbox_address']):
+        abort(404)
+
+    vcf = _inbox_vcard(user.inbox_address)
     return send_file(
         BytesIO(vcf.encode('utf-8')),
         mimetype='text/vcard',

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -424,7 +424,7 @@ CONTACT_EXTRACTION_SCHEMA = {
                 "required": [
                     "first_name", "last_name", "email", "phone",
                     "street_address", "city", "state", "zip_code",
-                    "notes", "confidence",
+                    "notes", "group_name", "confidence",
                 ],
                 "properties": {
                     "first_name": {"type": ["string", "null"]},
@@ -440,6 +440,15 @@ CONTACT_EXTRACTION_SCHEMA = {
                         "description": (
                             "Brief context: company, title, where the contact "
                             "came from. Keep under 280 chars."
+                        ),
+                    },
+                    "group_name": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Only set when the sender explicitly says which "
+                            "CRM group/tag/list these contacts should go into, "
+                            "for example 'add to Buyers', 'group: Sphere', or "
+                            "'put these in Past Clients'. Otherwise null."
                         ),
                     },
                     "confidence": {
@@ -464,6 +473,11 @@ CONTACT_EXTRACTION_SYSTEM_PROMPT = (
     "Set confidence='high' only when you have at least a full name plus one of "
     "email or phone. Use 'medium' for partial business-card style data, 'low' "
     "for ambiguous mentions. "
+    "If the sender clearly asks to put the contact(s) in a group, tag, bucket, "
+    "or list, copy that requested group name into group_name for each affected "
+    "contact. Examples: 'add these to Buyers', 'group: Sphere', 'tag as Open "
+    "House Leads'. Do not infer a group from the person's job title, company, "
+    "or email content unless the sender explicitly asks for it. "
     "Skip generic mailing-list footers, automated 'do-not-reply' senders, and "
     "the recipient themselves."
 )

--- a/services/contact_extraction.py
+++ b/services/contact_extraction.py
@@ -124,17 +124,23 @@ def _existing_contact_for(user_id: int, *, email: str | None, phone: str | None,
     return None
 
 
-def _resolve_group_for_alias(org_id: int, alias: str | None) -> ContactGroup | None:
-    """Map a plus-alias (`investors` from `you-token+investors@…`) onto an
-    existing ContactGroup in the user's org, if one matches by name (case
-    insensitive). Anything fancier (auto-create groups, etc.) is v2.
-    """
-    if not alias:
+def _group_lookup_key(value: str | None) -> str:
+    return ''.join(ch for ch in (value or '').lower() if ch.isalnum())
+
+
+def _resolve_group_by_name(org_id: int,
+                           requested_name: str | None) -> ContactGroup | None:
+    """Resolve body/alias group hints to an existing group in the org."""
+    key = _group_lookup_key(requested_name)
+    if not key:
         return None
-    return (ContactGroup.query
-            .filter(ContactGroup.organization_id == org_id)
-            .filter(func.lower(ContactGroup.name) == alias.lower())
-            .first())
+    groups = (ContactGroup.query
+              .filter(ContactGroup.organization_id == org_id)
+              .all())
+    for group in groups:
+        if _group_lookup_key(group.name) == key:
+            return group
+    return None
 
 
 def _build_notes(raw_notes: str | None,
@@ -254,6 +260,7 @@ def process_inbound(user: User, message: InboundMessage,
             'state': (entry.get('state') or '').strip() or None,
             'zip_code': (entry.get('zip_code') or '').strip() or None,
             'notes': entry.get('notes'),
+            'group_name': (entry.get('group_name') or '').strip() or None,
         })
 
     # --- Free-tier limit check (per user_id is the contact owner) ------
@@ -267,7 +274,6 @@ def process_inbound(user: User, message: InboundMessage,
                 'reason': limit_reason}
 
     # --- Dedupe + create -----------------------------------------------
-    group = _resolve_group_for_alias(org.id, bundle.plus_alias)
     created: list[Contact] = []
     skipped_dupes = 0
 
@@ -295,6 +301,10 @@ def process_inbound(user: User, message: InboundMessage,
             notes=_build_notes(c['notes'],
                                sender_email=message.sender_email,
                                source_kind=bundle.source_kind),
+        )
+        group = _resolve_group_by_name(
+            org.id,
+            c.get('group_name') or bundle.plus_alias,
         )
         if group is not None:
             contact.groups.append(group)

--- a/services/sendgrid_outbound.py
+++ b/services/sendgrid_outbound.py
@@ -93,6 +93,14 @@ def _serializer() -> URLSafeTimedSerializer:
     )
 
 
+def _vcard_serializer() -> URLSafeTimedSerializer:
+    """Signed serializer for public Magic Inbox vCard download links."""
+    return URLSafeTimedSerializer(
+        current_app.config['SECRET_KEY'],
+        salt='magic-inbox-vcard-v1',
+    )
+
+
 # ---------------------------------------------------------------------------
 # Undo token
 # ---------------------------------------------------------------------------
@@ -138,6 +146,34 @@ def verify_undo_token(token: str) -> int | None:
     """
     payload = parse_undo_token(token)
     return payload['inbound_id'] if payload else None
+
+
+def make_vcard_token(user) -> str | None:
+    """Return a signed token for saving this user's current inbox contact."""
+    if not user or not getattr(user, 'id', None) or not user.inbox_address:
+        return None
+    return _vcard_serializer().dumps({
+        'user_id': int(user.id),
+        'inbox_address': user.inbox_address,
+    })
+
+
+def parse_vcard_token(token: str) -> dict | None:
+    """Return signed vCard payload if valid, else None."""
+    try:
+        payload = _vcard_serializer().loads(token)
+    except BadSignature:
+        logger.info('Magic Inbox vCard token failed signature check.')
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return {
+            'user_id': int(payload['user_id']),
+            'inbox_address': str(payload['inbox_address']),
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +270,13 @@ def _safe_url(endpoint: str, **values) -> str:
             return url_for(endpoint, **values)
         except Exception:
             return '#'
+
+
+def _public_vcard_url(user) -> str:
+    token = make_vcard_token(user)
+    if not token:
+        return _safe_url('inbound_email.download_vcard')
+    return _safe_url('inbound_email.public_vcard', token=token)
 
 
 # ---------------------------------------------------------------------------
@@ -466,7 +509,7 @@ def send_account_welcome(user) -> bool:
     dashboard_url = _safe_url('main.dashboard')
     contacts_url = _safe_url('main.contacts')
     inbox_url = _safe_url('inbound_email.inbox_home')
-    vcard_url = _safe_url('inbound_email.download_vcard')
+    vcard_url = _public_vcard_url(user)
 
     subject = 'Welcome to Origen'
     template_data = _account_welcome_template_data(
@@ -516,7 +559,7 @@ def send_inbox_welcome(user) -> bool:
         return False
 
     inbox_url = _safe_url('inbound_email.inbox_home')
-    vcard_url = _safe_url('inbound_email.download_vcard')
+    vcard_url = _public_vcard_url(user)
 
     subject = 'Stop typing contacts by hand'
     template_data = _welcome_template_data(

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -86,9 +86,9 @@
           </div>
 
           <p class="mt-3 text-xs text-slate-500">
-            Tip: add <span class="font-mono text-slate-700">+leads</span>,
-            <span class="font-mono text-slate-700">+sphere</span>, or any tag
-            before the <span class="font-mono">@</span> to drop new contacts
+            Tip: write <span class="font-mono text-slate-700">Group: Leads</span>
+            in the email body, or add <span class="font-mono text-slate-700">+leads</span>
+            before the <span class="font-mono">@</span>, to drop new contacts
             into a matching group.
           </p>
         </div>

--- a/tests/test_magic_inbox.py
+++ b/tests/test_magic_inbox.py
@@ -272,7 +272,7 @@ class TestSendGridTemplateData:
             assert template_id == 'd-8ca289d2b7fa4778a8c4b3d10992aab5'
             assert data['first_name'] == user.first_name
             assert data['inbox_address'] == user.inbox_address
-            assert data['vcard_url'].endswith('/inbox/vcard')
+            assert '/inbox/vcard/' in data['vcard_url']
             assert data['dashboard_url'].endswith('/dashboard')
             assert data['contacts_url'].endswith('/contacts')
             assert data['inbox_url'].endswith('/inbox')
@@ -293,7 +293,7 @@ class TestSendGridTemplateData:
             assert template_id == 'd-d89070c074554464a728867471e173e1'
             assert data['inbox_address'] == user.inbox_address
             assert data['inbound_domain'] == get_inbox_domain()
-            assert data['vcard_url'].endswith('/inbox/vcard')
+            assert '/inbox/vcard/' in data['vcard_url']
             assert data['inbox_url'].endswith('/inbox')
             send_html.assert_not_called()
 
@@ -693,6 +693,51 @@ class TestOrchestrator:
                 db.session.delete(target)
                 db.session.commit()
 
+    def test_resolves_group_from_email_body_instruction(self, app, seed):
+        from services.contact_extraction import process_inbound
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            target = ContactGroup(
+                name='Open House Leads',
+                organization_id=user.organization_id,
+                category='custom',
+                sort_order=100,
+            )
+            db.session.add(target)
+            db.session.commit()
+
+            try:
+                msg = self._new_message(user)
+                ai_payload = {
+                    'contacts': [{
+                        'first_name': 'Group', 'last_name': 'Lead',
+                        'email': 'group.lead@example.com', 'phone': None,
+                        'street_address': None, 'city': None,
+                        'state': None, 'zip_code': None,
+                        'notes': None, 'group_name': 'open house leads',
+                        'confidence': 'high',
+                    }],
+                    '_meta': {'model': 'gpt-5.4-nano',
+                              'tokens_in': 10, 'tokens_out': 5},
+                }
+                with patch(
+                    'services.contact_extraction.generate_contact_extraction',
+                    return_value=ai_payload,
+                ):
+                    result = process_inbound(
+                        user, msg,
+                        self._bundle(
+                            text='Please add this contact to Open House Leads.'
+                        ))
+
+                assert len(result['created_contacts']) == 1
+                c = result['created_contacts'][0]
+                assert target in c.groups
+            finally:
+                db.session.delete(target)
+                db.session.commit()
+
     def test_rejects_empty_payload(self, app, seed):
         from services.contact_extraction import process_inbound
 
@@ -780,6 +825,23 @@ class TestInboxRoute:
         assert rv.mimetype == 'text/vcard'
         body = rv.data.decode('utf-8')
         assert 'BEGIN:VCARD' in body
+        assert 'Origen Inbox' in body
+
+    def test_public_vcard_download_from_signed_email_link(
+            self, app, seed, client):
+        from services.sendgrid_outbound import make_vcard_token
+
+        with app.app_context():
+            user = _ensure_inbox(seed, 'owner_a')
+            address = user.inbox_address
+            token = make_vcard_token(user)
+
+        rv = client.get(f'/inbox/vcard/{token}')
+        assert rv.status_code == 200
+        assert rv.mimetype == 'text/vcard'
+        body = rv.data.decode('utf-8')
+        assert 'BEGIN:VCARD' in body
+        assert address in body
         assert 'Origen Inbox' in body
 
     def test_dismiss_onboarding_persists(self, app, seed, owner_a_client):


### PR DESCRIPTION
## Summary
- Add signed public Magic Inbox vCard links for welcome emails so users can save the contact card without logging in.
- Teach Magic Inbox extraction to respect explicit group instructions in the email body, such as `Group: Buyers`, while preserving `+buyers` aliases.
- Update inbox UI, feature email copy, and docs to explain the body-based group workflow.

## Test plan
- [x] `python3 -m pytest tests/test_magic_inbox.py -q` (`61 passed`)
- [x] `python3 -m py_compile services/sendgrid_outbound.py routes/inbound_email.py services/ai_service.py services/contact_extraction.py`
- [x] Linter diagnostics on touched Python files show no errors

Made with [Cursor](https://cursor.com)