### PR TITLE
chore: default to light theme on first visit instead of OS preference

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,14 +6,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Origen TechnolOG{% endblock %}</title>
-    <!-- Theme guard: applies stored theme before any paint to avoid FOUC. -->
+    <!-- Theme guard: applies stored theme before any paint to avoid FOUC.
+         Default is Light. We deliberately don't follow the OS color scheme so
+         dark mode is opt-in via the toggle. Users who have explicitly chosen
+         a theme keep their choice (persisted in localStorage as 'crm-theme'). -->
     <script>
         (function () {
             try {
-                var stored = localStorage.getItem('crm-theme');
-                if (!stored) {
-                    stored = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-                }
+                var stored = localStorage.getItem('crm-theme') || 'light';
                 document.documentElement.dataset.theme = stored === 'dark' ? 'dark' : 'light';
             } catch (e) { /* ignore */ }
         })();


### PR DESCRIPTION
## Summary

The head theme guard in [`templates/base.html`](templates/base.html) used to fall back to the user's OS \`prefers-color-scheme\` when no theme was stored in \`localStorage\`. That meant users on macOS/Windows with system dark mode landed in dark on their first visit -- even though Light is the intended default for the product. This PR drops that OS fallback so first-time / unauthenticated visitors always start in Light.

## Behavior

- **First visit / cleared storage**: Light. Always.
- **Users who have explicitly toggled Dark**: keep Dark (still persisted in \`localStorage.crm-theme\`).
- **Users who have explicitly toggled Light**: keep Light.
- The existing toggle, cross-tab sync via the \`storage\` event, and the \`crm:theme\` custom event for chart components are unchanged.

## Why

Dark mode in this product is currently a polish/preference feature, not the primary visual identity. Letting the OS dictate the default meant some users never saw the canonical Light look -- which is also what the design system tokens are tuned around first.

## Test plan

- [ ] On macOS with system dark mode, open an incognito window and visit \`/\` -> lands in Light.
- [ ] Toggle to Dark via the theme button in the header -> persists across reloads.
- [ ] Open a second tab -> theme stays in sync via the \`storage\` event.
- [ ] Run \`localStorage.removeItem('crm-theme'); location.reload();\` in DevTools -> back to Light.

Made with [Cursor](https://cursor.com)