### PR TITLE
feat: tailor transaction workflows by type

### DIFF
--- a/intake_schemas/buyer.json
+++ b/intake_schemas/buyer.json
@@ -1,0 +1,340 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "buyer",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Buyer Questionnaire",
+  "description": "Answer these questions to create the buyer-side document checklist. Agents prepare and send forms in their e-sign system, then upload the signed copies here.",
+  "sections": [
+    {
+      "id": "buyer_representation",
+      "title": "Buyer Representation",
+      "questions": [
+        {
+          "id": "buyer_stage",
+          "type": "select",
+          "label": "Where is this buyer in the transaction?",
+          "options": [
+            {"value": "representation_only", "label": "Representation or showings only"},
+            {"value": "preparing_offer", "label": "Preparing an offer"},
+            {"value": "under_contract", "label": "Under contract"}
+          ],
+          "help_text": "Buyer representation documents are always included. Contract and closing placeholders are added once the buyer is preparing an offer or under contract.",
+          "required": true
+        },
+        {
+          "id": "purchase_type",
+          "type": "select",
+          "label": "What type of property is the buyer pursuing?",
+          "options": [
+            {"value": "resale_one_to_four", "label": "Resale one-to-four family"},
+            {"value": "condominium", "label": "Condominium"},
+            {"value": "new_construction_complete", "label": "New construction - completed"},
+            {"value": "new_construction_incomplete", "label": "New construction - incomplete"},
+            {"value": "farm_and_ranch", "label": "Farm and ranch"},
+            {"value": "not_sure", "label": "Not sure yet"}
+          ],
+          "required": true
+        },
+        {
+          "id": "financing",
+          "type": "select",
+          "label": "How will the buyer finance the purchase?",
+          "options": [
+            {"value": "cash", "label": "Cash"},
+            {"value": "third_party", "label": "Third-party financing"},
+            {"value": "assumption_seller_financing_other", "label": "Assumption, seller financing, or other"},
+            {"value": "not_sure", "label": "Not sure yet"}
+          ],
+          "required": true
+        },
+        {
+          "id": "built_before_1978",
+          "type": "select",
+          "label": "Was the property built before 1978?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "help_text": "Lead-based paint disclosures are commonly required for residential properties built before 1978.",
+          "required": true
+        },
+        {
+          "id": "has_association",
+          "type": "select",
+          "label": "Is the property subject to an HOA, POA, condo association, or mandatory membership association?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "special_district",
+          "type": "select",
+          "label": "Is the property in a special taxing or assessment district?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "help_text": "Examples include MUD, PID, improvement district, or similar district notices.",
+          "required": true
+        },
+        {
+          "id": "buyer_sale_contingency",
+          "type": "boolean",
+          "label": "Does the buyer need to sell another property to purchase this one?",
+          "required": true
+        },
+        {
+          "id": "temporary_lease",
+          "type": "select",
+          "label": "Is a temporary residential lease or special possession timing expected?",
+          "options": [
+            {"value": "none", "label": "No"},
+            {"value": "buyer_temporary_lease", "label": "Buyer temporary lease"},
+            {"value": "seller_temporary_lease", "label": "Seller temporary lease"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "referral_fee",
+          "type": "boolean",
+          "label": "Will a referral fee be paid for this buyer?",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required for buyer representation"
+    },
+    {
+      "slug": "buyer-tenant-representation-agreement",
+      "name": "Residential Buyer/Tenant Representation Agreement",
+      "always": true,
+      "reason": "Required written buyer representation agreement"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for all buyer transactions"
+    },
+    {
+      "slug": "one-to-four-family-contract",
+      "name": "One to Four Family Residential Contract",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "resale_one_to_four"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract on a resale one-to-four family property"
+    },
+    {
+      "slug": "condominium-contract",
+      "name": "Residential Condominium Contract",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "condominium"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract on a condominium"
+    },
+    {
+      "slug": "new-home-completed-construction-contract",
+      "name": "New Home Contract - Completed Construction",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "new_construction_complete"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract on completed new construction"
+    },
+    {
+      "slug": "new-home-incomplete-construction-contract",
+      "name": "New Home Contract - Incomplete Construction",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "new_construction_incomplete"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract on incomplete new construction"
+    },
+    {
+      "slug": "farm-and-ranch-contract",
+      "name": "Farm and Ranch Contract",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "farm_and_ranch"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract on farm and ranch property"
+    },
+    {
+      "slug": "purchase-contract",
+      "name": "Purchase Contract",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "purchase_type", "equals": "not_sure"}
+        ]
+      },
+      "reason": "Buyer is preparing an offer or under contract and the contract type is not yet known"
+    },
+    {
+      "slug": "sellers-disclosure",
+      "name": "Seller's Disclosure Notice",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Commonly needed once a buyer is preparing an offer or under contract"
+    },
+    {
+      "slug": "pre-approval-or-proof-of-funds",
+      "name": "Pre-Approval Letter or Proof of Funds",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Commonly included with buyer offers"
+    },
+    {
+      "slug": "earnest-option-receipt",
+      "name": "Earnest Money / Option Fee Receipt",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Tracks buyer funds after contract execution"
+    },
+    {
+      "slug": "inspection-report",
+      "name": "Inspection Report",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Common buyer due diligence document"
+    },
+    {
+      "slug": "repair-amendment",
+      "name": "Amendment to Contract / Repair Amendment",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Commonly used after inspections or negotiation"
+    },
+    {
+      "slug": "survey",
+      "name": "Survey",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Common contract and title document"
+    },
+    {
+      "slug": "title-commitment",
+      "name": "Title Commitment",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Commonly received during closing process"
+    },
+    {
+      "slug": "closing-disclosure",
+      "name": "Closing Disclosure / Final Settlement Statement",
+      "condition": {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+      "reason": "Needed before closing"
+    },
+    {
+      "slug": "third-party-financing-addendum",
+      "name": "Third Party Financing Addendum",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "financing", "in": ["third_party", "not_sure"]}
+        ]
+      },
+      "reason": "Buyer financing is third-party or not yet known"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Addendum for Seller's Disclosure of Information on Lead-Based Paint",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "built_before_1978", "in": ["yes", "not_sure"]}
+        ]
+      },
+      "reason": "Property may have been built before 1978"
+    },
+    {
+      "slug": "hoa-addendum",
+      "name": "Addendum for Property Subject to Mandatory Membership in Owners' Association",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "has_association", "in": ["yes", "not_sure"]}
+        ]
+      },
+      "reason": "Property may be subject to an HOA, POA, condo, or mandatory membership association"
+    },
+    {
+      "slug": "subdivision-resale-certificate",
+      "name": "Subdivision Information / Resale Certificate",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "has_association", "in": ["yes", "not_sure"]}
+        ]
+      },
+      "reason": "Association resale or subdivision information may be needed"
+    },
+    {
+      "slug": "special-tax-district-notice",
+      "name": "Notice to Purchaser of Real Property Located in a Special Taxing or Assessment District",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "special_district", "in": ["yes", "not_sure"]}
+        ]
+      },
+      "reason": "Property may be located in a special taxing or assessment district"
+    },
+    {
+      "slug": "sale-of-other-property-addendum",
+      "name": "Addendum for Sale of Other Property by Buyer",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "buyer_sale_contingency", "equals": true}
+        ]
+      },
+      "reason": "Buyer needs to sell another property"
+    },
+    {
+      "slug": "buyers-temporary-residential-lease",
+      "name": "Buyer's Temporary Residential Lease",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "temporary_lease", "in": ["buyer_temporary_lease", "not_sure"]}
+        ]
+      },
+      "reason": "Buyer may need temporary occupancy before closing"
+    },
+    {
+      "slug": "sellers-temporary-residential-lease",
+      "name": "Seller's Temporary Residential Lease",
+      "condition": {
+        "all": [
+          {"field": "buyer_stage", "in": ["preparing_offer", "under_contract"]},
+          {"field": "temporary_lease", "in": ["seller_temporary_lease", "not_sure"]}
+        ]
+      },
+      "reason": "Seller may need temporary occupancy after closing"
+    },
+    {
+      "slug": "referral-agreement",
+      "name": "Referral Agreement",
+      "condition": {"field": "referral_fee", "equals": true},
+      "reason": "Referral fee will be paid"
+    }
+  ]
+}

