### PR TITLE
feat: make dashboard KPI charts data-driven

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -469,6 +469,54 @@ def dashboard():
     group_stats_raw = group_stats_query.group_by(ContactGroup.id, ContactGroup.name).all()
     group_stats = [{'name': name, 'count': count} for name, count in group_stats_raw if count > 0]
 
+    top_opportunity_rows = []
+    top_contact_values = [float(contact.potential_commission or 0) for contact in top_contacts]
+    max_top_contact_value = max(top_contact_values) if top_contact_values else 0
+    for contact in top_contacts[:3]:
+        value = float(contact.potential_commission or 0)
+        full_name = f"{contact.first_name} {contact.last_name}".strip()
+        top_opportunity_rows.append({
+            'label': full_name or 'Unnamed contact',
+            'value': f"${value:,.0f}",
+            'percent': int((value / max_top_contact_value) * 100) if max_top_contact_value else 0,
+        })
+
+    sorted_group_stats = sorted(group_stats, key=lambda item: item['count'], reverse=True)
+    max_group_count = max((group['count'] for group in sorted_group_stats), default=0)
+    contact_mix_rows = [
+        {
+            'label': group['name'],
+            'value': str(group['count']),
+            'percent': int((group['count'] / max_group_count) * 100) if max_group_count else 0,
+        }
+        for group in sorted_group_stats[:3]
+    ]
+
+    commission_tiers = base_contact_query.with_entities(
+        func.coalesce(func.sum(case((Contact.potential_commission < 5000, 1), else_=0)), 0).label('under_5k'),
+        func.coalesce(func.sum(case((Contact.potential_commission.between(5000, 14999.99), 1), else_=0)), 0).label('mid_5k_15k'),
+        func.coalesce(func.sum(case((Contact.potential_commission >= 15000, 1), else_=0)), 0).label('over_15k'),
+    ).first()
+    tier_rows_raw = [
+        {'label': '< $5k', 'value': int(commission_tiers.under_5k or 0)},
+        {'label': '$5k-$15k', 'value': int(commission_tiers.mid_5k_15k or 0)},
+        {'label': '$15k+', 'value': int(commission_tiers.over_15k or 0)},
+    ]
+    max_tier_count = max((row['value'] for row in tier_rows_raw), default=0)
+    commission_tier_rows = [
+        {
+            'label': row['label'],
+            'value': str(row['value']),
+            'percent': int((row['value'] / max_tier_count) * 100) if max_tier_count else 0,
+        }
+        for row in tier_rows_raw
+    ]
+    kpi_breakdowns = {
+        'top_opportunities': top_opportunity_rows,
+        'contact_mix': contact_mix_rows,
+        'commission_tiers': commission_tier_rows,
+    }
+
     # Get user's timezone (default to 'America/Chicago' if not set)
     user_tz = pytz.timezone('America/Chicago')
     
@@ -730,6 +778,7 @@ def dashboard():
                          total_commission=total_commission,
                          total_contacts=total_contacts,
                          avg_commission=avg_commission,
+                         kpi_breakdowns=kpi_breakdowns,
                          group_stats=group_stats,
                          top_contacts=top_contacts,
                          upcoming_tasks=upcoming_tasks,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,6 +1,29 @@
 {% extends "base.html" %}
 {% from "components/ui.html" import page_header, section_header, avatar, badge, empty_state %}
 
