### PR TITLE
feat: org-wide Partner Directory for transaction closing partners

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,7 @@ from routes.tax_protest import tax_protest_bp
 from routes.market_insights import market_insights_bp
 from routes.notifications import notifications_bp
 from routes.inbound_email import inbound_bp
+from routes.partner_directory import partner_directory_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
@@ -216,6 +217,7 @@ def create_app():
     app.register_blueprint(market_insights_bp)
     app.register_blueprint(notifications_bp)
     app.register_blueprint(inbound_bp)
+    app.register_blueprint(partner_directory_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/migrations/versions/add_partner_directory.py
+++ b/migrations/versions/add_partner_directory.py
@@ -1,0 +1,170 @@
+"""Add org-wide partner directory tables
+
+Revision ID: add_partner_directory
+Revises: add_task_transaction_link
+Create Date: 2026-04-30
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_partner_directory'
+down_revision = 'add_task_transaction_link'
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def _column_exists(conn, table_name, column_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return column_name in {column['name'] for column in inspect(conn).get_columns(table_name)}
+
+
+def _index_exists(conn, table_name, index_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return index_name in {idx['name'] for idx in inspect(conn).get_indexes(table_name)}
+
+
+def _foreign_key_exists(conn, table_name, fk_name):
+    if not _table_exists(conn, table_name):
+        return False
+    return fk_name in {fk.get('name') for fk in inspect(conn).get_foreign_keys(table_name) if fk.get('name')}
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _table_exists(conn, 'partner_organizations'):
+        op.create_table(
+            'partner_organizations',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('organization_id', sa.Integer(), sa.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False),
+            sa.Column('created_by_id', sa.Integer(), sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True),
+            sa.Column('updated_by_id', sa.Integer(), sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True),
+            sa.Column('name', sa.String(length=200), nullable=False),
+            sa.Column('normalized_name', sa.String(length=200), nullable=False),
+            sa.Column('partner_type', sa.String(length=50), nullable=False, server_default='other'),
+            sa.Column('phone', sa.String(length=30), nullable=True),
+            sa.Column('normalized_phone', sa.String(length=30), nullable=True),
+            sa.Column('email', sa.String(length=200), nullable=True),
+            sa.Column('website', sa.String(length=300), nullable=True),
+            sa.Column('street_address', sa.String(length=200), nullable=True),
+            sa.Column('city', sa.String(length=100), nullable=True),
+            sa.Column('state', sa.String(length=50), nullable=True),
+            sa.Column('zip_code', sa.String(length=20), nullable=True),
+            sa.Column('normalized_address', sa.String(length=500), nullable=True),
+            sa.Column('notes', sa.Text(), nullable=True),
+            sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+            sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.UniqueConstraint('organization_id', 'normalized_name', name='uq_partner_org_normalized_name'),
+        )
+
+    if not _index_exists(conn, 'partner_organizations', 'ix_partner_organizations_organization_id'):
+        op.create_index('ix_partner_organizations_organization_id', 'partner_organizations', ['organization_id'])
+    if not _index_exists(conn, 'partner_organizations', 'ix_partner_organizations_partner_type'):
+        op.create_index('ix_partner_organizations_partner_type', 'partner_organizations', ['partner_type'])
+    if not _index_exists(conn, 'partner_organizations', 'ix_partner_organizations_normalized_address'):
+        op.create_index('ix_partner_organizations_normalized_address', 'partner_organizations', ['normalized_address'])
+
+    if not _table_exists(conn, 'partner_contacts'):
+        op.create_table(
+            'partner_contacts',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('organization_id', sa.Integer(), sa.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False),
+            sa.Column('partner_organization_id', sa.Integer(), sa.ForeignKey('partner_organizations.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('created_by_id', sa.Integer(), sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True),
+            sa.Column('updated_by_id', sa.Integer(), sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True),
+            sa.Column('first_name', sa.String(length=80), nullable=False),
+            sa.Column('last_name', sa.String(length=80), nullable=False),
+            sa.Column('normalized_full_name', sa.String(length=180), nullable=False),
+            sa.Column('title', sa.String(length=120), nullable=True),
+            sa.Column('email', sa.String(length=200), nullable=True),
+            sa.Column('normalized_email', sa.String(length=200), nullable=True),
+            sa.Column('phone', sa.String(length=30), nullable=True),
+            sa.Column('normalized_phone', sa.String(length=30), nullable=True),
+            sa.Column('notes', sa.Text(), nullable=True),
+            sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+            sa.Column('is_primary_contact', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+            sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.UniqueConstraint('partner_organization_id', 'normalized_full_name', name='uq_partner_contact_org_full_name'),
+        )
+
+    if not _index_exists(conn, 'partner_contacts', 'ix_partner_contacts_organization_id'):
+        op.create_index('ix_partner_contacts_organization_id', 'partner_contacts', ['organization_id'])
+    if not _index_exists(conn, 'partner_contacts', 'ix_partner_contacts_partner_organization_id'):
+        op.create_index('ix_partner_contacts_partner_organization_id', 'partner_contacts', ['partner_organization_id'])
+
+    if _table_exists(conn, 'transaction_participants'):
+        if not _column_exists(conn, 'transaction_participants', 'partner_organization_id'):
+            op.add_column('transaction_participants', sa.Column('partner_organization_id', sa.Integer(), nullable=True))
+        if not _column_exists(conn, 'transaction_participants', 'partner_contact_id'):
+            op.add_column('transaction_participants', sa.Column('partner_contact_id', sa.Integer(), nullable=True))
+
+        if not _foreign_key_exists(conn, 'transaction_participants', 'fk_transaction_participants_partner_organization_id'):
+            try:
+                op.create_foreign_key(
+                    'fk_transaction_participants_partner_organization_id',
+                    'transaction_participants',
+                    'partner_organizations',
+                    ['partner_organization_id'],
+                    ['id'],
+                    ondelete='SET NULL',
+                )
+            except Exception:
+                pass
+        if not _foreign_key_exists(conn, 'transaction_participants', 'fk_transaction_participants_partner_contact_id'):
+            try:
+                op.create_foreign_key(
+                    'fk_transaction_participants_partner_contact_id',
+                    'transaction_participants',
+                    'partner_contacts',
+                    ['partner_contact_id'],
+                    ['id'],
+                    ondelete='SET NULL',
+                )
+            except Exception:
+                pass
+
+        if not _index_exists(conn, 'transaction_participants', 'ix_transaction_participants_partner_organization_id'):
+            op.create_index('ix_transaction_participants_partner_organization_id', 'transaction_participants', ['partner_organization_id'])
+        if not _index_exists(conn, 'transaction_participants', 'ix_transaction_participants_partner_contact_id'):
+            op.create_index('ix_transaction_participants_partner_contact_id', 'transaction_participants', ['partner_contact_id'])
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _table_exists(conn, 'transaction_participants'):
+        if _index_exists(conn, 'transaction_participants', 'ix_transaction_participants_partner_contact_id'):
+            op.drop_index('ix_transaction_participants_partner_contact_id', table_name='transaction_participants')
+        if _index_exists(conn, 'transaction_participants', 'ix_transaction_participants_partner_organization_id'):
+            op.drop_index('ix_transaction_participants_partner_organization_id', table_name='transaction_participants')
+
+        for fk_name in (
+            'fk_transaction_participants_partner_contact_id',
+            'fk_transaction_participants_partner_organization_id',
+        ):
+            if _foreign_key_exists(conn, 'transaction_participants', fk_name):
+                try:
+                    op.drop_constraint(fk_name, 'transaction_participants', type_='foreignkey')
+                except Exception:
+                    pass
+
+        if _column_exists(conn, 'transaction_participants', 'partner_contact_id'):
+            op.drop_column('transaction_participants', 'partner_contact_id')
+        if _column_exists(conn, 'transaction_participants', 'partner_organization_id'):
+            op.drop_column('transaction_participants', 'partner_organization_id')
+
+    if _table_exists(conn, 'partner_contacts'):
+        op.drop_table('partner_contacts')
+    if _table_exists(conn, 'partner_organizations'):
+        op.drop_table('partner_organizations')

--- a/models.py
+++ b/models.py
@@ -6,6 +6,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask import current_app
 from itsdangerous import URLSafeTimedSerializer as Serializer
 import secrets
+import re
 
 db = SQLAlchemy()
 
@@ -362,6 +363,169 @@ class Contact(db.Model):
 
     def __repr__(self):
         return f'<Contact {self.first_name} {self.last_name}>'
+
+
+# =============================================================================
+# ORG-WIDE PARTNER DIRECTORY MODELS
+# =============================================================================
+
+def normalize_partner_text(value):
+    """Normalize partner text for duplicate checks and unique constraints."""
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    normalized = re.sub(r'[^\w\s]', '', normalized)
+    normalized = re.sub(r'\s+', ' ', normalized)
+    return normalized or None
+
+
+def normalize_partner_phone(value):
+    """Normalize phone numbers to digits for duplicate detection."""
+    if not value:
+        return None
+    digits = re.sub(r'\D', '', value)
+    return digits or None
+
+
+def normalize_partner_address(street_address, city=None, state=None, zip_code=None):
+    """Normalize address parts enough to catch obvious duplicate companies."""
+    street = normalize_partner_text(street_address)
+    if street:
+        replacements = {
+            r'\bstreet\b': 'st',
+            r'\bavenue\b': 'ave',
+            r'\broad\b': 'rd',
+            r'\bdrive\b': 'dr',
+            r'\blane\b': 'ln',
+            r'\bboulevard\b': 'blvd',
+            r'\bhighway\b': 'hwy',
+            r'\bsuite\b': 'ste',
+            r'\bapartment\b': 'apt',
+        }
+        for pattern, replacement in replacements.items():
+            street = re.sub(pattern, replacement, street)
+
+    parts = [
+        street,
+        normalize_partner_text(city),
+        normalize_partner_text(state),
+        normalize_partner_text(zip_code),
+    ]
+    return ' '.join(part for part in parts if part) or None
+
+
+class PartnerOrganization(db.Model):
+    """Org-wide company/vendor record used by transaction participants."""
+    __tablename__ = 'partner_organizations'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False, index=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+    updated_by_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+
+    name = db.Column(db.String(200), nullable=False)
+    normalized_name = db.Column(db.String(200), nullable=False)
+    partner_type = db.Column(db.String(50), nullable=False, default='other', index=True)
+
+    phone = db.Column(db.String(30))
+    normalized_phone = db.Column(db.String(30))
+    email = db.Column(db.String(200))
+    website = db.Column(db.String(300))
+    street_address = db.Column(db.String(200))
+    city = db.Column(db.String(100))
+    state = db.Column(db.String(50))
+    zip_code = db.Column(db.String(20))
+    normalized_address = db.Column(db.String(500), index=True)
+    notes = db.Column(db.Text)
+
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    created_by = db.relationship('User', foreign_keys=[created_by_id], backref=db.backref('created_partner_organizations', lazy='dynamic'))
+    updated_by = db.relationship('User', foreign_keys=[updated_by_id], backref=db.backref('updated_partner_organizations', lazy='dynamic'))
+    contacts = db.relationship('PartnerContact', back_populates='partner_organization', cascade='all, delete-orphan', lazy='dynamic')
+    transaction_participants = db.relationship('TransactionParticipant', back_populates='partner_organization', lazy='dynamic')
+
+    __table_args__ = (
+        db.UniqueConstraint('organization_id', 'normalized_name', name='uq_partner_org_normalized_name'),
+    )
+
+    @property
+    def type_label(self):
+        return {
+            'brokerage': 'Brokerage',
+            'title_company': 'Title Company',
+            'lender': 'Lender',
+            'attorney': 'Attorney',
+            'inspector': 'Inspector',
+            'other': 'Other Partner',
+        }.get(self.partner_type, self.partner_type.replace('_', ' ').title())
+
+    @property
+    def full_address(self):
+        parts = [self.street_address, self.city, self.state, self.zip_code]
+        return ', '.join(part for part in parts if part)
+
+    def sync_normalized_fields(self):
+        self.normalized_name = normalize_partner_text(self.name)
+        self.normalized_phone = normalize_partner_phone(self.phone)
+        self.normalized_address = normalize_partner_address(
+            self.street_address,
+            self.city,
+            self.state,
+            self.zip_code,
+        )
+
+    def __repr__(self):
+        return f'<PartnerOrganization {self.name}>'
+
+
+class PartnerContact(db.Model):
+    """Person associated with an org-wide partner company."""
+    __tablename__ = 'partner_contacts'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False, index=True)
+    partner_organization_id = db.Column(db.Integer, db.ForeignKey('partner_organizations.id', ondelete='CASCADE'), nullable=False, index=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+    updated_by_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+
+    first_name = db.Column(db.String(80), nullable=False)
+    last_name = db.Column(db.String(80), nullable=False)
+    normalized_full_name = db.Column(db.String(180), nullable=False)
+    title = db.Column(db.String(120))
+    email = db.Column(db.String(200))
+    normalized_email = db.Column(db.String(200))
+    phone = db.Column(db.String(30))
+    normalized_phone = db.Column(db.String(30))
+    notes = db.Column(db.Text)
+
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    is_primary_contact = db.Column(db.Boolean, nullable=False, default=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    partner_organization = db.relationship('PartnerOrganization', back_populates='contacts')
+    created_by = db.relationship('User', foreign_keys=[created_by_id], backref=db.backref('created_partner_contacts', lazy='dynamic'))
+    updated_by = db.relationship('User', foreign_keys=[updated_by_id], backref=db.backref('updated_partner_contacts', lazy='dynamic'))
+    transaction_participants = db.relationship('TransactionParticipant', back_populates='partner_contact', lazy='dynamic')
+
+    __table_args__ = (
+        db.UniqueConstraint('partner_organization_id', 'normalized_full_name', name='uq_partner_contact_org_full_name'),
+    )
+
+    @property
+    def full_name(self):
+        return f'{self.first_name} {self.last_name}'.strip()
+
+    def sync_normalized_fields(self):
+        self.normalized_full_name = normalize_partner_text(self.full_name)
+        self.normalized_email = self.email.strip().lower() if self.email else None
+        self.normalized_phone = normalize_partner_phone(self.phone)
+
+    def __repr__(self):
+        return f'<PartnerContact {self.full_name}>'
 
 class Interaction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -823,9 +987,11 @@ class TransactionParticipant(db.Model):
     organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id', ondelete='RESTRICT'), nullable=False, index=True)
     transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id', ondelete='CASCADE'), nullable=False)
     
-    # Can link to existing contact or user (both optional for external parties)
+    # Can link to existing contact, user, or org-wide partner directory record.
     contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'), nullable=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    partner_organization_id = db.Column(db.Integer, db.ForeignKey('partner_organizations.id', ondelete='SET NULL'), nullable=True)
+    partner_contact_id = db.Column(db.Integer, db.ForeignKey('partner_contacts.id', ondelete='SET NULL'), nullable=True)
     
     # Role in the transaction
     # Values: seller, co_seller, buyer, co_buyer, listing_agent, buyers_agent, 
@@ -846,6 +1012,8 @@ class TransactionParticipant(db.Model):
     # Relationships
     contact = db.relationship('Contact', backref=db.backref('transaction_participations', lazy='dynamic'))
     user = db.relationship('User', backref=db.backref('transaction_participations', lazy='dynamic'))
+    partner_organization = db.relationship('PartnerOrganization', back_populates='transaction_participants')
+    partner_contact = db.relationship('PartnerContact', back_populates='transaction_participants')
     
     @property
     def display_name(self):

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -4,6 +4,7 @@ from .tasks import tasks_bp
 from .main import main_bp
 from .admin import admin_bp
 from .marketing import marketing
+from .partner_directory import partner_directory_bp
 
 def register_blueprints(app):
     app.register_blueprint(auth_bp)
@@ -12,3 +13,4 @@ def register_blueprints(app):
     app.register_blueprint(main_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(marketing)
+    app.register_blueprint(partner_directory_bp)

--- a/routes/partner_directory.py
+++ b/routes/partner_directory.py
@@ -1,0 +1,413 @@
+"""Org-wide Partner Directory routes."""
+from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+
+from feature_flags import can_access_transactions
+from models import PartnerContact, PartnerOrganization, Transaction, TransactionParticipant, db
+from services.partners import (
+    PARTNER_TYPES,
+    find_company_duplicate_candidates,
+    find_contact_duplicate_candidates,
+    is_admin_role,
+    sync_partner_contact_fields,
+    sync_partner_organization_fields,
+)
+from services.tenant_service import org_query
+
+
+partner_directory_bp = Blueprint(
+    'partner_directory',
+    __name__,
+    url_prefix='/partners',
+)
+
+
+def _require_transactions_access():
+    if not can_access_transactions(current_user):
+        abort(403)
+
+
+def _require_admin():
+    if not is_admin_role(current_user):
+        abort(403)
+
+
+def _partner_or_404(partner_id):
+    return org_query(PartnerOrganization).filter_by(id=partner_id).first_or_404()
+
+
+def _contact_or_404(partner, contact_id):
+    return PartnerContact.query.filter_by(
+        id=contact_id,
+        organization_id=current_user.organization_id,
+        partner_organization_id=partner.id,
+    ).first_or_404()
+
+
+def _company_form_data():
+    return {
+        'name': request.form.get('name', '').strip(),
+        'partner_type': request.form.get('partner_type', 'other').strip(),
+        'phone': request.form.get('phone', '').strip() or None,
+        'email': request.form.get('email', '').strip() or None,
+        'website': request.form.get('website', '').strip() or None,
+        'street_address': request.form.get('street_address', '').strip() or None,
+        'city': request.form.get('city', '').strip() or None,
+        'state': request.form.get('state', '').strip() or None,
+        'zip_code': request.form.get('zip_code', '').strip() or None,
+        'notes': request.form.get('notes', '').strip() or None,
+    }
+
+
+def _contact_form_data():
+    return {
+        'first_name': request.form.get('first_name', '').strip(),
+        'last_name': request.form.get('last_name', '').strip(),
+        'title': request.form.get('title', '').strip() or None,
+        'email': request.form.get('email', '').strip() or None,
+        'phone': request.form.get('phone', '').strip() or None,
+        'notes': request.form.get('notes', '').strip() or None,
+        'is_primary_contact': request.form.get('is_primary_contact') == 'on',
+    }
+
+
+def _usage_counts():
+    rows = db.session.query(
+        TransactionParticipant.partner_organization_id,
+        func.count(TransactionParticipant.id),
+    ).filter(
+        TransactionParticipant.organization_id == current_user.organization_id,
+        TransactionParticipant.partner_organization_id.isnot(None),
+    ).group_by(TransactionParticipant.partner_organization_id).all()
+    return {partner_id: count for partner_id, count in rows}
+
+
+def _render_index(**extra_context):
+    search_query = request.args.get('q', '').strip()
+    selected_type = request.args.get('type', '').strip()
+    active_filter = request.args.get('active', 'active')
+
+    query = org_query(PartnerOrganization)
+
+    if active_filter == 'inactive':
+        query = query.filter_by(is_active=False)
+    elif active_filter != 'all':
+        query = query.filter_by(is_active=True)
+
+    if selected_type in PARTNER_TYPES:
+        query = query.filter_by(partner_type=selected_type)
+
+    if search_query:
+        search = f'%{search_query}%'
+        query = query.filter(or_(
+            PartnerOrganization.name.ilike(search),
+            PartnerOrganization.email.ilike(search),
+            PartnerOrganization.phone.ilike(search),
+            PartnerOrganization.city.ilike(search),
+        ))
+
+    partners = query.order_by(PartnerOrganization.name.asc()).all()
+
+    context = {
+        'partners': partners,
+        'partner_types': PARTNER_TYPES,
+        'usage_counts': _usage_counts(),
+        'search_query': search_query,
+        'selected_type': selected_type,
+        'active_filter': active_filter,
+        'can_manage_partners': is_admin_role(current_user),
+        'pending_company': None,
+        'duplicate_warnings': [],
+    }
+    context.update(extra_context)
+    return render_template('partner_directory/index.html', **context)
+
+
+@partner_directory_bp.before_request
+@login_required
+def require_partner_directory_access():
+    _require_transactions_access()
+
+
+@partner_directory_bp.route('/')
+def index():
+    return _render_index()
+
+
+@partner_directory_bp.route('/', methods=['POST'])
+def create_partner():
+    form_data = _company_form_data()
+    if not form_data['name']:
+        flash('Company name is required.', 'error')
+        return _render_index(pending_company=form_data)
+
+    duplicates = find_company_duplicate_candidates(
+        current_user.organization_id,
+        form_data['name'],
+        form_data['street_address'],
+        form_data['city'],
+        form_data['state'],
+        form_data['zip_code'],
+    )
+
+    if duplicates['exact']:
+        duplicate = duplicates['exact'][0]
+        flash(f'{duplicate.name} already exists in the Partner Directory.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=duplicate.id))
+
+    if duplicates['warnings'] and request.form.get('force_create') != '1':
+        flash('Possible duplicate found. Review the matches before creating a new partner.', 'warning')
+        return _render_index(
+            pending_company=form_data,
+            duplicate_warnings=duplicates['warnings'],
+        )
+
+    partner = PartnerOrganization(
+        organization_id=current_user.organization_id,
+        created_by_id=current_user.id,
+        updated_by_id=current_user.id,
+        **form_data,
+    )
+    sync_partner_organization_fields(partner)
+
+    try:
+        db.session.add(partner)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        flash('That company already exists in the Partner Directory.', 'error')
+        return _render_index(pending_company=form_data)
+
+    flash(f'{partner.name} was added to the Partner Directory.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+
+def _linked_transactions_for(partner):
+    """Build a deduplicated list of transactions this partner has been attached to."""
+    participants = (
+        TransactionParticipant.query
+        .join(Transaction, TransactionParticipant.transaction_id == Transaction.id)
+        .filter(
+            TransactionParticipant.organization_id == current_user.organization_id,
+            TransactionParticipant.partner_organization_id == partner.id,
+        )
+        .order_by(Transaction.created_at.desc())
+        .all()
+    )
+    seen = set()
+    out = []
+    for p in participants:
+        txn = p.transaction
+        if txn.id in seen:
+            continue
+        seen.add(txn.id)
+        out.append({
+            'id': txn.id,
+            'address': txn.full_address or txn.street_address,
+            'type': txn.transaction_type.display_name if txn.transaction_type else '',
+            'status': (txn.status or '').replace('_', ' ').title(),
+            'role': p.role.replace('_', ' ').title(),
+            'person': p.display_name,
+            'close_date': txn.actual_close_date or txn.expected_close_date,
+        })
+    return out
+
+
+@partner_directory_bp.route('/<int:partner_id>')
+def detail(partner_id):
+    partner = _partner_or_404(partner_id)
+    contacts = partner.contacts.order_by(
+        PartnerContact.is_active.desc(),
+        PartnerContact.last_name.asc(),
+        PartnerContact.first_name.asc(),
+    ).all()
+    linked_transactions = _linked_transactions_for(partner)
+
+    return render_template(
+        'partner_directory/detail.html',
+        partner=partner,
+        contacts=contacts,
+        partner_types=PARTNER_TYPES,
+        usage_count=len(linked_transactions),
+        linked_transactions=linked_transactions,
+        can_manage_partners=is_admin_role(current_user),
+        pending_contact=None,
+        duplicate_warnings=[],
+    )
+
+
+@partner_directory_bp.route('/<int:partner_id>/edit', methods=['POST'])
+def edit_partner(partner_id):
+    _require_admin()
+    partner = _partner_or_404(partner_id)
+    form_data = _company_form_data()
+
+    if not form_data['name']:
+        flash('Company name is required.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    duplicates = find_company_duplicate_candidates(
+        current_user.organization_id,
+        form_data['name'],
+        form_data['street_address'],
+        form_data['city'],
+        form_data['state'],
+        form_data['zip_code'],
+        exclude_id=partner.id,
+    )
+    if duplicates['exact']:
+        flash(f'{duplicates["exact"][0].name} already uses that company name.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    for key, value in form_data.items():
+        setattr(partner, key, value)
+    partner.is_active = request.form.get('is_active') == 'on'
+    partner.updated_by_id = current_user.id
+    sync_partner_organization_fields(partner)
+
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        flash('That company name is already in use.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    if duplicates['warnings']:
+        flash('Saved. This company still looks similar to another directory record; review duplicates when convenient.', 'warning')
+    else:
+        flash('Partner company updated.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+
+@partner_directory_bp.route('/<int:partner_id>/deactivate', methods=['POST'])
+def deactivate_partner(partner_id):
+    _require_admin()
+    partner = _partner_or_404(partner_id)
+    partner.is_active = not partner.is_active
+    partner.updated_by_id = current_user.id
+    db.session.commit()
+    flash(f'{partner.name} is now {"active" if partner.is_active else "inactive"}.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+
+@partner_directory_bp.route('/<int:partner_id>/contacts', methods=['POST'])
+def create_contact(partner_id):
+    partner = _partner_or_404(partner_id)
+    form_data = _contact_form_data()
+
+    if not form_data['first_name'] or not form_data['last_name']:
+        flash('First and last name are required.', 'error')
+        return _render_detail_with_contact_form(partner, form_data)
+
+    duplicates = find_contact_duplicate_candidates(
+        partner.id,
+        form_data['first_name'],
+        form_data['last_name'],
+        form_data['email'],
+        form_data['phone'],
+    )
+
+    if duplicates['exact']:
+        flash(f'{duplicates["exact"][0].full_name} already exists under {partner.name}.', 'error')
+        return _render_detail_with_contact_form(partner, form_data)
+
+    if duplicates['warnings'] and request.form.get('force_create') != '1':
+        flash('Possible duplicate person found. Review before creating another contact.', 'warning')
+        return _render_detail_with_contact_form(partner, form_data, duplicates['warnings'])
+
+    contact = PartnerContact(
+        organization_id=current_user.organization_id,
+        partner_organization_id=partner.id,
+        created_by_id=current_user.id,
+        updated_by_id=current_user.id,
+        **form_data,
+    )
+    sync_partner_contact_fields(contact)
+
+    try:
+        db.session.add(contact)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        flash('That person already exists under this company.', 'error')
+        return _render_detail_with_contact_form(partner, form_data)
+
+    flash(f'{contact.full_name} was added under {partner.name}.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+
+def _render_detail_with_contact_form(partner, form_data, duplicate_warnings=None):
+    contacts = partner.contacts.order_by(
+        PartnerContact.is_active.desc(),
+        PartnerContact.last_name.asc(),
+        PartnerContact.first_name.asc(),
+    ).all()
+    linked_transactions = _linked_transactions_for(partner)
+    return render_template(
+        'partner_directory/detail.html',
+        partner=partner,
+        contacts=contacts,
+        partner_types=PARTNER_TYPES,
+        usage_count=len(linked_transactions),
+        linked_transactions=linked_transactions,
+        can_manage_partners=is_admin_role(current_user),
+        pending_contact=form_data,
+        duplicate_warnings=duplicate_warnings or [],
+    )
+
+
+@partner_directory_bp.route('/<int:partner_id>/contacts/<int:contact_id>/edit', methods=['POST'])
+def edit_contact(partner_id, contact_id):
+    _require_admin()
+    partner = _partner_or_404(partner_id)
+    contact = _contact_or_404(partner, contact_id)
+    form_data = _contact_form_data()
+
+    if not form_data['first_name'] or not form_data['last_name']:
+        flash('First and last name are required.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    duplicates = find_contact_duplicate_candidates(
+        partner.id,
+        form_data['first_name'],
+        form_data['last_name'],
+        form_data['email'],
+        form_data['phone'],
+        exclude_id=contact.id,
+    )
+    if duplicates['exact']:
+        flash(f'{duplicates["exact"][0].full_name} already exists under {partner.name}.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    for key, value in form_data.items():
+        setattr(contact, key, value)
+    contact.is_active = request.form.get('is_active') == 'on'
+    contact.updated_by_id = current_user.id
+    sync_partner_contact_fields(contact)
+
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        flash('That person already exists under this company.', 'error')
+        return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+    if duplicates['warnings']:
+        flash('Saved. This person shares an email or phone with another contact under this company.', 'warning')
+    else:
+        flash('Partner contact updated.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))
+
+
+@partner_directory_bp.route('/<int:partner_id>/contacts/<int:contact_id>/deactivate', methods=['POST'])
+def deactivate_contact(partner_id, contact_id):
+    _require_admin()
+    partner = _partner_or_404(partner_id)
+    contact = _contact_or_404(partner, contact_id)
+    contact.is_active = request.form.get('is_active') == '1'
+    contact.updated_by_id = current_user.id
+    db.session.commit()
+    flash(f'{contact.full_name} is now {"active" if contact.is_active else "inactive"}.', 'success')
+    return redirect(url_for('partner_directory.detail', partner_id=partner.id))

--- a/routes/transactions/api.py
+++ b/routes/transactions/api.py
@@ -7,8 +7,9 @@ import logging
 from datetime import datetime, timedelta
 from flask import request, jsonify
 from flask_login import login_required, current_user
-from models import db, Transaction, Contact, TransactionDocument
+from models import db, Transaction, Contact, TransactionDocument, PartnerContact, PartnerOrganization
 from services import audit_service
+from services.partners import PARTNER_TYPES, partner_search_payload, partner_type_for_role
 from services.transaction_helpers import build_listing_info
 from config import Config
 from . import transactions_bp
@@ -50,6 +51,85 @@ def search_contacts():
         'email': c.email,
         'phone': c.phone
     } for c in contacts])
+
+
+@transactions_bp.route('/api/partners/search')
+@login_required
+@transactions_required
+def search_partners():
+    """Search org-wide Partner Directory records for the transaction participant picker.
+
+    The `type` param is used to *rank* matching-type results first, not to
+    exclude other types.  This way a user searching for "Austin" with role
+    Lender will still find "Austin Title" even though it's categorized as a
+    title company.
+    """
+    query = request.args.get('q', '').strip()
+    role = request.args.get('role', '').strip()
+    preferred_type = request.args.get('type', '').strip() or partner_type_for_role(role)
+    if preferred_type not in PARTNER_TYPES:
+        preferred_type = None
+
+    base_filter = PartnerOrganization.query.filter_by(
+        organization_id=current_user.organization_id,
+        is_active=True,
+    )
+
+    if query:
+        search = f'%{query}%'
+        base_filter = base_filter.filter(db.or_(
+            PartnerOrganization.name.ilike(search),
+            PartnerOrganization.email.ilike(search),
+            PartnerOrganization.phone.ilike(search),
+            PartnerOrganization.city.ilike(search),
+        ))
+
+    # Sort preferred type first, then alphabetical
+    if preferred_type:
+        type_sort = db.case(
+            (PartnerOrganization.partner_type == preferred_type, 0),
+            else_=1,
+        )
+        partners = base_filter.order_by(type_sort, PartnerOrganization.name.asc()).limit(15).all()
+    else:
+        partners = base_filter.order_by(PartnerOrganization.name.asc()).limit(15).all()
+
+    results = []
+    seen = set()
+
+    for partner in partners:
+        results.append(partner_search_payload(partner))
+        seen.add((partner.id, None))
+        contacts = partner.contacts.filter_by(is_active=True).order_by(
+            PartnerContact.last_name.asc(),
+            PartnerContact.first_name.asc(),
+        ).limit(4).all()
+        for contact in contacts:
+            results.append(partner_search_payload(partner, contact))
+            seen.add((partner.id, contact.id))
+
+    if query:
+        contact_query = PartnerContact.query.join(PartnerOrganization).filter(
+            PartnerContact.organization_id == current_user.organization_id,
+            PartnerContact.is_active.is_(True),
+            PartnerOrganization.is_active.is_(True),
+        )
+        search = f'%{query}%'
+        contact_query = contact_query.filter(db.or_(
+            PartnerContact.first_name.ilike(search),
+            PartnerContact.last_name.ilike(search),
+            PartnerContact.email.ilike(search),
+            PartnerContact.phone.ilike(search),
+            PartnerOrganization.name.ilike(search),
+        ))
+
+        for contact in contact_query.order_by(PartnerContact.last_name.asc()).limit(12).all():
+            key = (contact.partner_organization_id, contact.id)
+            if key not in seen:
+                results.append(partner_search_payload(contact.partner_organization, contact))
+                seen.add(key)
+
+    return jsonify(results[:20])
 
 
 @transactions_bp.route('/api/<int:id>/signers')

--- a/routes/transactions/helpers.py
+++ b/routes/transactions/helpers.py
@@ -95,7 +95,8 @@ def build_prefill_data(transaction, participants):
     # Add title company info if present
     title_company = next((p for p in participants if p.role == 'title_company'), None)
     if title_company:
-        data['title_company_name'] = title_company.display_name
+        data['title_company_name'] = title_company.company or title_company.display_name
+        data['title_company_contact_name'] = title_company.display_name
         data['title_company_email'] = title_company.display_email or ''
         data['title_company_phone'] = get_phone(title_company)
     

--- a/routes/transactions/participants.py
+++ b/routes/transactions/participants.py
@@ -5,8 +5,9 @@ Transaction participant management routes.
 
 from flask import request, jsonify, abort
 from flask_login import login_required, current_user
-from models import db, Transaction, TransactionParticipant, Contact
+from models import db, Transaction, TransactionParticipant, Contact, PartnerContact, PartnerOrganization
 from services import audit_service
+from services.partners import build_partner_participant
 from . import transactions_bp
 from .decorators import transactions_required
 
@@ -22,47 +23,69 @@ def add_participant(id):
     """Add a participant to a transaction."""
     transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
     
-    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+    if transaction.created_by_id != current_user.id and current_user.org_role not in ('admin', 'owner'):
         abort(403)
     
     try:
         role = request.form.get('role')
         contact_id = request.form.get('contact_id')
+        partner_organization_id = request.form.get('partner_organization_id')
+        partner_contact_id = request.form.get('partner_contact_id')
         
         if not role:
             return jsonify({'success': False, 'error': 'Role is required'}), 400
-        
-        if not contact_id:
-            return jsonify({'success': False, 'error': 'Please select a contact'}), 400
-        
-        # Get and validate the contact
-        contact = Contact.query.filter_by(id=int(contact_id), user_id=current_user.id).first()
-        if not contact:
-            return jsonify({'success': False, 'error': 'Contact not found'}), 404
-        
-        # Validate contact has required fields
-        if not contact.first_name or not contact.last_name:
-            return jsonify({
-                'success': False, 
-                'error': 'This contact is missing a name. Please update the contact first.'
-            }), 400
-        
-        if not contact.email:
-            return jsonify({
-                'success': False, 
-                'error': 'This contact is missing an email address. Please update the contact first.'
-            }), 400
-        
-        participant = TransactionParticipant(
-            organization_id=current_user.organization_id,
-            transaction_id=transaction.id,
-            role=role,
-            contact_id=contact.id,
-            name=f'{contact.first_name} {contact.last_name}',
-            email=contact.email,
-            phone=contact.phone,
-            is_primary=False
-        )
+
+        if partner_organization_id:
+            partner_organization = PartnerOrganization.query.filter_by(
+                id=int(partner_organization_id),
+                organization_id=current_user.organization_id,
+            ).first()
+            if not partner_organization:
+                return jsonify({'success': False, 'error': 'Partner company not found'}), 404
+
+            partner_contact = None
+            if partner_contact_id:
+                partner_contact = PartnerContact.query.filter_by(
+                    id=int(partner_contact_id),
+                    organization_id=current_user.organization_id,
+                    partner_organization_id=partner_organization.id,
+                ).first()
+                if not partner_contact:
+                    return jsonify({'success': False, 'error': 'Partner contact not found'}), 404
+
+            participant = build_partner_participant(transaction, role, partner_organization, partner_contact)
+        else:
+            if not contact_id:
+                return jsonify({'success': False, 'error': 'Please select a contact or partner'}), 400
+
+            # Get and validate the contact
+            contact = Contact.query.filter_by(id=int(contact_id), user_id=current_user.id).first()
+            if not contact:
+                return jsonify({'success': False, 'error': 'Contact not found'}), 404
+
+            # Validate contact has required fields
+            if not contact.first_name or not contact.last_name:
+                return jsonify({
+                    'success': False,
+                    'error': 'This contact is missing a name. Please update the contact first.'
+                }), 400
+
+            if not contact.email:
+                return jsonify({
+                    'success': False,
+                    'error': 'This contact is missing an email address. Please update the contact first.'
+                }), 400
+
+            participant = TransactionParticipant(
+                organization_id=current_user.organization_id,
+                transaction_id=transaction.id,
+                role=role,
+                contact_id=contact.id,
+                name=f'{contact.first_name} {contact.last_name}',
+                email=contact.email,
+                phone=contact.phone,
+                is_primary=False
+            )
         db.session.add(participant)
         db.session.flush()  # Get participant ID
 
@@ -77,7 +100,8 @@ def add_participant(id):
                 'id': participant.id,
                 'name': participant.display_name,
                 'role': participant.role,
-                'email': participant.display_email
+                'email': participant.display_email,
+                'company': participant.company
             }
         })
 
@@ -93,7 +117,7 @@ def remove_participant(id, participant_id):
     """Remove a participant from a transaction."""
     transaction = Transaction.query.filter_by(id=id, organization_id=current_user.organization_id).first_or_404()
 
-    if transaction.created_by_id != current_user.id and current_user.role != 'admin':
+    if transaction.created_by_id != current_user.id and current_user.org_role not in ('admin', 'owner'):
         abort(403)
 
     participant = TransactionParticipant.query.filter_by(

--- a/services/partners.py
+++ b/services/partners.py
@@ -1,0 +1,184 @@
+"""Partner Directory helpers for duplicate detection and transaction snapshots."""
+from difflib import SequenceMatcher
+
+from models import (
+    PartnerContact,
+    PartnerOrganization,
+    TransactionParticipant,
+    db,
+    normalize_partner_address,
+    normalize_partner_phone,
+    normalize_partner_text,
+)
+
+
+PARTNER_TYPES = {
+    'brokerage': 'Brokerage',
+    'title_company': 'Title Company',
+    'lender': 'Lender',
+    'attorney': 'Attorney',
+    'inspector': 'Inspector',
+    'other': 'Other Partner',
+}
+
+
+ROLE_PARTNER_TYPE_MAP = {
+    'buyers_agent': 'brokerage',
+    'listing_agent': 'brokerage',
+    'title_company': 'title_company',
+    'lender': 'lender',
+    'transaction_coordinator': 'other',
+}
+
+
+EXTERNAL_PARTICIPANT_ROLES = {
+    'buyers_agent',
+    'title_company',
+    'lender',
+    'transaction_coordinator',
+}
+
+
+def coerce_partner_type(value):
+    return value if value in PARTNER_TYPES else 'other'
+
+
+def partner_type_for_role(role):
+    return ROLE_PARTNER_TYPE_MAP.get(role or '', 'other')
+
+
+def is_admin_role(user):
+    return getattr(user, 'org_role', None) in ('owner', 'admin')
+
+
+def sync_partner_organization_fields(partner):
+    partner.partner_type = coerce_partner_type(partner.partner_type)
+    partner.sync_normalized_fields()
+
+
+def sync_partner_contact_fields(contact):
+    contact.sync_normalized_fields()
+
+
+def find_company_duplicate_candidates(
+    organization_id,
+    name,
+    street_address=None,
+    city=None,
+    state=None,
+    zip_code=None,
+    exclude_id=None,
+):
+    """Return exact and warning duplicate candidates for a company create/edit."""
+    normalized_name = normalize_partner_text(name)
+    normalized_address = normalize_partner_address(street_address, city, state, zip_code)
+    query = PartnerOrganization.query.filter_by(organization_id=organization_id)
+    if exclude_id:
+        query = query.filter(PartnerOrganization.id != exclude_id)
+
+    exact = []
+    warnings = []
+
+    if normalized_name:
+        exact = query.filter(PartnerOrganization.normalized_name == normalized_name).all()
+
+    candidates = query.limit(200).all()
+    for partner in candidates:
+        if partner in exact:
+            continue
+
+        same_zip = bool(zip_code and partner.zip_code and partner.zip_code.strip() == zip_code.strip())
+        address_match = bool(normalized_address and partner.normalized_address == normalized_address)
+        name_similarity = SequenceMatcher(None, normalized_name or '', partner.normalized_name or '').ratio()
+
+        if (same_zip and name_similarity >= 0.86) or (address_match and name_similarity >= 0.72):
+            warnings.append(partner)
+
+    return {'exact': exact, 'warnings': warnings}
+
+
+def find_contact_duplicate_candidates(
+    partner_organization_id,
+    first_name,
+    last_name,
+    email=None,
+    phone=None,
+    exclude_id=None,
+):
+    """Return exact and warning duplicate candidates for a child partner contact."""
+    normalized_full_name = normalize_partner_text(f'{first_name or ""} {last_name or ""}')
+    normalized_email = email.strip().lower() if email else None
+    normalized_phone = normalize_partner_phone(phone)
+
+    query = PartnerContact.query.filter_by(partner_organization_id=partner_organization_id)
+    if exclude_id:
+        query = query.filter(PartnerContact.id != exclude_id)
+
+    exact = []
+    warnings = []
+
+    if normalized_full_name:
+        exact = query.filter(PartnerContact.normalized_full_name == normalized_full_name).all()
+
+    warning_filters = []
+    if normalized_email:
+        warning_filters.append(PartnerContact.normalized_email == normalized_email)
+    if normalized_phone:
+        warning_filters.append(PartnerContact.normalized_phone == normalized_phone)
+
+    if warning_filters:
+        warnings = query.filter(db.or_(*warning_filters)).all()
+        warnings = [candidate for candidate in warnings if candidate not in exact]
+
+    return {'exact': exact, 'warnings': warnings}
+
+
+def build_partner_participant(transaction, role, partner_organization, partner_contact=None):
+    """Create a TransactionParticipant snapshot from Partner Directory records."""
+    if partner_contact:
+        name = partner_contact.full_name
+        email = partner_contact.email
+        phone = partner_contact.phone
+    else:
+        name = partner_organization.name
+        email = partner_organization.email
+        phone = partner_organization.phone
+
+    return TransactionParticipant(
+        organization_id=transaction.organization_id,
+        transaction_id=transaction.id,
+        role=role,
+        partner_organization_id=partner_organization.id,
+        partner_contact_id=partner_contact.id if partner_contact else None,
+        name=name,
+        email=email,
+        phone=phone,
+        company=partner_organization.name,
+        is_primary=False,
+    )
+
+
+def partner_search_payload(partner, contact=None):
+    label = partner.name
+    name = partner.name
+    email = partner.email
+    phone = partner.phone
+
+    if contact:
+        name = contact.full_name
+        label = f'{partner.name} - {contact.full_name}'
+        email = contact.email or partner.email
+        phone = contact.phone or partner.phone
+
+    return {
+        'partner_organization_id': partner.id,
+        'partner_contact_id': contact.id if contact else None,
+        'company': partner.name,
+        'name': name,
+        'label': label,
+        'type': partner.partner_type,
+        'type_label': partner.type_label,
+        'email': email,
+        'phone': phone,
+        'address': partner.full_address,
+    }

--- a/services/tenant_service.py
+++ b/services/tenant_service.py
@@ -14,7 +14,8 @@ from flask import abort, flash, redirect, url_for
 TENANT_MODELS = [
     'Contact', 'ContactGroup', 'Task', 'Transaction', 'TransactionDocument',
     'TransactionParticipant', 'DocumentSignature', 'ActionPlan',
-    'DailyTodoList', 'UserTodo', 'CompanyUpdate', 'ContactFile', 'SendGridTemplate'
+    'DailyTodoList', 'UserTodo', 'CompanyUpdate', 'ContactFile', 'SendGridTemplate',
+    'PartnerOrganization', 'PartnerContact'
 ]
 
 

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -114,13 +114,17 @@ function closeDeleteModal() {
 }
 
 function showAddParticipantModal() {
-    // Reset form and state
     document.getElementById('addParticipantForm').reset();
     document.getElementById('participantContactId').value = '';
+    document.getElementById('participantPartnerOrganizationId').value = '';
+    document.getElementById('participantPartnerContactId').value = '';
     document.getElementById('participantContactSearch').value = '';
     document.getElementById('selectedContactPreview').classList.add('hidden');
     document.getElementById('participantSearchResults').classList.add('hidden');
+    document.getElementById('participantSearchWrap').classList.add('hidden');
+    document.getElementById('participantCreateHint').classList.add('hidden');
     document.getElementById('addParticipantBtn').disabled = true;
+    _participantSource = 'partners';
     document.getElementById('addParticipantModal').classList.remove('hidden');
 }
 
@@ -221,10 +225,71 @@ document.addEventListener('keydown', function(e) {
 // PARTICIPANT MANAGEMENT
 // =============================================================================
 
-// Contact search for participant modal
+// Role → partner type, search hint, and default source mapping
+const ROLE_CONFIG = {
+    seller:                  { source: 'contacts', hint: 'Search for the seller' },
+    co_seller:               { source: 'contacts', hint: 'Search for the co-seller' },
+    buyer:                   { source: 'contacts', hint: 'Search for the buyer' },
+    co_buyer:                { source: 'contacts', hint: 'Search for the co-buyer' },
+    listing_agent:           { source: 'partners', type: 'brokerage', hint: 'Search for a listing agent or brokerage' },
+    buyers_agent:            { source: 'partners', type: 'brokerage', hint: 'Search for a buyer\'s agent or brokerage' },
+    title_company:           { source: 'partners', type: 'title_company', hint: 'Search for a title company' },
+    lender:                  { source: 'partners', type: 'lender', hint: 'Search for a lender' },
+    transaction_coordinator: { source: 'partners', type: 'other', hint: 'Search for a transaction coordinator' },
+};
+
+// Current participant source state (managed in JS, not DOM)
+let _participantSource = 'partners'; // 'partners' | 'contacts'
+
 let participantSearchTimeout;
 const participantContactSearch = document.getElementById('participantContactSearch');
 const participantSearchResults = document.getElementById('participantSearchResults');
+
+function _getParticipantRole() {
+    return document.getElementById('participantRole').value;
+}
+
+function _isPartnerSource() {
+    return _participantSource === 'partners';
+}
+
+function switchParticipantSource() {
+    _participantSource = _isPartnerSource() ? 'contacts' : 'partners';
+    _applyParticipantSourceUI();
+    clearSelectedContact();
+}
+
+function _applyParticipantSourceUI() {
+    const role = _getParticipantRole();
+    const cfg = ROLE_CONFIG[role] || {};
+    const isPartner = _isPartnerSource();
+
+    // Role-aware label and placeholder
+    const hint = cfg.hint || (isPartner ? 'Search Partner Directory' : 'Search my contacts');
+    document.getElementById('participantSearchLabel').textContent = hint;
+    participantContactSearch.placeholder =
+        isPartner ? 'Type company or person name…' : 'Type contact name…';
+
+    // Switch link — offers opposite source
+    const switchBtn = document.getElementById('participantSwitchSource');
+    switchBtn.textContent = isPartner ? 'Use my contacts instead' : 'Search Partner Directory instead';
+
+    // Create hint
+    const hintWrap = document.getElementById('participantCreateHint');
+    const hintText = document.getElementById('participantCreateHintText');
+    const createLink = document.getElementById('participantCreateLink');
+    const createLinkText = document.getElementById('participantCreateLinkText');
+    hintWrap.classList.remove('hidden');
+    if (isPartner) {
+        hintText.textContent = "Company not in the directory yet?";
+        createLink.href = '/partners/';
+        createLinkText.textContent = 'Add to Partner Directory';
+    } else {
+        hintText.textContent = "Can't find who you're looking for?";
+        createLink.href = '/contacts/create';
+        createLinkText.textContent = 'Create a new contact';
+    }
+}
 
 participantContactSearch.addEventListener('input', function() {
     clearTimeout(participantSearchTimeout);
@@ -236,15 +301,41 @@ participantContactSearch.addEventListener('input', function() {
     }
 
     participantSearchTimeout = setTimeout(() => {
-        fetch(`/transactions/api/contacts/search?q=${encodeURIComponent(query)}`)
+        const role = _getParticipantRole();
+        const isPartner = _isPartnerSource();
+        const cfg = ROLE_CONFIG[role] || {};
+        const partnerType = cfg.type || '';
+        const url = isPartner
+            ? `/transactions/api/partners/search?q=${encodeURIComponent(query)}&role=${encodeURIComponent(role)}&type=${encodeURIComponent(partnerType)}`
+            : `/transactions/api/contacts/search?q=${encodeURIComponent(query)}`;
+
+        fetch(url)
             .then(res => res.json())
-            .then(contacts => {
-                if (contacts.length === 0) {
-                    participantSearchResults.innerHTML = '<div class="p-4 text-slate-500 text-sm text-center">No contacts found</div>';
+            .then(results => {
+                if (results.length === 0) {
+                    participantSearchResults.innerHTML =
+                        `<div class="p-4 text-sm text-slate-500 text-center">No ${isPartner ? 'partners' : 'contacts'} found</div>`;
                 } else {
-                    participantSearchResults.innerHTML = contacts.map(c => {
+                    participantSearchResults.innerHTML = results.map(c => {
+                        if (isPartner) {
+                            // Show person name on top line, company below (when different)
+                            const topLine = c.name !== c.company ? c.name : c.company;
+                            const subLine = (c.name !== c.company && c.company)
+                                ? `${c.company} · ${c.type_label}`
+                                : c.type_label;
+                            return `
+                                <div class="p-3 hover:bg-orange-50 cursor-pointer transition-colors border-b border-slate-100 last:border-0"
+                                     onclick='selectParticipantPartner(${JSON.stringify(c).replace(/'/g, "&#39;")})'>
+                                    <div class="font-medium text-slate-800">${topLine}</div>
+                                    <div class="text-sm text-slate-500">${subLine}${c.email ? ' · ' + c.email : ''}</div>
+                                    ${c.address ? `<div class="text-xs text-slate-400">${c.address}</div>` : ''}
+                                </div>
+                            `;
+                        }
                         const hasRequired = c.first_name && c.last_name && c.email;
-                        const missingBadge = !hasRequired ? '<span class="text-xs text-amber-600 ml-2"><i class="fas fa-exclamation-triangle"></i> Missing info</span>' : '';
+                        const missingBadge = !hasRequired
+                            ? '<span class="text-xs text-amber-600 ml-2"><i class="fas fa-exclamation-triangle"></i> Missing info</span>'
+                            : '';
                         return `
                             <div class="p-3 hover:bg-orange-50 cursor-pointer transition-colors border-b border-slate-100 last:border-0"
                                  onclick='selectParticipantContact(${JSON.stringify(c).replace(/'/g, "&#39;")})'>
@@ -267,7 +358,6 @@ document.addEventListener('click', function(e) {
 });
 
 function selectParticipantContact(contact) {
-    // Validate contact has required fields
     if (!contact.first_name || !contact.last_name) {
         showToast('This contact is missing a name. Please update the contact first.', 'error');
         return;
@@ -277,13 +367,14 @@ function selectParticipantContact(contact) {
         return;
     }
 
-    // Set the contact ID
     document.getElementById('participantContactId').value = contact.id;
+    document.getElementById('participantPartnerOrganizationId').value = '';
+    document.getElementById('participantPartnerContactId').value = '';
 
-    // Show the preview
     document.getElementById('selectedContactInitials').textContent =
         (contact.first_name[0] + contact.last_name[0]).toUpperCase();
     document.getElementById('selectedContactName').textContent = contact.name;
+    document.getElementById('selectedContactCompany').textContent = '';
     document.getElementById('selectedContactEmail').textContent = contact.email || '';
     document.getElementById('selectedContactPhone').textContent = contact.phone || '';
 
@@ -291,12 +382,39 @@ function selectParticipantContact(contact) {
     document.getElementById('participantContactSearch').classList.add('hidden');
     participantSearchResults.classList.add('hidden');
 
-    // Enable submit button
+    updateAddParticipantButton();
+}
+
+function selectParticipantPartner(partner) {
+    document.getElementById('participantContactId').value = '';
+    document.getElementById('participantPartnerOrganizationId').value = partner.partner_organization_id;
+    document.getElementById('participantPartnerContactId').value = partner.partner_contact_id || '';
+
+    // Person name on top, company below when different
+    const hasPerson = partner.name && partner.company && partner.name !== partner.company;
+    const displayName = hasPerson ? partner.name : partner.company;
+    const displayCompany = hasPerson ? partner.company : '';
+
+    const initials = displayName
+        .split(/\s+/).filter(Boolean).slice(0, 2).map(p => p[0]).join('').toUpperCase() || 'P';
+
+    document.getElementById('selectedContactInitials').textContent = initials;
+    document.getElementById('selectedContactName').textContent = displayName;
+    document.getElementById('selectedContactCompany').textContent = displayCompany;
+    document.getElementById('selectedContactEmail').textContent = partner.email || '';
+    document.getElementById('selectedContactPhone').textContent = partner.phone || '';
+
+    document.getElementById('selectedContactPreview').classList.remove('hidden');
+    document.getElementById('participantContactSearch').classList.add('hidden');
+    participantSearchResults.classList.add('hidden');
+
     updateAddParticipantButton();
 }
 
 function clearSelectedContact() {
     document.getElementById('participantContactId').value = '';
+    document.getElementById('participantPartnerOrganizationId').value = '';
+    document.getElementById('participantPartnerContactId').value = '';
     document.getElementById('selectedContactPreview').classList.add('hidden');
     document.getElementById('participantContactSearch').classList.remove('hidden');
     document.getElementById('participantContactSearch').value = '';
@@ -305,12 +423,27 @@ function clearSelectedContact() {
 
 function updateAddParticipantButton() {
     const hasContact = document.getElementById('participantContactId').value !== '';
-    const hasRole = document.getElementById('participantRole').value !== '';
-    document.getElementById('addParticipantBtn').disabled = !(hasContact && hasRole);
+    const hasPartner = document.getElementById('participantPartnerOrganizationId').value !== '';
+    const hasRole = _getParticipantRole() !== '';
+    document.getElementById('addParticipantBtn').disabled = !((hasContact || hasPartner) && hasRole);
 }
 
-// Update button state when role changes
-document.getElementById('participantRole').addEventListener('change', updateAddParticipantButton);
+// When role changes: auto-pick the best source and show the search area
+document.getElementById('participantRole').addEventListener('change', function() {
+    const role = this.value;
+    if (!role) {
+        document.getElementById('participantSearchWrap').classList.add('hidden');
+        document.getElementById('participantCreateHint').classList.add('hidden');
+        return;
+    }
+
+    const cfg = ROLE_CONFIG[role] || { source: 'partners' };
+    _participantSource = cfg.source;
+    _applyParticipantSourceUI();
+    document.getElementById('participantSearchWrap').classList.remove('hidden');
+    clearSelectedContact();
+    updateAddParticipantButton();
+});
 
 document.getElementById('addParticipantForm').addEventListener('submit', function(e) {
     e.preventDefault();

--- a/templates/base.html
+++ b/templates/base.html
@@ -1296,6 +1296,11 @@
                     <i class="fas fa-file-contract"></i>
                     <span>Transactions</span>
                 </a>
+                <a href="{{ url_for('partner_directory.index') }}"
+                   class="crm-nav-link {% if request.endpoint and request.endpoint.startswith('partner_directory.') %}is-active{% endif %}">
+                    <i class="fas fa-handshake"></i>
+                    <span>Partner Directory</span>
+                </a>
                 {% endif %}
 
                 <a href="{{ url_for('tasks.tasks') }}"

--- a/templates/partner_directory/detail.html
+++ b/templates/partner_directory/detail.html
@@ -1,0 +1,430 @@
+{% extends "base.html" %}
+{% from "components/ui.html" import page_header, badge, avatar, empty_state %}
+
+{% block title %}{{ partner.name }} - Partner Directory{% endblock %}
+
+{% block content %}
+<div class="crm-page">
+    <div class="crm-page__inner">
+
+        {# ── Page header ─────────────────────────────────────────────────────── #}
+        <div class="mb-6">
+            <a href="{{ url_for('partner_directory.index') }}" class="mb-3 inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 hover:text-slate-700">
+                <i class="fas fa-arrow-left text-[10px]"></i> Partner Directory
+            </a>
+            <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <h1 class="text-xl font-bold text-slate-900">{{ partner.name }}</h1>
+                        {{ badge(partner.type_label, 'info') }}
+                        {% if not partner.is_active %}{{ badge('Inactive', 'warning') }}{% endif %}
+                    </div>
+                    <div class="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-sm text-slate-500">
+                        {% if partner.phone %}<span><i class="fas fa-phone mr-1.5 text-[11px]"></i>{{ partner.phone }}</span>{% endif %}
+                        {% if partner.email %}<span><i class="fas fa-envelope mr-1.5 text-[11px]"></i>{{ partner.email }}</span>{% endif %}
+                        {% if partner.full_address %}<span><i class="fas fa-map-marker-alt mr-1.5 text-[11px]"></i>{{ partner.full_address }}</span>{% endif %}
+                        {% if partner.website %}<span><a href="{{ partner.website }}" target="_blank" rel="noopener" class="text-orange-600 hover:underline"><i class="fas fa-external-link-alt mr-1.5 text-[11px]"></i>{{ partner.website }}</a></span>{% endif %}
+                    </div>
+                    {% if partner.notes %}
+                    <p class="mt-2 text-sm text-slate-500 max-w-prose">{{ partner.notes }}</p>
+                    {% endif %}
+                    <div class="mt-2 text-xs text-slate-400">Used in {{ usage_count }} transaction{{ '' if usage_count == 1 else 's' }}</div>
+                </div>
+                {% if can_manage_partners %}
+                <div class="flex gap-2">
+                    <button type="button" onclick="openEditCompanyModal()" class="crm-btn crm-btn-secondary text-sm">
+                        <i class="fas fa-pen text-xs"></i> Edit company
+                    </button>
+                    <form method="POST" action="{{ url_for('partner_directory.deactivate_partner', partner_id=partner.id) }}"
+                          onsubmit="return confirm('{% if partner.is_active %}Deactivate this company?{% else %}Reactivate this company?{% endif %}')">
+                        <button type="submit" class="crm-btn crm-btn-secondary text-sm {% if not partner.is_active %}text-green-700{% else %}text-slate-500{% endif %}">
+                            {% if partner.is_active %}<i class="fas fa-ban text-xs"></i> Deactivate{% else %}<i class="fas fa-check text-xs"></i> Reactivate{% endif %}
+                        </button>
+                    </form>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        {# ── Duplicate person warning ─────────────────────────────────────────── #}
+        {% if duplicate_warnings %}
+        <div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-5 py-4">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <p class="text-sm font-semibold text-amber-900">Possible duplicate person found</p>
+                    <p class="mt-0.5 text-xs text-amber-700">Review these before creating another record under {{ partner.name }}.</p>
+                </div>
+                <form method="POST" action="{{ url_for('partner_directory.create_contact', partner_id=partner.id) }}">
+                    {% for key, value in pending_contact.items() %}
+                    <input type="hidden" name="{{ key }}" value="{{ value or '' }}">
+                    {% endfor %}
+                    {% if pending_contact.is_primary_contact %}<input type="hidden" name="is_primary_contact" value="on">{% endif %}
+                    <input type="hidden" name="force_create" value="1">
+                    <button type="submit" class="text-xs font-medium text-orange-600 hover:text-orange-700">None of these — create anyway &rarr;</button>
+                </form>
+            </div>
+            <div class="mt-3 grid gap-2 sm:grid-cols-2">
+                {% for dup in duplicate_warnings %}
+                <div class="rounded border border-amber-200 bg-white px-3 py-2">
+                    <span class="text-sm font-semibold text-amber-900">{{ dup.full_name }}</span>
+                    <span class="block text-xs text-amber-700">{{ dup.email or dup.phone or 'Existing contact' }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+        {# ── People section ──────────────────────────────────────────────────── #}
+        <section class="crm-surface">
+            <div class="crm-surface-header">
+                <div>
+                    <h2 class="crm-section-title">People at {{ partner.name }}</h2>
+                    <p class="crm-section-description">Individual contacts agents can attach to transactions.</p>
+                </div>
+                <button type="button" onclick="openAddPersonModal()" class="crm-btn crm-btn-secondary">
+                    <i class="fas fa-plus text-xs text-slate-400"></i>
+                    Add person
+                </button>
+            </div>
+            <div class="crm-surface-body">
+                {% if contacts %}
+                <div class="divide-y divide-slate-100">
+                    {% for contact in contacts %}
+                    <div class="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0" id="person-{{ contact.id }}">
+                        <div class="flex min-w-0 items-start gap-3">
+                            {{ avatar(contact.full_name[:2]|upper, 'sm') }}
+                            <div class="min-w-0">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <span class="text-sm font-semibold text-slate-900">{{ contact.full_name }}</span>
+                                    {% if contact.is_primary_contact %}{{ badge('Primary', 'accent') }}{% endif %}
+                                    {% if not contact.is_active %}{{ badge('Inactive', 'warning') }}{% endif %}
+                                </div>
+                                {% if contact.title %}<div class="text-xs text-slate-500">{{ contact.title }}</div>{% endif %}
+                                <div class="mt-0.5 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-slate-400">
+                                    {% if contact.email %}<span><i class="fas fa-envelope mr-1 text-[10px]"></i>{{ contact.email }}</span>{% endif %}
+                                    {% if contact.phone %}<span><i class="fas fa-phone mr-1 text-[10px]"></i>{{ contact.phone }}</span>{% endif %}
+                                </div>
+                                {% if contact.notes %}<p class="mt-1.5 text-xs text-slate-400">{{ contact.notes }}</p>{% endif %}
+                            </div>
+                        </div>
+                        {% if can_manage_partners %}
+                        <button type="button"
+                                class="js-edit-person shrink-0 text-xs font-medium text-orange-600 hover:text-orange-700 mt-0.5"
+                                data-id="{{ contact.id }}"
+                                data-first="{{ contact.first_name }}"
+                                data-last="{{ contact.last_name }}"
+                                data-title="{{ contact.title or '' }}"
+                                data-email="{{ contact.email or '' }}"
+                                data-phone="{{ contact.phone or '' }}"
+                                data-notes="{{ contact.notes or '' }}"
+                                data-primary="{{ 'true' if contact.is_primary_contact else 'false' }}"
+                                data-active="{{ 'true' if contact.is_active else 'false' }}">
+                            Edit
+                        </button>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                {% call empty_state('No people added yet', 'Add the agent, escrow officer, lender, or other person your team works with here.', 'fa-user-plus') %}
+                    <button type="button" onclick="openAddPersonModal()" class="crm-btn crm-btn-secondary">Add person</button>
+                {% endcall %}
+                {% endif %}
+            </div>
+        </section>
+
+        {# ── Transaction history ──────────────────────────────────────────────── #}
+        <section class="crm-surface mt-4">
+            <div class="crm-surface-header">
+                <div>
+                    <h2 class="crm-section-title">Transaction History</h2>
+                    <p class="crm-section-description">{{ linked_transactions|length }} deal{{ '' if linked_transactions|length == 1 else 's' }} involving {{ partner.name }}.</p>
+                </div>
+            </div>
+            {% if linked_transactions %}
+            <div class="crm-table-wrap">
+                <table class="crm-table">
+                    <thead>
+                        <tr>
+                            <th>Property</th>
+                            <th>Type</th>
+                            <th>Role</th>
+                            <th>Person</th>
+                            <th>Status</th>
+                            <th>Close Date</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for txn in linked_transactions %}
+                        <tr onclick="window.location.href='{{ url_for('transactions.view_transaction', id=txn.id) }}'" class="cursor-pointer">
+                            <td>
+                                <span class="font-medium text-slate-900">{{ txn.address }}</span>
+                            </td>
+                            <td class="text-slate-600">{{ txn.type }}</td>
+                            <td class="text-slate-600">{{ txn.role }}</td>
+                            <td class="text-slate-600">{{ txn.person }}</td>
+                            <td>
+                                {% if txn.status == 'Closed' %}
+                                    {{ badge('Closed', 'success') }}
+                                {% elif txn.status == 'Cancelled' %}
+                                    {{ badge('Cancelled', 'warning') }}
+                                {% elif txn.status == 'Under Contract' %}
+                                    {{ badge('Under Contract', 'info') }}
+                                {% else %}
+                                    {{ badge(txn.status, 'neutral') }}
+                                {% endif %}
+                            </td>
+                            <td class="text-sm text-slate-500">
+                                {% if txn.close_date %}{{ txn.close_date.strftime('%b %d, %Y') }}{% else %}<span class="text-slate-400">—</span>{% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="crm-surface-body">
+                <div class="py-6 text-center">
+                    <p class="text-sm text-slate-500">Not attached to any transactions yet.</p>
+                </div>
+            </div>
+            {% endif %}
+        </section>
+    </div>
+</div>
+
+{# ── Add Person Modal ─────────────────────────────────────────────────────── #}
+<div id="addPersonModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-slate-900/50" onclick="closeAddPersonModal()"></div>
+    <div class="absolute inset-4 flex max-h-[90vh] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:w-full md:max-w-md md:-translate-x-1/2 md:-translate-y-1/2">
+        <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <div>
+                <h3 class="text-base font-semibold text-slate-900">Add person</h3>
+                <p class="text-xs text-slate-500 mt-0.5">at {{ partner.name }}</p>
+            </div>
+            <button type="button" onclick="closeAddPersonModal()"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700">
+                <i class="fas fa-times text-sm"></i>
+            </button>
+        </div>
+        <form method="POST" action="{{ url_for('partner_directory.create_contact', partner_id=partner.id) }}" class="flex flex-1 flex-col overflow-hidden">
+            <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+                <div class="grid grid-cols-2 gap-3">
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">First name <span class="text-red-500">*</span></label>
+                        <input name="first_name" required autofocus value="{{ pending_contact.first_name if pending_contact else '' }}" class="crm-input">
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Last name <span class="text-red-500">*</span></label>
+                        <input name="last_name" required value="{{ pending_contact.last_name if pending_contact else '' }}" class="crm-input">
+                    </div>
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Title / role</label>
+                    <input name="title" value="{{ pending_contact.title if pending_contact else '' }}" class="crm-input" placeholder="Escrow officer, agent, lender rep…">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Email</label>
+                    <input type="email" name="email" value="{{ pending_contact.email if pending_contact else '' }}" class="crm-input">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Phone</label>
+                    <input name="phone" value="{{ pending_contact.phone if pending_contact else '' }}" class="crm-input">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Notes</label>
+                    <textarea name="notes" rows="2" class="crm-input">{{ pending_contact.notes if pending_contact else '' }}</textarea>
+                </div>
+                <label class="flex items-center gap-2 text-sm text-slate-600">
+                    <input type="checkbox" name="is_primary_contact" {% if pending_contact and pending_contact.is_primary_contact %}checked{% endif %} class="rounded border-slate-300">
+                    Primary contact for {{ partner.name }}
+                </label>
+            </div>
+            <div class="flex justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                <button type="button" onclick="closeAddPersonModal()" class="crm-btn crm-btn-secondary">Cancel</button>
+                <button type="submit" class="crm-btn crm-btn-primary">Save person</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{# ── Edit Person Modal ────────────────────────────────────────────────────── #}
+{% if can_manage_partners %}
+<div id="editPersonModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-slate-900/50" onclick="closeEditPersonModal()"></div>
+    <div class="absolute inset-4 flex max-h-[90vh] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:w-full md:max-w-md md:-translate-x-1/2 md:-translate-y-1/2">
+        <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <h3 class="text-base font-semibold text-slate-900">Edit person</h3>
+            <button type="button" onclick="closeEditPersonModal()"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700">
+                <i class="fas fa-times text-sm"></i>
+            </button>
+        </div>
+        <form id="editPersonForm" method="POST" action="" class="flex flex-1 flex-col overflow-hidden">
+            <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+                <div class="grid grid-cols-2 gap-3">
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">First name <span class="text-red-500">*</span></label>
+                        <input id="editPersonFirstName" name="first_name" required class="crm-input">
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Last name <span class="text-red-500">*</span></label>
+                        <input id="editPersonLastName" name="last_name" required class="crm-input">
+                    </div>
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Title / role</label>
+                    <input id="editPersonTitle" name="title" class="crm-input" placeholder="Escrow officer, agent, lender rep…">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Email</label>
+                    <input type="email" id="editPersonEmail" name="email" class="crm-input">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Phone</label>
+                    <input id="editPersonPhone" name="phone" class="crm-input">
+                </div>
+                <div>
+                    <label class="mb-1.5 block text-xs font-medium text-slate-600">Notes</label>
+                    <textarea id="editPersonNotes" name="notes" rows="2" class="crm-input"></textarea>
+                </div>
+                <label class="flex items-center gap-2 text-sm text-slate-600">
+                    <input type="checkbox" id="editPersonPrimary" name="is_primary_contact" class="rounded border-slate-300">
+                    Primary contact for {{ partner.name }}
+                </label>
+                <label class="flex items-center gap-2 text-sm text-slate-600">
+                    <input type="checkbox" id="editPersonActive" name="is_active" class="rounded border-slate-300">
+                    Active
+                </label>
+            </div>
+            <div class="flex justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                <button type="button" onclick="closeEditPersonModal()" class="crm-btn crm-btn-secondary">Cancel</button>
+                <button type="submit" class="crm-btn crm-btn-primary">Save changes</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{# ── Edit Company Modal ───────────────────────────────────────────────────── #}
+<div id="editCompanyModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-slate-900/50" onclick="closeEditCompanyModal()"></div>
+    <div class="absolute inset-4 flex max-h-[90vh] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:w-full md:max-w-xl md:-translate-x-1/2 md:-translate-y-1/2">
+        <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <h3 class="text-base font-semibold text-slate-900">Edit company</h3>
+            <button type="button" onclick="closeEditCompanyModal()"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700">
+                <i class="fas fa-times text-sm"></i>
+            </button>
+        </div>
+        <form method="POST" action="{{ url_for('partner_directory.edit_partner', partner_id=partner.id) }}" class="flex flex-1 flex-col overflow-hidden">
+            <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Company name <span class="text-red-500">*</span></label>
+                        <input name="name" value="{{ partner.name }}" required class="crm-input">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Type</label>
+                        <div class="flex flex-wrap gap-2">
+                            {% for value, label in partner_types.items() %}
+                            <label class="cursor-pointer select-none rounded-md border border-slate-200 px-3 py-1.5 text-sm transition-colors hover:border-orange-400 hover:bg-orange-50 has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50 has-[:checked]:text-orange-700 has-[:checked]:font-medium">
+                                <input type="radio" name="partner_type" value="{{ value }}" {% if partner.partner_type == value %}checked{% endif %} class="sr-only">
+                                {{ label }}
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Phone</label>
+                        <input name="phone" value="{{ partner.phone or '' }}" class="crm-input">
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Email</label>
+                        <input type="email" name="email" value="{{ partner.email or '' }}" class="crm-input">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Street address</label>
+                        <input name="street_address" value="{{ partner.street_address or '' }}" class="crm-input">
+                    </div>
+                    <div>
+                        <input name="city" placeholder="City" value="{{ partner.city or '' }}" class="crm-input">
+                    </div>
+                    <div class="grid grid-cols-2 gap-2">
+                        <input name="state" placeholder="State" value="{{ partner.state or '' }}" class="crm-input">
+                        <input name="zip_code" placeholder="ZIP" value="{{ partner.zip_code or '' }}" class="crm-input">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Website</label>
+                        <input name="website" value="{{ partner.website or '' }}" class="crm-input">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Notes</label>
+                        <textarea name="notes" rows="2" class="crm-input">{{ partner.notes or '' }}</textarea>
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="flex items-center gap-2 text-sm text-slate-600">
+                            <input type="checkbox" name="is_active" {% if partner.is_active %}checked{% endif %} class="rounded border-slate-300">
+                            Active
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="flex justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                <button type="button" onclick="closeEditCompanyModal()" class="crm-btn crm-btn-secondary">Cancel</button>
+                <button type="submit" class="crm-btn crm-btn-primary">Save company</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endif %}
+
+<script>
+function openAddPersonModal() {
+    document.getElementById('addPersonModal').classList.remove('hidden');
+    setTimeout(() => document.querySelector('#addPersonModal input[name="first_name"]').focus(), 50);
+}
+function closeAddPersonModal() {
+    document.getElementById('addPersonModal').classList.add('hidden');
+}
+function openEditCompanyModal() {
+    var el = document.getElementById('editCompanyModal');
+    if (el) el.classList.remove('hidden');
+}
+function closeEditCompanyModal() {
+    var el = document.getElementById('editCompanyModal');
+    if (el) el.classList.add('hidden');
+}
+function openEditPersonModal(btn) {
+    var form = document.getElementById('editPersonForm');
+    var modal = document.getElementById('editPersonModal');
+    if (!form || !modal) return;
+    form.action = '/partners/{{ partner.id }}/contacts/' + btn.dataset.id + '/edit';
+    document.getElementById('editPersonFirstName').value = btn.dataset.first;
+    document.getElementById('editPersonLastName').value = btn.dataset.last;
+    document.getElementById('editPersonTitle').value = btn.dataset.title;
+    document.getElementById('editPersonEmail').value = btn.dataset.email;
+    document.getElementById('editPersonPhone').value = btn.dataset.phone;
+    document.getElementById('editPersonNotes').value = btn.dataset.notes;
+    document.getElementById('editPersonPrimary').checked = btn.dataset.primary === 'true';
+    document.getElementById('editPersonActive').checked = btn.dataset.active === 'true';
+    modal.classList.remove('hidden');
+}
+document.querySelectorAll('.js-edit-person').forEach(function(btn) {
+    btn.addEventListener('click', function() { openEditPersonModal(this); });
+});
+function closeEditPersonModal() {
+    var el = document.getElementById('editPersonModal');
+    if (el) el.classList.add('hidden');
+}
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        closeAddPersonModal();
+        closeEditPersonModal();
+        closeEditCompanyModal();
+    }
+});
+{% if duplicate_warnings or pending_contact %}
+document.addEventListener('DOMContentLoaded', function() { openAddPersonModal(); });
+{% endif %}
+</script>
+{% endblock %}

--- a/templates/partner_directory/index.html
+++ b/templates/partner_directory/index.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %}
+{% from "components/ui.html" import page_header, badge, empty_state %}
+
+{% block title %}Partner Directory - Origen TechnolOG{% endblock %}
+
+{% block content %}
+<div class="crm-page">
+    <div class="crm-page__inner">
+        {% call page_header('Partner Directory', 'Companies and people your team works with at closing.', 'Transactions') %}
+            <button type="button" onclick="openAddPartnerModal()" class="crm-btn crm-btn-primary">
+                <i class="fas fa-plus text-xs"></i>
+                Add Company
+            </button>
+        {% endcall %}
+
+        <section class="crm-surface mb-4">
+            <div class="crm-surface-body">
+                <form method="GET" action="{{ url_for('partner_directory.index') }}" class="flex flex-wrap items-end gap-3">
+                    <div class="min-w-[220px] flex-1">
+                        <input type="search" name="q" value="{{ search_query }}" placeholder="Search name, email, phone, city…" class="crm-input">
+                    </div>
+                    <select name="type" class="crm-select w-auto">
+                        <option value="">All types</option>
+                        {% for value, label in partner_types.items() %}
+                        <option value="{{ value }}" {% if selected_type == value %}selected{% endif %}>{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                    <select name="active" class="crm-select w-auto">
+                        <option value="active" {% if active_filter == 'active' %}selected{% endif %}>Active only</option>
+                        <option value="all" {% if active_filter == 'all' %}selected{% endif %}>All</option>
+                        <option value="inactive" {% if active_filter == 'inactive' %}selected{% endif %}>Inactive</option>
+                    </select>
+                    <button type="submit" class="crm-btn crm-btn-secondary">Filter</button>
+                </form>
+            </div>
+        </section>
+
+        <section class="crm-surface">
+            <div class="crm-surface-header">
+                <div>
+                    <h2 class="crm-section-title">Companies</h2>
+                    <p class="crm-section-description">{{ partners|length }} record{{ '' if partners|length == 1 else 's' }}</p>
+                </div>
+            </div>
+            {% if partners %}
+            <div class="crm-table-wrap">
+                <table class="crm-table">
+                    <thead>
+                        <tr>
+                            <th>Company</th>
+                            <th>Type</th>
+                            <th>People</th>
+                            <th>Used in</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for partner in partners %}
+                        <tr onclick="window.location.href='{{ url_for('partner_directory.detail', partner_id=partner.id) }}'">
+                            <td>
+                                <div class="font-semibold text-slate-900">{{ partner.name }}</div>
+                                <div class="mt-0.5 text-xs text-slate-500">
+                                    {% if partner.phone %}{{ partner.phone }}{% endif %}
+                                    {% if partner.phone and partner.city %} &middot; {% endif %}
+                                    {% if partner.city %}{{ partner.city }}{% if partner.state %}, {{ partner.state }}{% endif %}{% endif %}
+                                    {% if not partner.phone and not partner.city %}<span class="italic text-slate-400">No contact info</span>{% endif %}
+                                </div>
+                            </td>
+                            <td>{{ badge(partner.type_label, 'info') }}</td>
+                            <td class="text-slate-600">{{ partner.contacts.filter_by(is_active=True).count() }}</td>
+                            <td class="text-slate-500 text-sm">{{ usage_counts.get(partner.id, 0) }} deal{{ '' if usage_counts.get(partner.id, 0) == 1 else 's' }}</td>
+                            <td>
+                                {% if partner.is_active %}{{ badge('Active', 'success') }}{% else %}{{ badge('Inactive', 'warning') }}{% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="crm-surface-body">
+                {% call empty_state('No partners yet', 'Add title companies, brokerages, lenders, and other companies your team works with on transactions.', 'fa-building') %}
+                    <button type="button" onclick="openAddPartnerModal()" class="crm-btn crm-btn-primary">Add Company</button>
+                {% endcall %}
+            </div>
+            {% endif %}
+        </section>
+    </div>
+</div>
+
+{# ── Add Company Modal ──────────────────────────────────────────────────────── #}
+<div id="addPartnerModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-slate-900/50" onclick="closeAddPartnerModal()"></div>
+    <div class="absolute inset-4 flex max-h-[90vh] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:w-full md:max-w-xl md:-translate-x-1/2 md:-translate-y-1/2">
+        <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <div>
+                <h3 class="text-base font-semibold text-slate-900">Add company</h3>
+                <p class="text-xs text-slate-500 mt-0.5">Available to all agents in your organization.</p>
+            </div>
+            <button type="button" onclick="closeAddPartnerModal()"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700">
+                <i class="fas fa-times text-sm"></i>
+            </button>
+        </div>
+
+        {# Duplicate warning (shown when POST returns with warnings) #}
+        {% if duplicate_warnings %}
+        <div class="border-b border-amber-200 bg-amber-50 px-6 py-4">
+            <p class="text-sm font-medium text-amber-900">Possible duplicate — review before creating</p>
+            <div class="mt-2 grid gap-2 sm:grid-cols-2">
+                {% for dup in duplicate_warnings %}
+                <a href="{{ url_for('partner_directory.detail', partner_id=dup.id) }}"
+                   class="rounded border border-amber-200 bg-white px-3 py-2 text-sm hover:bg-amber-50">
+                    <span class="font-semibold text-amber-900">{{ dup.name }}</span>
+                    <span class="block text-xs text-amber-700">{{ dup.full_address or dup.type_label }}</span>
+                </a>
+                {% endfor %}
+            </div>
+            <form method="POST" action="{{ url_for('partner_directory.create_partner') }}" class="mt-3">
+                {% if pending_company %}
+                {% for key, value in pending_company.items() %}
+                <input type="hidden" name="{{ key }}" value="{{ value or '' }}">
+                {% endfor %}
+                {% endif %}
+                <input type="hidden" name="force_create" value="1">
+                <button type="submit" class="text-xs font-medium text-orange-600 hover:text-orange-700">
+                    None of these match — create anyway &rarr;
+                </button>
+            </form>
+        </div>
+        {% endif %}
+
+        <form method="POST" action="{{ url_for('partner_directory.create_partner') }}" class="flex flex-1 flex-col overflow-hidden">
+            <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Company name <span class="text-red-500">*</span></label>
+                        <input name="name" required autofocus value="{{ pending_company.name if pending_company else '' }}" class="crm-input" placeholder="e.g. Austin Title Company">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Type</label>
+                        <div class="flex flex-wrap gap-2" id="partnerTypeButtons">
+                            {% for value, label in partner_types.items() %}
+                            <label class="partner-type-btn cursor-pointer select-none rounded-md border border-slate-200 px-3 py-1.5 text-sm transition-colors hover:border-orange-400 hover:bg-orange-50 has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50 has-[:checked]:text-orange-700 has-[:checked]:font-medium">
+                                <input type="radio" name="partner_type" value="{{ value }}" {% if (pending_company and pending_company.partner_type == value) or (not pending_company and value == 'other') %}checked{% endif %} class="sr-only">
+                                {{ label }}
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Phone</label>
+                        <input name="phone" value="{{ pending_company.phone if pending_company else '' }}" class="crm-input" placeholder="(555) 000-0000">
+                    </div>
+                    <div>
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Email</label>
+                        <input type="email" name="email" value="{{ pending_company.email if pending_company else '' }}" class="crm-input" placeholder="info@company.com">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Street address</label>
+                        <input name="street_address" value="{{ pending_company.street_address if pending_company else '' }}" class="crm-input">
+                    </div>
+                    <div>
+                        <input name="city" placeholder="City" value="{{ pending_company.city if pending_company else '' }}" class="crm-input">
+                    </div>
+                    <div class="grid grid-cols-2 gap-2">
+                        <input name="state" placeholder="State" value="{{ pending_company.state if pending_company else '' }}" class="crm-input">
+                        <input name="zip_code" placeholder="ZIP" value="{{ pending_company.zip_code if pending_company else '' }}" class="crm-input">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Website</label>
+                        <input name="website" value="{{ pending_company.website if pending_company else '' }}" class="crm-input" placeholder="https://…">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="mb-1.5 block text-xs font-medium text-slate-600">Notes</label>
+                        <textarea name="notes" rows="2" class="crm-input">{{ pending_company.notes if pending_company else '' }}</textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="flex justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                <button type="button" onclick="closeAddPartnerModal()" class="crm-btn crm-btn-secondary">Cancel</button>
+                <button type="submit" class="crm-btn crm-btn-primary">Save company</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+function openAddPartnerModal() {
+    document.getElementById('addPartnerModal').classList.remove('hidden');
+    document.querySelector('#addPartnerModal input[name="name"]').focus();
+}
+function closeAddPartnerModal() {
+    document.getElementById('addPartnerModal').classList.add('hidden');
+}
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closeAddPartnerModal();
+});
+{% if duplicate_warnings or pending_company %}
+document.addEventListener('DOMContentLoaded', function() { openAddPartnerModal(); });
+{% endif %}
+</script>
+{% endblock %}

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -2031,7 +2031,10 @@
                                         <span class="text-[10px] font-semibold uppercase tracking-wide text-orange-600">Primary</span>
                                         {% endif %}
                                     </div>
-                                    <div class="text-xs text-slate-500">{{ participant.role|replace('_', ' ')|title }}</div>
+                                    {% if participant.company and participant.company != participant.display_name %}
+                                    <div class="text-xs font-medium text-slate-500">{{ participant.company }}</div>
+                                    {% endif %}
+                                    <div class="text-xs text-slate-400">{{ participant.role|replace('_', ' ')|title }}</div>
                                     {% if participant.display_email %}
                                     <div class="mt-0.5 truncate text-xs text-slate-400">
                                         <i class="fas fa-envelope mr-1 text-[10px]"></i>{{ participant.display_email }}
@@ -2040,11 +2043,6 @@
                                     {% if participant.display_phone %}
                                     <div class="mt-0.5 truncate text-xs text-slate-400">
                                         <i class="fas fa-phone mr-1 text-[10px]"></i>{{ participant.display_phone }}
-                                    </div>
-                                    {% endif %}
-                                    {% if participant.company %}
-                                    <div class="mt-0.5 truncate text-xs text-slate-400">
-                                        <i class="fas fa-building mr-1 text-[10px]"></i>{{ participant.company }}
                                     </div>
                                     {% endif %}
                                 </div>
@@ -2659,13 +2657,15 @@
         </div>
         <form id="addParticipantForm" class="flex flex-1 flex-col overflow-hidden">
             <input type="hidden" name="contact_id" id="participantContactId">
+            <input type="hidden" name="partner_organization_id" id="participantPartnerOrganizationId">
+            <input type="hidden" name="partner_contact_id" id="participantPartnerContactId">
             <div class="flex-1 space-y-4 overflow-y-auto px-5 py-5">
                 <div>
                     <label class="mb-1.5 block text-xs font-medium text-slate-600">
                         Role <span class="text-red-500">*</span>
                     </label>
                     <select name="role" id="participantRole" required class="crm-select">
-                        <option value="">Select role...</option>
+                        <option value="">Select role…</option>
                         <option value="seller">Seller</option>
                         <option value="co_seller">Co-Seller</option>
                         <option value="buyer">Buyer</option>
@@ -2678,19 +2678,24 @@
                     </select>
                 </div>
 
-                <div class="relative">
-                    <label class="mb-1.5 block text-xs font-medium text-slate-600">
-                        Search contact <span class="text-red-500">*</span>
-                    </label>
+                <div id="participantSearchWrap" class="hidden">
+                    <div class="mb-1.5 flex items-center justify-between">
+                        <label class="text-xs font-medium text-slate-600">
+                            <span id="participantSearchLabel">Search</span> <span class="text-red-500">*</span>
+                        </label>
+                        <button type="button" id="participantSwitchSource"
+                                onclick="switchParticipantSource()"
+                                class="text-xs text-orange-600 hover:text-orange-700 hover:underline"></button>
+                    </div>
                     <div class="relative">
                         <input type="text" id="participantContactSearch"
-                               placeholder="Type to search contacts..."
+                               placeholder="Type to search…"
                                autocomplete="off"
                                class="crm-input pl-9">
                         <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-xs text-slate-400"></i>
                     </div>
                     <div id="participantSearchResults"
-                         class="absolute left-0 right-0 z-20 mt-1 hidden max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-white shadow-lg"></div>
+                         class="mt-1 hidden max-h-60 overflow-y-auto rounded-md border border-slate-200 bg-white shadow-md"></div>
                 </div>
 
                 <div id="selectedContactPreview" class="hidden">
@@ -2701,8 +2706,9 @@
                                      class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-orange-500 text-sm font-semibold text-white"></div>
                                 <div>
                                     <div class="text-sm font-semibold text-slate-900" id="selectedContactName"></div>
-                                    <div class="text-xs text-slate-500" id="selectedContactEmail"></div>
-                                    <div class="text-xs text-slate-500" id="selectedContactPhone"></div>
+                                    <div class="text-xs text-slate-500" id="selectedContactCompany"></div>
+                                    <div class="text-xs text-slate-400" id="selectedContactEmail"></div>
+                                    <div class="text-xs text-slate-400" id="selectedContactPhone"></div>
                                 </div>
                             </div>
                             <button type="button" onclick="clearSelectedContact()"
@@ -2713,12 +2719,11 @@
                     </div>
                 </div>
 
-                <div class="border-t border-slate-100 pt-3 text-center">
-                    <p class="mb-1 text-xs text-slate-500">Can't find the contact you're looking for?</p>
-                    <a href="{{ url_for('contacts.create_contact', return_to='transaction', transaction_id=transaction.id) }}"
-                       class="inline-flex items-center gap-1 text-sm font-medium text-orange-600 hover:text-orange-700">
+                <div id="participantCreateHint" class="hidden border-t border-slate-100 pt-3 text-center">
+                    <p class="mb-1 text-xs text-slate-500" id="participantCreateHintText"></p>
+                    <a id="participantCreateLink" href="#" class="inline-flex items-center gap-1 text-sm font-medium text-orange-600 hover:text-orange-700">
                         <i class="fas fa-plus text-xs"></i>
-                        Create a new contact
+                        <span id="participantCreateLinkText"></span>
                     </a>
                 </div>
             </div>

--- a/tests/test_partner_directory.py
+++ b/tests/test_partner_directory.py
@@ -1,0 +1,147 @@
+"""Tests for org-wide Partner Directory behavior."""
+from models import db, PartnerContact, PartnerOrganization, TransactionParticipant
+from services.partners import sync_partner_contact_fields, sync_partner_organization_fields
+
+
+def _partner(org_id, user_id, name='Remax Extreme', partner_type='brokerage'):
+    partner = PartnerOrganization(
+        organization_id=org_id,
+        created_by_id=user_id,
+        updated_by_id=user_id,
+        name=name,
+        partner_type=partner_type,
+        street_address='123 Closing Way',
+        city='Austin',
+        state='TX',
+        zip_code='78701',
+    )
+    sync_partner_organization_fields(partner)
+    db.session.add(partner)
+    db.session.flush()
+    return partner
+
+
+def _partner_contact(org_id, user_id, partner, first='Julie', last='Agent', email='julie@example.com'):
+    contact = PartnerContact(
+        organization_id=org_id,
+        partner_organization_id=partner.id,
+        created_by_id=user_id,
+        updated_by_id=user_id,
+        first_name=first,
+        last_name=last,
+        email=email,
+        phone='5553334444',
+    )
+    sync_partner_contact_fields(contact)
+    db.session.add(contact)
+    db.session.flush()
+    return contact
+
+
+class TestPartnerDirectory:
+    def test_agent_can_create_partner_company(self, app, agent_a_client, seed):
+        resp = agent_a_client.post('/partners/', data={
+            'name': 'Austin Title Co',
+            'partner_type': 'title_company',
+            'phone': '555-111-2222',
+            'street_address': '10 Main Street',
+            'city': 'Austin',
+            'state': 'TX',
+            'zip_code': '78701',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        with app.app_context():
+            partner = PartnerOrganization.query.filter_by(
+                organization_id=seed['org_a'],
+                normalized_name='austin title co',
+            ).first()
+            assert partner is not None
+            assert partner.created_by_id == seed['agent_a']
+
+    def test_agent_cannot_edit_existing_partner(self, app, agent_a_client, seed):
+        with app.app_context():
+            partner = _partner(seed['org_a'], seed['owner_a'], name='Admin Managed Title', partner_type='title_company')
+            db.session.commit()
+            partner_id = partner.id
+
+        resp = agent_a_client.post(f'/partners/{partner_id}/edit', data={
+            'name': 'Changed Title',
+            'partner_type': 'title_company',
+        })
+
+        assert resp.status_code == 403
+
+    def test_exact_company_duplicate_is_blocked(self, app, owner_a_client, seed):
+        with app.app_context():
+            partner = _partner(seed['org_a'], seed['owner_a'], name='Clean Title')
+            db.session.commit()
+            partner_id = partner.id
+
+        resp = owner_a_client.post('/partners/', data={
+            'name': ' clean   title ',
+            'partner_type': 'title_company',
+        }, follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert f'/partners/{partner_id}' in resp.headers['Location']
+        with app.app_context():
+            assert PartnerOrganization.query.filter_by(
+                organization_id=seed['org_a'],
+                normalized_name='clean title',
+            ).count() == 1
+
+    def test_child_duplicate_name_is_blocked_but_email_match_warns(self, app, owner_a_client, seed):
+        with app.app_context():
+            partner = _partner(seed['org_a'], seed['owner_a'], name='Brokerage With People')
+            _partner_contact(seed['org_a'], seed['owner_a'], partner, first='Julie', last='Agent', email='julie@example.com')
+            db.session.commit()
+            partner_id = partner.id
+
+        duplicate_name = owner_a_client.post(f'/partners/{partner_id}/contacts', data={
+            'first_name': 'Julie',
+            'last_name': 'Agent',
+            'email': 'other@example.com',
+        })
+        assert duplicate_name.status_code == 200
+
+        duplicate_email = owner_a_client.post(f'/partners/{partner_id}/contacts', data={
+            'first_name': 'Julia',
+            'last_name': 'Closer',
+            'email': 'julie@example.com',
+        })
+        assert duplicate_email.status_code == 200
+        assert b'Possible duplicate person found' in duplicate_email.data
+
+        with app.app_context():
+            assert PartnerContact.query.filter_by(partner_organization_id=partner_id).count() == 1
+
+    def test_transaction_can_attach_partner_snapshot(self, app, owner_a_client, seed):
+        with app.app_context():
+            partner = _partner(seed['org_a'], seed['owner_a'], name='Snapshot Title', partner_type='title_company')
+            contact = _partner_contact(seed['org_a'], seed['owner_a'], partner, first='Tina', last='Closer', email='tina@example.com')
+            db.session.commit()
+            partner_id = partner.id
+            contact_id = contact.id
+
+        search_resp = owner_a_client.get('/transactions/api/partners/search?q=Snapshot&role=title_company')
+        assert search_resp.status_code == 200
+        assert any(result['company'] == 'Snapshot Title' for result in search_resp.get_json())
+
+        attach_resp = owner_a_client.post(f'/transactions/{seed["tx_a"]}/participants', data={
+            'role': 'title_company',
+            'partner_organization_id': str(partner_id),
+            'partner_contact_id': str(contact_id),
+        })
+        assert attach_resp.status_code == 200
+        assert attach_resp.get_json()['success'] is True
+
+        with app.app_context():
+            participant = TransactionParticipant.query.filter_by(
+                transaction_id=seed['tx_a'],
+                partner_organization_id=partner_id,
+            ).first()
+            assert participant is not None
+            assert participant.name == 'Tina Closer'
+            assert participant.company == 'Snapshot Title'
+            assert participant.email == 'tina@example.com'


### PR DESCRIPTION
## Summary

- **New Partner Directory** — org-wide shared directory of external companies (title companies, brokerages, lenders, attorneys, inspectors) and their people. Accessible via new sidebar tab, gated by transaction access.
- **Modal-based CRUD** — clean modal forms for adding/editing companies and people (replaces the awkward sidebar forms). Type selection uses pill-style radio buttons. Admin-only edit/deactivate with toggle behavior.
- **Transaction integration** — redesigned participant modal auto-selects Partner Directory or My Contacts based on role (e.g. Title Company → searches partners, Seller → searches contacts). One-click toggle to switch sources. Search ranks preferred type first without hard-filtering. Participant list shows both person name and company.
- **Data quality** — normalized duplicate detection with hard blocks on exact name matches and soft warnings on fuzzy/address matches. Force-create option for false positives.
- **Snapshot semantics** — partner details are copied onto TransactionParticipant at attach time so historical records stay accurate even if the directory entry is later updated.
- **Transaction history on detail page** — clicking into a partner shows every deal they've been involved in with clickable rows to jump straight to the transaction.

## Bug fixes included

- Reactivate button always deactivated (was reading a missing form field instead of toggling)
- Edit person modal broken (inline `onclick` with `tojson` double-quotes inside HTML attribute — switched to `data-*` attributes)
- Search results clipped by modal overflow (removed absolute positioning)
- Listing Agent incorrectly defaulted to My Contacts instead of Partner Directory

## Test plan

- [ ] Add a new company from the Partner Directory page via the modal
- [ ] Verify duplicate warning appears for similar company names
- [ ] Add a person under a company, confirm edit and deactivate/reactivate work
- [ ] From a transaction, add a participant with Title Company role — confirm it searches Partner Directory
- [ ] Switch role to Seller — confirm it searches My Contacts with toggle link to switch
- [ ] Confirm participant list shows both person name and company name
- [ ] Verify transaction history table appears on partner detail page
- [ ] Run `pytest tests/test_partner_directory.py`


Made with [Cursor](https://cursor.com)