### PR TITLE
feat: auto-create recurring seller check-in tasks for active listings

### DIFF
--- a/migrations/versions/add_task_transaction_link.py
+++ b/migrations/versions/add_task_transaction_link.py
@@ -1,0 +1,73 @@
+"""Add transaction_id and is_auto_checkin to tasks
+
+Revision ID: add_task_transaction_link
+Revises: add_seller_contract_documents
+Create Date: 2026-04-28
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_task_transaction_link'
+down_revision = 'add_seller_contract_documents'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def _column_exists(conn, table_name, column_name):
+    if not _table_exists(conn, table_name):
+        return False
+    columns = {col['name'] for col in inspect(conn).get_columns(table_name)}
+    return column_name in columns
+
+
+def _index_exists(conn, table_name, index_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return index_name in {idx['name'] for idx in inspect(conn).get_indexes(table_name)}
+
+
+TABLE = 'task'
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _table_exists(conn, TABLE):
+        return
+
+    if not _column_exists(conn, TABLE, 'transaction_id'):
+        op.add_column(TABLE, sa.Column(
+            'transaction_id', sa.Integer(),
+            sa.ForeignKey('transactions.id', ondelete='SET NULL'),
+            nullable=True,
+        ))
+
+    if not _column_exists(conn, TABLE, 'is_auto_checkin'):
+        op.add_column(TABLE, sa.Column(
+            'is_auto_checkin', sa.Boolean(),
+            server_default=sa.text('false'),
+            nullable=False,
+        ))
+
+    if not _index_exists(conn, TABLE, 'ix_task_transaction_id'):
+        op.create_index('ix_task_transaction_id', TABLE, ['transaction_id'])
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _index_exists(conn, TABLE, 'ix_task_transaction_id'):
+        op.drop_index('ix_task_transaction_id', table_name=TABLE)
+
+    if _column_exists(conn, TABLE, 'is_auto_checkin'):
+        op.drop_column(TABLE, 'is_auto_checkin')
+
+    if _column_exists(conn, TABLE, 'transaction_id'):
+        op.drop_column(TABLE, 'transaction_id')

--- a/models.py
+++ b/models.py
@@ -401,6 +401,7 @@ class Task(db.Model):
                                 ondelete='RESTRICT'), nullable=True, index=True)  # Made NOT NULL after migration
     
     contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'), nullable=False)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id', ondelete='SET NULL'), nullable=True, index=True)
     assigned_to_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     
@@ -436,8 +437,12 @@ class Task(db.Model):
     google_calendar_event_id = db.Column(db.String(255), nullable=True)  # Calendar event ID
     calendar_sync_error = db.Column(db.Text, nullable=True)  # Last sync error if any
     
+    # Auto-checkin flag (system-generated recurring seller check-in tasks)
+    is_auto_checkin = db.Column(db.Boolean, default=False, nullable=False)
+    
     # Relationships
     contact = db.relationship('Contact', backref=db.backref('tasks', lazy=True))
+    transaction = db.relationship('Transaction', backref=db.backref('tasks', lazy='dynamic'))
     assigned_to = db.relationship('User', foreign_keys=[assigned_to_id], backref='assigned_tasks')
     created_by = db.relationship('User', foreign_keys=[created_by_id], backref='created_tasks')
     task_type = db.relationship('TaskType')

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -103,9 +103,12 @@ def create_task():
             # Convert to UTC for storage
             utc_due_date = convert_to_utc(due_date, user_tz)
 
+            transaction_id = request.form.get('transaction_id', type=int)
+
             task = Task(
                 organization_id=current_user.organization_id,
                 contact_id=contact_id,
+                transaction_id=transaction_id,
                 assigned_to_id=request.form.get('assigned_to_id', current_user.id),
                 created_by_id=current_user.id,
                 type_id=request.form.get('type_id'),
@@ -149,6 +152,8 @@ def create_task():
             if return_to == 'contact':
                 contact_id = request.form.get('return_contact_id')
                 return redirect(url_for('contacts.view_contact', contact_id=contact_id))
+            if return_to == 'transaction' and transaction_id:
+                return redirect(url_for('transactions.view_transaction', id=transaction_id))
             return redirect(url_for('tasks.tasks'))
 
         except Exception as e:
@@ -165,10 +170,20 @@ def create_task():
     # Only show users from the same organization
     users = User.query.filter_by(organization_id=current_user.organization_id).all() if current_user.role == 'admin' else [current_user]
 
+    # Pre-fill property address from linked transaction
+    prefill_address = ''
+    txn_id = request.args.get('transaction_id', type=int)
+    if txn_id:
+        from models import Transaction
+        txn = Transaction.query.filter_by(id=txn_id, organization_id=current_user.organization_id).first()
+        if txn:
+            prefill_address = txn.street_address or ''
+
     return render_template('tasks/create.html',
                          contacts=contacts,
                          task_types=task_types,
-                         users=users)
+                         users=users,
+                         prefill_address=prefill_address)
 
 @tasks_bp.route('/tasks/<int:task_id>/edit', methods=['POST'])
 @login_required
@@ -177,6 +192,7 @@ def edit_task(task_id):
 
     try:
         user_tz = get_user_timezone()
+        old_status = task.status
         
         task.subject = request.form.get('subject')
         task.status = request.form.get('status')
@@ -214,6 +230,11 @@ def edit_task(task_id):
         if request.form.get('contact_id'):
             task.contact_id = int(request.form.get('contact_id'))
 
+        if task.status == 'completed' and old_status != 'completed':
+            task.completed_at = datetime.now(timezone.utc)
+        elif task.status != 'completed':
+            task.completed_at = None
+
         db.session.commit()
         
         # Sync to Google Calendar (non-blocking)
@@ -223,6 +244,20 @@ def edit_task(task_id):
             calendar_service.update_calendar_event(task, base_url)
         except Exception as e:
             logger.warning(f"Calendar sync failed for task {task.id}: {e}")
+        
+        # Auto-create next seller check-in if this was an auto-checkin task
+        if task.status == 'completed' and old_status != 'completed' and task.is_auto_checkin and task.transaction_id:
+            try:
+                from models import Transaction
+                from services.listing_checkin_service import (
+                    create_seller_checkin_task, should_auto_create_next,
+                )
+                txn = db.session.get(Transaction, task.transaction_id)
+                if txn and should_auto_create_next(txn):
+                    create_seller_checkin_task(txn, current_user)
+                    db.session.commit()
+            except Exception as e:
+                logger.warning(f"Auto-checkin creation failed for task {task.id}: {e}")
         
         return jsonify({'status': 'success'}), 200
 
@@ -353,14 +388,26 @@ def quick_update_task(task_id):
         try:
             from services import calendar_service
             if new_status == 'completed' and not was_completed:
-                # Task was just completed - mark event as completed
                 calendar_service.mark_event_completed(task)
             elif new_status == 'pending' and was_completed:
-                # Task was uncompleted - update event to remove completed prefix
                 base_url = request.url_root.rstrip('/')
                 calendar_service.update_calendar_event(task, base_url)
         except Exception as e:
             logger.warning(f"Calendar sync failed for task {task.id}: {e}")
+        
+        # Auto-create next seller check-in if this was an auto-checkin task
+        if new_status == 'completed' and not was_completed and task.is_auto_checkin and task.transaction_id:
+            try:
+                from models import Transaction
+                from services.listing_checkin_service import (
+                    create_seller_checkin_task, should_auto_create_next,
+                )
+                txn = db.session.get(Transaction, task.transaction_id)
+                if txn and should_auto_create_next(txn):
+                    create_seller_checkin_task(txn, current_user)
+                    db.session.commit()
+            except Exception as e:
+                logger.warning(f"Auto-checkin creation failed for task {task.id}: {e}")
         
         return jsonify({'status': 'success'}), 200
         

--- a/routes/transactions/api.py
+++ b/routes/transactions/api.py
@@ -3,6 +3,7 @@
 Transaction API endpoints (JSON responses).
 """
 