+{% macro kpi_breakdown(rows, tone='blue', empty='No data yet') -%}
+{% set fill_class = 'bg-orange-500' if tone == 'orange' else ('bg-slate-500' if tone == 'slate' else 'bg-sky-500') %}
+{% if rows %}
+<div class="min-w-[8.5rem] max-w-[10rem] flex-1 space-y-2">
+    {% for row in rows %}
+    <div>
+        <div class="mb-1 flex items-center justify-between gap-3 text-[11px] leading-none">
+            <span class="max-w-[6.5rem] truncate text-slate-500" title="{{ row.label }}">{{ row.label }}</span>
+            <span class="shrink-0 font-semibold text-slate-700">{{ row.value }}</span>
+        </div>
+        <div class="h-1.5 overflow-hidden rounded-full bg-slate-100">
+            <div class="h-full rounded-full {{ fill_class }}" style="width: {{ row.percent }}%"></div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="min-w-[8.5rem] rounded-md border border-dashed border-slate-200 px-3 py-4 text-center text-xs text-slate-400">
+    {{ empty }}
+</div>
+{% endif %}
+{%- endmacro %}
+
 {% block head_scripts %}
 <script src="{{ url_for('static', filename='js/todo-manager.js') }}" defer></script>
 <script defer src="https://cdn.jsdelivr.net/npm/apexcharts@3.49.1/dist/apexcharts.min.js"></script>
@@ -359,12 +382,10 @@
                     <div>
                         <div class="crm-kpi__label">Potential commission</div>
                         <div class="crm-kpi__value">${{ "{:,.0f}".format(total_commission) }}</div>
-                        <div class="crm-kpi__meta">Across {{ total_contacts }} tracked contacts.</div>
+                        <div class="crm-kpi__meta">Top contacts by estimated value.</div>
                     </div>
                 </div>
-                <svg class="crm-sparkline" viewBox="0 0 100 30" preserveAspectRatio="none" aria-hidden="true">
-                    <path d="M0,24 L15,22 L28,20 L42,16 L55,18 L70,11 L85,7 L100,4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
+                {{ kpi_breakdown(kpi_breakdowns.top_opportunities, 'blue', 'No commission values') }}
             </div>
             <div class="crm-kpi">
                 <div class="crm-kpi__main">
@@ -374,12 +395,10 @@
                     <div>
                         <div class="crm-kpi__label">Tracked contacts</div>
                         <div class="crm-kpi__value">{{ total_contacts }}</div>
-                        <div class="crm-kpi__meta">{% if show_all %}Organization-wide view{% else %}Your working book{% endif %}</div>
+                        <div class="crm-kpi__meta">Largest active contact groups.</div>
                     </div>
                 </div>
-                <svg class="crm-sparkline crm-sparkline--orange" viewBox="0 0 100 30" preserveAspectRatio="none" aria-hidden="true">
-                    <path d="M0,22 L15,20 L28,17 L42,19 L55,14 L70,13 L85,9 L100,6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
+                {{ kpi_breakdown(kpi_breakdowns.contact_mix, 'orange', 'No groups yet') }}
             </div>
             <div class="crm-kpi">
                 <div class="crm-kpi__main">
@@ -389,12 +408,10 @@
                     <div>
                         <div class="crm-kpi__label">Average commission</div>
                         <div class="crm-kpi__value">${{ "{:,.0f}".format(avg_commission) }}</div>
-                        <div class="crm-kpi__meta">Per contact with tracked value.</div>
+                        <div class="crm-kpi__meta">Contact count by value range.</div>
                     </div>
                 </div>
-                <svg class="crm-sparkline" viewBox="0 0 100 30" preserveAspectRatio="none" aria-hidden="true">
-                    <path d="M0,20 L15,18 L28,19 L42,14 L55,13 L70,10 L85,7 L100,5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
+                {{ kpi_breakdown(kpi_breakdowns.commission_tiers, 'slate', 'No values yet') }}
             </div>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- Replace decorative dashboard KPI sparklines with data-backed mini bar breakdowns.
- Surface top opportunity values, largest contact groups, and commission tier distribution in the KPI cards.

## Test plan
- `.venv/bin/python -m py_compile routes/main.py`
- Jinja compile smoke test for `dashboard.html`
- Cursor linter diagnostics for `routes/main.py` and `templates/dashboard.html`


Made with [Cursor](https://cursor.com)