### PR TITLE
fix: route seller offer PDF uploads through extraction

### DIFF
--- a/migrations/versions/widen_seller_contract_survey_choice.py
+++ b/migrations/versions/widen_seller_contract_survey_choice.py
@@ -1,0 +1,48 @@
+"""Widen seller accepted contract survey choice
+
+Revision ID: widen_seller_contract_survey_choice
+Revises: add_seller_transaction_workflow
+Create Date: 2026-04-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'widen_seller_contract_survey_choice'
+down_revision = 'add_seller_transaction_workflow'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not _table_exists(conn, 'seller_accepted_contracts'):
+        return
+
+    with op.batch_alter_table('seller_accepted_contracts') as batch_op:
+        batch_op.alter_column(
+            'survey_choice',
+            existing_type=sa.String(length=100),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    if not _table_exists(conn, 'seller_accepted_contracts'):
+        return
+
+    with op.batch_alter_table('seller_accepted_contracts') as batch_op:
+        batch_op.alter_column(
+            'survey_choice',
+            existing_type=sa.Text(),
+            type_=sa.String(length=100),
+            existing_nullable=True,
+        )

--- a/models.py
+++ b/models.py
@@ -1260,7 +1260,7 @@ class SellerAcceptedContract(db.Model):
     financing_approval_deadline = db.Column(db.Date)
     title_company = db.Column(db.String(200))
     escrow_officer = db.Column(db.String(200))
-    survey_choice = db.Column(db.String(100))
+    survey_choice = db.Column(db.Text)
     hoa_applicable = db.Column(db.Boolean)
     seller_disclosure_required = db.Column(db.Boolean)
     seller_disclosure_delivered_at = db.Column(db.DateTime)

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -21,6 +21,25 @@ from . import transactions_bp
 from .decorators import transactions_required
 
 
+def _merge_extraction_status(current_status, candidate_status):
+    """Return the highest-priority extraction state for seller offer surfaces."""
+    priority = {
+        'failed': 4,
+        'processing': 3,
+        'pending': 2,
+        'complete': 1,
+    }
+    if not candidate_status:
+        return current_status
+    if not current_status:
+        return candidate_status
+    return (
+        candidate_status
+        if priority.get(candidate_status, 0) > priority.get(current_status, 0)
+        else current_status
+    )
+
+
 # =============================================================================
 # TRANSACTION LIST
 # =============================================================================
@@ -483,6 +502,12 @@ def view_transaction(id):
             ).all()
             for offer_document in offer_documents:
                 seller_offer_documents_by_offer.setdefault(offer_document.offer_id, []).append(offer_document)
+                document = offer_document.document
+                if document and document.extraction_status:
+                    seller_offer_extraction_status[offer_document.offer_id] = _merge_extraction_status(
+                        seller_offer_extraction_status.get(offer_document.offer_id),
+                        document.extraction_status,
+                    )
 
             offer_activities = SellerOfferActivity.query.filter(
                 SellerOfferActivity.offer_id.in_(offer_ids),
@@ -501,7 +526,10 @@ def view_transaction(id):
             ).all()
             for version in current_versions:
                 if version.document:
-                    seller_offer_extraction_status[version.offer_id] = version.document.extraction_status
+                    seller_offer_extraction_status[version.offer_id] = _merge_extraction_status(
+                        seller_offer_extraction_status.get(version.offer_id),
+                        version.document.extraction_status,
+                    )
         urgent_seller_offer = active_seller_offers[0] if active_seller_offers else None
         primary_seller_contract = SellerAcceptedContract.query.filter_by(
             transaction_id=transaction.id,

--- a/routes/transactions/offers.py
+++ b/routes/transactions/offers.py
@@ -418,6 +418,8 @@ def upload_seller_offer_document(id):
             })
 
         offer.last_activity_at = datetime.utcnow()
+        if uploaded and offer.status == 'new':
+            offer.status = 'needs_review'
         db.session.commit()
 
         for item in uploaded:

--- a/routes/transactions/offers.py
+++ b/routes/transactions/offers.py
@@ -90,6 +90,43 @@ def _parse_int(value):
         return None
 
 
+def _merge_extraction_status(current_status, candidate_status):
+    priority = {
+        'failed': 4,
+        'processing': 3,
+        'pending': 2,
+        'complete': 1,
+    }
+    if not candidate_status:
+        return current_status
+    if not current_status:
+        return candidate_status
+    return (
+        candidate_status
+        if priority.get(candidate_status, 0) > priority.get(current_status, 0)
+        else current_status
+    )
+
+
+def _offer_extraction_status(offer):
+    status = None
+    for offer_document in offer.offer_documents.all():
+        document = offer_document.document
+        if document:
+            status = _merge_extraction_status(status, document.extraction_status)
+
+    if offer.current_version_id:
+        version = SellerOfferVersion.query.filter_by(
+            id=offer.current_version_id,
+            offer_id=offer.id,
+            organization_id=offer.organization_id,
+        ).first()
+        if version and version.document:
+            status = _merge_extraction_status(status, version.document.extraction_status)
+
+    return status
+
+
 def _normalize_terms(data):
     terms = dict(data.get('terms_data') or data.get('terms') or {})
     for key in ('response_deadline_at',):
@@ -100,6 +137,8 @@ def _normalize_terms(data):
 
 def _offer_payload(offer):
     urgency = offer_urgency(offer)
+    document_count = offer.offer_documents.count()
+    version_count = offer.versions.count()
     return {
         'id': offer.id,
         'status': offer.status,
@@ -119,6 +158,9 @@ def _offer_payload(offer):
         'accepted_version_id': offer.accepted_version_id,
         'source_showing_id': offer.source_showing_id,
         'last_activity_label': offer.last_activity_label,
+        'document_count': document_count,
+        'version_count': version_count,
+        'extraction_status': _offer_extraction_status(offer),
     }
 
 

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -533,6 +533,16 @@ const sellerOfferForm = document.getElementById('sellerOfferForm');
 if (sellerOfferForm) {
     sellerOfferForm.addEventListener('submit', function(e) {
         e.preventDefault();
+        const newOfferModal = document.getElementById('sellerNewOfferModal');
+        const uploadForm = newOfferModal ? newOfferModal.querySelector('.seller-offer-upload-form') : null;
+        const uploadInput = uploadForm ? uploadForm.querySelector('.seller-offer-file-input') : null;
+        const selectedFiles = Array.from((uploadInput && uploadInput.files) || []);
+        if (selectedFiles.length && uploadForm) {
+            showToast('Uploading selected PDFs for extraction...', 'success');
+            uploadForm.requestSubmit();
+            return;
+        }
+
         sellerPost(
             `/transactions/${transactionId}/offers`,
             sellerFormData(this),
@@ -670,6 +680,14 @@ document.querySelectorAll('.seller-offer-upload-form').forEach(form => {
         }
         const rows = Array.from(this.querySelectorAll('[data-offer-upload-row]'));
         const formData = new FormData();
+        const isNewOfferUpload = Boolean(this.closest('#sellerNewOfferModal'));
+        if (isNewOfferUpload && sellerOfferForm) {
+            new FormData(sellerOfferForm).forEach((value, key) => {
+                if (value !== '') {
+                    formData.append(key, value);
+                }
+            });
+        }
         new FormData(this).forEach((value, key) => {
             if (key !== 'files' && key !== 'file' && key !== 'document_type') {
                 formData.append(key, value);

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -4,6 +4,24 @@
  */
 
 const transactionId = TX_CONFIG.transactionId;
+const SELLER_WORKSPACE_TAB_KEY = `sellerWorkspaceTab:${transactionId}`;
+
+function setSellerWorkspaceReloadTab(tabName) {
+    if (!tabName) return;
+    sessionStorage.setItem(SELLER_WORKSPACE_TAB_KEY, tabName);
+}
+
+function getActiveSellerWorkspaceTab() {
+    const activeTab = document.querySelector('[id^="seller-tab-"].is-active');
+    return activeTab ? activeTab.id.replace('seller-tab-', '') : null;
+}
+
+function restoreSellerWorkspaceTab() {
+    const savedTab = sessionStorage.getItem(SELLER_WORKSPACE_TAB_KEY);
+    if (savedTab && document.getElementById(`seller-panel-${savedTab}`)) {
+        sellerWorkspaceTab(savedTab, { persist: false });
+    }
+}
 
 // =============================================================================
 // TAB SWITCHING (Buyer Transactions)
@@ -38,6 +56,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const cleanUrl = window.location.pathname;
         window.history.replaceState({}, document.title, cleanUrl);
     }
+
+    restoreSellerWorkspaceTab();
+    startSellerOfferExtractionPolling();
 });
 
 // =============================================================================
@@ -445,7 +466,7 @@ function showToast(message, type = 'info') {
 // SELLER WORKSPACE
 // =============================================================================
 
-function sellerWorkspaceTab(tabName) {
+function sellerWorkspaceTab(tabName, options = {}) {
     document.querySelectorAll('[id^="seller-tab-"]').forEach(btn => btn.classList.remove('is-active'));
     document.querySelectorAll('.seller-tab-panel').forEach(panel => panel.classList.add('hidden'));
 
@@ -453,6 +474,9 @@ function sellerWorkspaceTab(tabName) {
     const panel = document.getElementById(`seller-panel-${tabName}`);
     if (tab) tab.classList.add('is-active');
     if (panel) panel.classList.remove('hidden');
+    if (tab && panel && options.persist !== false) {
+        setSellerWorkspaceReloadTab(tabName);
+    }
 }
 
 function sellerFormData(form) {
@@ -482,6 +506,8 @@ function sellerPost(url, payload, successMessage) {
             throw new Error(data.error || 'Request failed');
         }
         if (successMessage) showToast(successMessage, 'success');
+        const activeSellerTab = getActiveSellerWorkspaceTab();
+        if (activeSellerTab) setSellerWorkspaceReloadTab(activeSellerTab);
         setTimeout(() => location.reload(), 500);
         return data;
     })
@@ -533,6 +559,7 @@ const sellerOfferForm = document.getElementById('sellerOfferForm');
 if (sellerOfferForm) {
     sellerOfferForm.addEventListener('submit', function(e) {
         e.preventDefault();
+        setSellerWorkspaceReloadTab('offers');
         const newOfferModal = document.getElementById('sellerNewOfferModal');
         const uploadForm = newOfferModal ? newOfferModal.querySelector('.seller-offer-upload-form') : null;
         const uploadInput = uploadForm ? uploadForm.querySelector('.seller-offer-file-input') : null;
@@ -603,6 +630,148 @@ function escapeHtml(value) {
         '"': '&quot;',
         "'": '&#039;'
     }[char]));
+}
+
+function formatSellerLabel(value) {
+    return String(value || '')
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function formatSellerCurrency(value) {
+    if (value === null || value === undefined || value === '') return 'Price TBD';
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return String(value);
+    return numericValue.toLocaleString(undefined, {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0
+    });
+}
+
+function formatSellerDateTime(value) {
+    if (!value) return 'No response deadline';
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return String(value);
+    return parsed.toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+    });
+}
+
+function sellerDeadlineClass(state) {
+    if (['critical', 'strong_warning', 'expired'].includes(state)) return 'font-medium text-red-700';
+    if (state === 'warning') return 'font-medium text-orange-700';
+    return 'text-slate-600';
+}
+
+function updateSellerOfferText(row, selector, value) {
+    const element = row.querySelector(selector);
+    if (element) element.textContent = value;
+}
+
+function renderSellerOfferExtractionStatus(offer) {
+    const status = offer.extraction_status;
+    if (status && status !== 'complete') {
+        const isFailed = status === 'failed';
+        const icon = isFailed ? 'fa-exclamation-circle' : 'fa-spinner fa-spin';
+        const color = isFailed ? 'text-red-600' : 'text-sky-600';
+        return {
+            html: `<i class="fas ${icon} mr-0.5 text-[10px]"></i>${escapeHtml(status.replace(/_/g, ' '))}`,
+            classes: `text-xs ${color}`,
+        };
+    }
+
+    const versionCount = Number(offer.version_count || 0);
+    return {
+        html: `${versionCount} version${versionCount === 1 ? '' : 's'}`,
+        classes: 'text-xs text-slate-500',
+    };
+}
+
+function updateSellerOfferRow(offer) {
+    const row = document.querySelector(`[data-seller-offer-row="${offer.id}"]`);
+    if (!row) return;
+
+    updateSellerOfferText(row, '[data-seller-offer-buyer]', offer.buyer_names || 'Unnamed buyer');
+    const agentLabel = [
+        offer.buyer_agent_name || 'No agent yet',
+        offer.buyer_agent_brokerage || ''
+    ].filter(Boolean).join(' · ');
+    updateSellerOfferText(row, '[data-seller-offer-agent]', agentLabel);
+    updateSellerOfferText(row, '[data-seller-offer-price]', formatSellerCurrency(offer.offer_price));
+    updateSellerOfferText(row, '[data-seller-offer-financing]', offer.financing_type || 'Financing TBD');
+
+    const urgency = offer.urgency || {};
+    const deadlineLabel = row.querySelector('[data-seller-offer-deadline-label]');
+    if (deadlineLabel) {
+        deadlineLabel.className = sellerDeadlineClass(urgency.state);
+        deadlineLabel.textContent = urgency.label || 'No deadline';
+    }
+    updateSellerOfferText(row, '[data-seller-offer-deadline-at]', formatSellerDateTime(offer.response_deadline_at));
+
+    const documentCount = Number(offer.document_count || 0);
+    updateSellerOfferText(
+        row,
+        '[data-seller-offer-doc-count]',
+        `${documentCount} document${documentCount === 1 ? '' : 's'}`
+    );
+
+    const extractionElement = row.querySelector('[data-seller-offer-extraction-status]');
+    if (extractionElement) {
+        const rendered = renderSellerOfferExtractionStatus(offer);
+        extractionElement.className = rendered.classes;
+        extractionElement.innerHTML = rendered.html;
+    }
+
+    updateSellerOfferText(row, '[data-seller-offer-status]', formatSellerLabel(offer.status));
+}
+
+let sellerOfferPollingTimer = null;
+let sellerOfferPollCount = 0;
+
+function hasSellerOfferExtractionInProgress(offers) {
+    return offers.some(offer => ['pending', 'processing'].includes(offer.extraction_status));
+}
+
+function pollSellerOfferExtractionStatus() {
+    fetch(`/transactions/${transactionId}/offers`)
+    .then(res => res.json())
+    .then(data => {
+        if (!data.success) throw new Error(data.error || 'Unable to refresh offers');
+        const offers = data.offers || [];
+        offers.forEach(updateSellerOfferRow);
+
+        sellerOfferPollCount += 1;
+        const stillWorking = hasSellerOfferExtractionInProgress(offers);
+        if (stillWorking && sellerOfferPollCount < 100) {
+            sellerOfferPollingTimer = setTimeout(pollSellerOfferExtractionStatus, 3000);
+        } else {
+            sellerOfferPollingTimer = null;
+        }
+    })
+    .catch(() => {
+        sellerOfferPollCount += 1;
+        if (sellerOfferPollCount < 5) {
+            sellerOfferPollingTimer = setTimeout(pollSellerOfferExtractionStatus, 5000);
+        } else {
+            sellerOfferPollingTimer = null;
+        }
+    });
+}
+
+function startSellerOfferExtractionPolling() {
+    if (sellerOfferPollingTimer || !document.getElementById('seller-panel-offers')) return;
+    const hasPendingRow = Array.from(document.querySelectorAll('[data-seller-offer-extraction-status]')).some(element => {
+        const value = element.textContent.trim().toLowerCase();
+        return value.includes('pending') || value.includes('processing');
+    });
+    if (!hasPendingRow) return;
+
+    sellerOfferPollCount = 0;
+    sellerOfferPollingTimer = setTimeout(pollSellerOfferExtractionStatus, 2500);
 }
 
 function updateSellerOfferDropzone(form, files) {
@@ -726,6 +895,7 @@ document.querySelectorAll('.seller-offer-upload-form').forEach(form => {
                 }
             });
             showToast(data.message || 'Offer document uploaded.', 'success');
+            setSellerWorkspaceReloadTab('offers');
             setTimeout(() => location.reload(), 800);
         })
         .catch(err => {

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -438,34 +438,34 @@
                                             {% set package_documents = seller_offer_documents_by_offer.get(offer.id, []) %}
                                             {% set legacy_documents = offer_versions|selectattr('document')|list %}
                                             {% set offer_document_count = package_documents|length if package_documents else legacy_documents|length %}
-                                            <tr class="group cursor-pointer hover:bg-slate-50" onclick="openSellerOfferModal({{ offer.id }})">
+                                            <tr class="group cursor-pointer hover:bg-slate-50" data-seller-offer-row="{{ offer.id }}" onclick="openSellerOfferModal({{ offer.id }})">
                                                 <td>
-                                                    <div class="font-medium text-slate-900">{{ offer.buyer_names or 'Unnamed buyer' }}</div>
-                                                    <div class="text-xs text-slate-500">{{ offer.buyer_agent_name or 'No agent yet' }}{% if offer.buyer_agent_brokerage %} · {{ offer.buyer_agent_brokerage }}{% endif %}</div>
+                                                    <div class="font-medium text-slate-900" data-seller-offer-buyer>{{ offer.buyer_names or 'Unnamed buyer' }}</div>
+                                                    <div class="text-xs text-slate-500" data-seller-offer-agent>{{ offer.buyer_agent_name or 'No agent yet' }}{% if offer.buyer_agent_brokerage %} · {{ offer.buyer_agent_brokerage }}{% endif %}</div>
                                                 </td>
                                                 <td>
-                                                    <div class="font-semibold text-slate-900">{% if offer.offer_price %}${{ "{:,.0f}".format(offer.offer_price) }}{% else %}Price TBD{% endif %}</div>
-                                                    <div class="text-xs text-slate-500">{{ offer.financing_type or 'Financing TBD' }}</div>
+                                                    <div class="font-semibold text-slate-900" data-seller-offer-price>{% if offer.offer_price %}${{ "{:,.0f}".format(offer.offer_price) }}{% else %}Price TBD{% endif %}</div>
+                                                    <div class="text-xs text-slate-500" data-seller-offer-financing>{{ offer.financing_type or 'Financing TBD' }}</div>
                                                 </td>
                                                 <td>
-                                                    <div class="{% if urgency.state in ['critical', 'strong_warning', 'expired'] %}font-medium text-red-700{% elif urgency.state == 'warning' %}font-medium text-orange-700{% else %}text-slate-600{% endif %}">
+                                                    <div data-seller-offer-deadline-label class="{% if urgency.state in ['critical', 'strong_warning', 'expired'] %}font-medium text-red-700{% elif urgency.state == 'warning' %}font-medium text-orange-700{% else %}text-slate-600{% endif %}">
                                                         {{ urgency.label }}
                                                     </div>
-                                                    <div class="text-xs text-slate-500">{% if offer.response_deadline_at %}{{ offer.response_deadline_at.strftime('%b %d, %I:%M %p') }}{% else %}No response deadline{% endif %}</div>
+                                                    <div class="text-xs text-slate-500" data-seller-offer-deadline-at>{% if offer.response_deadline_at %}{{ offer.response_deadline_at.strftime('%b %d, %I:%M %p') }}{% else %}No response deadline{% endif %}</div>
                                                 </td>
                                                 <td>
-                                                    <div class="text-slate-700">{{ offer_document_count }} document{% if offer_document_count != 1 %}s{% endif %}</div>
+                                                    <div class="text-slate-700" data-seller-offer-doc-count>{{ offer_document_count }} document{% if offer_document_count != 1 %}s{% endif %}</div>
                                                     {% if extraction_state and extraction_state != 'complete' %}
-                                                    <div class="text-xs {% if extraction_state == 'failed' %}text-red-600{% else %}text-sky-600{% endif %}">
+                                                    <div class="text-xs {% if extraction_state == 'failed' %}text-red-600{% else %}text-sky-600{% endif %}" data-seller-offer-extraction-status>
                                                         <i class="fas {% if extraction_state == 'failed' %}fa-exclamation-circle{% else %}fa-spinner fa-spin{% endif %} mr-0.5 text-[10px]"></i>
                                                         {{ extraction_state|replace('_', ' ') }}
                                                     </div>
                                                     {% else %}
-                                                    <div class="text-xs text-slate-500">{{ offer_versions|length }} version{% if offer_versions|length != 1 %}s{% endif %}</div>
+                                                    <div class="text-xs text-slate-500" data-seller-offer-extraction-status>{{ offer_versions|length }} version{% if offer_versions|length != 1 %}s{% endif %}</div>
                                                     {% endif %}
                                                 </td>
                                                 <td>
-                                                    <span class="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-700">
+                                                    <span class="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-700" data-seller-offer-status>
                                                         {{ offer.status|replace('_', ' ')|title }}
                                                     </span>
                                                 </td>

--- a/tests/test_offer_document_package.py
+++ b/tests/test_offer_document_package.py
@@ -125,6 +125,16 @@ def test_offer_upload_accepts_multiple_documents(owner_a_client, app, db, seed):
     assert [doc['document_type'] for doc in payload['documents']] == ['buyer_offer', 'pre_approval']
     assert post_upload_processing.call_count == 2
 
+    offers_response = owner_a_client.get(f'/transactions/{seed["tx_a"]}/offers')
+    assert offers_response.status_code == 200
+    offer_payload = next(
+        offer for offer in offers_response.get_json()['offers']
+        if offer['id'] == payload['offer_id']
+    )
+    assert offer_payload['document_count'] == 2
+    assert offer_payload['version_count'] == 1
+    assert offer_payload['extraction_status'] == 'pending'
+
     with app.app_context():
         offer = db.session.get(SellerOffer, payload['offer_id'])
         assert offer.buyer_names == 'Upload Buyer'
@@ -191,6 +201,10 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
 
     with app.app_context():
         owner = User.query.filter_by(username='owner_a').first()
+        survey_choice = (
+            "Seller's existing survey with affidavit or declaration; "
+            "Buyer to obtain new survey at Seller's expense if needed."
+        )
         offer = SellerOffer(
             organization_id=seed['org_a'],
             transaction_id=seed['tx_a'],
@@ -199,6 +213,7 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
             status='reviewing',
             terms_summary={
                 'offer_price': '260000',
+                'survey_choice': survey_choice,
                 'supporting_documents': {
                     'third_party_financing': {
                         'financing_type': 'conventional',
@@ -284,6 +299,7 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
         assert contract.lead_based_paint_required is True
         assert contract.seller_disclosure_delivered_at.date().isoformat() == '2026-04-23'
         assert contract.financing_approval_deadline.isoformat() == '2026-05-09'
+        assert contract.survey_choice == survey_choice
         assert 'third_party_financing' in contract.frozen_terms['supporting_documents']
         assert len(contract.extra_data['offer_package_documents']) == 3
         assert len(contract.extra_data['supporting_document_ids']) == 2

--- a/tests/test_offer_document_package.py
+++ b/tests/test_offer_document_package.py
@@ -96,12 +96,14 @@ def test_supporting_document_merge_preserves_primary_terms(app, db, seed):
 
 
 def test_offer_upload_accepts_multiple_documents(owner_a_client, app, db, seed):
-    from models import SellerOfferDocument
+    from models import SellerOffer, SellerOfferDocument
 
     def fake_upload(transaction_id, file_data, original_filename, content_type):
         return {'path': f'test/{transaction_id}/{original_filename}'}
 
     data = {
+        'buyer_names': 'Upload Buyer',
+        'buyer_agent_name': 'Upload Agent',
         'files': [
             (io.BytesIO(b'%PDF-1.4 contract'), 'One to Four Family Residential Contract (Resale) - 1124.pdf'),
             (io.BytesIO(b'%PDF-1.4 prequal'), 'Draughn PreQual.pdf'),
@@ -109,7 +111,7 @@ def test_offer_upload_accepts_multiple_documents(owner_a_client, app, db, seed):
     }
 
     with patch('services.supabase_storage.upload_external_document', side_effect=fake_upload), \
-         patch('routes.transactions.offers.post_upload_processing'):
+         patch('routes.transactions.offers.post_upload_processing') as post_upload_processing:
         response = owner_a_client.post(
             f'/transactions/{seed["tx_a"]}/offers/upload',
             data=data,
@@ -121,11 +123,60 @@ def test_offer_upload_accepts_multiple_documents(owner_a_client, app, db, seed):
     assert payload['success'] is True
     assert payload['offer_id']
     assert [doc['document_type'] for doc in payload['documents']] == ['buyer_offer', 'pre_approval']
+    assert post_upload_processing.call_count == 2
 
     with app.app_context():
+        offer = db.session.get(SellerOffer, payload['offer_id'])
+        assert offer.buyer_names == 'Upload Buyer'
+        assert offer.buyer_agent_name == 'Upload Agent'
+        assert offer.status == 'needs_review'
+
         offer_docs = SellerOfferDocument.query.filter_by(offer_id=payload['offer_id']).all()
         assert len(offer_docs) == 2
         assert {doc.document_type for doc in offer_docs} == {'buyer_offer', 'pre_approval'}
+
+
+def test_offer_upload_marks_existing_new_offer_needs_review(owner_a_client, app, db, seed):
+    from models import SellerOffer, SellerOfferDocument, User
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Existing Upload Buyer',
+            status='new',
+        )
+        db.session.add(offer)
+        db.session.commit()
+        offer_id = offer.id
+
+    def fake_upload(transaction_id, file_data, original_filename, content_type):
+        return {'path': f'test/{transaction_id}/{original_filename}'}
+
+    data = {
+        'offer_id': str(offer_id),
+        'files': [
+            (io.BytesIO(b'%PDF-1.4 contract'), 'One to Four Family Residential Contract (Resale) - 1124.pdf'),
+        ],
+    }
+
+    with patch('services.supabase_storage.upload_external_document', side_effect=fake_upload), \
+         patch('routes.transactions.offers.post_upload_processing') as post_upload_processing:
+        response = owner_a_client.post(
+            f'/transactions/{seed["tx_a"]}/offers/upload',
+            data=data,
+            content_type='multipart/form-data',
+        )
+
+    assert response.status_code == 201
+    assert post_upload_processing.call_count == 1
+
+    with app.app_context():
+        offer = db.session.get(SellerOffer, offer_id)
+        assert offer.status == 'needs_review'
+        assert SellerOfferDocument.query.filter_by(offer_id=offer_id).count() == 1
 
 
 def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_client, app, db, seed):


### PR DESCRIPTION
## Summary
- Ensure selected PDFs in the new seller offer modal submit through the upload/extraction path instead of creating a blank manual offer version.
- Keep agents on the Seller Workspace Offers tab after offer create/upload actions and poll extraction status into the offer table without a manual refresh.
- Widen accepted-contract `survey_choice` storage so long AI-extracted survey terms do not fail primary acceptance.

## Test plan
- `pytest tests/test_offer_document_package.py`
- `node --check static/js/transaction_detail.js`
- Alembic migration heads check returns `widen_seller_contract_survey_choice`