+import logging
 from datetime import datetime, timedelta
 from flask import request, jsonify
 from flask_login import login_required, current_user
@@ -12,6 +13,8 @@ from services.transaction_helpers import build_listing_info
 from config import Config
 from . import transactions_bp
 from .decorators import transactions_required
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -116,6 +119,18 @@ def update_status(id):
         # Log the status change
         if old_status != new_status:
             audit_service.log_transaction_status_changed(transaction, old_status, new_status)
+        
+        # Auto-create first seller check-in task when listing goes active
+        if (new_status == 'active' and old_status != 'active'
+                and tx_type_name in ('seller', 'landlord')):
+            try:
+                from services.listing_checkin_service import (
+                    create_seller_checkin_task, should_auto_create_next,
+                )
+                if should_auto_create_next(transaction):
+                    create_seller_checkin_task(transaction, current_user)
+            except Exception as e:
+                logger.warning("Auto-checkin creation failed for transaction %s: %s", id, e)
         
         db.session.commit()
         return jsonify({'success': True, 'status': new_status})

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -3,12 +3,15 @@
 Transaction CRUD routes (create, read, update, delete).
 """
 
+import logging
 from datetime import datetime as dt
 from flask import request, render_template, redirect, url_for, flash, abort
+
+logger = logging.getLogger(__name__)
 from flask_login import login_required, current_user
 from models import (
     db, Transaction, TransactionType, TransactionParticipant,
-    TransactionDocument, DocumentSignature, AuditEvent, Contact, ContactFile,
+    TransactionDocument, DocumentSignature, AuditEvent, Contact, ContactFile, Task,
     SellerListingProfile, SellerOffer, SellerOfferActivity, SellerAcceptedContract,
     SellerContractMilestone, SellerCommissionTerms, SellerListingPriceChange,
     SellerOfferDocument, SellerOfferVersion, SellerContractDocument
@@ -658,6 +661,12 @@ def view_transaction(id):
     has_intake_schema = intake_schema is not None
     document_workflow_mode = intake_schema.get('document_workflow', 'docuseal') if intake_schema else None
     
+    # Load tasks linked to this transaction (pending/overdue first, then completed)
+    transaction_tasks = Task.query.filter_by(
+        transaction_id=transaction.id,
+        organization_id=current_user.organization_id,
+    ).order_by(Task.status.asc(), Task.due_date.asc()).all()
+    
     return render_template(
         'transactions/detail.html',
         transaction=transaction,
@@ -688,6 +697,7 @@ def view_transaction(id):
         rentcast_fetched_at=rentcast_fetched_at,
         has_intake_schema=has_intake_schema,
         document_workflow_mode=document_workflow_mode,
+        transaction_tasks=transaction_tasks,
         now=dt.utcnow()
     )
 
@@ -876,6 +886,18 @@ def update_transaction(id):
             if 'status' in changed_fields and old_status != new_status:
                 audit_service.log_transaction_status_changed(transaction, old_status, new_status)
                 changed_fields.remove('status')
+
+                # Auto-create first seller check-in task when listing goes active
+                if (new_status == 'active' and old_status != 'active'
+                        and tx_type_name in ('seller', 'landlord')):
+                    try:
+                        from services.listing_checkin_service import (
+                            create_seller_checkin_task, should_auto_create_next,
+                        )
+                        if should_auto_create_next(transaction):
+                            create_seller_checkin_task(transaction, current_user)
+                    except Exception as e:
+                        logger.warning("Auto-checkin creation failed for transaction %s: %s", id, e)
 
             # Log other field changes
             if changed_fields:

--- a/services/listing_checkin_service.py
+++ b/services/listing_checkin_service.py
@@ -1,0 +1,117 @@
+"""
+Seller Check-in Task Service
+
+Auto-creates recurring weekly check-in tasks for active seller listings.
+Tasks are created when a listing goes active and re-created every 7 days
+when the previous check-in is completed, until the transaction leaves
+active status.
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def should_auto_create_next(transaction):
+    """Return True if a new auto-checkin task should be created for this transaction."""
+    from models import Task
+
+    if transaction.status != 'active':
+        return False
+
+    pending_checkin = Task.query.filter_by(
+        transaction_id=transaction.id,
+        is_auto_checkin=True,
+        status='pending',
+    ).first()
+
+    return pending_checkin is None
+
+
+def create_seller_checkin_task(transaction, created_by_user):
+    """
+    Create a weekly seller check-in task linked to the transaction.
+
+    Finds the primary seller contact, assigns the task to the listing agent
+    (transaction creator), and sets the due date 7 days out.
+
+    Returns the created Task or None if prerequisites are missing.
+    """
+    from models import db, Task, TaskType, TaskSubtype, TransactionParticipant
+
+    org_id = transaction.organization_id
+
+    seller_participant = TransactionParticipant.query.filter(
+        TransactionParticipant.transaction_id == transaction.id,
+        TransactionParticipant.role.in_(['seller', 'co_seller']),
+        TransactionParticipant.contact_id.isnot(None),
+    ).order_by(
+        TransactionParticipant.is_primary.desc()
+    ).first()
+
+    if not seller_participant:
+        logger.info(
+            "No seller contact linked to transaction %s — skipping auto-checkin",
+            transaction.id,
+        )
+        return None
+
+    contact = seller_participant.contact
+    seller_name = f"{contact.first_name} {contact.last_name}".strip() or "Seller"
+
+    task_type = TaskType.query.filter_by(
+        organization_id=org_id, name='Call',
+    ).first()
+    if not task_type:
+        task_type = TaskType.query.filter_by(
+            organization_id=org_id,
+        ).order_by(TaskType.sort_order.asc()).first()
+    if not task_type:
+        logger.warning("No task types for org %s — cannot create auto-checkin", org_id)
+        return None
+
+    task_subtype = TaskSubtype.query.filter_by(
+        task_type_id=task_type.id,
+        organization_id=org_id,
+        name='Check-in',
+    ).first()
+    if not task_subtype:
+        task_subtype = TaskSubtype.query.filter_by(
+            task_type_id=task_type.id,
+            organization_id=org_id,
+        ).order_by(TaskSubtype.sort_order.asc()).first()
+    if not task_subtype:
+        logger.warning("No subtypes for task type %s — cannot create auto-checkin", task_type.id)
+        return None
+
+    address = transaction.street_address or "listing"
+    due_date = datetime.now(timezone.utc) + timedelta(days=7)
+
+    task = Task(
+        organization_id=org_id,
+        contact_id=contact.id,
+        transaction_id=transaction.id,
+        assigned_to_id=transaction.created_by_id,
+        created_by_id=created_by_user.id,
+        type_id=task_type.id,
+        subtype_id=task_subtype.id,
+        subject=f"Check in with {seller_name} — {address}",
+        description=(
+            f"Weekly seller check-in for {address}. "
+            f"Touch base with {seller_name}: discuss current market conditions, "
+            f"review any recent showing feedback, and share updated comps if available."
+        ),
+        priority='medium',
+        status='pending',
+        due_date=due_date,
+        property_address=transaction.street_address,
+        is_auto_checkin=True,
+    )
+    db.session.add(task)
+    db.session.flush()
+
+    logger.info(
+        "Created auto-checkin task %s for transaction %s, due %s",
+        task.id, transaction.id, due_date.strftime('%Y-%m-%d'),
+    )
+    return task

