### PR TITLE
fix: disable market insights panel

### DIFF
--- a/feature_flags.py
+++ b/feature_flags.py
@@ -29,6 +29,7 @@ TIER_FEATURES = {
         'AI_TASK_SUGGESTIONS': False,
         'TRANSACTIONS': False,
         'DOCUMENT_GENERATION': False,
+        'MARKET_INSIGHTS': True,
         'MARKETING': False,
         'TAX_PROTEST': False,
     },
@@ -44,6 +45,7 @@ TIER_FEATURES = {
         'AI_TASK_SUGGESTIONS': True,
         'TRANSACTIONS': True,
         'DOCUMENT_GENERATION': True,
+        'MARKET_INSIGHTS': True,
         'MARKETING': False,  # Still disabled for all
         'TAX_PROTEST': False,
     },
@@ -59,6 +61,7 @@ TIER_FEATURES = {
         'AI_TASK_SUGGESTIONS': True,
         'TRANSACTIONS': True,
         'DOCUMENT_GENERATION': True,
+        'MARKET_INSIGHTS': True,
         'MARKETING': True,
         'TAX_PROTEST': True,
     }
@@ -69,6 +72,7 @@ TIER_FEATURES = {
 # to any user while leaving their normal tier configuration intact for later.
 GLOBAL_FEATURE_OVERRIDES = {
     'AI_DAILY_TODO': False,
+    'MARKET_INSIGHTS': False,
 }
 
 # Legacy global flags for backwards compatibility during migration

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -139,6 +139,7 @@
         </script>
         {% endif %}
 
+        {% if org_has_feature('MARKET_INSIGHTS') %}
         <section class="crm-surface crm-mi mb-6"
                  data-controller="market-insights"
                  data-market-insights-default-slug-value="mont-belvieu"
@@ -283,6 +284,7 @@
                 </div>
             </div>
         </section>
+        {% endif %}
 
         {% if is_first_run %}
         <div class="crm-surface mb-6" {% if not current_user.has_seen_dashboard_onboarding %}data-dashboard-page-target="onboarding"{% endif %}>

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -57,9 +57,15 @@ class TestProTierAccess:
         assert b'dailyTodoModal' not in resp.data
         assert b'js/ai_chat.js' in resp.data
 
+    def test_market_insights_panel_globally_disabled(self, owner_a_client, seed):
+        resp = owner_a_client.get('/dashboard')
+        assert resp.status_code == 200
+        assert b'Market Insights' not in resp.data
+        assert b'market-insights-panel' not in resp.data
 
-class TestDailyTodoGlobalOverride:
-    """Daily todo is disabled for every org while the global override is active."""
+
+class TestGlobalFeatureOverrides:
+    """Feature overrides can disable features for every org."""
 
     def test_global_override_beats_platform_admin_and_org_override(self):
         org = Organization(
@@ -69,6 +75,7 @@ class TestDailyTodoGlobalOverride:
         )
 
         assert org_has_feature('AI_DAILY_TODO', org) is False
+        assert org_has_feature('MARKET_INSIGHTS', org) is False
         assert org_has_feature('AI_CHAT', org) is True
 
     def test_feature_context_keeps_daily_todo_disabled(self):
@@ -79,6 +86,7 @@ class TestDailyTodoGlobalOverride:
 
         features = get_org_features(org)
         assert features['AI_DAILY_TODO'] is False
+        assert features['MARKET_INSIGHTS'] is False
         assert features['AI_CHAT'] is True
 
 


### PR DESCRIPTION
## Summary
- Add a `MARKET_INSIGHTS` feature flag with a global override set to disabled.
- Hide the dashboard Market Insights panel when the flag is disabled.
- Cover the hidden panel and global override behavior in feature flag tests.

## Test plan
- `.venv/bin/python -m pytest tests/test_feature_flags.py -q`

Made with [Cursor](https://cursor.com)