### PR TITLE
feat: split combined offer PDFs

### DIFF
--- a/migrations/versions/add_offer_contract_detail_fields.py
+++ b/migrations/versions/add_offer_contract_detail_fields.py
@@ -1,0 +1,88 @@
+"""Add seller offer and contract detail fields
+
+Revision ID: add_offer_contract_detail_fields
+Revises: widen_seller_contract_survey_choice
+Create Date: 2026-04-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_offer_contract_detail_fields'
+down_revision = 'widen_seller_contract_survey_choice'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def _column_exists(conn, table_name, column_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return column_name in {column['name'] for column in inspect(conn).get_columns(table_name)}
+
+
+def _add_column_if_missing(conn, table_name, column):
+    if _table_exists(conn, table_name) and not _column_exists(conn, table_name, column.name):
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_exists(conn, table_name, column_name):
+    if _column_exists(conn, table_name, column_name):
+        op.drop_column(table_name, column_name)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    offer_columns = [
+        sa.Column('financing_amount', sa.Numeric(12, 2)),
+        sa.Column('survey_furnished_by', sa.Text()),
+        sa.Column('residential_service_contract', sa.Text()),
+        sa.Column('buyer_agent_commission_percent', sa.Numeric(6, 3)),
+        sa.Column('buyer_agent_commission_flat', sa.Numeric(12, 2)),
+    ]
+    for column in offer_columns:
+        _add_column_if_missing(conn, 'seller_offers', column)
+
+    contract_columns = [
+        sa.Column('financing_type', sa.String(length=100)),
+        sa.Column('cash_down_payment', sa.Numeric(12, 2)),
+        sa.Column('financing_amount', sa.Numeric(12, 2)),
+        sa.Column('seller_concessions_amount', sa.Numeric(12, 2)),
+        sa.Column('survey_furnished_by', sa.Text()),
+        sa.Column('residential_service_contract', sa.Text()),
+        sa.Column('buyer_agent_commission_percent', sa.Numeric(6, 3)),
+        sa.Column('buyer_agent_commission_flat', sa.Numeric(12, 2)),
+    ]
+    for column in contract_columns:
+        _add_column_if_missing(conn, 'seller_accepted_contracts', column)
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    for column_name in (
+        'financing_amount',
+        'survey_furnished_by',
+        'residential_service_contract',
+        'buyer_agent_commission_percent',
+        'buyer_agent_commission_flat',
+    ):
+        _drop_column_if_exists(conn, 'seller_offers', column_name)
+
+    for column_name in (
+        'financing_type',
+        'cash_down_payment',
+        'financing_amount',
+        'seller_concessions_amount',
+        'survey_furnished_by',
+        'residential_service_contract',
+        'buyer_agent_commission_percent',
+        'buyer_agent_commission_flat',
+    ):
+        _drop_column_if_exists(conn, 'seller_accepted_contracts', column_name)

--- a/migrations/versions/add_transaction_document_split_lineage.py
+++ b/migrations/versions/add_transaction_document_split_lineage.py
@@ -1,0 +1,100 @@
+"""Add parent/page lineage columns for AI-split transaction documents
+
+Revision ID: add_transaction_document_split_lineage
+Revises: add_offer_contract_detail_fields
+Create Date: 2026-04-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_transaction_document_split_lineage'
+down_revision = 'add_offer_contract_detail_fields'
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = 'transaction_documents'
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def _column_exists(conn, table_name, column_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return column_name in {column['name'] for column in inspect(conn).get_columns(table_name)}
+
+
+def _index_exists(conn, table_name, index_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return index_name in {idx['name'] for idx in inspect(conn).get_indexes(table_name)}
+
+
+def _foreign_key_exists(conn, table_name, fk_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return fk_name in {fk.get('name') for fk in inspect(conn).get_foreign_keys(table_name) if fk.get('name')}
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if _table_exists(conn, TABLE_NAME):
+        if not _column_exists(conn, TABLE_NAME, 'parent_document_id'):
+            op.add_column(
+                TABLE_NAME,
+                sa.Column('parent_document_id', sa.Integer(), nullable=True),
+            )
+        if not _column_exists(conn, TABLE_NAME, 'page_start'):
+            op.add_column(TABLE_NAME, sa.Column('page_start', sa.Integer(), nullable=True))
+        if not _column_exists(conn, TABLE_NAME, 'page_end'):
+            op.add_column(TABLE_NAME, sa.Column('page_end', sa.Integer(), nullable=True))
+        if not _column_exists(conn, TABLE_NAME, 'split_source'):
+            op.add_column(TABLE_NAME, sa.Column('split_source', sa.String(length=50), nullable=True))
+
+        if not _foreign_key_exists(conn, TABLE_NAME, 'fk_transaction_documents_parent_document_id'):
+            try:
+                op.create_foreign_key(
+                    'fk_transaction_documents_parent_document_id',
+                    TABLE_NAME,
+                    TABLE_NAME,
+                    ['parent_document_id'],
+                    ['id'],
+                    ondelete='SET NULL',
+                )
+            except Exception:
+                # SQLite (used for local dev) does not support adding FKs after the fact.
+                pass
+
+        if not _index_exists(conn, TABLE_NAME, 'ix_transaction_documents_parent_document_id'):
+            op.create_index(
+                'ix_transaction_documents_parent_document_id',
+                TABLE_NAME,
+                ['parent_document_id'],
+            )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _index_exists(conn, TABLE_NAME, 'ix_transaction_documents_parent_document_id'):
+        op.drop_index('ix_transaction_documents_parent_document_id', table_name=TABLE_NAME)
+
+    if _foreign_key_exists(conn, TABLE_NAME, 'fk_transaction_documents_parent_document_id'):
+        try:
+            op.drop_constraint(
+                'fk_transaction_documents_parent_document_id',
+                TABLE_NAME,
+                type_='foreignkey',
+            )
+        except Exception:
+            pass
+
+    for column_name in ('split_source', 'page_end', 'page_start', 'parent_document_id'):
+        if _column_exists(conn, TABLE_NAME, column_name):
+            op.drop_column(TABLE_NAME, column_name)

--- a/models.py
+++ b/models.py
@@ -936,11 +936,29 @@ class TransactionDocument(db.Model):
     # AI extraction status for uploaded documents (null = not applicable)
     extraction_status = db.Column(db.String(20))  # pending, processing, complete, failed
     extraction_error = db.Column(db.Text)  # error details on failure
-    
+
+    # Lineage for AI-split combined packets. parent_document_id points at the original
+    # uploaded packet; page_start/page_end are 1-based pages inside that parent.
+    parent_document_id = db.Column(
+        db.Integer,
+        db.ForeignKey('transaction_documents.id', ondelete='SET NULL'),
+        nullable=True,
+        index=True,
+    )
+    page_start = db.Column(db.Integer, nullable=True)
+    page_end = db.Column(db.Integer, nullable=True)
+    split_source = db.Column(db.String(50), nullable=True)  # e.g. 'ai_packet_split'
+
     # Relationships
     signatures = db.relationship('DocumentSignature', backref='document',
                                 cascade='all, delete-orphan', lazy='dynamic')
     sent_by = db.relationship('User', foreign_keys=[sent_by_id], backref='sent_documents')
+    split_children = db.relationship(
+        'TransactionDocument',
+        backref=db.backref('parent_document', remote_side='TransactionDocument.id'),
+        foreign_keys=[parent_document_id],
+        lazy='dynamic',
+    )
 
     def __repr__(self):
         return f'<TransactionDocument {self.template_name} ({self.status})>'
@@ -1105,6 +1123,7 @@ class SellerOffer(db.Model):
     offer_price = db.Column(db.Numeric(12, 2))
     financing_type = db.Column(db.String(100))
     cash_down_payment = db.Column(db.Numeric(12, 2))
+    financing_amount = db.Column(db.Numeric(12, 2))
     earnest_money = db.Column(db.Numeric(12, 2))
     additional_earnest_money = db.Column(db.Numeric(12, 2))
     option_fee = db.Column(db.Numeric(12, 2))
@@ -1119,7 +1138,11 @@ class SellerOffer(db.Model):
     inspection_or_repair_terms_summary = db.Column(db.Text)
     title_policy_payer = db.Column(db.String(50))
     survey_payer = db.Column(db.String(50))
+    survey_furnished_by = db.Column(db.Text)
     hoa_resale_certificate_payer = db.Column(db.String(50))
+    residential_service_contract = db.Column(db.Text)
+    buyer_agent_commission_percent = db.Column(db.Numeric(6, 3))
+    buyer_agent_commission_flat = db.Column(db.Numeric(12, 2))
     net_to_seller_estimate = db.Column(db.Numeric(12, 2))
 
     last_activity_at = db.Column(db.DateTime)
@@ -1258,9 +1281,17 @@ class SellerAcceptedContract(db.Model):
     closing_date = db.Column(db.Date)
     option_period_days = db.Column(db.Integer)
     financing_approval_deadline = db.Column(db.Date)
+    financing_type = db.Column(db.String(100))
+    cash_down_payment = db.Column(db.Numeric(12, 2))
+    financing_amount = db.Column(db.Numeric(12, 2))
+    seller_concessions_amount = db.Column(db.Numeric(12, 2))
     title_company = db.Column(db.String(200))
     escrow_officer = db.Column(db.String(200))
     survey_choice = db.Column(db.Text)
+    survey_furnished_by = db.Column(db.Text)
+    residential_service_contract = db.Column(db.Text)
+    buyer_agent_commission_percent = db.Column(db.Numeric(6, 3))
+    buyer_agent_commission_flat = db.Column(db.Numeric(12, 2))
     hoa_applicable = db.Column(db.Boolean)
     seller_disclosure_required = db.Column(db.Boolean)
     seller_disclosure_delivered_at = db.Column(db.DateTime)

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -40,6 +40,52 @@ def _merge_extraction_status(current_status, candidate_status):
     )
 
 
+def _order_offer_package_documents(offer_documents):
+    """Order offer documents so AI-split children render under their parent packet."""
+    if not offer_documents:
+        return offer_documents
+
+    by_doc_id = {}
+    parents = []
+    children_by_parent = {}
+    orphans = []
+
+    for offer_document in offer_documents:
+        doc = offer_document.document
+        if not doc:
+            orphans.append(offer_document)
+            continue
+        by_doc_id[doc.id] = offer_document
+        if doc.parent_document_id:
+            children_by_parent.setdefault(doc.parent_document_id, []).append(offer_document)
+        else:
+            parents.append(offer_document)
+
+    for parent_id, child_list in children_by_parent.items():
+        child_list.sort(key=lambda od: (
+            od.document.page_start if od.document and od.document.page_start else 0,
+            od.document.page_end if od.document and od.document.page_end else 0,
+            od.created_at or od.id,
+        ))
+
+    ordered = []
+    seen_parent_ids = set()
+    for offer_document in parents:
+        ordered.append(offer_document)
+        seen_parent_ids.add(offer_document.document.id)
+        for child in children_by_parent.get(offer_document.document.id, []):
+            ordered.append(child)
+
+    for parent_id, child_list in children_by_parent.items():
+        if parent_id in seen_parent_ids:
+            continue
+        for child in child_list:
+            ordered.append(child)
+
+    ordered.extend(orphans)
+    return ordered
+
+
 # =============================================================================
 # TRANSACTION LIST
 # =============================================================================
@@ -509,6 +555,9 @@ def view_transaction(id):
                         document.extraction_status,
                     )
 
+            for offer_id, docs in list(seller_offer_documents_by_offer.items()):
+                seller_offer_documents_by_offer[offer_id] = _order_offer_package_documents(docs)
+
             offer_activities = SellerOfferActivity.query.filter(
                 SellerOfferActivity.offer_id.in_(offer_ids),
                 SellerOfferActivity.organization_id == current_user.organization_id
@@ -554,7 +603,7 @@ def view_transaction(id):
             for offer_document in contract_offer_documents:
                 docs_by_offer.setdefault(offer_document.offer_id, []).append(offer_document)
             seller_contract_documents_by_contract = {
-                contract.id: docs_by_offer.get(contract.offer_id, [])
+                contract.id: _order_offer_package_documents(docs_by_offer.get(contract.offer_id, []))
                 for contract in seller_contracts
             }
         if primary_seller_contract:

--- a/routes/transactions/offers.py
+++ b/routes/transactions/offers.py
@@ -18,9 +18,11 @@ from services.seller_workflow import (
     apply_offer_terms,
     create_contract_milestones,
     create_offer_activity,
+    derive_financing_approval_deadline,
     expire_offer_if_needed,
     get_offer_document_type,
     infer_offer_document_type,
+    infer_offer_document_type_from_pdf,
     offer_urgency,
 )
 from services.intake_service import post_upload_processing
@@ -127,6 +129,15 @@ def _offer_extraction_status(offer):
     return status
 
 
+def _pending_offer_extraction_documents(offer):
+    pending = []
+    for offer_document in offer.offer_documents.all():
+        document = offer_document.document
+        if document and document.extraction_status in ('pending', 'processing'):
+            pending.append(offer_document.display_name or document.template_name or document.signed_original_filename)
+    return pending
+
+
 def _normalize_terms(data):
     terms = dict(data.get('terms_data') or data.get('terms') or {})
     for key in ('response_deadline_at',):
@@ -150,10 +161,16 @@ def _offer_payload(offer):
         'urgency': urgency,
         'offer_price': str(offer.offer_price) if offer.offer_price is not None else None,
         'financing_type': offer.financing_type,
+        'cash_down_payment': str(offer.cash_down_payment) if offer.cash_down_payment is not None else None,
+        'financing_amount': str(offer.financing_amount) if offer.financing_amount is not None else None,
         'proposed_close_date': offer.proposed_close_date.isoformat() if offer.proposed_close_date else None,
         'option_period_days': offer.option_period_days,
         'earnest_money': str(offer.earnest_money) if offer.earnest_money is not None else None,
         'seller_concessions_amount': str(offer.seller_concessions_amount) if offer.seller_concessions_amount is not None else None,
+        'survey_furnished_by': offer.survey_furnished_by,
+        'residential_service_contract': offer.residential_service_contract,
+        'buyer_agent_commission_percent': str(offer.buyer_agent_commission_percent) if offer.buyer_agent_commission_percent is not None else None,
+        'buyer_agent_commission_flat': str(offer.buyer_agent_commission_flat) if offer.buyer_agent_commission_flat is not None else None,
         'current_version_id': offer.current_version_id,
         'accepted_version_id': offer.accepted_version_id,
         'source_showing_id': offer.source_showing_id,
@@ -372,7 +389,8 @@ def upload_seller_offer_document(id):
                 return jsonify({'success': False, 'error': f'{file.filename}: file too large. Maximum size is 25MB.'}), 400
 
             explicit_type = document_types[index] if index < len(document_types) else None
-            document_type = infer_offer_document_type(
+            document_type = infer_offer_document_type_from_pdf(
+                file_data,
                 file.filename,
                 explicit_type or request.form.get('document_type') or request.form.get('direction'),
             )
@@ -648,6 +666,14 @@ def accept_seller_offer(id, offer_id):
         if not active_primary:
             return jsonify({'success': False, 'error': 'Accept a primary contract before accepting a backup'}), 400
 
+    pending_extractions = _pending_offer_extraction_documents(offer)
+    if pending_extractions:
+        return jsonify({
+            'success': False,
+            'error': 'AI extraction is still running for this offer. Wait for extraction to finish before accepting it as a contract.',
+            'pending_documents': pending_extractions,
+        }), 409
+
     version = None
     if offer.current_version_id:
         version = SellerOfferVersion.query.filter_by(
@@ -665,20 +691,8 @@ def accept_seller_offer(id, offer_id):
         seller_disclosure.get('buyer_received_date')
         or seller_disclosure.get('seller_signed_date')
     )
-    financing_deadline = (
-        terms.get('financing_approval_deadline')
-        or financing_addendum.get('financing_approval_deadline')
-        or financing_addendum.get('buyer_approval_deadline')
-    )
-    if not financing_deadline and financing_addendum.get('buyer_approval_days'):
-        effective_date = _parse_date(data.get('effective_date') or terms.get('effective_date'))
-        try:
-            approval_days = int(str(financing_addendum.get('buyer_approval_days')).strip())
-        except (TypeError, ValueError):
-            approval_days = None
-        if effective_date and approval_days is not None:
-            from datetime import timedelta
-            financing_deadline = effective_date + timedelta(days=approval_days)
+    manual_effective_date = _parse_date(data.get('effective_date'))
+    financing_deadline = derive_financing_approval_deadline(terms, manual_effective_date)
 
     accepted_contract = SellerAcceptedContract(
         organization_id=current_user.organization_id,
@@ -690,14 +704,22 @@ def accept_seller_offer(id, offer_id):
         backup_position=data.get('backup_position') if position == 'backup' else None,
         backup_addendum_document_id=data.get('backup_addendum_document_id') or None,
         accepted_price=offer.offer_price or terms.get('offer_price') or terms.get('sales_price'),
-        effective_date=_parse_date(data.get('effective_date') or terms.get('effective_date')),
-        effective_at=_parse_datetime(data.get('effective_at') or terms.get('effective_at')),
+        effective_date=manual_effective_date,
+        effective_at=_parse_datetime(data.get('effective_at')),
         closing_date=offer.proposed_close_date or _parse_date(terms.get('proposed_close_date') or terms.get('closing_date')),
         option_period_days=offer.option_period_days or _parse_int(terms.get('option_period_days')),
         financing_approval_deadline=_parse_date(financing_deadline),
+        financing_type=offer.financing_type or terms.get('financing_type'),
+        cash_down_payment=offer.cash_down_payment or terms.get('cash_down_payment'),
+        financing_amount=offer.financing_amount or terms.get('financing_amount') or financing_addendum.get('total_financing_amount'),
+        seller_concessions_amount=offer.seller_concessions_amount or terms.get('seller_concessions_amount'),
         title_company=terms.get('title_company'),
         escrow_officer=terms.get('escrow_officer'),
         survey_choice=terms.get('survey_choice'),
+        survey_furnished_by=offer.survey_furnished_by or terms.get('survey_furnished_by'),
+        residential_service_contract=offer.residential_service_contract or terms.get('residential_service_contract'),
+        buyer_agent_commission_percent=offer.buyer_agent_commission_percent or terms.get('buyer_agent_commission_percent'),
+        buyer_agent_commission_flat=offer.buyer_agent_commission_flat or terms.get('buyer_agent_commission_flat'),
         hoa_applicable=terms.get('hoa_applicable') if terms.get('hoa_applicable') is not None else bool(hoa_addendum),
         seller_disclosure_required=terms.get('seller_disclosure_required') if terms.get('seller_disclosure_required') is not None else bool(seller_disclosure),
         seller_disclosure_delivered_at=_parse_datetime(seller_disclosure_delivered),

--- a/routes/transactions/seller_contracts.py
+++ b/routes/transactions/seller_contracts.py
@@ -7,7 +7,13 @@ from flask import abort, jsonify, request
 from flask_login import current_user, login_required
 
 from models import SellerAcceptedContract, SellerContractMilestone, Transaction, db
-from services.seller_workflow import close_contract, promote_backup_contract, terminate_contract
+from services.seller_workflow import (
+    close_contract,
+    create_contract_milestones,
+    derive_financing_approval_deadline,
+    promote_backup_contract,
+    terminate_contract,
+)
 from . import transactions_bp
 from .decorators import transactions_required
 
@@ -91,6 +97,41 @@ def _get_contract_for_update(transaction, contract_id):
     ).first_or_404()
 
 
+def _json_safe_value(value):
+    if value is None:
+        return None
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return value
+
+
+def _sync_contract_frozen_terms(contract):
+    from sqlalchemy.orm.attributes import flag_modified
+
+    terms = dict(contract.frozen_terms or {})
+    for field in (
+        'accepted_price',
+        'effective_date',
+        'closing_date',
+        'option_period_days',
+        'financing_approval_deadline',
+        'financing_type',
+        'cash_down_payment',
+        'financing_amount',
+        'seller_concessions_amount',
+        'survey_choice',
+        'survey_furnished_by',
+        'residential_service_contract',
+        'buyer_agent_commission_percent',
+        'buyer_agent_commission_flat',
+    ):
+        terms[field] = _json_safe_value(getattr(contract, field))
+    contract.frozen_terms = terms
+    flag_modified(contract, 'frozen_terms')
+
+
 def _apply_milestone_data(milestone, data):
     title = (data.get('title') or '').strip()
     if not title:
@@ -111,6 +152,68 @@ def _apply_milestone_data(milestone, data):
     else:
         milestone.completed_at = None
     return milestone
+
+
+@transactions_bp.route('/<int:id>/seller/contracts/<int:contract_id>/details', methods=['POST', 'PATCH'])
+@login_required
+@transactions_required
+def update_seller_contract_details(id, contract_id):
+    """Update accepted contract terms that drive seller milestones."""
+    transaction = _get_seller_transaction(id)
+    if transaction is None:
+        return jsonify({'success': False, 'error': 'Contracts are only available for seller transactions'}), 400
+
+    contract = _get_contract_for_update(transaction, contract_id)
+    data = request.get_json(silent=True) or request.form
+
+    try:
+        if 'accepted_price' in data:
+            contract.accepted_price = _decimal(data.get('accepted_price'))
+        if 'effective_date' in data:
+            contract.effective_date = _parse_date(data.get('effective_date'))
+            contract.effective_at = _parse_datetime(data.get('effective_at')) if data.get('effective_at') else None
+        if 'closing_date' in data:
+            contract.closing_date = _parse_date(data.get('closing_date'))
+        if 'option_period_days' in data:
+            contract.option_period_days = int(data.get('option_period_days')) if data.get('option_period_days') else None
+
+        for field in (
+            'financing_type',
+            'survey_choice',
+            'survey_furnished_by',
+            'residential_service_contract',
+        ):
+            if field in data:
+                setattr(contract, field, data.get(field) or None)
+
+        for field in (
+            'cash_down_payment',
+            'financing_amount',
+            'seller_concessions_amount',
+            'buyer_agent_commission_percent',
+            'buyer_agent_commission_flat',
+        ):
+            if field in data:
+                setattr(contract, field, _decimal(data.get(field)))
+
+        if 'financing_approval_deadline' in data and data.get('financing_approval_deadline'):
+            contract.financing_approval_deadline = _parse_date(data.get('financing_approval_deadline'))
+        else:
+            contract.financing_approval_deadline = derive_financing_approval_deadline(
+                contract.frozen_terms or {},
+                contract.effective_date,
+            )
+
+        _sync_contract_frozen_terms(contract)
+        create_contract_milestones(contract, replace=True)
+        db.session.commit()
+        return jsonify({'success': True, 'accepted_contract_id': contract.id})
+    except ValueError as e:
+        db.session.rollback()
+        return jsonify({'success': False, 'error': str(e)}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 
 @transactions_bp.route('/<int:id>/seller/contracts/<int:contract_id>/milestones', methods=['POST'])

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -627,7 +627,9 @@ def _usage_meta(model: str, usage) -> dict:
 # DOCUMENT EXTRACTION (structured data from document images)
 # =============================================================================
 
-EXTRACTION_MODEL = "gpt-4.1-mini"
+EXTRACTION_MODEL = os.getenv("DOCUMENT_EXTRACTION_MODEL", "gpt-5.1")
+EXTRACTION_FALLBACK_MODEL = os.getenv("DOCUMENT_EXTRACTION_FALLBACK_MODEL", "gpt-5-mini")
+EXTRACTION_LEGACY_MODEL = os.getenv("DOCUMENT_EXTRACTION_LEGACY_MODEL", "gpt-4.1-mini")
 
 
 def generate_document_extraction(
@@ -663,18 +665,36 @@ def generate_document_extraction(
             "image_url": {"url": f"data:image/png;base64,{img_b64}", "detail": "high"}
         })
 
-    logger.info(f"Document extraction: sending {len(images or [])} page images to {EXTRACTION_MODEL}")
+    models = [EXTRACTION_MODEL, EXTRACTION_FALLBACK_MODEL, EXTRACTION_LEGACY_MODEL]
+    last_error = None
+    logger.info(f"Document extraction: sending {len(images or [])} page images to {models[0]}")
 
-    response = client.chat.completions.create(
-        model=EXTRACTION_MODEL,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_content}
-        ],
-        response_format={"type": "json_object"},
-        temperature=0.1
-    )
+    for index, model in enumerate(dict.fromkeys(models), start=1):
+        try:
+            kwargs = {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content}
+                ],
+                "response_format": {"type": "json_object"},
+            }
+            if not model.startswith("gpt-5"):
+                kwargs["temperature"] = 0.1
 