--- a/templates/tasks/create.html
+++ b/templates/tasks/create.html
@@ -238,7 +238,8 @@
                                     Property Address <span class="text-slate-400">(Optional)</span>
                                 </label>
                         <input type="text" name="property_address" id="property_address"
-                                       class="premium-input" placeholder="Enter property address">
+                                       class="premium-input" placeholder="Enter property address"
+                                       value="{{ prefill_address or '' }}">
                             </div>
                         </div>
                     </div>
@@ -259,10 +260,13 @@
 
                 <!-- Form Actions -->
                 <div class="p-6 bg-slate-50/50">
-                    <input type="hidden" name="return_to" value="{{ request.args.get('return_to', '') }}">
+                    <input type="hidden" name="return_to" value="{% if request.args.get('transaction_id') %}transaction{% else %}{{ request.args.get('return_to', '') }}{% endif %}">
                     <input type="hidden" name="return_contact_id" value="{{ request.args.get('contact_id', '') }}">
+                    {% if request.args.get('transaction_id') %}
+                    <input type="hidden" name="transaction_id" value="{{ request.args.get('transaction_id') }}">
+                    {% endif %}
                     <div class="flex flex-col sm:flex-row justify-end gap-3">
-                    <a href="{% if request.args.get('return_to') == 'contact' %}{{ url_for('contacts.view_contact', contact_id=request.args.get('contact_id')) }}{% else %}{{ url_for('tasks.tasks') }}{% endif %}" 
+                    <a href="{% if request.args.get('transaction_id') %}{{ url_for('transactions.view_transaction', id=request.args.get('transaction_id')) }}{% elif request.args.get('return_to') == 'contact' %}{{ url_for('contacts.view_contact', contact_id=request.args.get('contact_id')) }}{% else %}{{ url_for('tasks.tasks') }}{% endif %}" 
                            class="inline-flex items-center justify-center gap-2 px-6 py-3 border-2 border-slate-200 rounded-xl text-sm font-medium text-slate-700 hover:bg-white hover:border-slate-300 transition-all">
                         Cancel
                     </a>
