### PR TITLE
fix: remove per-request DB write, add tenant scoping and input validation

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -604,11 +604,3 @@ def delete_user(user_id):
     
     return redirect(url_for('auth.manage_users'))
 
-@auth_bp.before_request
-def update_last_login():
-    if current_user.is_authenticated:
-        current_user.last_login = datetime.utcnow()
-        try:
-            db.session.commit()
-        except:
-            db.session.rollback()

--- a/routes/main.py
+++ b/routes/main.py
@@ -329,13 +329,21 @@ def contacts():
 
     owners = request.args.get('owners')
     if show_all and owners:
-        owner_ids = [int(id) for id in owners.split(',')]
-        query = query.filter(Contact.user_id.in_(owner_ids))
+        try:
+            owner_ids = [int(x) for x in owners.split(',') if x.strip()]
+        except (ValueError, TypeError):
+            owner_ids = []
+        if owner_ids:
+            query = query.filter(Contact.user_id.in_(owner_ids))
 
     groups = request.args.get('groups')
     if groups:
-        group_ids = [int(id) for id in groups.split(',')]
-        query = query.join(Contact.groups).filter(ContactGroup.id.in_(group_ids))
+        try:
+            group_ids = [int(x) for x in groups.split(',') if x.strip()]
+        except (ValueError, TypeError):
+            group_ids = []
+        if group_ids:
+            query = query.join(Contact.groups).filter(ContactGroup.id.in_(group_ids))
 
     zips = request.args.get('zips')
     if zips:

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request, abort, jsonify
 from flask_login import login_required, current_user
 from models import db, Task, Contact, TaskType, TaskSubtype, User
+from services.tenant_service import org_query
 from datetime import datetime, timezone, time
 import pytz
 from sqlalchemy.orm import joinedload
@@ -38,7 +39,9 @@ def tasks():
     status_filter = request.args.get('status', 'pending')
     user_tz = get_user_timezone()
 
-    query = Task.query.options(
+    query = Task.query.filter_by(
+        organization_id=current_user.organization_id
+    ).options(
         joinedload(Task.contact),
         joinedload(Task.assigned_to),
         joinedload(Task.task_type),
@@ -82,7 +85,7 @@ def create_task():
     if request.method == 'POST':
         try:
             contact_id = request.form.get('contact_id')
-            contact = db.session.get(Contact, contact_id)
+            contact = org_query(Contact).filter_by(id=contact_id).first()
             if not contact:
                 abort(404)
 


### PR DESCRIPTION
## Summary

- **Remove `update_last_login` before_request hook** — was firing a DB write + commit on every authenticated request, making `last_login` track "last page view" instead of "last login" and adding unnecessary latency (especially to remote Supabase). The login, registration, and invite-acceptance flows already set `last_login` correctly.
- **Add `organization_id` filter to task list query** — admin "view all" was missing the org scope, potentially leaking tasks across tenants in non-RLS environments. Also switched `create_task` contact lookup to `org_query()` for consistent tenant isolation.
- **Wrap `int()` parsing of `?owners=` and `?groups=` query params** — malformed input (e.g. `?owners=abc`) caused an unhandled `ValueError` and a 500. Now gracefully falls back to an empty filter.

## Test plan

- [ ] Verify `last_login` only updates on actual login, not on page navigation
- [ ] Verify task list as admin with "view all" only shows current org's tasks
- [ ] Verify creating a task still works normally
- [ ] Verify contacts page handles `?owners=invalid` and `?groups=invalid` without crashing

Made with [Cursor](https://cursor.com)