### PR TITLE
fix: separate seller contract document workflow

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python3 manage_db.py upgrade
 web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500

--- a/migrations/versions/add_seller_contract_documents.py
+++ b/migrations/versions/add_seller_contract_documents.py
@@ -1,0 +1,107 @@
+"""Add seller contract documents
+
+Revision ID: add_seller_contract_documents
+Revises: add_transaction_document_split_lineage
+Create Date: 2026-04-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_seller_contract_documents'
+down_revision = 'add_transaction_document_split_lineage'
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = 'seller_contract_documents'
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def _index_exists(conn, table_name, index_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return index_name in {idx['name'] for idx in inspect(conn).get_indexes(table_name)}
+
+
+def _create_index_if_missing(conn, index_name, table_name, columns, unique=False):
+    if not _index_exists(conn, table_name, index_name):
+        op.create_index(index_name, table_name, columns, unique=unique)
+
+
+def _enable_rls(conn):
+    if conn.dialect.name != 'postgresql':
+        return
+
+    op.execute(f'ALTER TABLE {TABLE_NAME} ENABLE ROW LEVEL SECURITY')
+    op.execute(f'ALTER TABLE {TABLE_NAME} FORCE ROW LEVEL SECURITY')
+    op.execute(f'DROP POLICY IF EXISTS tenant_isolation_{TABLE_NAME} ON {TABLE_NAME}')
+    op.execute(f"""
+        CREATE POLICY tenant_isolation_{TABLE_NAME} ON {TABLE_NAME}
+        FOR ALL
+        USING (
+            organization_id = current_setting(
+                'app.current_org_id', true
+            )::integer
+        )
+        WITH CHECK (
+            organization_id = current_setting(
+                'app.current_org_id', true
+            )::integer
+        )
+    """)
+
+
+def _disable_rls(conn):
+    if conn.dialect.name != 'postgresql':
+        return
+
+    if _table_exists(conn, TABLE_NAME):
+        op.execute(f'DROP POLICY IF EXISTS tenant_isolation_{TABLE_NAME} ON {TABLE_NAME}')
+        op.execute(f'ALTER TABLE {TABLE_NAME} DISABLE ROW LEVEL SECURITY')
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _table_exists(conn, TABLE_NAME):
+        op.create_table(
+            TABLE_NAME,
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('organization_id', sa.Integer(), sa.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False),
+            sa.Column('transaction_id', sa.Integer(), sa.ForeignKey('transactions.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('accepted_contract_id', sa.Integer(), sa.ForeignKey('seller_accepted_contracts.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('transaction_document_id', sa.Integer(), sa.ForeignKey('transaction_documents.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('created_by_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=False),
+            sa.Column('document_type', sa.String(length=100), nullable=False),
+            sa.Column('display_name', sa.String(length=200), nullable=False),
+            sa.Column('is_primary_contract_document', sa.Boolean(), server_default=sa.text('false')),
+            sa.Column('extraction_summary', sa.JSON()),
+            sa.Column('created_at', sa.DateTime(), server_default=sa.func.now()),
+            sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now()),
+        )
+
+    index_specs = (
+        ('ix_seller_contract_documents_org_id', TABLE_NAME, ['organization_id']),
+        ('ix_seller_contract_documents_transaction_id', TABLE_NAME, ['transaction_id']),
+        ('ix_seller_contract_documents_contract_id', TABLE_NAME, ['accepted_contract_id']),
+        ('ix_seller_contract_documents_document_id', TABLE_NAME, ['transaction_document_id']),
+        ('ix_seller_contract_documents_type', TABLE_NAME, ['document_type']),
+    )
+    for index_name, table_name, columns in index_specs:
+        _create_index_if_missing(conn, index_name, table_name, columns)
+
+    _enable_rls(conn)
+
+
+def downgrade():
+    conn = op.get_bind()
+    _disable_rls(conn)
+
+    if _table_exists(conn, TABLE_NAME):
+        op.drop_table(TABLE_NAME)

--- a/models.py
+++ b/models.py
@@ -1231,6 +1231,37 @@ class SellerOfferDocument(db.Model):
         return f'<SellerOfferDocument offer={self.offer_id} type={self.document_type}>'
 
 
+class SellerContractDocument(db.Model):
+    """A PDF that belongs to an accepted seller contract workspace."""
+    __tablename__ = 'seller_contract_documents'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False, index=True)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id', ondelete='CASCADE'), nullable=False, index=True)
+    accepted_contract_id = db.Column(db.Integer, db.ForeignKey('seller_accepted_contracts.id', ondelete='CASCADE'), nullable=False, index=True)
+    transaction_document_id = db.Column(db.Integer, db.ForeignKey('transaction_documents.id', ondelete='CASCADE'), nullable=False, index=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+    document_type = db.Column(db.String(100), nullable=False)
+    display_name = db.Column(db.String(200), nullable=False)
+    is_primary_contract_document = db.Column(db.Boolean, default=False)
+    extraction_summary = db.Column(db.JSON, default={})
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    accepted_contract = db.relationship(
+        'SellerAcceptedContract',
+        foreign_keys=[accepted_contract_id],
+        backref=db.backref('contract_documents', lazy='dynamic'),
+    )
+    document = db.relationship('TransactionDocument', foreign_keys=[transaction_document_id])
+    created_by = db.relationship('User', foreign_keys=[created_by_id])
+
+    def __repr__(self):
+        return f'<SellerContractDocument contract={self.accepted_contract_id} type={self.document_type}>'
+
+
 class SellerOfferActivity(db.Model):
     """Chronological activity log for a seller offer thread."""
     __tablename__ = 'seller_offer_activities'

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,4 @@ cmds = ["pip install -r requirements.txt", "npm ci"]
 cmds = ["npm run build"]
 
 [start]
-cmd = "gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500"
+cmd = "python3 manage_db.py upgrade && gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500"

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -11,7 +11,7 @@ from models import (
     TransactionDocument, DocumentSignature, AuditEvent, Contact, ContactFile,
     SellerListingProfile, SellerOffer, SellerOfferActivity, SellerAcceptedContract,
     SellerContractMilestone, SellerCommissionTerms, SellerListingPriceChange,
-    SellerOfferDocument, SellerOfferVersion
+    SellerOfferDocument, SellerOfferVersion, SellerContractDocument
 )
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy import func, case, and_
@@ -467,6 +467,7 @@ def view_transaction(id):
     documents = TransactionDocument.query.filter_by(
         transaction_id=id
     ).order_by(TransactionDocument.created_at).all()
+    listing_documents = documents
     
     # Get files from all contacts associated with this transaction
     contact_ids = [p.contact_id for p in participants if p.contact_id]
@@ -481,6 +482,24 @@ def view_transaction(id):
     listing_extraction_status = None
     listing_info_overrides = {}
     if transaction.transaction_type.name == 'seller':
+        offer_scoped_document_ids = {
+            row[0] for row in db.session.query(SellerOfferDocument.transaction_document_id).filter(
+                SellerOfferDocument.transaction_id == transaction.id,
+                SellerOfferDocument.organization_id == current_user.organization_id,
+            ).all()
+        }
+        contract_scoped_document_ids = {
+            row[0] for row in db.session.query(SellerContractDocument.transaction_document_id).filter(
+                SellerContractDocument.transaction_id == transaction.id,
+                SellerContractDocument.organization_id == current_user.organization_id,
+            ).all()
+        }
+        non_listing_document_ids = offer_scoped_document_ids | contract_scoped_document_ids
+        listing_documents = [
+            doc for doc in documents
+            if doc.id not in non_listing_document_ids
+        ]
+
         extra_data = transaction.extra_data or {}
         listing_info_overrides = extra_data.get('listing_info_overrides') or {}
         from services.transaction_helpers import build_listing_info
@@ -593,17 +612,20 @@ def view_transaction(id):
             status='active'
         ).order_by(SellerAcceptedContract.backup_position.asc()).all()
         seller_contracts = ([primary_seller_contract] if primary_seller_contract else []) + backup_seller_contracts
-        contract_offer_ids = [contract.offer_id for contract in seller_contracts if contract.offer_id]
-        if contract_offer_ids:
-            docs_by_offer = {}
-            contract_offer_documents = SellerOfferDocument.query.filter(
-                SellerOfferDocument.offer_id.in_(contract_offer_ids),
-                SellerOfferDocument.organization_id == current_user.organization_id
-            ).order_by(SellerOfferDocument.created_at.asc()).all()
-            for offer_document in contract_offer_documents:
-                docs_by_offer.setdefault(offer_document.offer_id, []).append(offer_document)
+        contract_ids = [contract.id for contract in seller_contracts]
+        if contract_ids:
+            docs_by_contract = {}
+            contract_documents = SellerContractDocument.query.filter(
+                SellerContractDocument.accepted_contract_id.in_(contract_ids),
+                SellerContractDocument.organization_id == current_user.organization_id
+            ).order_by(
+                SellerContractDocument.accepted_contract_id.asc(),
+                SellerContractDocument.created_at.asc()
+            ).all()
+            for contract_document in contract_documents:
+                docs_by_contract.setdefault(contract_document.accepted_contract_id, []).append(contract_document)
             seller_contract_documents_by_contract = {
-                contract.id: _order_offer_package_documents(docs_by_offer.get(contract.offer_id, []))
+                contract.id: _order_offer_package_documents(docs_by_contract.get(contract.id, []))
                 for contract in seller_contracts
             }
         if primary_seller_contract:
@@ -641,6 +663,7 @@ def view_transaction(id):
         transaction=transaction,
         participants=participants,
         documents=documents,
+        listing_documents=listing_documents,
         contact_files=contact_files,
         listing_info=listing_info,
         listing_extraction_status=listing_extraction_status,

--- a/routes/transactions/offers.py
+++ b/routes/transactions/offers.py
@@ -30,14 +30,6 @@ from . import transactions_bp
 from .decorators import transactions_required
 
 
-SUPPORTING_DOCUMENT_TYPES = {
-    'sellers_disclosure',
-    'hoa_addendum',
-    'pre_approval',
-    'third_party_financing',
-}
-
-
 def _as_dict(value):
     """Return JSON object values only; extracted document fields may be free-form strings."""
     return value if isinstance(value, dict) else {}
@@ -202,29 +194,11 @@ def _merged_acceptance_terms(offer, version):
     if addenda:
         terms['addenda'] = addenda
 
-    package_docs = []
-    for offer_doc in offer.offer_documents.order_by(SellerOfferDocument.created_at.asc()).all():
-        doc = offer_doc.document
-        package_docs.append({
-            'offer_document_id': offer_doc.id,
-            'document_id': offer_doc.transaction_document_id,
-            'document_type': offer_doc.document_type,
-            'display_name': offer_doc.display_name,
-            'template_slug': doc.template_slug if doc else None,
-            'filename': doc.signed_original_filename if doc else None,
-            'extraction_status': doc.extraction_status if doc else None,
-            'is_primary_terms_document': offer_doc.is_primary_terms_document,
-            'offer_version_id': offer_doc.offer_version_id,
-        })
-    if package_docs:
-        terms['offer_package_documents'] = package_docs
-
     return terms
 
 
 def _contract_extra_data_from_offer(offer, terms):
     supporting = _as_dict(terms.get('supporting_documents'))
-    package_docs = terms.get('offer_package_documents') or []
     return {
         'source_offer_id': offer.id,
         'source_offer_status': offer.status,
@@ -233,18 +207,7 @@ def _contract_extra_data_from_offer(offer, terms):
         'buyer_agent_email': offer.buyer_agent_email,
         'buyer_agent_phone': offer.buyer_agent_phone,
         'buyer_agent_brokerage': offer.buyer_agent_brokerage,
-        'offer_package_documents': package_docs,
         'supporting_documents': supporting,
-        'supporting_document_ids': [
-            doc['document_id']
-            for doc in package_docs
-            if doc.get('document_type') in SUPPORTING_DOCUMENT_TYPES and doc.get('document_id')
-        ],
-        'primary_document_ids': [
-            doc['document_id']
-            for doc in package_docs
-            if doc.get('is_primary_terms_document') and doc.get('document_id')
-        ],
     }
 
 

--- a/routes/transactions/seller_contracts.py
+++ b/routes/transactions/seller_contracts.py
@@ -6,11 +6,21 @@ from decimal import Decimal, InvalidOperation
 from flask import abort, jsonify, request
 from flask_login import current_user, login_required
 
-from models import SellerAcceptedContract, SellerContractMilestone, Transaction, db
+from models import (
+    SellerAcceptedContract,
+    SellerContractDocument,
+    SellerContractMilestone,
+    Transaction,
+    TransactionDocument,
+    db,
+)
+from services.intake_service import post_upload_processing
 from services.seller_workflow import (
     close_contract,
     create_contract_milestones,
     derive_financing_approval_deadline,
+    get_offer_document_type,
+    infer_offer_document_type_from_pdf,
     promote_backup_contract,
     terminate_contract,
 )
@@ -97,6 +107,20 @@ def _get_contract_for_update(transaction, contract_id):
     ).first_or_404()
 
 
+def _contract_document_payload(contract_document):
+    doc = contract_document.document
+    return {
+        'contract_document_id': contract_document.id,
+        'document_id': contract_document.transaction_document_id,
+        'document_type': contract_document.document_type,
+        'display_name': contract_document.display_name,
+        'template_slug': doc.template_slug if doc else None,
+        'extraction_status': doc.extraction_status if doc else None,
+        'filename': doc.signed_original_filename if doc else None,
+        'is_primary_contract_document': contract_document.is_primary_contract_document,
+    }
+
+
 def _json_safe_value(value):
     if value is None:
         return None
@@ -130,6 +154,137 @@ def _sync_contract_frozen_terms(contract):
         terms[field] = _json_safe_value(getattr(contract, field))
     contract.frozen_terms = terms
     flag_modified(contract, 'frozen_terms')
+
+
+@transactions_bp.route('/<int:id>/seller/contracts/<int:contract_id>/documents/upload', methods=['POST'])
+@login_required
+@transactions_required
+def upload_seller_contract_document(id, contract_id):
+    """Upload executed contract PDFs to an accepted seller contract workspace."""
+    transaction = _get_seller_transaction(id)
+    if transaction is None:
+        return jsonify({'success': False, 'error': 'Contracts are only available for seller transactions'}), 400
+
+    contract = _get_contract_for_update(transaction, contract_id)
+    if contract.status != 'active':
+        return jsonify({'success': False, 'error': 'Documents can only be uploaded to an active contract'}), 400
+
+    files = request.files.getlist('files') or request.files.getlist('file')
+    files = [file for file in files if file and file.filename]
+    if not files:
+        return jsonify({'success': False, 'error': 'No file uploaded'}), 400
+
+    document_types = (
+        request.form.getlist('document_type')
+        or request.form.getlist('document_types[]')
+        or request.form.getlist('direction')
+    )
+
+    try:
+        from services.supabase_storage import upload_external_document as upload_storage
+
+        uploaded = []
+        max_size = 25 * 1024 * 1024
+        for index, file in enumerate(files):
+            file_ext = file.filename.rsplit('.', 1)[1].lower() if '.' in file.filename else ''
+            if file_ext != 'pdf':
+                return jsonify({'success': False, 'error': f'{file.filename}: only PDF files are allowed'}), 400
+
+            file_data = file.read()
+            if len(file_data) > max_size:
+                return jsonify({'success': False, 'error': f'{file.filename}: file too large. Maximum size is 25MB.'}), 400
+
+            explicit_type = document_types[index] if index < len(document_types) else None
+            document_type = infer_offer_document_type_from_pdf(
+                file_data,
+                file.filename,
+                explicit_type or request.form.get('document_type') or 'final_acceptance',
+            )
+            if document_type in ('buyer_offer', 'offer_package'):
+                document_type = 'final_acceptance'
+            doc_config = get_offer_document_type(document_type)
+            template_slug = doc_config['template_slug']
+            display_name = doc_config['label']
+
+            result = upload_storage(
+                transaction_id=transaction.id,
+                file_data=file_data,
+                original_filename=file.filename,
+                content_type='application/pdf',
+            )
+
+            doc = TransactionDocument(
+                organization_id=current_user.organization_id,
+                transaction_id=transaction.id,
+                template_slug=template_slug,
+                template_name=display_name,
+                status='signed',
+                document_source='completed',
+                signed_file_path=result['path'],
+                signed_file_size=len(file_data),
+                signed_original_filename=file.filename,
+                signed_at=datetime.utcnow(),
+                extraction_status='pending',
+                field_data={},
+            )
+            db.session.add(doc)
+            db.session.flush()
+
+            contract_document = SellerContractDocument(
+                organization_id=current_user.organization_id,
+                transaction_id=transaction.id,
+                accepted_contract_id=contract.id,
+                transaction_document_id=doc.id,
+                created_by_id=current_user.id,
+                document_type=document_type,
+                display_name=display_name,
+                is_primary_contract_document=doc_config['primary_terms'],
+                extraction_summary={},
+            )
+            db.session.add(contract_document)
+            db.session.flush()
+            uploaded.append(contract_document)
+
+        db.session.commit()
+
+        for contract_document in uploaded:
+            post_upload_processing(contract_document.document)
+
+        documents_payload = [_contract_document_payload(contract_document) for contract_document in uploaded]
+        first = documents_payload[0] if documents_payload else {}
+        return jsonify({
+            'success': True,
+            'message': f'{len(documents_payload)} contract document{"s" if len(documents_payload) != 1 else ""} uploaded. Extraction has started.',
+            'accepted_contract_id': contract.id,
+            'document_id': first.get('document_id'),
+            'documents': documents_payload,
+        }), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@transactions_bp.route('/<int:id>/seller/contracts/<int:contract_id>/documents', methods=['GET'])
+@login_required
+@transactions_required
+def list_seller_contract_documents(id, contract_id):
+    """Return documents attached to an accepted seller contract workspace."""
+    transaction = _get_seller_transaction(id)
+    if transaction is None:
+        return jsonify({'success': False, 'error': 'Contracts are only available for seller transactions'}), 400
+
+    contract = _get_contract_for_update(transaction, contract_id)
+    documents = SellerContractDocument.query.filter_by(
+        accepted_contract_id=contract.id,
+        transaction_id=transaction.id,
+        organization_id=current_user.organization_id,
+    ).order_by(SellerContractDocument.created_at.asc()).all()
+
+    return jsonify({
+        'success': True,
+        'accepted_contract_id': contract.id,
+        'documents': [_contract_document_payload(document) for document in documents],
+    })
 
 
 def _apply_milestone_data(milestone, data):

--- a/services/document_extractor.py
+++ b/services/document_extractor.py
@@ -370,18 +370,19 @@ def extract_document_data(doc_id: int, org_id: int, file_data: bytes):
 
         try:
             _set_rls(org_id)
-            from services.seller_workflow import sync_offer_version_from_document
+            from services.seller_workflow import sync_contract_from_document, sync_offer_version_from_document
             sync_offer_version_from_document(doc_id)
+            sync_contract_from_document(doc_id)
             db.session.commit()
         except Exception as sync_error:
             db.session.rollback()
-            logger.error(f"Failed to sync extracted offer data for doc {doc_id}", exc_info=True)
+            logger.error(f"Failed to sync extracted transaction data for doc {doc_id}", exc_info=True)
             try:
                 _set_rls(org_id)
                 doc = TransactionDocument.query.get(doc_id)
                 if doc:
                     doc.extraction_status = 'failed'
-                    doc.extraction_error = f"Offer sync failed: {sync_error}"[:500]
+                    doc.extraction_error = f"Document sync failed: {sync_error}"[:500]
                     db.session.commit()
             except Exception:
                 logger.error(f"Failed to mark extraction sync failure for doc {doc_id}", exc_info=True)
@@ -390,8 +391,9 @@ def extract_document_data(doc_id: int, org_id: int, file_data: bytes):
         split_warning = None
         try:
             _set_rls(org_id)
-            from services.seller_workflow import split_offer_package_into_children
+            from services.seller_workflow import split_contract_package_into_children, split_offer_package_into_children
             children = split_offer_package_into_children(doc_id, file_data)
+            children.extend(split_contract_package_into_children(doc_id, file_data))
             if children:
                 db.session.commit()
                 logger.info(

--- a/services/seller_workflow.py
+++ b/services/seller_workflow.py
@@ -13,6 +13,7 @@ from models import (
     SellerClosingSummary,
     SellerContractMilestone,
     SellerContractTermination,
+    SellerContractDocument,
     SellerOffer,
     SellerOfferActivity,
     SellerOfferDocument,
@@ -771,6 +772,127 @@ def split_offer_package_into_children(doc_id, file_data, *, split_source='ai_pac
     return created_children
 
 
+def split_contract_package_into_children(doc_id, file_data, *, split_source='ai_packet_split'):
+    """Create split child documents under a contract packet parent."""
+    if not file_data:
+        return []
+
+    doc = TransactionDocument.query.get(doc_id)
+    if not doc or not doc.field_data:
+        return []
+
+    contract_document = SellerContractDocument.query.filter_by(transaction_document_id=doc.id).first()
+    if not contract_document or not contract_document.is_primary_contract_document:
+        return []
+
+    parent_contract_type = contract_document.document_type
+    if parent_contract_type not in ('offer_package', 'buyer_offer', 'final_acceptance'):
+        return []
+
+    detected = doc.field_data.get('detected_documents') if isinstance(doc.field_data, dict) else None
+    if not isinstance(detected, list) or not detected:
+        return []
+
+    from services.pdf_splitter import (
+        get_pdf_page_count,
+        normalize_segments,
+        split_pdf_by_segments,
+    )
+
+    total_pages = get_pdf_page_count(file_data)
+    if total_pages <= 0:
+        return []
+
+    segments = normalize_segments(detected, total_pages=total_pages)
+    if len(segments) < 2:
+        return []
+
+    existing_children = TransactionDocument.query.filter_by(parent_document_id=doc.id).count()
+    if existing_children:
+        return []
+
+    from services.supabase_storage import upload_external_document
+
+    organization_id = doc.organization_id
+    transaction_id = doc.transaction_id
+    primary_assigned = False
+    created_children = []
+
+    base_filename = doc.signed_original_filename or 'contract_packet.pdf'
+    name_root, _, ext = base_filename.rpartition('.')
+    name_root = name_root or 'contract_packet'
+    ext = (ext or 'pdf').lower()
+
+    for split_result in split_pdf_by_segments(file_data, segments):
+        seg = split_result.segment
+        document_type = _split_segment_to_offer_type(seg.document_type)
+        if document_type == 'buyer_offer':
+            document_type = 'final_acceptance'
+        if not document_type:
+            continue
+        if document_type == 'final_acceptance':
+            if primary_assigned:
+                continue
+            primary_assigned = True
+
+        doc_config = get_offer_document_type(document_type)
+        template_slug = doc_config['template_slug']
+        display_name = doc_config['label']
+        child_filename = f"{name_root}_p{seg.start_page}-{seg.end_page}_{document_type}.{ext}"
+
+        try:
+            upload_result = upload_external_document(
+                transaction_id=transaction_id,
+                file_data=split_result.pdf_bytes,
+                original_filename=child_filename,
+                content_type='application/pdf',
+            )
+        except Exception:
+            upload_result = {'path': None}
+
+        inherited_field_data = _inherited_field_data_for_segment(seg.document_type, doc.field_data)
+        if document_type == 'final_acceptance':
+            inherited_field_data = dict(doc.field_data or {})
+
+        child_doc = TransactionDocument(
+            organization_id=organization_id,
+            transaction_id=transaction_id,
+            template_slug=template_slug,
+            template_name=display_name,
+            status='signed',
+            document_source='completed',
+            signed_file_path=upload_result.get('path'),
+            signed_file_size=len(split_result.pdf_bytes),
+            signed_original_filename=child_filename,
+            signed_at=datetime.utcnow(),
+            extraction_status='complete' if inherited_field_data else None,
+            field_data=inherited_field_data,
+            parent_document_id=doc.id,
+            page_start=seg.start_page,
+            page_end=seg.end_page,
+            split_source=split_source,
+        )
+        db.session.add(child_doc)
+        db.session.flush()
+
+        child_contract_document = SellerContractDocument(
+            organization_id=organization_id,
+            transaction_id=transaction_id,
+            accepted_contract_id=contract_document.accepted_contract_id,
+            transaction_document_id=child_doc.id,
+            created_by_id=contract_document.created_by_id,
+            document_type=document_type,
+            display_name=seg.title or display_name,
+            is_primary_contract_document=doc_config['primary_terms'],
+            extraction_summary=inherited_field_data,
+        )
+        db.session.add(child_contract_document)
+        db.session.flush()
+        created_children.append(child_contract_document)
+
+    return created_children
+
+
 def sync_offer_version_from_document(doc_id):
     """Sync AI-extracted TransactionDocument.field_data into linked offer records."""
     doc = TransactionDocument.query.get(doc_id)
@@ -814,6 +936,135 @@ def sync_offer_version_from_document(doc_id):
         offer_document.extraction_summary = extracted
 
     return version
+
+
+def apply_contract_terms(contract, terms):
+    """Copy reviewed/extracted terms into canonical accepted contract columns."""
+    terms = normalize_offer_terms(terms)
+    addenda = _json_object(terms.get('addenda'))
+    supporting = _json_object(terms.get('supporting_documents'))
+    financing_addendum = (
+        _json_object(addenda.get('third_party_financing_addendum'))
+        or _json_object(supporting.get('third_party_financing'))
+    )
+    seller_disclosure = _json_object(supporting.get('sellers_disclosure'))
+    hoa_addendum = _json_object(addenda.get('hoa_addendum')) or _json_object(supporting.get('hoa_addendum'))
+
+    contract.accepted_price = _coerce_decimal(terms.get('offer_price') or terms.get('sales_price')) or contract.accepted_price
+    contract.effective_date = _parse_date(terms.get('effective_date')) or contract.effective_date
+    contract.effective_at = _parse_datetime(terms.get('effective_at')) or contract.effective_at
+    contract.closing_date = _parse_date(terms.get('proposed_close_date') or terms.get('closing_date')) or contract.closing_date
+    contract.option_period_days = _coerce_int(terms.get('option_period_days')) if terms.get('option_period_days') is not None else contract.option_period_days
+    contract.financing_type = _coerce_text(terms.get('financing_type')) or contract.financing_type
+    contract.cash_down_payment = _coerce_decimal(terms.get('cash_down_payment')) or contract.cash_down_payment
+    contract.financing_amount = _coerce_decimal(
+        terms.get('financing_amount')
+        or terms.get('total_financing_amount')
+        or financing_addendum.get('total_financing_amount')
+    ) or contract.financing_amount
+    contract.seller_concessions_amount = _coerce_decimal(terms.get('seller_concessions_amount')) or contract.seller_concessions_amount
+    contract.title_company = _coerce_text(terms.get('title_company')) or contract.title_company
+    contract.escrow_officer = _coerce_text(terms.get('escrow_officer')) or contract.escrow_officer
+    contract.survey_choice = _coerce_text(terms.get('survey_choice')) or contract.survey_choice
+    contract.survey_furnished_by = _coerce_text(terms.get('survey_furnished_by')) or contract.survey_furnished_by
+    contract.residential_service_contract = _coerce_text(terms.get('residential_service_contract')) or contract.residential_service_contract
+    contract.buyer_agent_commission_percent = _coerce_decimal(terms.get('buyer_agent_commission_percent')) or contract.buyer_agent_commission_percent
+    contract.buyer_agent_commission_flat = _coerce_decimal(terms.get('buyer_agent_commission_flat')) or contract.buyer_agent_commission_flat
+
+    if terms.get('hoa_applicable') is not None:
+        contract.hoa_applicable = _coerce_bool(terms.get('hoa_applicable'))
+    elif hoa_addendum:
+        contract.hoa_applicable = True
+
+    if terms.get('seller_disclosure_required') is not None:
+        contract.seller_disclosure_required = _coerce_bool(terms.get('seller_disclosure_required'))
+    elif seller_disclosure:
+        contract.seller_disclosure_required = True
+
+    seller_disclosure_delivered = (
+        seller_disclosure.get('buyer_received_date')
+        or seller_disclosure.get('seller_signed_date')
+    )
+    contract.seller_disclosure_delivered_at = (
+        _parse_datetime(seller_disclosure_delivered)
+        or contract.seller_disclosure_delivered_at
+    )
+
+    if terms.get('lead_based_paint_required') is not None:
+        contract.lead_based_paint_required = _coerce_bool(terms.get('lead_based_paint_required'))
+    elif seller_disclosure.get('built_before_1978') is not None:
+        contract.lead_based_paint_required = _coerce_bool(seller_disclosure.get('built_before_1978'))
+
+    financing_deadline = derive_financing_approval_deadline(terms, contract.effective_date)
+    contract.financing_approval_deadline = financing_deadline or contract.financing_approval_deadline
+    contract.frozen_terms = terms
+    contract.addenda_data = terms.get('addenda') or {}
+
+    extra_data = dict(contract.extra_data or {})
+    if terms.get('supporting_documents'):
+        extra_data['supporting_documents'] = terms.get('supporting_documents')
+    contract.extra_data = extra_data
+    return contract
+
+
+def _merge_existing_contract_context(contract, terms):
+    merged = dict(terms or {})
+    existing = dict(contract.frozen_terms or {}) if contract else {}
+    if existing.get('supporting_documents') and 'supporting_documents' not in merged:
+        merged['supporting_documents'] = existing['supporting_documents']
+    if existing.get('addenda') or merged.get('addenda'):
+        addenda = dict(existing.get('addenda') or {})
+        addenda.update(merged.get('addenda') or {})
+        merged['addenda'] = addenda
+    return normalize_offer_terms(merged)
+
+
+def sync_contract_from_document(doc_id):
+    """Sync AI-extracted TransactionDocument.field_data into a linked accepted contract."""
+    from sqlalchemy.orm.attributes import flag_modified
+
+    doc = TransactionDocument.query.get(doc_id)
+    if not doc or not doc.field_data:
+        return None
+
+    contract_document = SellerContractDocument.query.filter_by(transaction_document_id=doc.id).first()
+    if not contract_document:
+        return None
+
+    contract = contract_document.accepted_contract
+    if not contract:
+        return None
+
+    extracted = dict(doc.field_data or {})
+    terms = dict(contract.frozen_terms or {})
+    if contract_document.is_primary_contract_document:
+        terms.update(extracted)
+    else:
+        normalized = _normalized_supporting_payload(contract_document.document_type, extracted)
+        supporting = dict(terms.get('supporting_documents') or {})
+        supporting.update(normalized.get('supporting_documents') or {})
+        if supporting:
+            terms['supporting_documents'] = supporting
+
+        if normalized.get('addenda'):
+            addenda = dict(terms.get('addenda') or {})
+            addenda.update(normalized['addenda'])
+            terms['addenda'] = addenda
+
+        for key, value in (normalized.get('offer_terms') or {}).items():
+            if value is not None:
+                terms[key] = value
+
+    terms = _merge_existing_contract_context(contract, terms)
+    apply_contract_terms(contract, terms)
+    create_contract_milestones(contract, replace=True)
+    contract_document.extraction_summary = extracted
+
+    flag_modified(contract, 'frozen_terms')
+    flag_modified(contract, 'addenda_data')
+    flag_modified(contract, 'extra_data')
+    flag_modified(contract_document, 'extraction_summary')
+    return contract_document
 
 
 def _milestone(contract, key, title, due_at=None, source='calculated', responsible_party=None, source_data=None):

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -17,7 +17,8 @@ function getActiveSellerWorkspaceTab() {
 }
 
 function restoreSellerWorkspaceTab() {
-    const savedTab = sessionStorage.getItem(SELLER_WORKSPACE_TAB_KEY);
+    let savedTab = sessionStorage.getItem(SELLER_WORKSPACE_TAB_KEY);
+    if (savedTab === 'overview') savedTab = 'listing';
     if (savedTab && document.getElementById(`seller-panel-${savedTab}`)) {
         sellerWorkspaceTab(savedTab, { persist: false });
     }
@@ -467,8 +468,12 @@ function showToast(message, type = 'info') {
 // =============================================================================
 
 function sellerWorkspaceTab(tabName, options = {}) {
+    if (tabName === 'overview') tabName = 'listing';
     document.querySelectorAll('[id^="seller-tab-"]').forEach(btn => btn.classList.remove('is-active'));
     document.querySelectorAll('.seller-tab-panel').forEach(panel => panel.classList.add('hidden'));
+    document.querySelectorAll('[data-seller-listing-tab-content]').forEach(element => {
+        element.classList.toggle('hidden', tabName !== 'listing');
+    });
 
     const tab = document.getElementById(`seller-tab-${tabName}`);
     const panel = document.getElementById(`seller-panel-${tabName}`);
@@ -494,7 +499,7 @@ function sellerFormData(form) {
     return data;
 }
 
-function sellerPost(url, payload, successMessage) {
+function sellerPost(url, payload, successMessage, options = {}) {
     return fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -506,8 +511,8 @@ function sellerPost(url, payload, successMessage) {
             throw new Error(data.error || 'Request failed');
         }
         if (successMessage) showToast(successMessage, 'success');
-        const activeSellerTab = getActiveSellerWorkspaceTab();
-        if (activeSellerTab) setSellerWorkspaceReloadTab(activeSellerTab);
+        const reloadTab = options.reloadTab || getActiveSellerWorkspaceTab();
+        if (reloadTab) setSellerWorkspaceReloadTab(reloadTab);
         setTimeout(() => location.reload(), 500);
         return data;
     })
@@ -927,6 +932,168 @@ document.querySelectorAll('.seller-offer-upload-form').forEach(form => {
     });
 });
 
+const CONTRACT_DOCUMENT_TYPE_OPTIONS = [
+    ['final_acceptance', 'Executed contract'],
+    ['third_party_financing', 'Third party financing'],
+    ['hoa_addendum', 'HOA Addendum'],
+    ['sellers_disclosure', "Seller's Disclosure"],
+    ['pre_approval', 'Mortgage pre-approval'],
+    ['backup_acceptance', 'Backup addendum']
+];
+
+function inferContractDocumentType(filename) {
+    const words = (filename || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().split(/\s+/);
+    const tokens = new Set(words);
+    const has = (...items) => items.every(item => tokens.has(item));
+
+    if (has('third', 'financing')) return 'third_party_financing';
+    if (tokens.has('preapproval') || has('pre', 'approval') || tokens.has('prequal') || has('pre', 'qual') || tokens.has('prequalification')) {
+        return 'pre_approval';
+    }
+    if (tokens.has('hoa') || has('owners', 'association') || has('property', 'subject', 'mandatory') || has('mandatory', 'membership')) {
+        return 'hoa_addendum';
+    }
+    if (has('seller', 'disclosure') || has('sellers', 'disclosure') || tokens.has('sd')) return 'sellers_disclosure';
+    if (tokens.has('backup')) return 'backup_acceptance';
+    return 'final_acceptance';
+}
+
+function updateSellerContractDropzone(form, files) {
+    const title = form.querySelector('.seller-contract-dropzone-title');
+    const hint = form.querySelector('.seller-contract-dropzone-hint');
+    if (!title || !hint) return;
+    if (!files.length) {
+        title.textContent = 'Choose executed PDFs';
+        hint.textContent = 'Multiple PDFs allowed. Types are inferred from filename.';
+        return;
+    }
+    const totalSize = files.reduce((sum, file) => sum + (file.size || 0), 0);
+    const totalLabel = totalSize ? ` · ${(totalSize / 1024 / 1024).toFixed(2)} MB total` : '';
+    title.textContent = `${files.length} PDF${files.length === 1 ? '' : 's'} ready`;
+    hint.textContent = `Tap to add or replace${totalLabel}`;
+}
+
+function renderSellerContractFileList(form) {
+    const input = form.querySelector('.seller-contract-file-input');
+    const list = form.querySelector('.seller-contract-file-list');
+    if (!input || !list) return;
+
+    const files = Array.from(input.files || []);
+    updateSellerContractDropzone(form, files);
+
+    if (!files.length) {
+        list.classList.add('hidden');
+        list.innerHTML = '';
+        return;
+    }
+
+    list.innerHTML = files.map((file, index) => {
+        const inferredType = inferContractDocumentType(file.name);
+        const options = CONTRACT_DOCUMENT_TYPE_OPTIONS.map(([value, label]) => (
+            `<option value="${value}" ${value === inferredType ? 'selected' : ''}>${label}</option>`
+        )).join('');
+        const fileSize = file.size ? `${Math.max(file.size / 1024 / 1024, 0.01).toFixed(2)} MB` : '';
+        return `
+            <div class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-slate-200 bg-white px-3 py-2.5" data-contract-upload-row="${index}">
+                <span class="flex h-9 w-9 items-center justify-center rounded-md bg-rose-50 text-rose-600">
+                    <i class="fas fa-file-pdf text-sm"></i>
+                </span>
+                <div class="min-w-0">
+                    <div class="truncate text-sm font-medium text-slate-900">${escapeHtml(file.name)}</div>
+                    <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+                        ${fileSize ? `<span>${fileSize}</span><span class="text-slate-300">·</span>` : ''}
+                        <span>Auto-detected type</span>
+                    </div>
+                </div>
+                <select class="crm-select seller-contract-document-type-select h-9 w-44 px-3 py-1.5 text-xs">
+                    ${options}
+                </select>
+                <div class="seller-contract-upload-status col-span-3 hidden border-t border-slate-100 pt-2 text-[11px] text-slate-500"></div>
+            </div>
+        `;
+    }).join('');
+    list.classList.remove('hidden');
+}
+
+document.querySelectorAll('.seller-contract-upload-form').forEach(form => {
+    const input = form.querySelector('.seller-contract-file-input');
+    if (input) {
+        input.addEventListener('change', () => renderSellerContractFileList(form));
+    }
+
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const contractId = this.dataset.contractId;
+        const submit = this.querySelector('button[type="submit"]');
+        const originalText = submit ? submit.textContent : '';
+        const fileInput = this.querySelector('.seller-contract-file-input');
+        const files = Array.from((fileInput && fileInput.files) || []);
+        if (!contractId) {
+            showToast('Unable to find contract.', 'error');
+            return;
+        }
+        if (!files.length) {
+            showToast('Select at least one PDF.', 'error');
+            return;
+        }
+
+        const rows = Array.from(this.querySelectorAll('[data-contract-upload-row]'));
+        const formData = new FormData();
+        files.forEach((file, index) => {
+            const row = rows[index];
+            const select = row ? row.querySelector('.seller-contract-document-type-select') : null;
+            const status = row ? row.querySelector('.seller-contract-upload-status') : null;
+            formData.append('files', file);
+            formData.append('document_type', select ? select.value : inferContractDocumentType(file.name));
+            if (status) {
+                status.textContent = 'Uploading...';
+                status.classList.remove('hidden', 'text-red-600');
+                status.classList.add('text-sky-600');
+            }
+        });
+
+        if (submit) {
+            submit.disabled = true;
+            submit.textContent = 'Uploading...';
+        }
+
+        fetch(`/transactions/${transactionId}/seller/contracts/${contractId}/documents/upload`, {
+            method: 'POST',
+            body: formData
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (!data.success) throw new Error(data.error || 'Upload failed');
+            rows.forEach(row => {
+                const status = row.querySelector('.seller-contract-upload-status');
+                if (status) {
+                    status.textContent = 'Uploaded. Extraction queued.';
+                    status.classList.remove('hidden', 'text-red-600', 'text-sky-600');
+                    status.classList.add('text-emerald-600');
+                }
+            });
+            showToast(data.message || 'Contract document uploaded.', 'success');
+            setSellerWorkspaceReloadTab('contract');
+            setTimeout(() => location.reload(), 800);
+        })
+        .catch(err => {
+            showToast(err.message || 'Contract upload failed', 'error');
+            rows.forEach(row => {
+                const status = row.querySelector('.seller-contract-upload-status');
+                if (status) {
+                    status.textContent = err.message || 'Upload failed';
+                    status.classList.remove('hidden', 'text-sky-600');
+                    status.classList.add('text-red-600');
+                }
+            });
+            if (submit) {
+                submit.disabled = false;
+                submit.textContent = originalText;
+            }
+        });
+    });
+});
+
 function acceptSellerOffer(offerId, position) {
     const label = position === 'backup' ? 'accept this offer as backup' : 'accept this offer as primary';
     if (!confirm(`Are you sure you want to ${label}?`)) return;
@@ -940,7 +1107,8 @@ function acceptSellerOffer(offerId, position) {
     sellerPost(
         `/transactions/${transactionId}/offers/${offerId}/accept`,
         payload,
-        position === 'backup' ? 'Backup contract created.' : 'Primary contract accepted.'
+        position === 'backup' ? 'Backup contract created.' : 'Primary contract accepted.',
+        { reloadTab: 'contract' }
     );
 }
 

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -299,7 +299,7 @@
 
                 {% if transaction.transaction_type.name == 'seller' %}
                 {# ----- Property details card (seller: above workspace) ----- #}
-                <section id="transaction-documents-card" class="crm-surface scroll-mt-28">
+                <section id="transaction-documents-card" class="crm-surface scroll-mt-28" data-seller-listing-tab-content>
                     <div class="crm-surface-header">
                         {{ section_header('Property details') }}
                     </div>
@@ -367,8 +367,8 @@
                     </div>
                     <div class="crm-surface-body">
                         <div class="crm-segment mb-5" data-seller-tabs>
-                            <button type="button" id="seller-tab-overview" class="crm-segment__item is-active" onclick="sellerWorkspaceTab('overview')">
-                                Overview
+                            <button type="button" id="seller-tab-listing" class="crm-segment__item is-active" onclick="sellerWorkspaceTab('listing')">
+                                Listing Info
                             </button>
                             <button type="button" id="seller-tab-offers" class="crm-segment__item" onclick="sellerWorkspaceTab('offers')">
                                 Offers{% if active_seller_offers %} <span class="text-orange-600">({{ active_seller_offers|length }})</span>{% endif %}
@@ -378,31 +378,11 @@
                             </button>
                         </div>
 
-                        <div id="seller-panel-overview" class="seller-tab-panel space-y-4">
-                            <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
-                                <div class="rounded-md border border-slate-200 bg-slate-50 p-3">
-                                    <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Offer pressure</div>
-                                    {% if urgent_seller_offer %}
-                                    {% set urgent_state = offer_urgency(urgent_seller_offer) %}
-                                    <div class="mt-2 text-sm font-semibold {% if urgent_state.state in ['critical', 'strong_warning'] %}text-red-700{% elif urgent_state.state == 'warning' %}text-orange-700{% else %}text-slate-900{% endif %}">
-                                        {{ urgent_state.label }}
-                                    </div>
-                                    <div class="mt-1 truncate text-xs text-slate-500">{{ urgent_seller_offer.buyer_names or urgent_seller_offer.buyer_agent_name or 'Active offer' }}</div>
-                                    {% else %}
-                                    <div class="mt-2 text-sm text-slate-500">No active offers</div>
-                                    {% endif %}
-                                </div>
-                                <div class="rounded-md border border-slate-200 bg-slate-50 p-3">
-                                    <div class="text-xs font-medium uppercase tracking-wide text-slate-500">Contract state</div>
-                                    {% if primary_seller_contract %}
-                                    <div class="mt-2 text-sm font-semibold text-emerald-700">Under contract</div>
-                                    <div class="mt-1 text-xs text-slate-500">{{ backup_seller_contracts|length }} backup contract{% if backup_seller_contracts|length != 1 %}s{% endif %}</div>
-                                    {% else %}
-                                    <div class="mt-2 text-sm text-slate-500">Active listing workflow</div>
-                                    {% endif %}
-                                </div>
+                        <div id="seller-panel-listing" class="seller-tab-panel space-y-4">
+                            <div class="rounded-md border border-slate-200 bg-slate-50 p-4">
+                                <h3 class="text-sm font-semibold text-slate-900">Listing workspace</h3>
+                                <p class="mt-1 text-xs text-slate-500">Property details, listing questionnaire, listing documents, and extracted listing data stay on this tab.</p>
                             </div>
-
                         </div>
 
                         <div id="seller-panel-offers" class="seller-tab-panel hidden space-y-4">
@@ -968,25 +948,49 @@
                             <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_440px]">
                                 <div class="rounded-md border border-slate-200">
                                     <div class="border-b border-slate-200 px-4 py-3">
-                                        <h3 class="text-sm font-semibold text-slate-900">Contract package</h3>
-                                        <p class="mt-1 text-xs text-slate-500">Documents inherited from the accepted offer.</p>
+                                        <h3 class="text-sm font-semibold text-slate-900">Contract documents</h3>
+                                        <p class="mt-1 text-xs text-slate-500">Upload executed, signed contract documents for this contract workspace.</p>
                                     </div>
+                                    <form class="seller-contract-upload-form border-b border-slate-200 bg-slate-50/60 p-4" data-contract-id="{{ primary_seller_contract.id }}" enctype="multipart/form-data">
+                                        <div class="flex flex-wrap items-start justify-between gap-3">
+                                            <div class="min-w-0">
+                                                <h4 class="text-sm font-semibold text-slate-900">Upload executed PDFs</h4>
+                                                <p class="mt-1 text-xs text-slate-500">Attach the signed contract and related executed addenda. We'll extract contract terms from the files.</p>
+                                            </div>
+                                            <button class="crm-btn crm-btn-primary px-3 py-1.5 text-xs" type="submit">
+                                                <i class="fas fa-bolt text-[10px]"></i>
+                                                Upload &amp; extract
+                                            </button>
+                                        </div>
+                                        <label class="seller-contract-dropzone group mt-3 flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-slate-300 bg-white px-4 py-3.5 transition hover:border-slate-400 hover:bg-slate-50">
+                                            <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-rose-50 text-rose-600 ring-1 ring-slate-200">
+                                                <i class="fas fa-file-pdf text-base"></i>
+                                            </span>
+                                            <span class="min-w-0 flex-1">
+                                                <span class="seller-contract-dropzone-title block text-sm font-medium text-slate-900">Choose executed PDFs</span>
+                                                <span class="seller-contract-dropzone-hint mt-0.5 block text-xs text-slate-500">Multiple PDFs allowed. Types are inferred from filename.</span>
+                                            </span>
+                                            <span class="hidden shrink-0 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 group-hover:border-slate-300 group-hover:text-slate-800 sm:inline-block">Browse</span>
+                                            <input type="file" name="files" accept="application/pdf" class="seller-contract-file-input sr-only" multiple required>
+                                        </label>
+                                        <div class="seller-contract-file-list mt-3 hidden space-y-2"></div>
+                                    </form>
                                     <div class="overflow-hidden rounded-md border border-slate-200">
                                         {% set contract_parent_ids_with_children = [] %}
-                                        {% for offer_document in primary_contract_docs %}
-                                            {% set doc = offer_document.document %}
+                                        {% for contract_document in primary_contract_docs %}
+                                            {% set doc = contract_document.document %}
                                             {% if doc and doc.parent_document_id and doc.parent_document_id not in contract_parent_ids_with_children %}
                                                 {% set _ = contract_parent_ids_with_children.append(doc.parent_document_id) %}
                                             {% endif %}
                                         {% endfor %}
-                                        {% for offer_document in primary_contract_docs %}
-                                        {% set doc = offer_document.document %}
+                                        {% for contract_document in primary_contract_docs %}
+                                        {% set doc = contract_document.document %}
                                         {% set is_split_child = doc and doc.parent_document_id %}
                                         {% set is_original_packet = doc and (doc.id in contract_parent_ids_with_children) %}
                                         <div class="grid grid-cols-1 gap-3 border-b border-slate-100 bg-white px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center{% if is_split_child %} pl-6 sm:pl-8 border-l-2 border-l-slate-200{% endif %}">
                                             <div class="min-w-0">
                                                 <div class="flex flex-wrap items-center gap-2">
-                                                    <span class="text-sm font-semibold text-slate-900">{{ offer_document.display_name }}</span>
+                                                    <span class="text-sm font-semibold text-slate-900">{{ contract_document.display_name }}</span>
                                                     {% if is_original_packet %}
                                                     <span class="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-600" title="Original uploaded packet">Original upload</span>
                                                     {% elif is_split_child %}
@@ -1001,12 +1005,12 @@
                                                     {% endif %}
                                                 </div>
                                                 <div class="mt-2 flex flex-wrap gap-1.5">
-                                                    <span class="rounded-md bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">{{ offer_document.document_type|replace('_', ' ')|title }}</span>
+                                                    <span class="rounded-md bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">{{ contract_document.document_type|replace('_', ' ')|title }}</span>
                                                     {% if doc and doc.extraction_status %}
                                                     <span class="rounded-md bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">{{ doc.extraction_status|replace('_', ' ')|title }}</span>
                                                     {% endif %}
-                                                    {% if offer_document.extraction_summary %}
-                                                    <span class="rounded-md bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-500">{{ offer_document.extraction_summary|length }} fields extracted</span>
+                                                    {% if contract_document.extraction_summary %}
+                                                    <span class="rounded-md bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-500">{{ contract_document.extraction_summary|length }} fields extracted</span>
                                                     {% endif %}
                                                 </div>
                                             </div>
@@ -1018,7 +1022,7 @@
                                             {% endif %}
                                         </div>
                                         {% else %}
-                                        <div class="bg-white px-4 py-6 text-sm text-slate-500">No offer package documents were captured for this contract.</div>
+                                        <div class="bg-white px-4 py-6 text-sm text-slate-500">No contract documents uploaded yet.</div>
                                         {% endfor %}
                                     </div>
                                 </div>
@@ -1434,7 +1438,7 @@
 
                 {# ----- Property questionnaire card ----- #}
                 {% if has_intake_schema %}
-                <section class="crm-surface">
+                <section class="crm-surface" {% if transaction.transaction_type.name == 'seller' %}data-seller-listing-tab-content{% endif %}>
                     <div class="crm-surface-header">
                         <div class="flex items-center gap-3">
                             {{ section_header('Property questionnaire') }}
@@ -1488,15 +1492,16 @@
                 {% endif %}
 
                 {# ----- Listing documents card ----- #}
-                <section class="crm-surface">
+                {% set visible_documents = listing_documents if transaction.transaction_type.name == 'seller' else documents %}
+                <section class="crm-surface" {% if transaction.transaction_type.name == 'seller' %}data-seller-listing-tab-content{% endif %}>
                     <div class="crm-surface-header">
                         <div>
                             {{ section_header('Listing Documents') }}
-                            {% if document_workflow_mode == 'placeholder_upload_only' and documents %}
-                            {% set uploaded_count = documents|selectattr('status', 'equalto', 'signed')|list|length %}
-                            <p class="mt-1 text-xs text-slate-500">{{ uploaded_count }}/{{ documents|length }} uploaded</p>
+                            {% if document_workflow_mode == 'placeholder_upload_only' and visible_documents %}
+                            {% set uploaded_count = visible_documents|selectattr('status', 'equalto', 'signed')|list|length %}
+                            <p class="mt-1 text-xs text-slate-500">{{ uploaded_count }}/{{ visible_documents|length }} uploaded</p>
                             {% else %}
-                            <p class="mt-1 text-xs text-slate-500">{{ documents|length if documents else 0 }} document{% if documents|length != 1 %}s{% endif %}</p>
+                            <p class="mt-1 text-xs text-slate-500">{{ visible_documents|length if visible_documents else 0 }} document{% if visible_documents|length != 1 %}s{% endif %}</p>
                             {% endif %}
                         </div>
                         {% if document_workflow_mode == 'placeholder_upload_only' %}
@@ -1514,9 +1519,9 @@
                         {% endif %}
                     </div>
                     <div class="crm-surface-body">
-                        {% if documents %}
+                        {% if visible_documents %}
                         <div class="divide-y divide-slate-100">
-                            {% for doc in documents %}
+                            {% for doc in visible_documents %}
                             {% set awaiting_upload = (document_workflow_mode == 'placeholder_upload_only' and doc.status != 'signed') or (doc.is_placeholder and doc.status == 'pending') %}
                             <div id="transaction-document-{{ doc.id }}"
                                  class="group flex items-center justify-between gap-3 py-3 scroll-mt-28">
@@ -2057,7 +2062,7 @@
                 {% if transaction.transaction_type.name == 'seller' %}
                 {# ----- Listing info card (seller only) ----- #}
                 {% set listing_override_values = listing_info_overrides or {} %}
-                <section class="crm-surface" id="listing-info-card"
+                <section class="crm-surface" id="listing-info-card" data-seller-listing-tab-content
                          data-transaction-id="{{ transaction.id }}"
                          data-extraction-status="{{ listing_extraction_status or '' }}">
                     <div class="crm-surface-header">

--- a/tests/test_offer_document_package.py
+++ b/tests/test_offer_document_package.py
@@ -195,9 +195,97 @@ def test_offer_upload_marks_existing_new_offer_needs_review(owner_a_client, app,
         assert SellerOfferDocument.query.filter_by(offer_id=offer_id).count() == 1
 
 
-def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_client, app, db, seed):
+def test_listing_documents_exclude_offer_and_contract_documents(owner_a_client, app, db, seed):
     from models import (
         SellerAcceptedContract,
+        SellerContractDocument,
+        SellerOffer,
+        SellerOfferDocument,
+        TransactionDocument,
+        User,
+    )
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        offer = SellerOffer(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            created_by_id=owner.id,
+            buyer_names='Hidden Offer Buyer',
+            status='needs_review',
+        )
+        db.session.add(offer)
+        db.session.flush()
+
+        offer_doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-offer-contract',
+            template_name='Offer Contract Hidden From Listing',
+            status='signed',
+            signed_file_path='test/offer.pdf',
+        )
+        contract_doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-accepted-contract',
+            template_name='Executed Contract Hidden From Listing',
+            status='signed',
+            signed_file_path='test/contract.pdf',
+        )
+        db.session.add_all([offer_doc, contract_doc])
+        db.session.flush()
+
+        db.session.add(SellerOfferDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            transaction_document_id=offer_doc.id,
+            created_by_id=owner.id,
+            document_type='buyer_offer',
+            display_name='Offer Contract Hidden From Listing',
+            is_primary_terms_document=True,
+        ))
+
+        contract = SellerAcceptedContract(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            offer_id=offer.id,
+            created_by_id=owner.id,
+            position='primary',
+            status='active',
+        )
+        db.session.add(contract)
+        db.session.flush()
+
+        db.session.add(SellerContractDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            accepted_contract_id=contract.id,
+            transaction_document_id=contract_doc.id,
+            created_by_id=owner.id,
+            document_type='final_acceptance',
+            display_name='Executed Contract Hidden From Listing',
+            is_primary_contract_document=True,
+        ))
+        db.session.commit()
+
+    response = owner_a_client.get(f'/transactions/{seed["tx_a"]}')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    start = html.index('Listing Documents')
+    end = html.index('</section>', start)
+    listing_section = html[start:end]
+
+    assert 'Listing Agreement' in listing_section
+    assert 'Offer Contract Hidden From Listing' not in listing_section
+    assert 'Executed Contract Hidden From Listing' not in listing_section
+
+
+def test_accept_offer_keeps_supporting_data_without_contract_documents(owner_a_client, app, db, seed):
+    from models import (
+        SellerAcceptedContract,
+        SellerContractDocument,
         SellerOffer,
         SellerOfferDocument,
         SellerOfferVersion,
@@ -319,8 +407,11 @@ def test_accept_offer_freezes_package_documents_and_supporting_data(owner_a_clie
         assert contract.residential_service_contract == 'Seller to reimburse buyer up to $650.'
         assert contract.buyer_agent_commission_percent == 3
         assert 'third_party_financing' in contract.frozen_terms['supporting_documents']
-        assert len(contract.extra_data['offer_package_documents']) == 3
-        assert len(contract.extra_data['supporting_document_ids']) == 2
+        assert 'third_party_financing' in contract.extra_data['supporting_documents']
+        assert 'offer_package_documents' not in contract.extra_data
+        assert 'supporting_document_ids' not in contract.extra_data
+        assert 'primary_document_ids' not in contract.extra_data
+        assert SellerContractDocument.query.filter_by(accepted_contract_id=contract.id).count() == 0
 
 
 def test_primary_combined_package_extraction_populates_offer_terms(app, db, seed):

--- a/tests/test_seller_contract_milestones.py
+++ b/tests/test_seller_contract_milestones.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import io
+from unittest.mock import patch
 
 
 def _create_contract(app, db, seed):
@@ -87,3 +89,107 @@ def test_create_manual_seller_contract_milestone(owner_a_client, app, db, seed):
         assert milestone.due_at.isoformat() == '2026-05-04T10:00:00'
         assert milestone.status == 'waiting'
         assert milestone.source == 'manual'
+
+
+def test_upload_seller_contract_document(owner_a_client, app, db, seed):
+    from models import SellerContractDocument, TransactionDocument
+
+    contract_id = _create_contract(app, db, seed)
+
+    def fake_upload(transaction_id, file_data, original_filename, content_type):
+        return {'path': f'test/{transaction_id}/{original_filename}'}
+
+    with patch('services.supabase_storage.upload_external_document', side_effect=fake_upload), \
+         patch('routes.transactions.seller_contracts.post_upload_processing') as post_upload_processing:
+        response = owner_a_client.post(
+            f'/transactions/{seed["tx_a"]}/seller/contracts/{contract_id}/documents/upload',
+            data={
+                'files': [
+                    (io.BytesIO(b'%PDF-1.4 executed contract'), 'executed_contract.pdf'),
+                ],
+                'document_type': 'final_acceptance',
+            },
+            content_type='multipart/form-data',
+        )
+
+    assert response.status_code == 201, response.get_data(as_text=True)
+    payload = response.get_json()
+    assert payload['success'] is True
+    assert payload['accepted_contract_id'] == contract_id
+    assert payload['documents'][0]['document_type'] == 'final_acceptance'
+    assert post_upload_processing.call_count == 1
+
+    list_response = owner_a_client.get(
+        f'/transactions/{seed["tx_a"]}/seller/contracts/{contract_id}/documents'
+    )
+    assert list_response.status_code == 200
+    assert len(list_response.get_json()['documents']) == 1
+
+    with app.app_context():
+        contract_document = SellerContractDocument.query.filter_by(
+            accepted_contract_id=contract_id,
+        ).one()
+        doc = db.session.get(TransactionDocument, contract_document.transaction_document_id)
+        assert contract_document.display_name == 'Executed Contract'
+        assert contract_document.is_primary_contract_document is True
+        assert doc.template_slug == 'seller-accepted-contract'
+        assert doc.document_source == 'completed'
+        assert doc.extraction_status == 'pending'
+
+
+def test_contract_document_extraction_updates_contract_terms(app, db, seed):
+    from models import SellerAcceptedContract, SellerContractDocument, TransactionDocument, User
+    from services.seller_workflow import sync_contract_from_document
+
+    contract_id = _create_contract(app, db, seed)
+
+    with app.app_context():
+        owner = User.query.filter_by(username='owner_a').first()
+        doc = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            template_slug='seller-accepted-contract',
+            template_name='Executed Contract',
+            status='signed',
+            field_data={
+                'offer_price': '315000',
+                'effective_date': '2026-04-24',
+                'proposed_close_date': '2026-05-30',
+                'option_period_days': '7',
+                'financing_type': 'conventional',
+                'seller_concessions_amount': '4500',
+                'addenda': {
+                    'third_party_financing_addendum': {
+                        'buyer_approval_days': '15',
+                    },
+                },
+            },
+        )
+        db.session.add(doc)
+        db.session.flush()
+        db.session.add(SellerContractDocument(
+            organization_id=seed['org_a'],
+            transaction_id=seed['tx_a'],
+            accepted_contract_id=contract_id,
+            transaction_document_id=doc.id,
+            created_by_id=owner.id,
+            document_type='final_acceptance',
+            display_name='Executed Contract',
+            is_primary_contract_document=True,
+        ))
+        db.session.flush()
+
+        sync_contract_from_document(doc.id)
+        db.session.commit()
+
+        contract = db.session.get(SellerAcceptedContract, contract_id)
+        contract_document = SellerContractDocument.query.filter_by(
+            accepted_contract_id=contract_id,
+            transaction_document_id=doc.id,
+        ).one()
+        assert contract.accepted_price == 315000
+        assert contract.effective_date.isoformat() == '2026-04-24'
+        assert contract.closing_date.isoformat() == '2026-05-30'
+        assert contract.financing_approval_deadline.isoformat() == '2026-05-09'
+        assert contract.seller_concessions_amount == 4500
+        assert contract_document.extraction_summary['offer_price'] == '315000'


### PR DESCRIPTION
Keep listing, offer, and contract documents scoped to their own workspaces and run migrations before production startup so schema changes are applied before serving requests.

Made-with: Cursor