@@ -282,8 +286,11 @@
 function navigateBack() {
     const returnTo = '{{ request.args.get("return_to", "") }}';
     const contactId = '{{ request.args.get("contact_id", "") }}';
+    const transactionId = '{{ request.args.get("transaction_id", "") }}';
     
-    if (returnTo === 'contact' && contactId) {
+    if (transactionId) {
+        window.location.href = `/transactions/${transactionId}`;
+    } else if (returnTo === 'contact' && contactId) {
         window.location.href = `/contact/${contactId}`;
     } else {
         window.location.href = '{{ url_for('tasks.tasks') }}';

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -2063,6 +2063,73 @@
                     </div>
                 </section>
 
+                {# ----- Tasks card ----- #}
+                <section class="crm-surface">
+                    <div class="crm-surface-header">
+                        <div class="flex items-center gap-2">
+                            {{ section_header('Tasks') }}
+                            {% if transaction_tasks %}
+                            <span class="inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-slate-100 px-1.5 text-[11px] font-semibold text-slate-600">
+                                {{ transaction_tasks|selectattr('status', 'equalto', 'pending')|list|length }}
+                            </span>
+                            {% endif %}
+                        </div>
+                        {% set seller_contact = participants|selectattr('role', 'in', ['seller', 'co_seller'])|selectattr('contact_id')|first %}
+                        <a href="{{ url_for('tasks.create_task') }}?transaction_id={{ transaction.id }}{% if seller_contact %}&contact_id={{ seller_contact.contact_id }}{% endif %}"
+                           class="crm-btn crm-btn-secondary">
+                            <i class="fas fa-plus text-xs text-slate-400"></i>
+                            Add
+                        </a>
+                    </div>
+                    <div class="crm-surface-body">
+                        {% if transaction_tasks %}
+                        <div class="max-h-80 space-y-2 overflow-y-auto">
+                            {% for task in transaction_tasks %}
+                            {% set is_overdue = task.status == 'pending' and task.due_date and task.due_date < now %}
+                            <a href="{{ url_for('tasks.view_task', task_id=task.id) }}"
+                               class="group flex items-start gap-3 rounded-md border border-slate-200 px-3 py-2.5 transition-colors hover:border-slate-300 hover:bg-slate-50">
+                                {% if task.status == 'completed' %}
+                                <span class="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                                {% elif is_overdue %}
+                                <span class="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-red-400"></span>
+                                {% else %}
+                                <span class="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-orange-400"></span>
+                                {% endif %}
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-2">
+                                        <span class="truncate text-sm font-medium {% if task.status == 'completed' %}text-slate-400 line-through{% elif is_overdue %}text-red-700{% else %}text-slate-900{% endif %}">
+                                            {{ task.subject }}
+                                        </span>
+                                        {% if task.is_auto_checkin %}
+                                        <span class="flex-shrink-0 text-[10px] font-semibold uppercase tracking-wide text-sky-600">Auto</span>
+                                        {% endif %}
+                                    </div>
+                                    <div class="mt-0.5 flex items-center gap-2 text-xs text-slate-500">
+                                        {% if task.due_date %}
+                                        <span class="{% if is_overdue %}font-medium text-red-600{% endif %}">
+                                            {% if is_overdue %}Overdue{% else %}Due{% endif %} {{ task.due_date.strftime('%b %d') }}
+                                        </span>
+                                        {% endif %}
+                                        {% if task.assigned_to %}
+                                        <span class="text-slate-300">&middot;</span>
+                                        <span class="truncate">{{ task.assigned_to.first_name }} {{ task.assigned_to.last_name[:1] }}.</span>
+                                        {% endif %}
+                                    </div>
+                                    {% if task.status == 'completed' and task.outcome %}
+                                    <p class="mt-1 line-clamp-2 text-xs text-slate-400">{{ task.outcome }}</p>
+                                    {% endif %}
+                                </div>
+                            </a>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div class="py-6 text-center">
+                            <p class="text-sm text-slate-500">No tasks linked to this transaction.</p>
+                        </div>
+                        {% endif %}
+                    </div>
+                </section>
+
                 {# ----- Contact files card ----- #}
                 {% if contact_files %}
                 <section class="crm-surface">


### PR DESCRIPTION
## Summary

- Adds recurring weekly seller check-in tasks that auto-create when a listing goes active, assigned to the listing agent and linked to the seller contact
- Tasks appear in the right column of the transaction detail page, in the main task dashboard, and get the existing email/calendar reminders
- Completing a check-in auto-creates the next one 7 days out; the chain stops when the deal leaves active status
- Adding a task from the transaction page pre-fills the seller contact and property address

## Changes

- **models.py**: `transaction_id` FK and `is_auto_checkin` flag on Task
- **services/listing_checkin_service.py**: new service with `create_seller_checkin_task()` and `should_auto_create_next()` 
- **routes/transactions/api.py** + **crud.py**: hook status change to active
- **routes/tasks.py**: hook task completion for recurring chain; support `transaction_id` on create
- **templates/transactions/detail.html**: Tasks card in right column
- **templates/tasks/create.html**: pre-fill contact + address from transaction context
- **migrations/versions/add_task_transaction_link.py**: migration for new columns + index

## Test plan

- [x] Set a seller transaction to Active status -- verify a check-in task appears in the Tasks card
- [x] Complete the check-in task -- verify the next one is created 7 days out
- [x] Move transaction to Under Contract -- complete the pending task and verify no new one is created
- [x] Click "Add" on the Tasks card -- verify contact and property address are pre-filled
- [x] Verify tasks show up in the main /tasks dashboard and contact detail page

Made with [Cursor](https://cursor.com)