-    result = json.loads(response.choices[0].message.content)
-    logger.info(f"Document extraction: received {len(result)} fields from {EXTRACTION_MODEL}")
-    return result
+            response = client.chat.completions.create(**kwargs)
+            result = json.loads(response.choices[0].message.content)
+            logger.info(f"Document extraction: received {len(result)} fields from {model}")
+            return result
+        except Exception as error:
+            last_error = error
+            logger.warning(
+                "Document extraction model %s/%s failed for %s: %s",
+                index,
+                len(models),
+                model,
+                error,
+                exc_info=True,
+            )
+
+    raise last_error

--- a/services/document_extractor.py
+++ b/services/document_extractor.py
@@ -40,17 +40,19 @@ EXTRACTION_SCHEMAS = {
     },
     'seller-offer-contract': {
         'fields': {
+            'detected_document_types': 'Array of document types detected in this PDF package, using these labels when present: residential_contract, third_party_financing_addendum, hoa_addendum, sellers_disclosure, pre_approval, backup_addendum, other.',
             'buyer_names': 'Buyer name or names as written in Paragraph 1 or signature blocks.',
             'buyer_agent_name': 'Buyer agent name if visible on the contract or signature/email blocks.',
             'buyer_agent_brokerage': 'Buyer agent brokerage/company if visible.',
             'offer_price': 'Total sales price from Paragraph 3C (digits only, no $ or commas).',
-            'cash_down_payment': 'Cash portion/down payment from Paragraph 3A or financing terms (digits only, no $ or commas).',
+            'cash_down_payment': 'Cash portion from Paragraph 3A on page 1 (digits only, no $ or commas).',
+            'financing_amount': 'Sum of all financing from Paragraph 3B on page 1 (digits only, no $ or commas).',
             'financing_type': 'Financing type, such as cash, conventional, FHA, VA, seller financing, or other.',
             'earnest_money': 'Initial earnest money amount from Paragraph 5 (digits only, no $ or commas).',
             'additional_earnest_money': 'Additional earnest money amount, if any (digits only, no $ or commas).',
             'option_fee': 'Option fee amount, if any (digits only, no $ or commas).',
             'option_period_days': 'Number of option period days for unrestricted right to terminate.',
-            'seller_concessions_amount': 'Seller concessions, seller contribution, or buyer expense amount paid by seller (digits only, no $ or commas).',
+            'seller_concessions_amount': 'Seller contribution amount from Paragraph 12 on page 6, including buyer expenses paid by seller (digits only, no $ or commas).',
             'proposed_close_date': 'Closing date from Paragraph 9 (YYYY-MM-DD).',
             'possession_type': 'Possession terms, such as at closing/funding, temporary leaseback, or other.',
             'leaseback_days': 'Number of seller temporary leaseback days if shown.',
@@ -60,7 +62,11 @@ EXTRACTION_SCHEMAS = {
             'inspection_or_repair_terms_summary': 'Short summary of any repair/inspection/as-is terms written in the offer.',
             'title_policy_payer': 'Who pays owner title policy: buyer, seller, split, or null.',
             'survey_payer': 'Who pays for a new survey if needed: buyer, seller, split, or null.',
+            'survey_furnished_by': 'Survey furnished by selection from Paragraph 6C on page 3. Return a concise description such as seller existing survey, buyer new survey, or seller new survey.',
             'hoa_resale_certificate_payer': 'Who pays HOA/resale certificate fees if stated: buyer, seller, split, or null.',
+            'residential_service_contract': 'Residential Service Contract terms from Paragraph 7H on page 5. Include whether one is requested, who pays, and any dollar cap if written.',
+            'buyer_agent_commission_percent': 'Buyer agent/buyer broker compensation percentage if explicitly written in the contract or compensation addendum (number only, no %).',
+            'buyer_agent_commission_flat': 'Buyer agent/buyer broker compensation flat fee if explicitly written in the contract or compensation addendum (digits only, no $ or commas).',
             'response_deadline_at': 'Offer acceptance deadline/respond-by date and time if written. Use ISO-like YYYY-MM-DDTHH:MM when time is available, otherwise YYYY-MM-DD.',
             'effective_date': 'Effective date if the contract is already executed (YYYY-MM-DD).',
             'title_company': 'Escrow/title company name if written.',
@@ -70,14 +76,40 @@ EXTRACTION_SCHEMAS = {
             'seller_disclosure_required': 'Whether Seller Disclosure Notice is required or referenced. Return true, false, or null.',
             'lead_based_paint_required': 'Whether lead-based paint disclosure/addendum is required or attached. Return true, false, or null.',
             'addenda': (
-                'JSON object describing attached addenda and deadline-bearing terms. Include keys when present: '
-                'third_party_financing_addendum, sale_of_other_property_addendum, seller_temporary_residential_lease, '
-                'backup_addendum, hoa_addendum, lead_based_paint. Use nested simple key/value pairs.'
+                'JSON object describing attached addenda and deadline-bearing terms. For combined PDFs, inspect all pages and include keys when present: '
+                'third_party_financing_addendum with financing_type, first_mortgage_amount, second_mortgage_amount, total_financing_amount, buyer_approval_required, buyer_approval_days from Paragraph 2A page 2, buyer_approval_deadline only when a calendar date is written; '
+                'hoa_addendum with association_name, association_phone, selected_subdivision_information_option, subdivision_information_delivery_days, buyer_termination_days_after_receipt, updated_resale_certificate_required, updated_resale_certificate_delivery_days, transfer_fee_cap, title_company_info_payer; '
+                'sale_of_other_property_addendum, seller_temporary_residential_lease, backup_addendum, lead_based_paint. Use nested simple key/value pairs.'
+            ),
+            'supporting_documents': (
+                'JSON object keyed by supporting document type when the same PDF includes addenda or supporting docs. '
+                'Use keys third_party_financing, hoa_addendum, sellers_disclosure, pre_approval, backup_addendum when present, with the same nested values extracted for those documents.'
+            ),
+            'detected_documents': (
+                'JSON array of every distinct document/addendum identified inside this PDF, in the order they appear. '
+                'Each item must include "document_type" using one of these labels: '
+                'buyer_offer (TREC residential contract / One to Four Family / Farm and Ranch / New Home / Unimproved Property), '
+                'third_party_financing (Third Party Financing Addendum), '
+                'hoa_addendum (HOA/POA addendum), '
+                'sellers_disclosure (Seller\'s Disclosure Notice), '
+                'pre_approval (lender pre-approval letter or proof of funds), '
+                'backup_addendum (Back-Up Contract addendum), '
+                'lead_based_paint (Lead-Based Paint Disclosure/Addendum), '
+                'sale_of_other_property (Addendum for Sale of Other Property), '
+                'temporary_lease (Seller\'s/Buyer\'s Temporary Residential Lease), '
+                'compensation_agreement (broker compensation/cooperation agreement), '
+                'other (anything else, include a descriptive title). '
+                'Each item must also include 1-based "start_page" and "end_page" integers indicating the page range inside this PDF, an optional human "title" (e.g. "TREC One to Four Family Residential Contract"), and an optional "notes" string. '
+                'Page ranges must be contiguous and stay within the total number of pages in this PDF. '
+                'Always include the main contract first when present.'
             ),
             'special_provisions': 'Exact special provisions text if present, or null.',
         },
         'system_prompt': (
-            "You are a precise document data extractor for Texas residential purchase offers and TREC contracts. "
+            "You are a precise document data extractor for Texas residential purchase offer packages. "
+            "A single uploaded PDF may contain multiple document types, such as a TREC residential contract, Third Party Financing Addendum, HOA Addendum, Seller's Disclosure, and other addenda. "
+            "Do not rely on the filename. Read the document contents and extract every requested field from all pages. "
+            "Always populate detected_documents with one entry per distinct document found in the PDF, including accurate 1-based start_page and end_page values that cover every page in the file without gaps when possible. "
             "Extract ONLY values explicitly written on the document and attached addenda. "
             "Do NOT infer legal meaning, do NOT guess missing dates, and use null when a field is blank or not found."
         ),
@@ -185,12 +217,14 @@ EXTRACTION_SCHEMAS = {
             'financing_type': 'Selected financing type: conventional, FHA, VA, USDA, Texas Veterans, reverse mortgage, other, or null.',
             'first_mortgage_amount': 'First mortgage principal amount (digits only, no $ or commas).',
             'second_mortgage_amount': 'Second mortgage principal amount if any (digits only, no $ or commas).',
+            'total_financing_amount': 'Total of all financing shown on the addendum, or the sum of first and second mortgage amounts when both are visible (digits only, no $ or commas).',
             'loan_term_years': 'Loan term in years for selected financing.',
             'interest_rate_cap': 'Maximum interest rate percentage for selected financing (number only, no %).',
             'origination_charge_cap': 'Maximum origination charges percentage (number only, no %).',
             'other_lender_name': 'Lender name if other financing is selected.',
             'buyer_approval_required': 'Whether contract is subject to buyer obtaining buyer approval. Return true, false, or null.',
-            'buyer_approval_days': 'Number of days after effective date for buyer approval termination right.',
+            'buyer_approval_days': 'Number of days in Paragraph 2A on page 2 after the contract effective date for buyer approval termination right.',
+            'buyer_approval_deadline': 'Absolute buyer approval deadline date only if a specific calendar date is written (YYYY-MM-DD); otherwise null.',
             'property_approval_deadline_rule': 'Text summary of property approval/appraisal/insurability deadline rule.',
             'fha_va_appraisal_required': 'Whether FHA/VA required appraisal/value provision applies. Return true, false, or null.',
             'buyer_names': 'Buyer name or names if visible.',
@@ -224,6 +258,20 @@ def _render_pdf_to_images(file_data: bytes) -> list:
     return images
 
 
+def _extract_pdf_text(file_data: bytes) -> str:
+    """Extract selectable PDF text to help AI handle combined packets."""
+    chunks = []
+    doc = fitz.open(stream=file_data, filetype="pdf")
+    try:
+        for index, page in enumerate(doc, start=1):
+            page_text = (page.get_text("text") or "").strip()
+            if page_text:
+                chunks.append(f"--- Page {index} ---\n{page_text}")
+    finally:
+        doc.close()
+    return "\n\n".join(chunks)
+
+
 def _build_extraction_prompt(schema: dict) -> str:
     """Build the user prompt with field definitions and format instructions."""
     lines = [
@@ -243,6 +291,8 @@ def _build_extraction_prompt(schema: dict) -> str:
         "- Currency/price values: digits only, no $ sign or commas (e.g. 450000)",
         "- Percentage values: number only, no % sign (e.g. 6)",
         "- Flat fee values: digits only, no $ sign or commas",
+        "- For combined PDFs, detect all included document types and populate both top-level contract fields and nested addenda/supporting_documents fields when applicable",
+        "- Do not use the filename to decide what is in the PDF",
         "",
         "Return the JSON object now.",
     ])
@@ -283,13 +333,23 @@ def extract_document_data(doc_id: int, org_id: int, file_data: bytes):
         _set_rls(org_id)
 
         images = _render_pdf_to_images(file_data)
-        logger.info(f"Rendered {len(images)} pages for doc {doc_id}")
+        pdf_text = _extract_pdf_text(file_data)
+        logger.info(f"Rendered {len(images)} pages and extracted {len(pdf_text)} text chars for doc {doc_id}")
 
         from services.ai_service import generate_document_extraction
 
+        user_prompt = _build_extraction_prompt(schema)
+        if pdf_text:
+            user_prompt = (
+                f"{user_prompt}\n\n"
+                "Selectable PDF text extracted from the uploaded file follows. "
+                "Use this text together with the page images; the images are authoritative for checkbox marks and layout.\n\n"
+                f"{pdf_text[:60000]}"
+            )
+
         result = generate_document_extraction(
             system_prompt=schema['system_prompt'],
-            user_prompt=_build_extraction_prompt(schema),
+            user_prompt=user_prompt,
             images=images,
         )
 
@@ -300,19 +360,57 @@ def extract_document_data(doc_id: int, org_id: int, file_data: bytes):
         from sqlalchemy.orm.attributes import flag_modified
         flag_modified(doc, 'field_data')
 
-        doc.extraction_status = 'complete'
         doc.extraction_error = None
         db.session.commit()
-        logger.info(f"Extraction complete for doc {doc_id}: {len(doc.field_data)} fields populated")
+        logger.info(
+            "Extraction data stored for doc %s: %d fields populated; running post-processing",
+            doc_id,
+            len(doc.field_data),
+        )
 
         try:
             _set_rls(org_id)
             from services.seller_workflow import sync_offer_version_from_document
             sync_offer_version_from_document(doc_id)
             db.session.commit()
-        except Exception:
+        except Exception as sync_error:
             db.session.rollback()
             logger.error(f"Failed to sync extracted offer data for doc {doc_id}", exc_info=True)
+            try:
+                _set_rls(org_id)
+                doc = TransactionDocument.query.get(doc_id)
+                if doc:
+                    doc.extraction_status = 'failed'
+                    doc.extraction_error = f"Offer sync failed: {sync_error}"[:500]
+                    db.session.commit()
+            except Exception:
+                logger.error(f"Failed to mark extraction sync failure for doc {doc_id}", exc_info=True)
+            return
+
+        split_warning = None
+        try:
+            _set_rls(org_id)
+            from services.seller_workflow import split_offer_package_into_children
+            children = split_offer_package_into_children(doc_id, file_data)
+            if children:
+                db.session.commit()
+                logger.info(
+                    "Created %d split child documents for doc %s", len(children), doc_id,
+                )
+        except Exception as split_error:
+            db.session.rollback()
+            split_warning = f"Document split warning: {split_error}"
+            logger.error(
+                f"Failed to create split child documents for doc {doc_id}", exc_info=True,
+            )
+
+        _set_rls(org_id)
+        doc = TransactionDocument.query.get(doc_id)
+        if doc:
+            doc.extraction_status = 'complete'
+            doc.extraction_error = split_warning[:500] if split_warning else None
+            db.session.commit()
+            logger.info(f"Extraction complete for doc {doc_id}: {len(doc.field_data or {})} fields populated")
 
     except Exception as e:
         db.session.rollback()

--- a/services/pdf_splitter.py
+++ b/services/pdf_splitter.py
@@ -1,0 +1,174 @@
+"""
+PDF splitter service.
+
+Uses PyMuPDF (fitz) to slice a source PDF byte stream into multiple
+child PDFs based on 1-based start/end page ranges. Used to split
+combined offer packets into the individual addenda/contracts that
+the AI extraction service identifies.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import fitz  # PyMuPDF
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SplitSegment:
+    """A normalized 1-based page range for a single split request."""
+
+    start_page: int
+    end_page: int
+    document_type: Optional[str] = None
+    title: Optional[str] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class SplitResult:
+    """Output for a single produced child PDF."""
+
+    segment: SplitSegment
+    pdf_bytes: bytes
+    page_count: int
+
+
+def get_pdf_page_count(file_data: bytes) -> int:
+    """Return the number of pages in a PDF byte stream."""
+    if not file_data:
+        return 0
+    doc = fitz.open(stream=file_data, filetype="pdf")
+    try:
+        return doc.page_count
+    finally:
+        doc.close()
+
+
+def normalize_segments(
+    raw_segments: Iterable[dict],
+    *,
+    total_pages: int,
+) -> List[SplitSegment]:
+    """
+    Coerce raw AI-detected segments into clean SplitSegment instances.
+
+    - Drops anything without a usable page range.
+    - Clamps ranges to ``[1, total_pages]``.
+    - Sorts segments by start page.
+    - Skips segments that fully duplicate a previous one.
+    """
+    if total_pages <= 0:
+        return []
+
+    cleaned: List[SplitSegment] = []
+    for raw in raw_segments or []:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            start = int(raw.get('start_page')) if raw.get('start_page') is not None else None
+            end = int(raw.get('end_page')) if raw.get('end_page') is not None else None
+        except (TypeError, ValueError):
+            continue
+        if start is None or end is None:
+            continue
+        if start > end:
+            start, end = end, start
+        start = max(1, min(start, total_pages))
+        end = max(1, min(end, total_pages))
+        if end < start:
+            continue
+
+        document_type = raw.get('document_type')
+        if isinstance(document_type, str):
+            document_type = document_type.strip().lower() or None
+        else:
+            document_type = None
+
+        title = raw.get('title')
+        if isinstance(title, str):
+            title = title.strip() or None
+        else:
+            title = None
+
+        notes = raw.get('notes')
+        if isinstance(notes, str):
+            notes = notes.strip() or None
+        else:
+            notes = None
+
+        cleaned.append(SplitSegment(
+            start_page=start,
+            end_page=end,
+            document_type=document_type,
+            title=title,
+            notes=notes,
+        ))
+
+    cleaned.sort(key=lambda s: (s.start_page, s.end_page))
+
+    # Drop exact duplicates while preserving order.
+    deduped: List[SplitSegment] = []
+    seen: set[tuple[int, int, Optional[str]]] = set()
+    for seg in cleaned:
+        key = (seg.start_page, seg.end_page, seg.document_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(seg)
+    return deduped
+
+
+def split_pdf_by_segments(
+    file_data: bytes,
+    segments: Iterable[SplitSegment],
+) -> List[SplitResult]:
+    """
+    Slice ``file_data`` into one PDF per segment.
+
+    Returns a list of ``SplitResult`` objects whose order matches the
+    input segment order. Invalid segments are skipped silently and
+    logged.
+    """
+    if not file_data:
+        return []
+
+    seg_list = [s for s in segments if s is not None]
+    if not seg_list:
+        return []
+
+    results: List[SplitResult] = []
+    source = fitz.open(stream=file_data, filetype="pdf")
+    try:
+        total_pages = source.page_count
+        for seg in seg_list:
+            if seg.start_page < 1 or seg.end_page > total_pages or seg.end_page < seg.start_page:
+                logger.warning(
+                    "Skipping invalid PDF split segment %s-%s (total pages=%s)",
+                    seg.start_page, seg.end_page, total_pages,
+                )
+                continue
+            child = fitz.open()
+            try:
+                child.insert_pdf(
+                    source,
+                    from_page=seg.start_page - 1,
+                    to_page=seg.end_page - 1,
+                )
+                if child.page_count <= 0:
+                    continue
+                pdf_bytes = child.tobytes()
+            finally:
+                child.close()
+            results.append(SplitResult(
+                segment=seg,
+                pdf_bytes=pdf_bytes,
+                page_count=(seg.end_page - seg.start_page + 1),
+            ))
+    finally:
+        source.close()
+    return results

--- a/services/seller_workflow.py
+++ b/services/seller_workflow.py
@@ -31,6 +31,12 @@ ACTIVE_OFFER_STATUSES = {
 
 
 OFFER_DOCUMENT_TYPES = {
+    'offer_package': {
+        'label': 'Offer Package',
+        'template_slug': 'seller-offer-contract',
+        'direction': 'buyer_offer',
+        'primary_terms': True,
+    },
     'buyer_offer': {
         'label': 'Offer Contract',
         'template_slug': 'seller-offer-contract',
@@ -141,6 +147,67 @@ def infer_offer_document_type(filename='', explicit_type=None):
     return 'buyer_offer'
 
 
+def infer_offer_document_type_from_text(text='', filename='', explicit_type=None):
+    """Prefer document text over filenames/dropdown guesses when classifying uploads."""
+    normalized = re.sub(r'[^a-z0-9]+', ' ', (text or '').lower()).strip()
+    has_contract = (
+        'one to four family residential contract' in normalized
+        or ('sales price' in normalized and 'trec no 20' in normalized)
+    )
+    has_tpf = 'third party financing addendum' in normalized
+    has_hoa = (
+        'addendum for property subject to mandatory membership' in normalized
+        or 'property owners association' in normalized
+        or 'home owners association' in normalized
+    )
+    has_disclosure = (
+        'seller disclosure notice' in normalized
+        or 'seller s disclosure notice' in normalized
+    )
+    has_preapproval = (
+        'pre approval' in normalized
+        or 'preapproval' in normalized
+        or 'pre qualification' in normalized
+        or 'prequalification' in normalized
+    )
+    has_backup = 'addendum for back up contract' in normalized or 'backup contract' in normalized
+
+    if has_contract:
+        if has_tpf or has_hoa or has_disclosure:
+            return 'offer_package'
+        if explicit_type in ('buyer_offer', 'seller_counter', 'buyer_counter', 'final_acceptance'):
+            return explicit_type
+        return 'buyer_offer'
+    if has_tpf:
+        return 'third_party_financing'
+    if has_hoa:
+        return 'hoa_addendum'
+    if has_disclosure:
+        return 'sellers_disclosure'
+    if has_preapproval:
+        return 'pre_approval'
+    if has_backup:
+        return 'backup_acceptance'
+    return infer_offer_document_type(filename, explicit_type)
+
+
+def infer_offer_document_type_from_pdf(file_data, filename='', explicit_type=None):
+    """Infer upload type from PDF text, falling back to filename/dropdown metadata."""
+    try:
+        import fitz
+
+        chunks = []
+        doc = fitz.open(stream=file_data, filetype='pdf')
+        try:
+            for page in doc:
+                chunks.append(page.get_text('text') or '')
+        finally:
+            doc.close()
+        return infer_offer_document_type_from_text(' '.join(chunks), filename, explicit_type)
+    except Exception:
+        return infer_offer_document_type(filename, explicit_type)
+
+
 def _coerce_decimal(value):
     if value in (None, ''):
         return None
@@ -173,9 +240,24 @@ def _coerce_bool(value):
     return None
 
 
+def _coerce_text(value):
+    """Return a DB-safe display string for scalar text columns."""
+    if value in (None, ''):
+        return None
+    if isinstance(value, (list, tuple)):
+        parts = [_coerce_text(item) for item in value]
+        return ', '.join(part for part in parts if part)
+    if isinstance(value, dict):
+        parts = [_coerce_text(item) for item in value.values()]
+        return ', '.join(part for part in parts if part) or None
+    return str(value).strip() or None
+
+
 def _parse_date(value):
     if not value:
         return None
+    if isinstance(value, datetime):
+        return value.date()
     if hasattr(value, 'year') and hasattr(value, 'month') and hasattr(value, 'day'):
         return value
     if isinstance(value, str):
@@ -209,6 +291,40 @@ def _as_datetime(date_value, default_time=time(17, 0)):
     if isinstance(date_value, datetime):
         return date_value
     return datetime.combine(date_value, default_time)
+
+
+def _sum_financing_amount(data):
+    first = _coerce_decimal((data or {}).get('first_mortgage_amount'))
+    second = _coerce_decimal((data or {}).get('second_mortgage_amount'))
+    if first is None and second is None:
+        return None
+    return str((first or Decimal('0')) + (second or Decimal('0')))
+
+
+def derive_financing_approval_deadline(terms, effective_date=None):
+    """Calculate buyer approval deadline from explicit dates or TPF paragraph 2A days."""
+    terms = normalize_offer_terms(terms)
+    addenda = _json_object(terms.get('addenda'))
+    supporting = _json_object(terms.get('supporting_documents'))
+    financing_addendum = (
+        _json_object(addenda.get('third_party_financing_addendum'))
+        or _json_object(supporting.get('third_party_financing'))
+    )
+
+    explicit_deadline = (
+        terms.get('financing_approval_deadline')
+        or financing_addendum.get('financing_approval_deadline')
+        or financing_addendum.get('buyer_approval_deadline')
+    )
+    parsed_deadline = _parse_date(explicit_deadline)
+    if parsed_deadline:
+        return parsed_deadline
+
+    parsed_effective_date = _parse_date(effective_date)
+    approval_days = _coerce_int(financing_addendum.get('buyer_approval_days'))
+    if parsed_effective_date and approval_days is not None:
+        return parsed_effective_date + timedelta(days=approval_days)
+    return None
 
 
 def create_offer_activity(offer, event_type, label, actor_id=None, version_id=None, document_id=None, event_data=None):
@@ -278,25 +394,30 @@ def expire_offer_if_needed(offer, now=None, actor_id=None):
 
 def apply_offer_terms(offer, terms):
     """Copy reviewed/extracted terms into canonical offer comparison columns."""
-    terms = terms or {}
+    terms = normalize_offer_terms(terms)
     offer.offer_price = _coerce_decimal(terms.get('offer_price') or terms.get('sales_price'))
-    offer.financing_type = terms.get('financing_type')
+    offer.financing_type = _coerce_text(terms.get('financing_type'))
     offer.cash_down_payment = _coerce_decimal(terms.get('cash_down_payment'))
+    offer.financing_amount = _coerce_decimal(terms.get('financing_amount') or terms.get('total_financing_amount'))
     offer.earnest_money = _coerce_decimal(terms.get('earnest_money'))
     offer.additional_earnest_money = _coerce_decimal(terms.get('additional_earnest_money'))
     offer.option_fee = _coerce_decimal(terms.get('option_fee'))
     offer.option_period_days = _coerce_int(terms.get('option_period_days'))
     offer.seller_concessions_amount = _coerce_decimal(terms.get('seller_concessions_amount'))
     offer.proposed_close_date = _parse_date(terms.get('proposed_close_date') or terms.get('closing_date'))
-    offer.possession_type = terms.get('possession_type')
+    offer.possession_type = _coerce_text(terms.get('possession_type'))
     offer.leaseback_days = _coerce_int(terms.get('leaseback_days'))
     offer.appraisal_contingency = _coerce_bool(terms.get('appraisal_contingency'))
     offer.financing_contingency = _coerce_bool(terms.get('financing_contingency'))
     offer.sale_of_other_property_contingency = _coerce_bool(terms.get('sale_of_other_property_contingency'))
-    offer.inspection_or_repair_terms_summary = terms.get('inspection_or_repair_terms_summary')
-    offer.title_policy_payer = terms.get('title_policy_payer')
-    offer.survey_payer = terms.get('survey_payer')
-    offer.hoa_resale_certificate_payer = terms.get('hoa_resale_certificate_payer')
+    offer.inspection_or_repair_terms_summary = _coerce_text(terms.get('inspection_or_repair_terms_summary'))
+    offer.title_policy_payer = _coerce_text(terms.get('title_policy_payer'))
+    offer.survey_payer = _coerce_text(terms.get('survey_payer'))
+    offer.survey_furnished_by = _coerce_text(terms.get('survey_furnished_by'))
+    offer.hoa_resale_certificate_payer = _coerce_text(terms.get('hoa_resale_certificate_payer'))
+    offer.residential_service_contract = _coerce_text(terms.get('residential_service_contract'))
+    offer.buyer_agent_commission_percent = _coerce_decimal(terms.get('buyer_agent_commission_percent'))
+    offer.buyer_agent_commission_flat = _coerce_decimal(terms.get('buyer_agent_commission_flat'))
     offer.response_deadline_at = _parse_datetime(terms.get('response_deadline_at')) or offer.response_deadline_at
     existing_terms = dict(offer.terms_summary or {})
     summary_terms = dict(terms)
@@ -321,17 +442,19 @@ def _merge_existing_offer_context(offer, terms):
         addenda = dict(existing.get('addenda') or {})
         addenda.update(merged.get('addenda') or {})
         merged['addenda'] = addenda
-    return merged
+    return normalize_offer_terms(merged)
 
 
 def _normalized_supporting_payload(document_type, extracted):
     """Map supporting document extraction into offer terms namespaces."""
     extracted = dict(extracted or {})
     if document_type == 'third_party_financing':
+        financing_amount = extracted.get('total_financing_amount') or _sum_financing_amount(extracted)
         return {
             'offer_terms': {
                 'financing_type': extracted.get('financing_type'),
                 'financing_contingency': extracted.get('buyer_approval_required'),
+                'financing_amount': financing_amount,
             },
             'addenda': {
                 'third_party_financing_addendum': extracted,
@@ -436,6 +559,218 @@ def merge_offer_supporting_document(offer_document):
     return offer_document
 
 
+SPLIT_DOCUMENT_TYPE_TO_OFFER_TYPE = {
+    'buyer_offer': 'buyer_offer',
+    'residential_contract': 'buyer_offer',
+    'one_to_four_family': 'buyer_offer',
+    'farm_and_ranch': 'buyer_offer',
+    'new_home': 'buyer_offer',
+    'unimproved_property': 'buyer_offer',
+    'third_party_financing': 'third_party_financing',
+    'third_party_financing_addendum': 'third_party_financing',
+    'hoa_addendum': 'hoa_addendum',
+    'sellers_disclosure': 'sellers_disclosure',
+    'seller_disclosure': 'sellers_disclosure',
+    'pre_approval': 'pre_approval',
+    'preapproval': 'pre_approval',
+    'backup_addendum': 'backup_acceptance',
+    'backup_acceptance': 'backup_acceptance',
+    'lead_based_paint': 'sellers_disclosure',
+    'sale_of_other_property': 'buyer_offer',
+    'temporary_lease': 'buyer_offer',
+    'compensation_agreement': 'buyer_offer',
+}
+
+
+def _split_segment_to_offer_type(segment_type):
+    if not segment_type:
+        return None
+    return SPLIT_DOCUMENT_TYPE_TO_OFFER_TYPE.get(segment_type)
+
+
+def _inherited_field_data_for_segment(segment_type, parent_field_data):
+    """Pick the parent extraction subset that should appear on a split child."""
+    if not isinstance(parent_field_data, dict):
+        return {}
+    addenda = _json_object(parent_field_data.get('addenda'))
+    supporting = _json_object(parent_field_data.get('supporting_documents'))
+    offer_offer_type = _split_segment_to_offer_type(segment_type)
+
+    if offer_offer_type == 'third_party_financing':
+        payload = (
+            _json_object(addenda.get('third_party_financing_addendum'))
+            or _json_object(supporting.get('third_party_financing'))
+        )
+        if payload:
+            return dict(payload)
+    if offer_offer_type == 'hoa_addendum':
+        payload = _json_object(addenda.get('hoa_addendum')) or _json_object(supporting.get('hoa_addendum'))
+        if payload:
+            return dict(payload)
+    if offer_offer_type == 'sellers_disclosure':
+        payload = _json_object(supporting.get('sellers_disclosure'))
+        if payload:
+            return dict(payload)
+    if offer_offer_type == 'pre_approval':
+        payload = _json_object(supporting.get('pre_approval'))
+        if payload:
+            return dict(payload)
+    if offer_offer_type == 'backup_acceptance':
+        payload = (
+            _json_object(addenda.get('backup_addendum'))
+            or _json_object(supporting.get('backup_addendum'))
+        )
+        if payload:
+            return dict(payload)
+    return {}
+
+
+def split_offer_package_into_children(doc_id, file_data, *, split_source='ai_packet_split'):
+    """Create split child documents under an offer packet parent.
+
+    Reads ``detected_documents`` from the parent's ``field_data``, slices the
+    PDF using PyMuPDF, uploads each child PDF to Supabase, and links a
+    matching ``TransactionDocument`` + ``SellerOfferDocument`` to the same
+    offer. Skips when only one segment is detected (no real packet) or when
+    children already exist for this parent.
+    """
+    if not file_data:
+        return []
+
+    doc = TransactionDocument.query.get(doc_id)
+    if not doc or not doc.field_data:
+        return []
+
+    offer_document = SellerOfferDocument.query.filter_by(transaction_document_id=doc.id).first()
+    if not offer_document or not offer_document.is_primary_terms_document:
+        return []
+
+    parent_offer_type = offer_document.document_type
+    if parent_offer_type not in ('offer_package', 'buyer_offer'):
+        return []
+
+    detected = doc.field_data.get('detected_documents') if isinstance(doc.field_data, dict) else None
+    if not isinstance(detected, list) or not detected:
+        return []
+
+    from services.pdf_splitter import (
+        get_pdf_page_count,
+        normalize_segments,
+        split_pdf_by_segments,
+    )
+
+    total_pages = get_pdf_page_count(file_data)
+    if total_pages <= 0:
+        return []
+
+    segments = normalize_segments(detected, total_pages=total_pages)
+    if len(segments) < 2:
+        return []
+
+    existing_children = TransactionDocument.query.filter_by(parent_document_id=doc.id).count()
+    if existing_children:
+        return []
+
+    from services.supabase_storage import upload_external_document
+
+    offer = offer_document.offer
+    organization_id = doc.organization_id
+    transaction_id = doc.transaction_id
+    primary_assigned = False
+    created_children = []
+
+    base_filename = doc.signed_original_filename or 'offer_packet.pdf'
+    name_root, _, ext = base_filename.rpartition('.')
+    name_root = name_root or 'offer_packet'
+    ext = (ext or 'pdf').lower()
+
+    for split_result in split_pdf_by_segments(file_data, segments):
+        seg = split_result.segment
+        offer_type = _split_segment_to_offer_type(seg.document_type)
+        if not offer_type:
+            continue
+        # Avoid creating a redundant primary contract child when the parent itself is the
+        # buyer offer (which would re-trigger primary terms handling).
+        if offer_type == 'buyer_offer':
+            if parent_offer_type == 'buyer_offer' or primary_assigned:
+                continue
+            primary_assigned = True
+
+        doc_config = get_offer_document_type(offer_type)
+        template_slug = doc_config['template_slug']
+        display_name = doc_config['label']
+
+        child_filename = f"{name_root}_p{seg.start_page}-{seg.end_page}_{offer_type}.{ext}"
+
+        try:
+            upload_result = upload_external_document(
+                transaction_id=transaction_id,
+                file_data=split_result.pdf_bytes,
+                original_filename=child_filename,
+                content_type='application/pdf',
+            )
+        except Exception:
+            # Storage may not be configured in dev/tests; persist child without a file path.
+            upload_result = {'path': None}
+
+        inherited_field_data = _inherited_field_data_for_segment(seg.document_type, doc.field_data)
+
+        child_doc = TransactionDocument(
+            organization_id=organization_id,
+            transaction_id=transaction_id,
+            template_slug=template_slug,
+            template_name=display_name,
+            status='signed',
+            document_source='completed',
+            signed_file_path=upload_result.get('path'),
+            signed_file_size=len(split_result.pdf_bytes),
+            signed_original_filename=child_filename,
+            signed_at=datetime.utcnow(),
+            extraction_status='complete' if inherited_field_data else None,
+            field_data=inherited_field_data,
+            parent_document_id=doc.id,
+            page_start=seg.start_page,
+            page_end=seg.end_page,
+            split_source=split_source,
+        )
+        db.session.add(child_doc)
+        db.session.flush()
+
+        child_offer_document = SellerOfferDocument(
+            organization_id=organization_id,
+            transaction_id=transaction_id,
+            offer_id=offer_document.offer_id,
+            transaction_document_id=child_doc.id,
+            offer_version_id=None,
+            created_by_id=offer_document.created_by_id,
+            document_type=offer_type,
+            display_name=seg.title or display_name,
+            is_primary_terms_document=False,
+            extraction_summary=inherited_field_data,
+        )
+        db.session.add(child_offer_document)
+        db.session.flush()
+
+        if offer is not None:
+            create_offer_activity(
+                offer,
+                'document_split',
+                f'AI split {seg.title or display_name} from {offer_document.display_name}',
+                version_id=offer_document.offer_version_id,
+                document_id=child_doc.id,
+                event_data={
+                    'parent_document_id': doc.id,
+                    'page_start': seg.start_page,
+                    'page_end': seg.end_page,
+                    'document_type': offer_type,
+                    'segment_type': seg.document_type,
+                },
+            )
+        created_children.append(child_offer_document)
+
+    return created_children
+
+
 def sync_offer_version_from_document(doc_id):
     """Sync AI-extracted TransactionDocument.field_data into linked offer records."""
     doc = TransactionDocument.query.get(doc_id)
@@ -460,11 +795,11 @@ def sync_offer_version_from_document(doc_id):
         apply_offer_terms(offer, terms)
         offer.current_version_id = version.id
         if extracted.get('buyer_names') and not offer.buyer_names:
-            offer.buyer_names = extracted.get('buyer_names')
+            offer.buyer_names = _coerce_text(extracted.get('buyer_names'))
         if extracted.get('buyer_agent_name') and not offer.buyer_agent_name:
-            offer.buyer_agent_name = extracted.get('buyer_agent_name')
+            offer.buyer_agent_name = _coerce_text(extracted.get('buyer_agent_name'))
         if extracted.get('buyer_agent_brokerage') and not offer.buyer_agent_brokerage:
-            offer.buyer_agent_brokerage = extracted.get('buyer_agent_brokerage')
+            offer.buyer_agent_brokerage = _coerce_text(extracted.get('buyer_agent_brokerage'))
         offer.status = 'reviewing' if offer.status in ('draft', 'new') else offer.status
         create_offer_activity(
             offer,
@@ -500,6 +835,41 @@ def _json_object(value):
     return value if isinstance(value, dict) else {}
 
 
+def normalize_offer_terms(terms):
+    """Promote combined package/addendum extraction into canonical offer fields."""
+    normalized = dict(terms or {})
+    addenda = _json_object(normalized.get('addenda'))
+    supporting = _json_object(normalized.get('supporting_documents'))
+
+    financing_addendum = (
+        _json_object(addenda.get('third_party_financing_addendum'))
+        or _json_object(supporting.get('third_party_financing'))
+    )
+    if financing_addendum:
+        normalized.setdefault('financing_type', financing_addendum.get('financing_type'))
+        normalized.setdefault('financing_contingency', financing_addendum.get('buyer_approval_required'))
+        financing_amount = (
+            financing_addendum.get('total_financing_amount')
+            or _sum_financing_amount(financing_addendum)
+        )
+        normalized.setdefault('financing_amount', financing_amount)
+        addenda['third_party_financing_addendum'] = financing_addendum
+        supporting.setdefault('third_party_financing', financing_addendum)
+
+    hoa_addendum = _json_object(addenda.get('hoa_addendum')) or _json_object(supporting.get('hoa_addendum'))
+    if hoa_addendum:
+        normalized.setdefault('hoa_applicable', True)
+        normalized.setdefault('hoa_resale_certificate_payer', hoa_addendum.get('title_company_info_payer'))
+        addenda['hoa_addendum'] = hoa_addendum
+        supporting.setdefault('hoa_addendum', hoa_addendum)
+
+    if addenda:
+        normalized['addenda'] = addenda
+    if supporting:
+        normalized['supporting_documents'] = supporting
+    return normalized
+
+
 def build_contract_milestones(contract):
     """Build Texas seller contract milestones from accepted terms and addenda data."""
     addenda = _json_object(contract.addenda_data)
@@ -529,6 +899,10 @@ def build_contract_milestones(contract):
         _parse_date(financing_addendum.get('buyer_approval_deadline'))
         or contract.financing_approval_deadline
     )
+    if not financing_due:
+        approval_days = _coerce_int(financing_addendum.get('buyer_approval_days'))
+        if effective_dt and approval_days is not None:
+            financing_due = effective_dt + timedelta(days=approval_days)
     milestones.append(_milestone(
         contract,
         'financing_approval_due',
@@ -597,7 +971,8 @@ def create_contract_milestones(contract, replace=False):
     """Persist calculated milestones for an accepted contract."""
     if replace:
         for existing in contract.milestones.all():
-            db.session.delete(existing)
+            if existing.milestone_key != 'manual' and existing.source != 'manual':
+                db.session.delete(existing)
 
     milestones = build_contract_milestones(contract)
     for item in milestones:

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -592,7 +592,8 @@ document.querySelectorAll('.seller-offer-update-form').forEach(form => {
 });
 
 const OFFER_DOCUMENT_TYPE_OPTIONS = [
-    ['buyer_offer', 'Offer contract'],
+    ['offer_package', 'Offer package (contract + addenda)'],
+    ['buyer_offer', 'Offer contract only'],
     ['buyer_counter', 'Buyer counter'],
     ['seller_counter', 'Seller counter'],
     ['final_acceptance', 'Executed contract'],
@@ -617,9 +618,10 @@ function inferOfferDocumentType(filename) {
     }
     if (has('seller', 'disclosure') || has('sellers', 'disclosure') || tokens.has('sd')) return 'sellers_disclosure';
     if (tokens.has('backup')) return 'backup_acceptance';
-    if (tokens.has('executed') || tokens.has('signed') || tokens.has('acceptance')) return 'final_acceptance';
+    if (tokens.has('executed') || tokens.has('signed') || tokens.has('acceptance')) return 'offer_package';
     if (tokens.has('counter')) return tokens.has('seller') ? 'seller_counter' : 'buyer_counter';
-    return 'buyer_offer';
+    if (tokens.has('contract') || tokens.has('offer') || tokens.has('resale')) return 'offer_package';
+    return 'offer_package';
 }
 
 function escapeHtml(value) {
@@ -737,6 +739,11 @@ function hasSellerOfferExtractionInProgress(offers) {
 }
 
 function pollSellerOfferExtractionStatus() {
+    const hadWorkingRow = Array.from(document.querySelectorAll('[data-seller-offer-extraction-status]')).some(element => {
+        const value = element.textContent.trim().toLowerCase();
+        return value.includes('pending') || value.includes('processing');
+    });
+
     fetch(`/transactions/${transactionId}/offers`)
     .then(res => res.json())
     .then(data => {
@@ -750,6 +757,10 @@ function pollSellerOfferExtractionStatus() {
             sellerOfferPollingTimer = setTimeout(pollSellerOfferExtractionStatus, 3000);
         } else {
             sellerOfferPollingTimer = null;
+            if (hadWorkingRow) {
+                setSellerWorkspaceReloadTab('offers');
+                setTimeout(() => location.reload(), 350);
+            }
         }
     })
     .catch(() => {
@@ -1005,6 +1016,23 @@ if (sellerCloseForm) {
             `/transactions/${transactionId}/seller/contracts/${this.dataset.contractId}/close`,
             sellerFormData(this),
             'Transaction marked closed.'
+        );
+    });
+}
+
+const sellerContractDetailsForm = document.getElementById('sellerContractDetailsForm');
+if (sellerContractDetailsForm) {
+    sellerContractDetailsForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const contractId = this.dataset.contractId;
+        if (!contractId) {
+            showToast('Unable to find contract.', 'error');
+            return;
+        }
+        sellerPost(
+            `/transactions/${transactionId}/seller/contracts/${contractId}/details`,
+            sellerFormData(this),
+            'Contract details saved.'
         );
     });
 }

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -592,6 +592,9 @@
                             {% set offer_versions = seller_offer_versions_by_offer.get(offer.id, []) %}
                             {% set package_documents = seller_offer_documents_by_offer.get(offer.id, []) %}
                             {% set activities = seller_offer_activities_by_offer.get(offer.id, []) %}
+                            {% set offer_addenda = offer.terms_summary.get('addenda', {}) if offer.terms_summary else {} %}
+                            {% set raw_offer_financing_addendum = offer_addenda.get('third_party_financing_addendum', {}) if offer_addenda is mapping else {} %}
+                            {% set offer_financing_addendum = raw_offer_financing_addendum if raw_offer_financing_addendum is mapping else {} %}
                             <div id="sellerOfferModal-{{ offer.id }}" data-seller-offer-modal class="fixed inset-0 z-50 hidden">
                                 <button type="button" class="absolute inset-0 bg-slate-900/50" onclick="closeSellerOfferModal({{ offer.id }})" aria-label="Close"></button>
                                 <div class="absolute inset-3 flex min-h-0 flex-col overflow-hidden rounded-md bg-white shadow-xl md:inset-y-6 md:left-1/2 md:right-auto md:w-[min(1040px,90vw)] md:-translate-x-1/2">
@@ -670,6 +673,14 @@
                                                             <input name="terms_data[financing_type]" class="crm-input mt-1" value="{{ offer.financing_type or '' }}">
                                                         </label>
                                                         <label class="block">
+                                                            <span class="text-xs font-medium text-slate-600">Cash portion</span>
+                                                            <input name="terms_data[cash_down_payment]" class="crm-input mt-1" value="{{ offer.cash_down_payment or '' }}" placeholder="$">
+                                                        </label>
+                                                        <label class="block">
+                                                            <span class="text-xs font-medium text-slate-600">Sum of financing</span>
+                                                            <input name="terms_data[financing_amount]" class="crm-input mt-1" value="{{ offer.financing_amount or '' }}" placeholder="$">
+                                                        </label>
+                                                        <label class="block">
                                                             <span class="text-xs font-medium text-slate-600">Proposed close date</span>
                                                             <input type="date" name="terms_data[proposed_close_date]" class="crm-input mt-1" value="{% if offer.proposed_close_date %}{{ offer.proposed_close_date.strftime('%Y-%m-%d') }}{% endif %}">
                                                         </label>
@@ -682,8 +693,24 @@
                                                             <input name="terms_data[option_period_days]" class="crm-input mt-1" value="{{ offer.option_period_days or '' }}">
                                                         </label>
                                                         <label class="block md:col-span-2">
-                                                            <span class="text-xs font-medium text-slate-600">Seller concessions</span>
+                                                            <span class="text-xs font-medium text-slate-600">Seller contributions</span>
                                                             <input name="terms_data[seller_concessions_amount]" class="crm-input mt-1" value="{{ offer.seller_concessions_amount or '' }}">
+                                                        </label>
+                                                        <label class="block md:col-span-2">
+                                                            <span class="text-xs font-medium text-slate-600">Survey furnished by</span>
+                                                            <input name="terms_data[survey_furnished_by]" class="crm-input mt-1" value="{{ offer.survey_furnished_by or '' }}" placeholder="Seller existing survey, buyer new survey...">
+                                                        </label>
+                                                        <label class="block md:col-span-2">
+                                                            <span class="text-xs font-medium text-slate-600">Residential service contract</span>
+                                                            <textarea name="terms_data[residential_service_contract]" class="crm-input mt-1 min-h-20" placeholder="Who pays, dollar cap, or no service contract">{{ offer.residential_service_contract or '' }}</textarea>
+                                                        </label>
+                                                        <label class="block">
+                                                            <span class="text-xs font-medium text-slate-600">Buyer agent commission %</span>
+                                                            <input name="terms_data[buyer_agent_commission_percent]" class="crm-input mt-1" value="{{ offer.buyer_agent_commission_percent or '' }}" placeholder="%">
+                                                        </label>
+                                                        <label class="block">
+                                                            <span class="text-xs font-medium text-slate-600">Buyer agent commission $</span>
+                                                            <input name="terms_data[buyer_agent_commission_flat]" class="crm-input mt-1" value="{{ offer.buyer_agent_commission_flat or '' }}" placeholder="$">
                                                         </label>
                                                     </div>
                                                 </form>
@@ -716,12 +743,26 @@
                                                     </form>
                                                     <div class="mt-4 overflow-hidden rounded-md border border-slate-200">
                                                         {% if package_documents %}
+                                                        {% set parent_doc_ids_with_children = [] %}
+                                                        {% for offer_document in package_documents %}
+                                                            {% set doc = offer_document.document %}
+                                                            {% if doc and doc.parent_document_id and doc.parent_document_id not in parent_doc_ids_with_children %}
+                                                                {% set _ = parent_doc_ids_with_children.append(doc.parent_document_id) %}
+                                                            {% endif %}
+                                                        {% endfor %}
                                                         {% for offer_document in package_documents %}
                                                         {% set doc = offer_document.document %}
-                                                        <div class="grid grid-cols-1 gap-3 border-b border-slate-100 bg-white px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                                                        {% set is_split_child = doc and doc.parent_document_id %}
+                                                        {% set is_original_packet = doc and (doc.id in parent_doc_ids_with_children) %}
+                                                        <div class="grid grid-cols-1 gap-3 border-b border-slate-100 bg-white px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center{% if is_split_child %} pl-6 sm:pl-8 border-l-2 border-l-slate-200{% endif %}">
                                                             <div class="min-w-0">
                                                                 <div class="flex flex-wrap items-center gap-2">
                                                                     <span class="text-sm font-semibold text-slate-900">{{ offer_document.display_name }}</span>
+                                                                    {% if is_original_packet %}
+                                                                    <span class="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-600" title="Original uploaded packet">Original upload</span>
+                                                                    {% elif is_split_child %}
+                                                                    <span class="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-600" title="Split from the original uploaded packet">Split document{% if doc.page_start and doc.page_end %} · pages {{ doc.page_start }}-{{ doc.page_end }}{% endif %}</span>
+                                                                    {% endif %}
                                                                     {% if offer_document.is_primary_terms_document and offer_document.offer_version %}
                                                                     <span class="rounded-md bg-slate-100 px-1.5 py-0.5 text-[11px] font-medium text-slate-500">Version {{ offer_document.offer_version.version_number }}</span>
                                                                     {% if offer.current_version_id == offer_document.offer_version_id %}
@@ -837,6 +878,46 @@
                                                             <dt class="text-xs font-medium text-slate-500">Option</dt>
                                                             <dd class="mt-0.5 text-slate-900">{% if offer.option_period_days %}{{ offer.option_period_days }} days{% else %}TBD{% endif %}</dd>
                                                         </div>
+                                                        <div>
+                                                            <dt class="text-xs font-medium text-slate-500">Cash portion</dt>
+                                                            <dd class="mt-0.5 text-slate-900">{% if offer.cash_down_payment %}${{ "{:,.0f}".format(offer.cash_down_payment) }}{% else %}TBD{% endif %}</dd>
+                                                        </div>
+                                                        <div>
+                                                            <dt class="text-xs font-medium text-slate-500">Financing sum</dt>
+                                                            <dd class="mt-0.5 text-slate-900">{% if offer.financing_amount %}${{ "{:,.0f}".format(offer.financing_amount) }}{% else %}TBD{% endif %}</dd>
+                                                        </div>
+                                                        <div class="col-span-2">
+                                                            <dt class="text-xs font-medium text-slate-500">Seller contributions</dt>
+                                                            <dd class="mt-0.5 text-slate-900">{% if offer.seller_concessions_amount %}${{ "{:,.0f}".format(offer.seller_concessions_amount) }}{% else %}TBD{% endif %}</dd>
+                                                        </div>
+                                                        <div class="col-span-2">
+                                                            <dt class="text-xs font-medium text-slate-500">Financing approval</dt>
+                                                            <dd class="mt-0.5 text-slate-900">
+                                                                {% if offer_financing_addendum.get('buyer_approval_days') %}
+                                                                {{ offer_financing_addendum.get('buyer_approval_days') }} days after execution
+                                                                {% elif offer_financing_addendum.get('buyer_approval_deadline') %}
+                                                                {{ offer_financing_addendum.get('buyer_approval_deadline') }}
+                                                                {% else %}
+                                                                TBD
+                                                                {% endif %}
+                                                            </dd>
+                                                        </div>
+                                                        <div class="col-span-2">
+                                                            <dt class="text-xs font-medium text-slate-500">Survey furnished by</dt>
+                                                            <dd class="mt-0.5 text-slate-900">{{ offer.survey_furnished_by or 'TBD' }}</dd>
+                                                        </div>
+                                                        <div class="col-span-2">
+                                                            <dt class="text-xs font-medium text-slate-500">Residential service contract</dt>
+                                                            <dd class="mt-0.5 text-slate-900">{{ offer.residential_service_contract or 'TBD' }}</dd>
+                                                        </div>
+                                                        <div class="col-span-2">
+                                                            <dt class="text-xs font-medium text-slate-500">Buyer agent commission</dt>
+                                                            <dd class="mt-0.5 text-slate-900">
+                                                                {% if offer.buyer_agent_commission_percent %}{{ offer.buyer_agent_commission_percent }}%{% endif %}
+                                                                {% if offer.buyer_agent_commission_flat %}{% if offer.buyer_agent_commission_percent %} · {% endif %}${{ "{:,.0f}".format(offer.buyer_agent_commission_flat) }}{% endif %}
+                                                                {% if not offer.buyer_agent_commission_percent and not offer.buyer_agent_commission_flat %}TBD{% endif %}
+                                                            </dd>
+                                                        </div>
                                                     </dl>
                                                 </div>
 
@@ -882,18 +963,36 @@
                             </div>
                             {% set primary_contract_docs = seller_contract_documents_by_contract.get(primary_seller_contract.id, []) if seller_contract_documents_by_contract else [] %}
                             {% set contract_supporting = primary_seller_contract.extra_data.get('supporting_documents', {}) if primary_seller_contract.extra_data else {} %}
-                            <div class="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_360px]">
+                            {% set raw_contract_financing_addendum = primary_seller_contract.addenda_data.get('third_party_financing_addendum', {}) if primary_seller_contract.addenda_data is mapping else {} %}
+                            {% set contract_financing_addendum = raw_contract_financing_addendum if raw_contract_financing_addendum is mapping else {} %}
+                            <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_440px]">
                                 <div class="rounded-md border border-slate-200">
                                     <div class="border-b border-slate-200 px-4 py-3">
                                         <h3 class="text-sm font-semibold text-slate-900">Contract package</h3>
                                         <p class="mt-1 text-xs text-slate-500">Documents inherited from the accepted offer.</p>
                                     </div>
                                     <div class="overflow-hidden rounded-md border border-slate-200">
+                                        {% set contract_parent_ids_with_children = [] %}
+                                        {% for offer_document in primary_contract_docs %}
+                                            {% set doc = offer_document.document %}
+                                            {% if doc and doc.parent_document_id and doc.parent_document_id not in contract_parent_ids_with_children %}
+                                                {% set _ = contract_parent_ids_with_children.append(doc.parent_document_id) %}
+                                            {% endif %}
+                                        {% endfor %}
                                         {% for offer_document in primary_contract_docs %}
                                         {% set doc = offer_document.document %}
-                                        <div class="grid grid-cols-1 gap-3 border-b border-slate-100 bg-white px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                                        {% set is_split_child = doc and doc.parent_document_id %}
+                                        {% set is_original_packet = doc and (doc.id in contract_parent_ids_with_children) %}
+                                        <div class="grid grid-cols-1 gap-3 border-b border-slate-100 bg-white px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center{% if is_split_child %} pl-6 sm:pl-8 border-l-2 border-l-slate-200{% endif %}">
                                             <div class="min-w-0">
-                                                <div class="text-sm font-semibold text-slate-900">{{ offer_document.display_name }}</div>
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <span class="text-sm font-semibold text-slate-900">{{ offer_document.display_name }}</span>
+                                                    {% if is_original_packet %}
+                                                    <span class="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-600" title="Original uploaded packet">Original upload</span>
+                                                    {% elif is_split_child %}
+                                                    <span class="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-600" title="Split from the original uploaded packet">Split document{% if doc.page_start and doc.page_end %} · pages {{ doc.page_start }}-{{ doc.page_end }}{% endif %}</span>
+                                                    {% endif %}
+                                                </div>
                                                 <div class="mt-1 truncate text-xs text-slate-500">
                                                     {% if doc %}
                                                     {{ doc.signed_original_filename or doc.template_name }}
@@ -923,26 +1022,80 @@
                                         {% endfor %}
                                     </div>
                                 </div>
-                                <div class="rounded-md border border-slate-200 p-4">
-                                    <h3 class="text-sm font-semibold text-slate-900">Accepted contract details</h3>
-                                    <dl class="mt-3 grid grid-cols-2 gap-3 text-sm">
-                                        <div>
-                                            <dt class="text-xs font-medium text-slate-500">Price</dt>
-                                            <dd class="mt-0.5 font-semibold text-slate-900">{% if primary_seller_contract.accepted_price %}${{ "{:,.0f}".format(primary_seller_contract.accepted_price) }}{% else %}TBD{% endif %}</dd>
+                                <div class="rounded-md border border-slate-200 bg-white p-4">
+                                    <form id="sellerContractDetailsForm" data-contract-id="{{ primary_seller_contract.id }}">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <h3 class="text-sm font-semibold text-slate-900">Accepted contract details</h3>
+                                                <p class="mt-1 text-xs text-slate-500">Review extracted terms and save the manual fields that drive milestones.</p>
+                                            </div>
+                                            <button type="submit" class="crm-btn crm-btn-primary px-3 py-1.5 text-xs">Save</button>
                                         </div>
-                                        <div>
-                                            <dt class="text-xs font-medium text-slate-500">Close date</dt>
-                                            <dd class="mt-0.5 text-slate-900">{% if primary_seller_contract.closing_date %}{{ primary_seller_contract.closing_date.strftime('%b %d, %Y') }}{% else %}TBD{% endif %}</dd>
+                                        {% if not primary_seller_contract.effective_date %}
+                                        <div class="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                                            <div class="font-semibold">Enter the contract execution date.</div>
+                                            <p class="mt-1 text-xs text-amber-800">Milestones stay in waiting status until the agent saves this date. Financing approval uses the Third Party Financing Addendum Paragraph 2A day count when available.</p>
                                         </div>
-                                        <div>
-                                            <dt class="text-xs font-medium text-slate-500">Financing deadline</dt>
-                                            <dd class="mt-0.5 text-slate-900">{% if primary_seller_contract.financing_approval_deadline %}{{ primary_seller_contract.financing_approval_deadline.strftime('%b %d, %Y') }}{% else %}TBD{% endif %}</dd>
+                                        {% endif %}
+                                        <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                            <label class="block sm:col-span-2 rounded-md border border-orange-200 bg-orange-50 p-3">
+                                                <span class="text-xs font-semibold uppercase tracking-wide text-orange-700">Manual agent entry required</span>
+                                                <span class="mt-1 block text-sm font-medium text-slate-900">Contract execution date</span>
+                                                <input type="date" name="effective_date" class="crm-input mt-2" value="{% if primary_seller_contract.effective_date %}{{ primary_seller_contract.effective_date.strftime('%Y-%m-%d') }}{% endif %}">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Sales price</span>
+                                                <input name="accepted_price" class="crm-input mt-1" value="{{ primary_seller_contract.accepted_price or '' }}" placeholder="$">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Close date</span>
+                                                <input type="date" name="closing_date" class="crm-input mt-1" value="{% if primary_seller_contract.closing_date %}{{ primary_seller_contract.closing_date.strftime('%Y-%m-%d') }}{% endif %}">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Financing type</span>
+                                                <input name="financing_type" class="crm-input mt-1" value="{{ primary_seller_contract.financing_type or '' }}">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Option days</span>
+                                                <input name="option_period_days" class="crm-input mt-1" value="{{ primary_seller_contract.option_period_days or '' }}">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Cash portion</span>
+                                                <input name="cash_down_payment" class="crm-input mt-1" value="{{ primary_seller_contract.cash_down_payment or '' }}" placeholder="$">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Sum of financing</span>
+                                                <input name="financing_amount" class="crm-input mt-1" value="{{ primary_seller_contract.financing_amount or '' }}" placeholder="$">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Financing deadline</span>
+                                                <input type="date" name="financing_approval_deadline" class="crm-input mt-1" value="{% if primary_seller_contract.financing_approval_deadline %}{{ primary_seller_contract.financing_approval_deadline.strftime('%Y-%m-%d') }}{% endif %}">
+                                                {% if contract_financing_addendum.get('buyer_approval_days') %}
+                                                <span class="mt-1 block text-[11px] text-slate-500">TPF Paragraph 2A: {{ contract_financing_addendum.get('buyer_approval_days') }} days after execution.</span>
+                                                {% endif %}
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Seller contributions</span>
+                                                <input name="seller_concessions_amount" class="crm-input mt-1" value="{{ primary_seller_contract.seller_concessions_amount or '' }}" placeholder="$">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Buyer agent commission %</span>
+                                                <input name="buyer_agent_commission_percent" class="crm-input mt-1" value="{{ primary_seller_contract.buyer_agent_commission_percent or '' }}" placeholder="%">
+                                            </label>
+                                            <label class="block">
+                                                <span class="text-xs font-medium text-slate-600">Buyer agent commission $</span>
+                                                <input name="buyer_agent_commission_flat" class="crm-input mt-1" value="{{ primary_seller_contract.buyer_agent_commission_flat or '' }}" placeholder="$">
+                                            </label>
+                                            <label class="block sm:col-span-2">
+                                                <span class="text-xs font-medium text-slate-600">Survey furnished by</span>
+                                                <input name="survey_furnished_by" class="crm-input mt-1" value="{{ primary_seller_contract.survey_furnished_by or '' }}">
+                                            </label>
+                                            <label class="block sm:col-span-2">
+                                                <span class="text-xs font-medium text-slate-600">Residential service contract</span>
+                                                <textarea name="residential_service_contract" class="crm-input mt-1 min-h-20">{{ primary_seller_contract.residential_service_contract or '' }}</textarea>
+                                            </label>
                                         </div>
-                                        <div>
-                                            <dt class="text-xs font-medium text-slate-500">Option</dt>
-                                            <dd class="mt-0.5 text-slate-900">{% if primary_seller_contract.option_period_days %}{{ primary_seller_contract.option_period_days }} days{% else %}TBD{% endif %}</dd>
-                                        </div>
-                                    </dl>
+                                    </form>
                                     {% if contract_supporting %}
                                     <div class="mt-4 border-t border-slate-200 pt-3">
                                         <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Supporting data</div>

--- a/tests/test_idor_protection.py
+++ b/tests/test_idor_protection.py
@@ -10,31 +10,10 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
-from app import create_app
 from models import (
     db, User, Organization, Transaction, TransactionType,
     TransactionDocument, Task, TaskType, TaskSubtype, Contact, ContactGroup
 )
-
-os.environ['DATABASE_URL'] = 'sqlite:////tmp/test_idor.db'
-
-
-@pytest.fixture(scope='module')
-def app():
-    app = create_app()
-    app.config['TESTING'] = True
-    app.config['WTF_CSRF_ENABLED'] = False
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test_idor.db'
-    app.config['SERVER_NAME'] = 'localhost'
-
-    with app.app_context():
-        db.create_all()
-        yield app
-        db.session.remove()
-        db.drop_all()
-
-    if os.path.exists('/tmp/test_idor.db'):
-        os.remove('/tmp/test_idor.db')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_offer_document_package.py
+++ b/tests/test_offer_document_package.py
@@ -3,13 +3,19 @@ from unittest.mock import patch
 
 
 def test_offer_document_type_inference():
-    from services.seller_workflow import infer_offer_document_type
+    from services.seller_workflow import infer_offer_document_type, infer_offer_document_type_from_text
 
     assert infer_offer_document_type('One to Four Family Residential Contract (Resale) - 1124.pdf') == 'buyer_offer'
     assert infer_offer_document_type('6004 Lakeside SD.pdf') == 'sellers_disclosure'
     assert infer_offer_document_type('Addendum for Property Subject to Mandatory Member. in Owners Assoc. #4.pdf') == 'hoa_addendum'
     assert infer_offer_document_type('Draughn PreQual.pdf') == 'pre_approval'
     assert infer_offer_document_type('Third Party Financing Addendum for Credit Approval.pdf') == 'third_party_financing'
+    assert infer_offer_document_type_from_text(
+        'ONE TO FOUR FAMILY RESIDENTIAL CONTRACT (RESALE) Third Party Financing Addendum '
+        'ADDENDUM FOR PROPERTY SUBJECT TO MANDATORY MEMBERSHIP IN A PROPERTY OWNERS ASSOCIATION',
+        filename='random upload.pdf',
+        explicit_type='pre_approval',
+    ) == 'offer_package'
 
 
 def test_offer_extraction_schemas_registered():
@@ -213,7 +219,13 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
             status='reviewing',
             terms_summary={
                 'offer_price': '260000',
+                'cash_down_payment': '26000',
+                'financing_amount': '234000',
+                'seller_concessions_amount': '5000',
                 'survey_choice': survey_choice,
+                'survey_furnished_by': 'Seller existing survey',
+                'residential_service_contract': 'Seller to reimburse buyer up to $650.',
+                'buyer_agent_commission_percent': '3',
                 'supporting_documents': {
                     'third_party_financing': {
                         'financing_type': 'conventional',
@@ -285,7 +297,7 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
 
     response = owner_a_client.post(
         f'/transactions/{seed["tx_a"]}/offers/{offer_id}/accept',
-        json={'position': 'primary'},
+        json={'position': 'primary', 'effective_date': '2026-04-24'},
     )
 
     assert response.status_code == 200, response.get_data(as_text=True)
@@ -300,9 +312,233 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
         assert contract.seller_disclosure_delivered_at.date().isoformat() == '2026-04-23'
         assert contract.financing_approval_deadline.isoformat() == '2026-05-09'
         assert contract.survey_choice == survey_choice
+        assert contract.cash_down_payment == 26000
+        assert contract.financing_amount == 234000
+        assert contract.seller_concessions_amount == 5000
+        assert contract.survey_furnished_by == 'Seller existing survey'
+        assert contract.residential_service_contract == 'Seller to reimburse buyer up to $650.'
+        assert contract.buyer_agent_commission_percent == 3
         assert 'third_party_financing' in contract.frozen_terms['supporting_documents']
         assert len(contract.extra_data['offer_package_documents']) == 3
         assert len(contract.extra_data['supporting_document_ids']) == 2
+
+
+def test_primary_combined_package_extraction_populates_offer_terms(app, db, seed):
+    from models import SellerOffer, SellerOfferDocument, SellerOfferVersion, TransactionDocument, User
+    from services.seller_workflow import sync_offer_version_from_document
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            status='needs_review',
+        )
+        db.session.add(offer)
+        db.session.flush()
+
+        version = SellerOfferVersion(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            version_number=1,
+            direction='buyer_offer',
+            status='submitted',
+            terms_data={},
+        )
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+
+        doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Package',
+            status='signed',
+            extraction_status='complete',
+            field_data={
+                'detected_document_types': [
+                    'residential_contract',
+                    'third_party_financing_addendum',
+                    'hoa_addendum',
+                ],
+                'buyer_names': ['Clark Draughn', 'Rachel Draughn'],
+                'buyer_agent_name': 'Marilyn Kittrell',
+                'offer_price': '260000',
+                'cash_down_payment': '26000',
+                'seller_concessions_amount': '3',
+                'addenda': {
+                    'third_party_financing_addendum': {
+                        'financing_type': 'conventional',
+                        'first_mortgage_amount': '234000',
+                        'buyer_approval_required': True,
+                        'buyer_approval_days': '12',
+                    },
+                    'hoa_addendum': {
+                        'association_name': 'Travis Park Home Owners Association',
+                        'title_company_info_payer': 'seller',
+                    },
+                },
+            },
+        )
+        db.session.add(doc)
+        db.session.flush()
+        version.transaction_document_id = doc.id
+        db.session.add(SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            transaction_document_id=doc.id,
+            offer_version_id=version.id,
+            created_by_id=owner.id,
+            document_type='offer_package',
+            display_name='Offer Package',
+            is_primary_terms_document=True,
+        ))
+        db.session.flush()
+
+        sync_offer_version_from_document(doc.id)
+
+        assert offer.buyer_names == 'Clark Draughn, Rachel Draughn'
+        assert offer.buyer_agent_name == 'Marilyn Kittrell'
+        assert offer.offer_price == 260000
+        assert offer.cash_down_payment == 26000
+        assert offer.financing_amount == 234000
+        assert offer.financing_type == 'conventional'
+        assert offer.financing_contingency is True
+        assert offer.hoa_resale_certificate_payer == 'seller'
+        assert offer.terms_summary['supporting_documents']['third_party_financing']['buyer_approval_days'] == '12'
+        assert offer.terms_summary['supporting_documents']['hoa_addendum']['association_name'] == 'Travis Park Home Owners Association'
+
+
+def test_accept_offer_waits_for_pending_extraction(owner_a_client, app, db, seed):
+    from models import SellerOffer, SellerOfferDocument, SellerOfferVersion, TransactionDocument, User
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Pending Buyer',
+            status='needs_review',
+            terms_summary={'offer_price': '250000'},
+        )
+        db.session.add(offer)
+        db.session.flush()
+
+        version = SellerOfferVersion(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            version_number=1,
+            direction='buyer_offer',
+            status='submitted',
+            terms_data={'offer_price': '250000'},
+        )
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+
+        doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Contract',
+            status='signed',
+            extraction_status='processing',
+            field_data={},
+        )
+        db.session.add(doc)
+        db.session.flush()
+        db.session.add(SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            transaction_document_id=doc.id,
+            offer_version_id=version.id,
+            created_by_id=owner.id,
+            document_type='buyer_offer',
+            display_name='Offer Contract',
+            is_primary_terms_document=True,
+        ))
+        db.session.commit()
+        offer_id = offer.id
+
+    response = owner_a_client.post(
+        f'/transactions/{seed["tx_a"]}/offers/{offer_id}/accept',
+        json={'position': 'primary'},
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()['success'] is False
+
+
+def test_contract_execution_date_update_recalculates_financing_deadline(owner_a_client, app, db, seed):
+    from models import SellerAcceptedContract, SellerOffer, SellerOfferVersion, User
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Execution Date Buyer',
+            status='reviewing',
+            terms_summary={
+                'offer_price': '300000',
+                'addenda': {
+                    'third_party_financing_addendum': {
+                        'buyer_approval_days': '12',
+                    },
+                },
+            },
+        )
+        db.session.add(offer)
+        db.session.flush()
+
+        version = SellerOfferVersion(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            version_number=1,
+            direction='buyer_offer',
+            status='reviewed',
+            terms_data={'offer_price': '300000'},
+        )
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+        db.session.commit()
+        offer_id = offer.id
+
+    accept_response = owner_a_client.post(
+        f'/transactions/{seed["tx_a"]}/offers/{offer_id}/accept',
+        json={'position': 'primary'},
+    )
+    assert accept_response.status_code == 200, accept_response.get_data(as_text=True)
+    contract_id = accept_response.get_json()['accepted_contract_id']
+
+    with app.app_context():
+        contract = db.session.get(SellerAcceptedContract, contract_id)
+        assert contract.effective_date is None
+        assert contract.financing_approval_deadline is None
+
+    update_response = owner_a_client.post(
+        f'/transactions/{seed["tx_a"]}/seller/contracts/{contract_id}/details',
+        json={'effective_date': '2026-04-24'},
+    )
+    assert update_response.status_code == 200, update_response.get_data(as_text=True)
+
+    with app.app_context():
+        contract = db.session.get(SellerAcceptedContract, contract_id)
+        assert contract.effective_date.isoformat() == '2026-04-24'
+        assert contract.financing_approval_deadline.isoformat() == '2026-05-06'
 
 
 def test_accept_offer_handles_free_form_addendum_text(owner_a_client, app, db, seed):
@@ -355,3 +591,370 @@ def test_accept_offer_handles_free_form_addendum_text(owner_a_client, app, db, s
         contract = db.session.get(SellerAcceptedContract, payload['accepted_contract_id'])
         assert contract.accepted_price == 275000
         assert contract.frozen_terms['addenda']['third_party_financing_addendum'] == 'Third party financing addendum attached.'
+
+
+# ---------------------------------------------------------------------------
+# PDF splitter helpers + AI packet split flow
+# ---------------------------------------------------------------------------
+
+
+def _build_test_pdf(page_count: int) -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    try:
+        for index in range(page_count):
+            doc.insert_page(index, text=f'Test page {index + 1}')
+        return doc.tobytes()
+    finally:
+        doc.close()
+
+
+def test_pdf_splitter_normalizes_and_slices_segments():
+    from services.pdf_splitter import (
+        SplitSegment,
+        get_pdf_page_count,
+        normalize_segments,
+        split_pdf_by_segments,
+    )
+
+    pdf_bytes = _build_test_pdf(5)
+    assert get_pdf_page_count(pdf_bytes) == 5
+
+    raw_segments = [
+        {'document_type': 'Buyer_Offer', 'start_page': 1, 'end_page': 3, 'title': 'TREC Contract'},
+        {'document_type': 'third_party_financing', 'start_page': 4, 'end_page': 4},
+        {'document_type': 'hoa_addendum', 'start_page': 5, 'end_page': 8},  # clamped to 5
+        {'document_type': 'noise', 'start_page': None, 'end_page': 2},  # dropped
+        {'document_type': 'Buyer_Offer', 'start_page': 1, 'end_page': 3},  # duplicate of first
+    ]
+    segments = normalize_segments(raw_segments, total_pages=5)
+    assert [(s.document_type, s.start_page, s.end_page) for s in segments] == [
+        ('buyer_offer', 1, 3),
+        ('third_party_financing', 4, 4),
+        ('hoa_addendum', 5, 5),
+    ]
+
+    results = split_pdf_by_segments(pdf_bytes, segments)
+    assert len(results) == 3
+    assert [r.page_count for r in results] == [3, 1, 1]
+    assert all(r.pdf_bytes.startswith(b'%PDF') for r in results)
+
+
+def test_split_offer_package_creates_children_with_inherited_data(app, db, seed):
+    from models import (
+        SellerOffer,
+        SellerOfferDocument,
+        SellerOfferVersion,
+        TransactionDocument,
+        User,
+    )
+    from services.seller_workflow import split_offer_package_into_children
+
+    pdf_bytes = _build_test_pdf(6)
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Split Packet Buyer',
+            status='needs_review',
+        )
+        db.session.add(offer)
+        db.session.flush()
+
+        version = SellerOfferVersion(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            version_number=1,
+            direction='buyer_offer',
+            status='submitted',
+            terms_data={},
+        )
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+
+        parent_doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Package',
+            status='signed',
+            signed_original_filename='combined_packet.pdf',
+            signed_file_path='test/combined_packet.pdf',
+            extraction_status='complete',
+            field_data={
+                'detected_documents': [
+                    {'document_type': 'buyer_offer', 'start_page': 1, 'end_page': 4, 'title': 'Residential Contract'},
+                    {'document_type': 'third_party_financing', 'start_page': 5, 'end_page': 5, 'title': 'TPF Addendum'},
+                    {'document_type': 'hoa_addendum', 'start_page': 6, 'end_page': 6},
+                ],
+                'addenda': {
+                    'third_party_financing_addendum': {
+                        'financing_type': 'conventional',
+                        'first_mortgage_amount': '320000',
+                        'buyer_approval_days': '14',
+                    },
+                    'hoa_addendum': {
+                        'association_name': 'Lakeside HOA',
+                        'title_company_info_payer': 'seller',
+                    },
+                },
+            },
+        )
+        db.session.add(parent_doc)
+        db.session.flush()
+        version.transaction_document_id = parent_doc.id
+
+        parent_offer_doc = SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            transaction_document_id=parent_doc.id,
+            offer_version_id=version.id,
+            created_by_id=owner.id,
+            document_type='offer_package',
+            display_name='Offer Package',
+            is_primary_terms_document=True,
+        )
+        db.session.add(parent_offer_doc)
+        db.session.commit()
+
+        parent_doc_id = parent_doc.id
+        offer_id = offer.id
+
+    with app.app_context():
+        with patch(
+            'services.supabase_storage.upload_external_document',
+            side_effect=lambda transaction_id, file_data, original_filename, content_type: {'path': f'test/{original_filename}'},
+        ):
+            children = split_offer_package_into_children(parent_doc_id, pdf_bytes)
+        db.session.commit()
+
+        assert len(children) == 3
+        offer_documents = SellerOfferDocument.query.filter_by(offer_id=offer_id).order_by(SellerOfferDocument.id.asc()).all()
+        types = [od.document_type for od in offer_documents]
+        assert types == ['offer_package', 'buyer_offer', 'third_party_financing', 'hoa_addendum']
+
+        buyer_offer_child = next(od for od in offer_documents if od.document_type == 'buyer_offer')
+        assert buyer_offer_child.is_primary_terms_document is False
+        assert buyer_offer_child.document.parent_document_id == parent_doc_id
+        assert buyer_offer_child.document.page_start == 1
+        assert buyer_offer_child.document.page_end == 4
+
+        tpf = next(od for od in offer_documents if od.document_type == 'third_party_financing')
+        tpf_doc = tpf.document
+        assert tpf_doc.parent_document_id == parent_doc_id
+        assert tpf_doc.split_source == 'ai_packet_split'
+        assert tpf_doc.page_start == 5 and tpf_doc.page_end == 5
+        assert tpf_doc.field_data.get('financing_type') == 'conventional'
+        assert tpf_doc.field_data.get('buyer_approval_days') == '14'
+
+        hoa = next(od for od in offer_documents if od.document_type == 'hoa_addendum')
+        hoa_doc = hoa.document
+        assert hoa_doc.parent_document_id == parent_doc_id
+        assert hoa_doc.page_start == 6 and hoa_doc.page_end == 6
+        assert hoa_doc.field_data.get('association_name') == 'Lakeside HOA'
+
+        # Re-running the splitter should be idempotent (existing children block re-creation).
+        with patch(
+            'services.supabase_storage.upload_external_document',
+            side_effect=lambda transaction_id, file_data, original_filename, content_type: {'path': f'test/{original_filename}'},
+        ):
+            second_run = split_offer_package_into_children(parent_doc_id, pdf_bytes)
+        assert second_run == []
+
+
+def test_split_offer_package_skips_when_only_one_segment(app, db, seed):
+    from models import (
+        SellerOffer,
+        SellerOfferDocument,
+        SellerOfferVersion,
+        TransactionDocument,
+        User,
+    )
+    from services.seller_workflow import split_offer_package_into_children
+
+    pdf_bytes = _build_test_pdf(2)
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Single Document Buyer',
+            status='needs_review',
+        )
+        db.session.add(offer)
+        db.session.flush()
+        version = SellerOfferVersion(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            version_number=1,
+            direction='buyer_offer',
+            status='submitted',
+            terms_data={},
+        )
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+
+        parent_doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Contract',
+            status='signed',
+            signed_original_filename='single.pdf',
+            signed_file_path='test/single.pdf',
+            extraction_status='complete',
+            field_data={
+                'detected_documents': [
+                    {'document_type': 'buyer_offer', 'start_page': 1, 'end_page': 2},
+                ],
+            },
+        )
+        db.session.add(parent_doc)
+        db.session.flush()
+        version.transaction_document_id = parent_doc.id
+
+        db.session.add(SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            transaction_document_id=parent_doc.id,
+            offer_version_id=version.id,
+            created_by_id=owner.id,
+            document_type='offer_package',
+            display_name='Offer Package',
+            is_primary_terms_document=True,
+        ))
+        db.session.commit()
+
+        children = split_offer_package_into_children(parent_doc.id, pdf_bytes)
+        assert children == []
+        assert TransactionDocument.query.filter_by(parent_document_id=parent_doc.id).count() == 0
+
+
+def test_order_offer_package_documents_groups_children_under_parent(app, db, seed):
+    """The renderer helper should keep AI splits underneath their parent packet."""
+    from models import SellerOfferDocument, TransactionDocument
+    from routes.transactions.crud import _order_offer_package_documents
+
+    with app.app_context():
+        parent = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Package',
+            status='signed',
+            signed_original_filename='packet.pdf',
+            signed_file_path='test/packet.pdf',
+        )
+        db.session.add(parent)
+        db.session.flush()
+
+        sibling = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='pre-approval-or-proof-of-funds',
+            template_name='Pre-Approval',
+            status='signed',
+            signed_original_filename='preapproval.pdf',
+            signed_file_path='test/preapproval.pdf',
+        )
+        db.session.add(sibling)
+        db.session.flush()
+
+        child_a = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='hoa-addendum',
+            template_name='HOA Addendum',
+            status='signed',
+            signed_original_filename='packet_p6_hoa.pdf',
+            signed_file_path='test/packet_p6_hoa.pdf',
+            parent_document_id=parent.id,
+            page_start=6,
+            page_end=6,
+            split_source='ai_packet_split',
+        )
+        child_b = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='third-party-financing-addendum',
+            template_name='TPF Addendum',
+            status='signed',
+            signed_original_filename='packet_p5_tpf.pdf',
+            signed_file_path='test/packet_p5_tpf.pdf',
+            parent_document_id=parent.id,
+            page_start=5,
+            page_end=5,
+            split_source='ai_packet_split',
+        )
+        db.session.add_all([child_a, child_b])
+        db.session.flush()
+
+        owner_id = 1  # User exists from seed
+        offer_id = 1
+        # Add all offer documents so the .document relationship can be resolved.
+        parent_od = SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer_id,
+            transaction_document_id=parent.id,
+            created_by_id=owner_id,
+            document_type='offer_package',
+            display_name='Offer Package',
+            is_primary_terms_document=True,
+        )
+        child_a_od = SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer_id,
+            transaction_document_id=child_a.id,
+            created_by_id=owner_id,
+            document_type='hoa_addendum',
+            display_name='HOA Addendum',
+            is_primary_terms_document=False,
+        )
+        sibling_od = SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer_id,
+            transaction_document_id=sibling.id,
+            created_by_id=owner_id,
+            document_type='pre_approval',
+            display_name='Pre-Approval',
+            is_primary_terms_document=False,
+        )
+        child_b_od = SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer_id,
+            transaction_document_id=child_b.id,
+            created_by_id=owner_id,
+            document_type='third_party_financing',
+            display_name='TPF Addendum',
+            is_primary_terms_document=False,
+        )
+        db.session.add_all([parent_od, child_a_od, sibling_od, child_b_od])
+        db.session.flush()
+
+        # Simulate the DB query ordering offer documents by created_at desc,
+        # so the most-recently uploaded packet appears first in the input list.
+        offer_documents = [parent_od, child_a_od, sibling_od, child_b_od]
+
+        ordered = _order_offer_package_documents(offer_documents)
+        ordered_doc_ids = [od.transaction_document_id for od in ordered]
+        # Parent first (preserves input parent order), splits sorted by page right after,
+        # then unrelated sibling parent keeps its relative position.
+        assert ordered_doc_ids == [parent.id, child_b.id, child_a.id, sibling.id]


### PR DESCRIPTION
## Summary
- Add AI-detected document page ranges for combined offer packets and split uploaded PDFs into linked child documents while preserving the original packet.
- Sync extracted offer terms before completion, keep upload status processing through split creation, and refresh the offers UI when processing finishes.
- Add document lineage fields/migrations, neutral original/split document labels, and focused regression coverage.

## Test plan
- `python3 -m pytest tests/test_offer_document_package.py tests/test_document_extraction_job.py -q`
- `python3 -m pytest tests/ --ignore=tests/test_sendgrid.py --ignore=tests/integration -q`


Made with [Cursor](https://cursor.com)