--- a/intake_schemas/landlord.json
+++ b/intake_schemas/landlord.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "landlord",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Landlord Questionnaire",
+  "description": "Answer a few leasing questions to create the landlord-side document checklist. Agents prepare and send forms in their e-sign system, then upload the signed copies here.",
+  "sections": [
+    {
+      "id": "lease_details",
+      "title": "Lease Details",
+      "questions": [
+        {
+          "id": "built_before_1978",
+          "type": "select",
+          "label": "Was the property built before 1978?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "help_text": "Lead-based paint disclosures are commonly required for residential properties built before 1978.",
+          "required": true
+        },
+        {
+          "id": "pets_allowed",
+          "type": "boolean",
+          "label": "Will pets be allowed?",
+          "required": true
+        },
+        {
+          "id": "has_association",
+          "type": "select",
+          "label": "Is the property subject to an HOA, POA, condo association, or mandatory membership association?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "floodplain_notice",
+          "type": "select",
+          "label": "Is a landlord floodplain or flood notice expected?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required brokerage disclosure"
+    },
+    {
+      "slug": "residential-lease-listing-agreement",
+      "name": "Residential Lease Listing Agreement / Property Management Agreement",
+      "always": true,
+      "reason": "Core landlord representation document"
+    },
+    {
+      "slug": "residential-lease",
+      "name": "Residential Lease",
+      "always": true,
+      "reason": "Core landlord lease transaction document"
+    },
+    {
+      "slug": "residential-lease-application",
+      "name": "Residential Lease Application",
+      "always": true,
+      "reason": "Commonly used to screen prospective tenants"
+    },
+    {
+      "slug": "tenant-selection-criteria",
+      "name": "Tenant Selection Criteria",
+      "always": true,
+      "reason": "Common landlord leasing disclosure"
+    },
+    {
+      "slug": "security-deposit-receipt",
+      "name": "Security Deposit / Application Fee Receipt",
+      "always": true,
+      "reason": "Tracks tenant funds received during leasing"
+    },
+    {
+      "slug": "lease-inventory-condition-form",
+      "name": "Residential Lease Inventory and Condition Form",
+      "always": true,
+      "reason": "Documents property condition at move-in"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for transactions involving payments"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Lead-Based Paint Disclosure",
+      "condition": {"field": "built_before_1978", "in": ["yes", "not_sure"]},
+      "reason": "Property may have been built before 1978"
+    },
+    {
+      "slug": "pet-agreement",
+      "name": "Pet Agreement",
+      "condition": {"field": "pets_allowed", "equals": true},
+      "reason": "Pets will be allowed"
+    },
+    {
+      "slug": "association-rules-addendum",
+      "name": "HOA / POA / Condo Association Rules Addendum",
+      "condition": {"field": "has_association", "in": ["yes", "not_sure"]},
+      "reason": "Property may be subject to association rules"
+    },
+    {
+      "slug": "landlord-floodplain-flood-notice",
+      "name": "Landlord's Floodplain and Flood Notice",
+      "condition": {"field": "floodplain_notice", "in": ["yes", "not_sure"]},
+      "reason": "Floodplain or flood notice may be needed"
+    }
+  ]
+}

--- a/intake_schemas/referral.json
+++ b/intake_schemas/referral.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "referral",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Referral Questionnaire",
+  "description": "Answer a few referral questions to create the referral document checklist. Agents prepare and send forms in their e-sign system, then upload the signed copies here.",
+  "sections": [
+    {
+      "id": "referral_details",
+      "title": "Referral Details",
+      "questions": [
+        {
+          "id": "referral_side",
+          "type": "select",
+          "label": "What type of client is being referred?",
+          "options": [
+            {"value": "buyer", "label": "Buyer"},
+            {"value": "seller", "label": "Seller"},
+            {"value": "landlord", "label": "Landlord"},
+            {"value": "tenant", "label": "Tenant"},
+            {"value": "other", "label": "Other / not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "receiving_broker_known",
+          "type": "boolean",
+          "label": "Is the receiving broker or agent known?",
+          "required": true
+        },
+        {
+          "id": "relocation_partner",
+          "type": "boolean",
+          "label": "Is this tied to a relocation company or third-party referral network?",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "referral-agreement",
+      "name": "Broker-to-Broker Referral Agreement",
+      "always": true,
+      "reason": "Core referral transaction document"
+    },
+    {
+      "slug": "client-referral-authorization",
+      "name": "Client Referral Authorization / Introduction",
+      "always": true,
+      "reason": "Documents client permission and referral handoff"
+    },
+    {
+      "slug": "receiving-broker-confirmation",
+      "name": "Receiving Broker / Agent Confirmation",
+      "always": true,
+      "reason": "Confirms the receiving party and referral terms"
+    },
+    {
+      "slug": "commission-disbursement-instructions",
+      "name": "Commission Disbursement / Payment Instructions",
+      "always": true,
+      "reason": "Needed to collect referral compensation"
+    },
+    {
+      "slug": "closing-lease-confirmation",
+      "name": "Closing / Lease Confirmation",
+      "always": true,
+      "reason": "Supports referral fee tracking once the referred transaction closes"
+    },
+    {
+      "slug": "relocation-referral-agreement",
+      "name": "Relocation / Third-Party Referral Agreement",
+      "condition": {"field": "relocation_partner", "equals": true},
+      "reason": "Referral involves a relocation company or third-party network"
+    }
+  ]
+}

--- a/intake_schemas/seller_builder.json
+++ b/intake_schemas/seller_builder.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "seller",
+  "ownership_status": "builder",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Builder / New Construction Questionnaire",
+  "description": "Answer these questions to create the new-construction seller document checklist. Agents prepare and send forms in their e-sign system, then upload signed copies here.",
+  "sections": [
+    {
+      "id": "construction_details",
+      "title": "Construction Details",
+      "questions": [
+        {
+          "id": "construction_status",
+          "type": "select",
+          "label": "What is the construction status?",
+          "options": [
+            {"value": "completed", "label": "Completed construction"},
+            {"value": "incomplete", "label": "Incomplete / to be built"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "builder_contract",
+          "type": "select",
+          "label": "Will the builder use their own contract package?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No / TREC new home contract"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "has_hoa",
+          "type": "boolean",
+          "label": "Is the property subject to an owner's association?",
+          "help_text": "This includes HOAs, POAs, condo associations, and mandatory membership associations.",
+          "required": true
+        },
+        {
+          "id": "special_districts",
+          "type": "boolean",
+          "label": "Is the property located in a special taxing or assessment district?",
+          "help_text": "Examples include MUD, PID, improvement district, or similar notices.",
+          "required": true
+        },
+        {
+          "id": "flood_hazard",
+          "type": "boolean",
+          "label": "Is the property in a flood hazard area?",
+          "required": true
+        },
+        {
+          "id": "referral_fee",
+          "type": "boolean",
+          "label": "Will another party get a referral fee from you for this transaction?",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "listing-agreement",
+      "name": "New Construction Listing Agreement",
+      "always": true,
+      "reason": "Required for builder seller transactions"
+    },
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required brokerage disclosure"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for all seller transactions"
+    },
+    {
+      "slug": "seller-net-proceeds",
+      "name": "Seller's Estimated Net Proceeds",
+      "always": true,
+      "reason": "Recommended for seller transactions"
+    },
+    {
+      "slug": "builder-disclosure-package",
+      "name": "Builder Disclosure / Builder Contract Package",
+      "always": true,
+      "reason": "Builder sales commonly use a builder-specific disclosure or contract packet"
+    },
+    {
+      "slug": "new-home-completed-construction-contract",
+      "name": "New Home Contract - Completed Construction",
+      "condition": {
+        "all": [
+          {"field": "construction_status", "in": ["completed", "not_sure"]},
+          {"field": "builder_contract", "in": ["no", "not_sure"]}
+        ]
+      },
+      "reason": "Completed new construction using TREC new home contract"
+    },
+    {
+      "slug": "new-home-incomplete-construction-contract",
+      "name": "New Home Contract - Incomplete Construction",
+      "condition": {
+        "all": [
+          {"field": "construction_status", "in": ["incomplete", "not_sure"]},
+          {"field": "builder_contract", "in": ["no", "not_sure"]}
+        ]
+      },
+      "reason": "Incomplete or to-be-built new construction using TREC new home contract"
+    },
+    {
+      "slug": "plans-specifications-addendum",
+      "name": "Plans, Specifications, and Finish-Out Schedule",
+      "condition": {"field": "construction_status", "in": ["incomplete", "not_sure"]},
+      "reason": "Incomplete construction commonly requires plans and specifications"
+    },
+    {
+      "slug": "builder-warranty-documents",
+      "name": "Builder Warranty Documents",
+      "always": true,
+      "reason": "Common new construction closing document"
+    },
+    {
+      "slug": "hoa-addendum",
+      "name": "Addendum for Property Subject to Mandatory Membership in Owners' Association",
+      "condition": {"field": "has_hoa", "equals": true},
+      "reason": "Property subject to owner's association"
+    },
+    {
+      "slug": "special-tax-district-notice",
+      "name": "Notice to Purchaser of Real Property Located in a Special Taxing or Assessment District",
+      "condition": {"field": "special_districts", "equals": true},
+      "reason": "Property in special taxing or assessment district"
+    },
+    {
+      "slug": "flood-hazard",
+      "name": "Information About Special Flood Hazard Areas",
+      "condition": {"field": "flood_hazard", "equals": true},
+      "reason": "Property in flood hazard area"
+    },
+    {
+      "slug": "referral-agreement",
+      "name": "Referral Agreement",
+      "condition": {"field": "referral_fee", "equals": true},
+      "reason": "Referral fee will be paid"
+    }
+  ]
+}

--- a/intake_schemas/seller_reo.json
+++ b/intake_schemas/seller_reo.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "seller",
+  "ownership_status": "reo",
+  "document_workflow": "placeholder_upload_only",
+  "title": "REO / Foreclosure Questionnaire",
+  "description": "Answer these questions to create the REO seller document checklist. Agents prepare and send forms in their e-sign system, then upload signed copies here.",
+  "sections": [
+    {
+      "id": "reo_details",
+      "title": "REO Details",
+      "questions": [
+        {
+          "id": "built_before_1978",
+          "type": "select",
+          "label": "Was the property built before 1978?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "help_text": "REO sellers may be exempt from some seller disclosures, but lead-based paint disclosure may still apply.",
+          "required": true
+        },
+        {
+          "id": "has_hoa",
+          "type": "select",
+          "label": "Is the property subject to an owner's association?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "special_districts",
+          "type": "select",
+          "label": "Is the property located in a special taxing or assessment district?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "flood_hazard",
+          "type": "select",
+          "label": "Is the property in a flood hazard area?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "bank_addendum_required",
+          "type": "select",
+          "label": "Will the seller or asset manager require a bank addendum?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        },
+        {
+          "id": "has_survey",
+          "type": "select",
+          "label": "Is a survey available?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "listing-agreement",
+      "name": "REO Listing Agreement / Asset Manager Listing Package",
+      "always": true,
+      "reason": "Required for REO seller transactions"
+    },
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required brokerage disclosure"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for all seller transactions"
+    },
+    {
+      "slug": "seller-net-proceeds",
+      "name": "Seller's Estimated Net Proceeds",
+      "always": true,
+      "reason": "Recommended for seller transactions"
+    },
+    {
+      "slug": "seller-disclosure-exemption",
+      "name": "Seller's Disclosure Exemption / REO Disclosure Notice",
+      "always": true,
+      "reason": "REO sellers commonly use disclosure exemption or bank disclosure forms"
+    },
+    {
+      "slug": "reo-bank-addendum",
+      "name": "REO / Bank Addendum",
+      "condition": {"field": "bank_addendum_required", "in": ["yes", "not_sure"]},
+      "reason": "Bank or asset manager addendum may be required"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Addendum for Seller's Disclosure of Information on Lead-Based Paint",
+      "condition": {"field": "built_before_1978", "in": ["yes", "not_sure"]},
+      "reason": "Property may have been built before 1978"
+    },
+    {
+      "slug": "hoa-addendum",
+      "name": "Addendum for Property Subject to Mandatory Membership in Owners' Association",
+      "condition": {"field": "has_hoa", "in": ["yes", "not_sure"]},
+      "reason": "Property may be subject to owner's association"
+    },
+    {
+      "slug": "special-tax-district-notice",
+      "name": "Notice to Purchaser of Real Property Located in a Special Taxing or Assessment District",
+      "condition": {"field": "special_districts", "in": ["yes", "not_sure"]},
+      "reason": "Property may be in a special taxing or assessment district"
+    },
+    {
+      "slug": "flood-hazard",
+      "name": "Information About Special Flood Hazard Areas",
+      "condition": {"field": "flood_hazard", "in": ["yes", "not_sure"]},
+      "reason": "Property may be in a flood hazard area"
+    },
+    {
+      "slug": "t47-affidavit",
+      "name": "T-47.1 Residential Real Property Affidavit",
+      "condition": {"field": "has_survey", "equals": "yes"},
+      "reason": "Survey is available"
+    }
+  ]
+}

--- a/intake_schemas/seller_short_sale.json
+++ b/intake_schemas/seller_short_sale.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "seller",
+  "ownership_status": "short_sale",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Short Sale Questionnaire",
+  "description": "Answer these questions to create the short-sale seller document checklist. Agents prepare and send forms in their e-sign system, then upload signed copies here.",
+  "sections": [
+    {
+      "id": "short_sale_details",
+      "title": "Short Sale Details",
+      "questions": [
+        {
+          "id": "built_before_1978",
+          "type": "boolean",
+          "label": "Was the property built before 1978?",
+          "help_text": "Lead-based paint disclosure is required for properties built before 1978.",
+          "required": true
+        },
+        {
+          "id": "has_hoa",
+          "type": "boolean",
+          "label": "Is the property subject to an owner's association?",
+          "required": true
+        },
+        {
+          "id": "special_districts",
+          "type": "boolean",
+          "label": "Is the property located in a special taxing or assessment district?",
+          "required": true
+        },
+        {
+          "id": "flood_hazard",
+          "type": "boolean",
+          "label": "Is the property in a flood hazard area?",
+          "required": true
+        },
+        {
+          "id": "has_septic",
+          "type": "boolean",
+          "label": "Does this property have a septic system or on-site sewer facility?",
+          "required": true
+        },
+        {
+          "id": "multiple_lienholders",
+          "type": "boolean",
+          "label": "Are there multiple lienholders or servicers that must approve the sale?",
+          "required": true
+        },
+        {
+          "id": "referral_fee",
+          "type": "boolean",
+          "label": "Will another party get a referral fee from you for this transaction?",
+          "required": true
+        },
+        {
+          "id": "has_survey",
+          "type": "select",
+          "label": "Does your seller have a copy of their survey?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "listing-agreement",
+      "name": "Residential Real Estate Listing Agreement",
+      "always": true,
+      "reason": "Required for short sale seller transactions"
+    },
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required brokerage disclosure"
+    },
+    {
+      "slug": "sellers-disclosure",
+      "name": "Seller's Disclosure Notice",
+      "always": true,
+      "reason": "Commonly needed for short sale seller transactions"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for all seller transactions"
+    },
+    {
+      "slug": "seller-net-proceeds",
+      "name": "Seller's Estimated Net Proceeds",
+      "always": true,
+      "reason": "Required to estimate short sale deficiency and payoff needs"
+    },
+    {
+      "slug": "short-sale-addendum",
+      "name": "Short Sale Addendum",
+      "always": true,
+      "reason": "Required when sale is subject to lienholder approval"
+    },
+    {
+      "slug": "short-sale-lender-authorization",
+      "name": "Short Sale Lender Authorization",
+      "always": true,
+      "reason": "Allows lender or servicer communication"
+    },
+    {
+      "slug": "short-sale-hardship-package",
+      "name": "Seller Hardship / Financial Package",
+      "always": true,
+      "reason": "Common lender requirement for short sale approval"
+    },
+    {
+      "slug": "payoff-or-lienholder-statement",
+      "name": "Payoff / Lienholder Statement",
+      "always": true,
+      "reason": "Needed to support lienholder approval"
+    },
+    {
+      "slug": "multiple-lienholder-approval",
+      "name": "Multiple Lienholder Approval Package",
+      "condition": {"field": "multiple_lienholders", "equals": true},
+      "reason": "Multiple lienholders or servicers must approve the sale"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Addendum for Seller's Disclosure of Information on Lead-Based Paint",
+      "condition": {"field": "built_before_1978", "equals": true},
+      "reason": "Property built before 1978"
+    },
+    {
+      "slug": "hoa-addendum",
+      "name": "Addendum for Property Subject to Mandatory Membership in Owners' Association",
+      "condition": {"field": "has_hoa", "equals": true},
+      "reason": "Property subject to owner's association"
+    },
+    {
+      "slug": "special-tax-district-notice",
+      "name": "Notice to Purchaser of Real Property Located in a Special Taxing or Assessment District",
+      "condition": {"field": "special_districts", "equals": true},
+      "reason": "Property in special taxing or assessment district"
+    },
+    {
+      "slug": "flood-hazard",
+      "name": "Information About Special Flood Hazard Areas",
+      "condition": {"field": "flood_hazard", "equals": true},
+      "reason": "Property in flood hazard area"
+    },
+    {
+      "slug": "sewer-facility",
+      "name": "Information About On-Site Sewer Facility",
+      "condition": {"field": "has_septic", "equals": true},
+      "reason": "Property has septic system or on-site sewage facility"
+    },
+    {
+      "slug": "referral-agreement",
+      "name": "Referral Agreement",
+      "condition": {"field": "referral_fee", "equals": true},
+      "reason": "Referral fee will be paid"
+    },
+    {
+      "slug": "t47-affidavit",
+      "name": "T-47.1 Residential Real Property Affidavit",
+      "condition": {"field": "has_survey", "in": ["yes", "not_sure"]},
+      "reason": "Seller has survey or is unsure"
+    }
+  ]
+}

--- a/intake_schemas/tenant.json
+++ b/intake_schemas/tenant.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "1.0",
+  "transaction_type": "tenant",
+  "document_workflow": "placeholder_upload_only",
+  "title": "Tenant Questionnaire",
+  "description": "Answer a few rental questions to create the tenant-side document checklist. Agents prepare and send forms in their e-sign system, then upload the signed copies here.",
+  "sections": [
+    {
+      "id": "tenant_details",
+      "title": "Tenant Details",
+      "questions": [
+        {
+          "id": "has_pets",
+          "type": "boolean",
+          "label": "Will the tenant have pets?",
+          "required": true
+        },
+        {
+          "id": "built_before_1978",
+          "type": "select",
+          "label": "Was the property built before 1978?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "help_text": "Lead-based paint disclosures are commonly required for residential properties built before 1978.",
+          "required": true
+        },
+        {
+          "id": "has_association",
+          "type": "select",
+          "label": "Is the property subject to an HOA, POA, condo association, or mandatory membership association?",
+          "options": [
+            {"value": "yes", "label": "Yes"},
+            {"value": "no", "label": "No"},
+            {"value": "not_sure", "label": "Not sure"}
+          ],
+          "required": true
+        }
+      ]
+    }
+  ],
+  "document_rules": [
+    {
+      "slug": "iabs",
+      "name": "Information About Brokerage Services",
+      "always": true,
+      "reason": "Required brokerage disclosure"
+    },
+    {
+      "slug": "buyer-tenant-representation-agreement",
+      "name": "Residential Buyer/Tenant Representation Agreement",
+      "always": true,
+      "reason": "Core tenant representation document"
+    },
+    {
+      "slug": "residential-lease-application",
+      "name": "Residential Lease Application",
+      "always": true,
+      "reason": "Common tenant application document"
+    },
+    {
+      "slug": "tenant-selection-criteria",
+      "name": "Tenant Selection Criteria",
+      "always": true,
+      "reason": "Common rental application disclosure"
+    },
+    {
+      "slug": "application-fee-receipt",
+      "name": "Application Fee / Deposit Receipt",
+      "always": true,
+      "reason": "Tracks tenant funds submitted during application"
+    },
+    {
+      "slug": "income-id-verification",
+      "name": "Income / ID Verification",
+      "always": true,
+      "reason": "Common tenant application support document"
+    },
+    {
+      "slug": "residential-lease",
+      "name": "Residential Lease",
+      "always": true,
+      "reason": "Core tenant lease transaction document"
+    },
+    {
+      "slug": "lease-inventory-condition-form",
+      "name": "Residential Lease Inventory and Condition Form",
+      "always": true,
+      "reason": "Documents property condition at move-in"
+    },
+    {
+      "slug": "wire-fraud-warning",
+      "name": "Wire Fraud Warning",
+      "always": true,
+      "reason": "Recommended for transactions involving payments"
+    },
+    {
+      "slug": "pet-agreement",
+      "name": "Pet Agreement",
+      "condition": {"field": "has_pets", "equals": true},
+      "reason": "Tenant will have pets"
+    },
+    {
+      "slug": "lead-paint",
+      "name": "Lead-Based Paint Disclosure",
+      "condition": {"field": "built_before_1978", "in": ["yes", "not_sure"]},
+      "reason": "Property may have been built before 1978"
+    },
+    {
+      "slug": "association-rules-addendum",
+      "name": "HOA / POA / Condo Association Rules Addendum",
+      "condition": {"field": "has_association", "in": ["yes", "not_sure"]},
+      "reason": "Property may be subject to association rules"
+    }
+  ]
+}

--- a/routes/main.py
+++ b/routes/main.py
@@ -566,27 +566,76 @@ def dashboard():
         else:
             participants_by_tx = {}
         
-        # Define Kanban columns - 'preparing' combines preparing_to_list and showing
+        # Define neutral Kanban columns that work across seller, buyer, lease, and referral flows.
         status_config = {
-            'preparing': {'label': 'Preparing', 'order': 1, 'statuses': ['preparing_to_list', 'showing']},
-            'active': {'label': 'Active', 'order': 2, 'statuses': ['active']},
-            'under_contract': {'label': 'Under Contract', 'order': 3, 'statuses': ['under_contract']},
-            'closed': {'label': 'Closed YTD', 'order': 4, 'statuses': ['closed']},
+            'early': {
+                'label': 'Early Stage',
+                'description': 'New, preparing, or search-stage transactions',
+                'order': 1,
+                'statuses': ['preparing_to_list', 'showing'],
+                'tone': 'neutral',
+            },
+            'active': {
+                'label': 'Active / Listed',
+                'description': 'Listed, marketed, or referred-out work',
+                'order': 2,
+                'statuses': ['active'],
+                'tone': 'info',
+            },
+            'pending': {
+                'label': 'Pending',
+                'description': 'Under contract, application, lease, or referral in progress',
+                'order': 3,
+                'statuses': ['under_contract'],
+                'tone': 'warning',
+            },
+            'closed': {
+                'label': 'Closed YTD',
+                'description': 'Closed, leased, or paid this year',
+                'order': 4,
+                'statuses': ['closed'],
+                'tone': 'success',
+            },
         }
         
-        # Status display labels for cards
-        status_labels = {
-            'preparing_to_list': 'Preparing to List',
-            'showing': 'Showing',
-            'active': 'Active',
-            'under_contract': 'Under Contract',
-            'closed': 'Closed'
+        # Status display labels for cards, tailored by transaction type.
+        status_label_sets = {
+            'seller': {
+                'preparing_to_list': 'Preparing to List',
+                'active': 'Active',
+                'under_contract': 'Under Contract',
+                'closed': 'Closed',
+            },
+            'buyer': {
+                'showing': 'Home Search',
+                'under_contract': 'Under Contract',
+                'closed': 'Closed',
+            },
+            'landlord': {
+                'preparing_to_list': 'Preparing to Lease',
+                'active': 'Listed for Lease',
+                'under_contract': 'Lease Pending',
+                'closed': 'Leased',
+            },
+            'tenant': {
+                'showing': 'Rental Search',
+                'under_contract': 'Application Submitted',
+                'closed': 'Lease Signed',
+            },
+            'referral': {
+                'preparing_to_list': 'New Referral',
+                'active': 'Referred Out',
+                'under_contract': 'In Progress',
+                'closed': 'Closed/Paid',
+            },
         }
         
         # Group transactions by Kanban column
         for column_key in status_config.keys():
             transactions_by_status[column_key] = {
                 'label': status_config[column_key]['label'],
+                'description': status_config[column_key]['description'],
+                'tone': status_config[column_key]['tone'],
                 'transactions': [],
                 'count': 0
             }
@@ -613,6 +662,9 @@ def dashboard():
             elif primary_client:
                 client_name = primary_client.display_name
             
+            tx_type_name = tx.transaction_type.name if tx.transaction_type else 'seller'
+            status_labels = status_label_sets.get(tx_type_name, status_label_sets['seller'])
+
             # Build transaction data for template
             tx_data = {
                 'id': tx.id,

--- a/routes/transactions/api.py
+++ b/routes/transactions/api.py
@@ -96,7 +96,15 @@ def update_status(id):
     data = request.get_json()
     new_status = data.get('status')
     
-    valid_statuses = ['preparing_to_list', 'showing', 'active', 'under_contract', 'closed', 'cancelled']
+    status_options_by_type = {
+        'seller': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+        'buyer': ['showing', 'under_contract', 'closed', 'cancelled'],
+        'landlord': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+        'tenant': ['showing', 'under_contract', 'closed', 'cancelled'],
+        'referral': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    }
+    tx_type_name = transaction.transaction_type.name if transaction.transaction_type else 'seller'
+    valid_statuses = status_options_by_type.get(tx_type_name, status_options_by_type['seller'])
     if new_status not in valid_statuses:
         return jsonify({'success': False, 'error': 'Invalid status'}), 400
     

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -289,9 +289,10 @@ def create_transaction():
         # Get the transaction type to determine participant role and default status
         tx_type = TransactionType.query.get(int(transaction_type_id))
         
-        # Determine default status based on transaction type
-        # Buyer transactions start with 'showing', sellers start with 'preparing_to_list'
-        default_status = 'showing' if tx_type and tx_type.name == 'buyer' else 'preparing_to_list'
+        # Determine default status based on transaction type.
+        # Buyer/tenant work starts with search; listing/referral work starts in prep.
+        search_first_types = {'buyer', 'tenant'}
+        default_status = 'showing' if tx_type and tx_type.name in search_first_types else 'preparing_to_list'
         
         # Create the transaction
         transaction = Transaction(
@@ -600,6 +601,19 @@ def update_transaction(id):
         transaction.ownership_status = new_ownership
 
         new_status = request.form.get('status', transaction.status)
+        status_options_by_type = {
+            'seller': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+            'buyer': ['showing', 'under_contract', 'closed', 'cancelled'],
+            'landlord': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+            'tenant': ['showing', 'under_contract', 'closed', 'cancelled'],
+            'referral': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+        }
+        tx_type_name = transaction.transaction_type.name if transaction.transaction_type else 'seller'
+        valid_statuses = status_options_by_type.get(tx_type_name, status_options_by_type['seller'])
+        if new_status not in valid_statuses:
+            db.session.rollback()
+            flash('Invalid status for this transaction type.', 'error')
+            return redirect(url_for('transactions.edit_transaction', id=transaction.id))
         if new_status != transaction.status:
             changed_fields.append('status')
         transaction.status = new_status

--- a/services/intake_service.py
+++ b/services/intake_service.py
@@ -22,19 +22,46 @@ def get_intake_schema(transaction_type: str, ownership_status: str = None) -> di
     Returns:
         The schema dict or None if not found
     """
-    # Build the schema filename
+    # Prefer the most specific schema, then fall back to the transaction type.
     if ownership_status:
-        filename = f"{transaction_type}_{ownership_status}.json"
-    else:
-        filename = f"{transaction_type}.json"
-    
-    schema_path = SCHEMAS_DIR / filename
-    
-    if not schema_path.exists():
-        return None
-    
-    with open(schema_path, 'r') as f:
-        return json.load(f)
+        schema_path = SCHEMAS_DIR / f"{transaction_type}_{ownership_status}.json"
+        if schema_path.exists():
+            with open(schema_path, 'r') as f:
+                return json.load(f)
+
+    schema_path = SCHEMAS_DIR / f"{transaction_type}.json"
+    if schema_path.exists():
+        with open(schema_path, 'r') as f:
+            return json.load(f)
+
+    return None
+
+
+def _condition_matches(condition: dict, intake_data: dict) -> bool:
+    """Evaluate a document rule condition against intake answers."""
+    if not condition:
+        return False
+
+    if 'all' in condition:
+        return all(_condition_matches(item, intake_data) for item in condition['all'])
+
+    if 'any' in condition:
+        return any(_condition_matches(item, intake_data) for item in condition['any'])
+
+    field = condition.get('field')
+    if not field:
+        return False
+
+    field_value = intake_data.get(field)
+
+    if 'equals' in condition:
+        return field_value == condition['equals']
+    if 'in' in condition:
+        return field_value in condition['in']
+    if 'not_equals' in condition:
+        return field_value != condition['not_equals']
+
+    return False
 
 
 def evaluate_document_rules(schema: dict, intake_data: dict) -> list:
@@ -57,15 +84,7 @@ def evaluate_document_rules(schema: dict, intake_data: dict) -> list:
         if rule.get('always'):
             include = True
         elif 'condition' in rule:
-            condition = rule['condition']
-            field_value = intake_data.get(condition['field'])
-            
-            if 'equals' in condition:
-                include = field_value == condition['equals']
-            elif 'in' in condition:
-                include = field_value in condition['in']
-            elif 'not_equals' in condition:
-                include = field_value != condition['not_equals']
+            include = _condition_matches(rule['condition'], intake_data)
         
         if include:
             required_docs.append({

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -326,48 +326,53 @@ function removeParticipant(participantId) {
 // DOCUMENT MANAGEMENT
 // =============================================================================
 
-document.getElementById('docTemplateSelect').addEventListener('change', function() {
-    const customField = document.getElementById('customDocNameField');
-    if (this.value === 'custom') {
-        customField.classList.remove('hidden');
-        customField.querySelector('input').required = true;
-    } else {
-        customField.classList.add('hidden');
-        customField.querySelector('input').required = false;
-    }
-});
-
-document.getElementById('addDocumentForm').addEventListener('submit', function(e) {
-    e.preventDefault();
-    const formData = new FormData(this);
-
-    const select = document.getElementById('docTemplateSelect');
-    const selectedOption = select.options[select.selectedIndex];
-    let templateName = selectedOption.dataset.name;
-
-    if (formData.get('template_slug') === 'custom') {
-        templateName = formData.get('custom_name');
-    }
-
-    formData.append('template_name', templateName);
-
-    fetch(`/transactions/${transactionId}/documents`, {
-        method: 'POST',
-        body: formData
-    })
-    .then(res => res.json())
-    .then(data => {
-        if (data.success) {
-            if (data.placeholder_updated) {
-                // Show special message for placeholder conversion
-                showToast(data.message || 'Placeholder updated with generated document.', 'success');
-            }
-            location.reload();
+const docTemplateSelect = document.getElementById('docTemplateSelect');
+if (docTemplateSelect) {
+    docTemplateSelect.addEventListener('change', function() {
+        const customField = document.getElementById('customDocNameField');
+        if (this.value === 'custom') {
+            customField.classList.remove('hidden');
+            customField.querySelector('input').required = true;
         } else {
-            showToast('Error adding document: ' + data.error, 'error');
+            customField.classList.add('hidden');
+            customField.querySelector('input').required = false;
         }
     });
-});
+}
+
+const addDocumentForm = document.getElementById('addDocumentForm');
+if (addDocumentForm && docTemplateSelect) {
+    addDocumentForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const formData = new FormData(this);
+
+        const selectedOption = docTemplateSelect.options[docTemplateSelect.selectedIndex];
+        let templateName = selectedOption.dataset.name;
+
+        if (formData.get('template_slug') === 'custom') {
+            templateName = formData.get('custom_name');
+        }
+
+        formData.append('template_name', templateName);
+
+        fetch(`/transactions/${transactionId}/documents`, {
+            method: 'POST',
+            body: formData
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                if (data.placeholder_updated) {
+                    // Show special message for placeholder conversion
+                    showToast(data.message || 'Placeholder updated with generated document.', 'success');
+                }
+                location.reload();
+            } else {
+                showToast('Error adding document: ' + data.error, 'error');
+            }
+        });
+    });
+}
 
 function removeDocument(docId) {
     if (!confirm('Remove this document?')) return;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-{% set total_deals = transactions_by_status.preparing.count + transactions_by_status.active.count + transactions_by_status.under_contract.count + transactions_by_status.closed.count if show_transactions else 0 %}
+{% set total_deals = transactions_by_status.values()|map(attribute='count')|sum if show_transactions else 0 %}
 {% set is_first_run = total_contacts == 0 and total_deals == 0 and upcoming_tasks|length == 0 %}
 
 <div class="crm-page"
@@ -418,97 +418,32 @@
             <div class="crm-surface-body">
                 {% if total_deals > 0 %}
                 <div class="crm-board">
+                    {% for column in transactions_by_status.values() %}
                     <div class="crm-board-column">
                         <div class="crm-board-column__header">
-                            <div class="flex items-center gap-2">
-                                <span class="text-sm font-semibold text-slate-900">Preparing</span>
+                            <div class="min-w-0">
+                                <span class="text-sm font-semibold text-slate-900">{{ column.label }}</span>
+                                <p class="mt-0.5 truncate text-[11px] text-slate-500" title="{{ column.description }}">{{ column.description }}</p>
                             </div>
-                            {{ badge(transactions_by_status.preparing.count|string) }}
+                            {{ badge(column.count|string, column.tone) }}
                         </div>
                         <div class="crm-board-column__body">
-                            {% for tx in transactions_by_status.preparing.transactions %}
+                            {% for tx in column.transactions %}
                             <a href="{{ url_for('transactions.view_transaction', id=tx.id) }}" class="crm-deal-card block">
                                 <div class="text-sm font-semibold text-slate-900">{{ tx.address[:38] }}{% if tx.address|length > 38 %}...{% endif %}</div>
                                 <div class="mt-2 text-sm text-slate-500">{{ tx.client_name }}</div>
-                                <div class="mt-3 flex items-center justify-between text-xs text-slate-500">
-                                    <span>{{ tx.status_label }}</span>
+                                <div class="mt-2 truncate text-[11px] font-medium uppercase tracking-wide text-slate-400">{{ tx.type }}</div>
+                                <div class="mt-3 flex items-center justify-between gap-3 text-xs text-slate-500">
+                                    <span class="truncate">{{ tx.status_label }}</span>
                                     <span class="font-semibold text-slate-700">${{ "{:,.0f}".format(tx.commission) }}</span>
                                 </div>
                             </a>
                             {% else %}
-                            <div class="rounded-md border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-400">No deals</div>
+                            <div class="rounded-md border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-400">No transactions</div>
                             {% endfor %}
                         </div>
                     </div>
-
-                    <div class="crm-board-column">
-                        <div class="crm-board-column__header">
-                            <div class="flex items-center gap-2">
-                                <span class="text-sm font-semibold text-slate-900">Active</span>
-                            </div>
-                            {{ badge(transactions_by_status.active.count|string, 'info') }}
-                        </div>
-                        <div class="crm-board-column__body">
-                            {% for tx in transactions_by_status.active.transactions %}
-                            <a href="{{ url_for('transactions.view_transaction', id=tx.id) }}" class="crm-deal-card block">
-                                <div class="text-sm font-semibold text-slate-900">{{ tx.address[:38] }}{% if tx.address|length > 38 %}...{% endif %}</div>
-                                <div class="mt-2 text-sm text-slate-500">{{ tx.client_name }}</div>
-                                <div class="mt-3 flex items-center justify-between text-xs text-slate-500">
-                                    <span>{% if tx.expected_close_date %}{{ tx.expected_close_date.strftime('%b %d') }}{% else %}No close date{% endif %}</span>
-                                    <span class="font-semibold text-slate-700">${{ "{:,.0f}".format(tx.commission) }}</span>
-                                </div>
-                            </a>
-                            {% else %}
-                            <div class="rounded-md border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-400">No deals</div>
-                            {% endfor %}
-                        </div>
-                    </div>
-
-                    <div class="crm-board-column">
-                        <div class="crm-board-column__header">
-                            <div class="flex items-center gap-2">
-                                <span class="text-sm font-semibold text-slate-900">Under Contract</span>
-                            </div>
-                            {{ badge(transactions_by_status.under_contract.count|string, 'warning') }}
-                        </div>
-                        <div class="crm-board-column__body">
-                            {% for tx in transactions_by_status.under_contract.transactions %}
-                            <a href="{{ url_for('transactions.view_transaction', id=tx.id) }}" class="crm-deal-card block">
-                                <div class="text-sm font-semibold text-slate-900">{{ tx.address[:38] }}{% if tx.address|length > 38 %}...{% endif %}</div>
-                                <div class="mt-2 text-sm text-slate-500">{{ tx.client_name }}</div>
-                                <div class="mt-3 flex items-center justify-between text-xs text-slate-500">
-                                    <span>{% if tx.expected_close_date %}{{ tx.expected_close_date.strftime('%b %d') }}{% else %}No close date{% endif %}</span>
-                                    <span class="font-semibold text-slate-700">${{ "{:,.0f}".format(tx.commission) }}</span>
-                                </div>
-                            </a>
-                            {% else %}
-                            <div class="rounded-md border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-400">No deals</div>
-                            {% endfor %}
-                        </div>
-                    </div>
-
-                    <div class="crm-board-column">
-                        <div class="crm-board-column__header">
-                            <div class="flex items-center gap-2">
-                                <span class="text-sm font-semibold text-slate-900">Closed YTD</span>
-                            </div>
-                            {{ badge(transactions_by_status.closed.count|string, 'success') }}
-                        </div>
-                        <div class="crm-board-column__body">
-                            {% for tx in transactions_by_status.closed.transactions %}
-                            <a href="{{ url_for('transactions.view_transaction', id=tx.id) }}" class="crm-deal-card block">
-                                <div class="text-sm font-semibold text-slate-900">{{ tx.address[:38] }}{% if tx.address|length > 38 %}...{% endif %}</div>
-                                <div class="mt-2 text-sm text-slate-500">{{ tx.client_name }}</div>
-                                <div class="mt-3 flex items-center justify-between text-xs text-slate-500">
-                                    <span>{% if tx.actual_close_date %}Closed {{ tx.actual_close_date.strftime('%b %d') }}{% else %}Closed{% endif %}</span>
-                                    <span class="font-semibold text-slate-700">${{ "{:,.0f}".format(tx.commission) }}</span>
-                                </div>
-                            </a>
-                            {% else %}
-                            <div class="rounded-md border border-dashed border-slate-200 px-4 py-6 text-center text-sm text-slate-400">No deals</div>
-                            {% endfor %}
-                        </div>
-                    </div>
+                    {% endfor %}
                 </div>
                 {% else %}
                 {% call empty_state('No transactions yet', 'Add a transaction to get started.', 'fa-file-contract') %}

--- a/templates/transactions/create.html
+++ b/templates/transactions/create.html
@@ -10,6 +10,29 @@
         background: #fff7ed;
         box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.1);
     }
+
+    .tx-type-grid {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.75rem;
+    }
+
+    .tx-type-option {
+        width: 100%;
+    }
+
+    @media (min-width: 640px) {
+        .tx-type-option {
+            width: calc((100% - 0.75rem) / 2);
+        }
+    }
+
+    @media (min-width: 1024px) {
+        .tx-type-option {
+            width: calc((100% - 1.5rem) / 3);
+        }
+    }
 </style>
 <div class="crm-page">
     <div class="crm-page__inner max-w-4xl">
@@ -58,16 +81,16 @@
                     {{ section_header('Transaction type') }}
                 </div>
                 <div class="crm-surface-body">
-                    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                    <div class="tx-type-grid">
                         {% for tt in transaction_types %}
-                        <label class="cursor-pointer">
+                        <label class="tx-type-option cursor-pointer">
                             <input type="radio"
                                    name="transaction_type_id"
                                    value="{{ tt.id }}"
                                    data-type-name="{{ tt.name }}"
                                    class="sr-only"
                                    required>
-                            <div class="type-card tx-create-card flex flex-col items-center gap-2 rounded-md border border-slate-200 bg-white p-4 text-center transition-colors hover:border-slate-300 hover:bg-slate-50">
+                            <div class="type-card tx-create-card flex min-h-[6.875rem] flex-col items-center justify-center gap-2 rounded-md border border-slate-200 bg-white p-4 text-center transition-colors hover:border-slate-300 hover:bg-slate-50">
                                 <span class="inline-flex h-9 w-9 items-center justify-center rounded-md bg-slate-100 text-sm text-slate-600">
                                     {% if tt.name == 'seller' %}
                                     <i class="fas fa-home"></i>
@@ -297,6 +320,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 ownershipSection.classList.remove('hidden');
             } else {
                 ownershipSection.classList.add('hidden');
+                document.querySelectorAll('input[name="ownership_status"]').forEach(radio => {
+                    radio.checked = false;
+                });
+                document.querySelectorAll('.ownership-card').forEach(card => card.classList.remove('selected'));
             }
         });
     });

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -4,17 +4,86 @@
 {% block title %}{{ transaction.street_address }} - Origen TechnolOG{% endblock %}
 
 {% block content %}
-{% set status_labels = {
-    'preparing_to_list': 'Preparing to List',
-    'showing': 'Showing',
-    'active': 'Active',
-    'under_contract': 'Under Contract',
-    'closed': 'Closed',
-    'cancelled': 'Cancelled/Withdrawn'
+{% set tx_type_name = transaction.transaction_type.name if transaction.transaction_type else 'seller' %}
+{% set status_label_sets = {
+    'seller': {
+        'preparing_to_list': 'Preparing to List',
+        'active': 'Active',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled/Withdrawn'
+    },
+    'buyer': {
+        'showing': 'Home Search',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled/Withdrawn'
+    },
+    'landlord': {
+        'preparing_to_list': 'Preparing to Lease',
+        'active': 'Listed for Lease',
+        'under_contract': 'Lease Pending',
+        'closed': 'Leased',
+        'cancelled': 'Cancelled/Withdrawn'
+    },
+    'tenant': {
+        'showing': 'Rental Search',
+        'under_contract': 'Application Submitted',
+        'closed': 'Lease Signed',
+        'cancelled': 'Cancelled/Withdrawn'
+    },
+    'referral': {
+        'preparing_to_list': 'New Referral',
+        'active': 'Referred Out',
+        'under_contract': 'In Progress',
+        'closed': 'Closed/Paid',
+        'cancelled': 'Cancelled'
+    }
 } %}
+{% set status_option_sets = {
+    'seller': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'buyer': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'landlord': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'tenant': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'referral': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled']
+} %}
+{% set tracker_label_sets = {
+    'seller': {
+        'preparing_to_list': 'Preparing',
+        'active': 'Active',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed'
+    },
+    'buyer': {
+        'showing': 'Home Search',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed'
+    },
+    'landlord': {
+        'preparing_to_list': 'Preparing',
+        'active': 'Listed',
+        'under_contract': 'Lease Pending',
+        'closed': 'Leased'
+    },
+    'tenant': {
+        'showing': 'Rental Search',
+        'under_contract': 'Application',
+        'closed': 'Lease Signed'
+    },
+    'referral': {
+        'preparing_to_list': 'New',
+        'active': 'Referred',
+        'under_contract': 'In Progress',
+        'closed': 'Closed/Paid'
+    }
+} %}
+{% set status_labels = status_label_sets.get(tx_type_name, status_label_sets['seller']) %}
+{% set status_options = status_option_sets.get(tx_type_name, status_option_sets['seller']) %}
+{% set tracker_labels = tracker_label_sets.get(tx_type_name, tracker_label_sets['seller']) %}
+{% set tracker_statuses = status_options|reject('equalto', 'cancelled')|list %}
 {% set status_icons = {
     'preparing_to_list': 'clipboard-list',
-    'showing': 'eye',
+    'showing': 'search',
     'active': 'broadcast-tower',
     'under_contract': 'file-signature',
     'closed': 'check-circle',
@@ -139,36 +208,34 @@
                 </button>
                 <div id="statusDropdownMenu"
                      class="absolute left-0 top-full z-40 mt-1 hidden w-56 overflow-hidden rounded-md border border-slate-200 bg-white py-1 shadow-lg">
-                    {% for status_key, label in status_labels.items() %}
+                    {% for status_key in status_options %}
                     <button onclick="updateStatus('{{ status_key }}')" type="button"
                             class="flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors hover:bg-slate-50 {% if transaction.status == status_key %}font-semibold text-slate-900{% else %}text-slate-700{% endif %}">
                         <span class="flex items-center gap-2">
                             <span class="h-1.5 w-1.5 flex-shrink-0 rounded-full {{ status_dot_class.get(status_key, 'bg-slate-300') }}"></span>
-                            {{ label }}
+                            {{ status_labels[status_key] }}
                         </span>
                         {% if transaction.status == status_key %}
                         <i class="fas fa-check text-xs text-slate-500"></i>
                         {% endif %}
                     </button>
                     {% endfor %}
+                    {% if transaction.status and transaction.status not in status_options %}
+                    <button onclick="updateStatus('{{ transaction.status }}')" type="button"
+                            class="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-50">
+                        <span class="flex items-center gap-2">
+                            <span class="h-1.5 w-1.5 flex-shrink-0 rounded-full {{ status_dot_class.get(transaction.status, 'bg-slate-300') }}"></span>
+                            {{ transaction.status|replace('_', ' ')|title }} (Legacy)
+                        </span>
+                        <i class="fas fa-check text-xs text-slate-500"></i>
+                    </button>
+                    {% endif %}
                 </div>
             </div>
         </div>
 
         {# ===== Status tracker / Cancelled banner ===== #}
         {% if transaction.status != 'cancelled' %}
-        {% if transaction.transaction_type.name == 'buyer' %}
-            {% set tracker_statuses = ['showing', 'under_contract', 'closed'] %}
-        {% else %}
-            {% set tracker_statuses = ['preparing_to_list', 'active', 'under_contract', 'closed'] %}
-        {% endif %}
-        {% set tracker_labels = {
-            'preparing_to_list': 'Preparing',
-            'showing': 'Showing',
-            'active': 'Active',
-            'under_contract': 'Under Contract',
-            'closed': 'Closed'
-        } %}
         {% set current_index = tracker_statuses.index(transaction.status) if transaction.status in tracker_statuses else 0 %}
         {% set is_final_step = current_index == (tracker_statuses|length - 1) %}
         <section class="crm-surface mb-6">
@@ -1350,6 +1417,7 @@
     </div>
 </div>
 
+{% if document_workflow_mode != 'placeholder_upload_only' %}
 {# ----- Unified add document modal ----- #}
 <div id="addDocumentModal" class="fixed inset-0 z-50 hidden">
     <div class="absolute inset-0 bg-slate-900/50" onclick="closeAddDocumentModal()"></div>
@@ -1838,6 +1906,7 @@
         </form>
     </div>
 </div>
+{% endif %}
 
 {# ----- Fulfill placeholder modal ----- #}
 <div id="fulfillPlaceholderModal" class="fixed inset-0 z-50 hidden">

--- a/templates/transactions/edit.html
+++ b/templates/transactions/edit.html
@@ -19,15 +19,51 @@
     ('VT', 'Vermont'), ('VA', 'Virginia'), ('WA', 'Washington'), ('WV', 'West Virginia'),
     ('WI', 'Wisconsin'), ('WY', 'Wyoming')
 ] %}
-{% set status_labels = {
-    'preparing_to_list': 'Preparing to List',
-    'showing': 'Showing',
-    'active': 'Active',
-    'under_contract': 'Under Contract',
-    'closed': 'Closed',
-    'cancelled': 'Cancelled / Withdrawn'
+{% set tx_type_name = transaction.transaction_type.name if transaction.transaction_type else 'seller' %}
+{% set status_label_sets = {
+    'seller': {
+        'preparing_to_list': 'Preparing to List',
+        'active': 'Active',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled / Withdrawn'
+    },
+    'buyer': {
+        'showing': 'Home Search',
+        'under_contract': 'Under Contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled / Withdrawn'
+    },
+    'landlord': {
+        'preparing_to_list': 'Preparing to Lease',
+        'active': 'Listed for Lease',
+        'under_contract': 'Lease Pending',
+        'closed': 'Leased',
+        'cancelled': 'Cancelled / Withdrawn'
+    },
+    'tenant': {
+        'showing': 'Rental Search',
+        'under_contract': 'Application Submitted',
+        'closed': 'Lease Signed',
+        'cancelled': 'Cancelled / Withdrawn'
+    },
+    'referral': {
+        'preparing_to_list': 'New Referral',
+        'active': 'Referred Out',
+        'under_contract': 'In Progress',
+        'closed': 'Closed / Paid',
+        'cancelled': 'Cancelled'
+    }
 } %}
-{% set status_options = ['preparing_to_list', 'showing', 'active', 'under_contract', 'closed', 'cancelled'] %}
+{% set status_option_sets = {
+    'seller': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'buyer': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'landlord': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'tenant': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'referral': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled']
+} %}
+{% set status_labels = status_label_sets.get(tx_type_name, status_label_sets['seller']) %}
+{% set status_options = status_option_sets.get(tx_type_name, status_option_sets['seller']) %}
 
 <div class="crm-page">
     <div class="crm-page__inner max-w-4xl">

--- a/templates/transactions/list.html
+++ b/templates/transactions/list.html
@@ -5,12 +5,47 @@
 
 {% block content %}
 {% set status_labels = {
-    'preparing_to_list': 'Preparing to list',
-    'showing': 'Showing',
-    'active': 'Active',
-    'under_contract': 'Under contract',
+    'preparing_to_list': 'Preparing / New',
+    'showing': 'Search',
+    'active': 'Active / Listed / Referred',
+    'under_contract': 'Under contract / In progress',
     'closed': 'Closed',
     'cancelled': 'Cancelled / withdrawn'
+} %}
+{% set status_label_sets = {
+    'seller': {
+        'preparing_to_list': 'Preparing to list',
+        'active': 'Active',
+        'under_contract': 'Under contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled / withdrawn'
+    },
+    'buyer': {
+        'showing': 'Home search',
+        'under_contract': 'Under contract',
+        'closed': 'Closed',
+        'cancelled': 'Cancelled / withdrawn'
+    },
+    'landlord': {
+        'preparing_to_list': 'Preparing to lease',
+        'active': 'Listed for lease',
+        'under_contract': 'Lease pending',
+        'closed': 'Leased',
+        'cancelled': 'Cancelled / withdrawn'
+    },
+    'tenant': {
+        'showing': 'Rental search',
+        'under_contract': 'Application submitted',
+        'closed': 'Lease signed',
+        'cancelled': 'Cancelled / withdrawn'
+    },
+    'referral': {
+        'preparing_to_list': 'New referral',
+        'active': 'Referred out',
+        'under_contract': 'In progress',
+        'closed': 'Closed / paid',
+        'cancelled': 'Cancelled'
+    }
 } %}
 {% set status_dot_class = {
     'preparing_to_list': 'bg-amber-500',
@@ -205,9 +240,11 @@
                             {{ tx.transaction_type.display_name }}
                         </td>
                         <td class="align-top">
+                            {% set tx_type_name = tx.transaction_type.name if tx.transaction_type else 'seller' %}
+                            {% set tx_status_labels = status_label_sets.get(tx_type_name, status_label_sets['seller']) %}
                             <span class="inline-flex items-center gap-2 text-sm font-medium {% if tx.status == 'cancelled' %}text-red-600{% else %}text-slate-700{% endif %}">
                                 <span class="h-1.5 w-1.5 flex-shrink-0 rounded-full {{ status_dot_class.get(tx.status, 'bg-slate-300') }}"></span>
-                                {{ status_labels.get(tx.status, tx.status|replace('_', ' ')|title) }}
+                                {{ tx_status_labels.get(tx.status, tx.status|replace('_', ' ')|title) }}
                             </span>
                         </td>
                         <td>

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -1,0 +1,279 @@
+"""
+Tests for intake schema loading and document rule evaluation.
+
+Run with: python -m pytest tests/test_intake_service.py -v
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from services.intake_service import evaluate_document_rules, get_intake_schema
+
+
+def slugs_for(schema, intake_data):
+    """Return the generated document slugs for the provided intake answers."""
+    return {doc["slug"] for doc in evaluate_document_rules(schema, intake_data)}
+
+
+def test_buyer_schema_loads_placeholder_workflow():
+    schema = get_intake_schema("buyer")
+
+    assert schema is not None
+    assert schema["transaction_type"] == "buyer"
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+
+def test_buyer_schema_falls_back_when_ownership_status_is_present():
+    schema = get_intake_schema("buyer", "conventional")
+
+    assert schema is not None
+    assert schema["transaction_type"] == "buyer"
+
+
+def test_buyer_representation_stage_generates_core_documents_only():
+    schema = get_intake_schema("buyer")
+
+    slugs = slugs_for(schema, {
+        "buyer_stage": "representation_only",
+        "purchase_type": "resale_one_to_four",
+        "financing": "cash",
+        "built_before_1978": "no",
+        "has_association": "no",
+        "special_district": "no",
+        "buyer_sale_contingency": False,
+        "temporary_lease": "none",
+        "referral_fee": False,
+    })
+
+    assert slugs == {
+        "iabs",
+        "buyer-tenant-representation-agreement",
+        "wire-fraud-warning",
+    }
+
+
+def test_buyer_offer_answers_generate_conditional_placeholders():
+    schema = get_intake_schema("buyer")
+
+    slugs = slugs_for(schema, {
+        "buyer_stage": "preparing_offer",
+        "purchase_type": "condominium",
+        "financing": "third_party",
+        "built_before_1978": "yes",
+        "has_association": "yes",
+        "special_district": "yes",
+        "buyer_sale_contingency": True,
+        "temporary_lease": "not_sure",
+        "referral_fee": True,
+    })
+
+    expected = {
+        "iabs",
+        "buyer-tenant-representation-agreement",
+        "wire-fraud-warning",
+        "condominium-contract",
+        "sellers-disclosure",
+        "pre-approval-or-proof-of-funds",
+        "earnest-option-receipt",
+        "inspection-report",
+        "repair-amendment",
+        "survey",
+        "title-commitment",
+        "closing-disclosure",
+        "third-party-financing-addendum",
+        "lead-paint",
+        "hoa-addendum",
+        "subdivision-resale-certificate",
+        "special-tax-district-notice",
+        "sale-of-other-property-addendum",
+        "buyers-temporary-residential-lease",
+        "sellers-temporary-residential-lease",
+        "referral-agreement",
+    }
+
+    assert expected <= slugs
+    assert "one-to-four-family-contract" not in slugs
+
+
+def test_landlord_schema_generates_core_and_conditional_placeholders():
+    schema = get_intake_schema("landlord")
+
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "built_before_1978": "yes",
+        "pets_allowed": True,
+        "has_association": "yes",
+        "floodplain_notice": "not_sure",
+    })
+
+    expected = {
+        "iabs",
+        "residential-lease-listing-agreement",
+        "residential-lease",
+        "residential-lease-application",
+        "tenant-selection-criteria",
+        "security-deposit-receipt",
+        "lease-inventory-condition-form",
+        "wire-fraud-warning",
+        "lead-paint",
+        "pet-agreement",
+        "association-rules-addendum",
+        "landlord-floodplain-flood-notice",
+    }
+
+    assert expected <= slugs
+
+
+def test_tenant_schema_generates_core_and_conditional_placeholders():
+    schema = get_intake_schema("tenant")
+
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "has_pets": True,
+        "built_before_1978": "not_sure",
+        "has_association": "yes",
+    })
+
+    expected = {
+        "iabs",
+        "buyer-tenant-representation-agreement",
+        "residential-lease-application",
+        "tenant-selection-criteria",
+        "application-fee-receipt",
+        "income-id-verification",
+        "residential-lease",
+        "lease-inventory-condition-form",
+        "wire-fraud-warning",
+        "pet-agreement",
+        "lead-paint",
+        "association-rules-addendum",
+    }
+
+    assert expected <= slugs
+
+
+def test_referral_schema_generates_core_and_relocation_placeholders():
+    schema = get_intake_schema("referral")
+
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "referral_side": "buyer",
+        "receiving_broker_known": True,
+        "relocation_partner": True,
+    })
+
+    assert {
+        "referral-agreement",
+        "client-referral-authorization",
+        "receiving-broker-confirmation",
+        "commission-disbursement-instructions",
+        "closing-lease-confirmation",
+        "relocation-referral-agreement",
+    } <= slugs
+
+
+def test_seller_builder_schema_generates_new_construction_placeholders():
+    schema = get_intake_schema("seller", "builder")
+
+    assert schema["ownership_status"] == "builder"
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "construction_status": "incomplete",
+        "builder_contract": "no",
+        "has_hoa": True,
+        "special_districts": True,
+        "flood_hazard": True,
+        "referral_fee": True,
+    })
+
+    assert {
+        "listing-agreement",
+        "iabs",
+        "wire-fraud-warning",
+        "seller-net-proceeds",
+        "builder-disclosure-package",
+        "new-home-incomplete-construction-contract",
+        "plans-specifications-addendum",
+        "builder-warranty-documents",
+        "hoa-addendum",
+        "special-tax-district-notice",
+        "flood-hazard",
+        "referral-agreement",
+    } <= slugs
+    assert "new-home-completed-construction-contract" not in slugs
+
+
+def test_seller_reo_schema_generates_bank_and_exemption_placeholders():
+    schema = get_intake_schema("seller", "reo")
+
+    assert schema["ownership_status"] == "reo"
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "built_before_1978": "not_sure",
+        "has_hoa": "yes",
+        "special_districts": "yes",
+        "flood_hazard": "yes",
+        "bank_addendum_required": "not_sure",
+        "has_survey": "yes",
+    })
+
+    assert {
+        "listing-agreement",
+        "iabs",
+        "wire-fraud-warning",
+        "seller-net-proceeds",
+        "seller-disclosure-exemption",
+        "reo-bank-addendum",
+        "lead-paint",
+        "hoa-addendum",
+        "special-tax-district-notice",
+        "flood-hazard",
+        "t47-affidavit",
+    } <= slugs
+    assert "sellers-disclosure" not in slugs
+
+
+def test_seller_short_sale_schema_generates_lender_approval_placeholders():
+    schema = get_intake_schema("seller", "short_sale")
+
+    assert schema["ownership_status"] == "short_sale"
+    assert schema["document_workflow"] == "placeholder_upload_only"
+
+    slugs = slugs_for(schema, {
+        "built_before_1978": True,
+        "has_hoa": True,
+        "special_districts": True,
+        "flood_hazard": True,
+        "has_septic": True,
+        "multiple_lienholders": True,
+        "referral_fee": True,
+        "has_survey": "not_sure",
+    })
+
+    assert {
+        "listing-agreement",
+        "iabs",
+        "sellers-disclosure",
+        "wire-fraud-warning",
+        "seller-net-proceeds",
+        "short-sale-addendum",
+        "short-sale-lender-authorization",
+        "short-sale-hardship-package",
+        "payoff-or-lienholder-statement",
+        "multiple-lienholder-approval",
+        "lead-paint",
+        "hoa-addendum",
+        "special-tax-district-notice",
+        "flood-hazard",
+        "sewer-facility",
+        "referral-agreement",
+        "t47-affidavit",
+    } <= slugs


### PR DESCRIPTION
## Summary
- Add placeholder-upload intake schemas for buyer, lease, referral, and alternate seller transaction paths.
- Tailor transaction statuses, progress trackers, and dashboard pipeline labels by transaction type.
- Hide legacy template-document picking for placeholder workflows and cover intake rule generation with tests.

## Test plan
- `.venv/bin/python -m pytest tests/test_intake_service.py tests/test_document_definitions.py`
- Parsed affected transaction and dashboard templates with Flask/Jinja.
- Checked edited files with IDE diagnostics.

Made with [Cursor](https://cursor.com)