### PR TITLE
fix: retry redis connect on worker startup to survive Railway cold starts

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -9,21 +9,60 @@ Usage (local):
 
 Railway: set as the custom start command for the worker service.
 """
+import logging
+import socket
+import time
+
 from dotenv import load_dotenv
 load_dotenv()
 
 from redis import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
 from rq import Worker, Queue
 from app import app
 from config import Config
 
+log = logging.getLogger("worker")
+logging.basicConfig(level=logging.INFO)
+
+
+def _connect_redis(url: str, attempts: int = 12, delay: float = 2.5) -> Redis:
+    """
+    Connect to Redis with retries.
+
+    Railway's private DNS (*.railway.internal) is sometimes not resolvable for
+    the first few seconds after the container starts. Without this, the worker
+    crashes inside Worker.__init__ (which calls CLIENT SETNAME) and Railway
+    just restarts it in a loop. Retrying here turns a cold-start race into a
+    short delay instead of a manual-intervention outage.
+    """
+    last_err: Exception | None = None
+    for i in range(1, attempts + 1):
+        try:
+            conn = Redis.from_url(
+                url,
+                socket_connect_timeout=10,
+                socket_timeout=30,
+                health_check_interval=30,
+                retry_on_timeout=True,
+            )
+            conn.ping()
+            log.info("connected to redis on attempt %d", i)
+            return conn
+        except (RedisConnectionError, socket.gaierror, OSError) as e:
+            last_err = e
+            log.warning("redis connect attempt %d/%d failed: %s", i, attempts, e)
+            time.sleep(delay)
+    raise RuntimeError(f"could not connect to redis after {attempts} attempts") from last_err
+
+
 def main():
     with app.app_context():
-        conn = Redis.from_url(Config.REDIS_URL)
-        queues = [Queue('doc_extraction', connection=conn)]
+        conn = _connect_redis(Config.REDIS_URL)
+        queues = [Queue("doc_extraction", connection=conn)]
         worker = Worker(queues, connection=conn)
-        worker.work()
+        worker.work(with_scheduler=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- The document worker on Railway crash-looped this morning with `redis.exceptions.ConnectionError: Error -3 connecting to redis.railway.internal:6379. Temporary failure in name resolution.` A manual restart cleared it, which points to a startup race against Railway's private DNS rather than a real Redis outage.
- `worker.py` previously called `Redis.from_url(...)` and immediately handed the connection to `Worker(...)`, whose `__init__` issues `CLIENT SETNAME`. If DNS isn't ready yet, that call raises inside the worker constructor and the process exits — Railway then restarts it in a loop until someone intervenes.
- Wrap the connect in a small retry loop (12 attempts, 2.5s apart, ~30s budget) and `ping()` the connection before constructing `Worker`, so any DNS/TCP failure surfaces in code we control. Also set conservative socket timeouts and `health_check_interval` so transient blips during normal operation don't kill the worker either.
- Enable `with_scheduler=True` on `worker.work()` so RQ's in-process scheduler runs (no-op unless we ever use `enqueue_at` / `enqueue_in`, harmless otherwise).

## Behavior change to be aware of

If Redis is genuinely down or `REDIS_URL` is misconfigured, the worker now takes ~30s to die instead of failing instantly. That is the right tradeoff for cold-start flakiness, but worth knowing when debugging future Redis issues — look for `redis connect attempt N/12 failed:` lines in the worker logs.

## Test plan

- [ ] Deploy the worker service on Railway and confirm it starts cleanly.
- [ ] Tail worker logs across a redeploy and confirm we see at most a handful of `redis connect attempt N/12 failed:` lines (or none) before `connected to redis on attempt N`, instead of a crash + restart.
- [ ] Enqueue a document extraction job and verify it is picked up and processed.
- [ ] Locally: run `python worker.py` with `REDIS_URL` pointing at a bad host and confirm the process retries for ~30s and then exits with a clear `RuntimeError`, instead of an immediate stack trace from `Worker.__init__`.

Made with [Cursor](https://cursor.com)