### PR TITLE
feat: seller client portal

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,7 @@ from routes.market_insights import market_insights_bp
 from routes.notifications import notifications_bp
 from routes.inbound_email import inbound_bp
 from routes.partner_directory import partner_directory_bp
+from routes.portal import portal_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
@@ -228,6 +229,7 @@ def create_app():
     app.register_blueprint(notifications_bp)
     app.register_blueprint(inbound_bp)
     app.register_blueprint(partner_directory_bp)
+    app.register_blueprint(portal_bp)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/migrations/versions/add_client_portal_tables.py
+++ b/migrations/versions/add_client_portal_tables.py
@@ -1,0 +1,156 @@
+"""Add client portal tables (client_portal_access, portal_messages)
+
+Revision ID: add_client_portal_tables
+Revises: add_activation_events
+Create Date: 2026-06-05 15:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_client_portal_tables'
+down_revision = 'add_activation_events'
+branch_labels = None
+depends_on = None
+
+
+# Only portal_messages carries tenant RLS. client_portal_access is an
+# auth/bootstrap table (looked up by its globally-unique token BEFORE an org
+# context exists), exactly like the user table in Magic Inbox — so it is
+# intentionally excluded from RLS to avoid a chicken-and-egg lookup.
+TENANT_TABLES = (
+    'portal_messages',
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if 'client_portal_access' not in tables:
+        op.create_table(
+            'client_portal_access',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('transaction_id', sa.Integer(), nullable=False),
+            sa.Column('participant_id', sa.Integer(), nullable=False),
+            sa.Column('token', sa.String(length=64), nullable=False),
+            sa.Column('is_active', sa.Boolean(), nullable=False,
+                      server_default=sa.text('1')),
+            sa.Column('created_at', sa.DateTime(), nullable=False,
+                      server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.Column('revoked_at', sa.DateTime(), nullable=True),
+            sa.Column('last_viewed_at', sa.DateTime(), nullable=True),
+            sa.Column('view_count', sa.Integer(), nullable=False,
+                      server_default=sa.text('0')),
+            sa.PrimaryKeyConstraint('id', name='pk_client_portal_access'),
+            sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'],
+                                    name='fk_client_portal_access_org',
+                                    ondelete='RESTRICT'),
+            sa.ForeignKeyConstraint(['transaction_id'], ['transactions.id'],
+                                    name='fk_client_portal_access_tx',
+                                    ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['participant_id'],
+                                    ['transaction_participants.id'],
+                                    name='fk_client_portal_access_participant',
+                                    ondelete='CASCADE'),
+            sa.UniqueConstraint('token', name='uq_client_portal_access_token'),
+        )
+        op.create_index('ix_client_portal_access_org_id',
+                        'client_portal_access', ['organization_id'], unique=False)
+        op.create_index('ix_client_portal_access_tx_id',
+                        'client_portal_access', ['transaction_id'], unique=False)
+        op.create_index('ix_client_portal_access_participant_id',
+                        'client_portal_access', ['participant_id'], unique=False)
+        op.create_index('ix_client_portal_access_token',
+                        'client_portal_access', ['token'], unique=True)
+
+    if 'portal_messages' not in tables:
+        op.create_table(
+            'portal_messages',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('transaction_id', sa.Integer(), nullable=False),
+            sa.Column('participant_id', sa.Integer(), nullable=False),
+            sa.Column('sender', sa.String(length=20), nullable=False,
+                      server_default='agent'),
+            sa.Column('kind', sa.String(length=20), nullable=False,
+                      server_default='message'),
+            sa.Column('body', sa.Text(), nullable=False),
+            sa.Column('attachment_path', sa.String(length=500), nullable=True),
+            sa.Column('attachment_name', sa.String(length=255), nullable=True),
+            sa.Column('author_user_id', sa.Integer(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=False,
+                      server_default=sa.text('CURRENT_TIMESTAMP')),
+            sa.Column('read_by_agent_at', sa.DateTime(), nullable=True),
+            sa.Column('read_by_client_at', sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint('id', name='pk_portal_messages'),
+            sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'],
+                                    name='fk_portal_messages_org',
+                                    ondelete='RESTRICT'),
+            sa.ForeignKeyConstraint(['transaction_id'], ['transactions.id'],
+                                    name='fk_portal_messages_tx',
+                                    ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['participant_id'],
+                                    ['transaction_participants.id'],
+                                    name='fk_portal_messages_participant',
+                                    ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['author_user_id'], ['user.id'],
+                                    name='fk_portal_messages_author',
+                                    ondelete='SET NULL'),
+        )
+        op.create_index('ix_portal_messages_org_id', 'portal_messages',
+                        ['organization_id'], unique=False)
+        op.create_index('ix_portal_messages_tx_id', 'portal_messages',
+                        ['transaction_id'], unique=False)
+        op.create_index('ix_portal_messages_participant_id', 'portal_messages',
+                        ['participant_id'], unique=False)
+        op.create_index('ix_portal_messages_created_at', 'portal_messages',
+                        ['created_at'], unique=False)
+
+    # Row Level Security (PostgreSQL only) — mirrors enable_magic_inbox_rls.py
+    if conn.dialect.name == 'postgresql':
+        for table in TENANT_TABLES:
+            op.execute(f'ALTER TABLE {table} ENABLE ROW LEVEL SECURITY')
+            op.execute(f'DROP POLICY IF EXISTS tenant_isolation_{table} ON {table}')
+            op.execute(f"""
+                CREATE POLICY tenant_isolation_{table} ON {table}
+                FOR ALL
+                USING (
+                    organization_id = current_setting(
+                        'app.current_org_id', true
+                    )::integer
+                )
+                WITH CHECK (
+                    organization_id = current_setting(
+                        'app.current_org_id', true
+                    )::integer
+                )
+            """)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    tables = inspector.get_table_names()
+
+    if conn.dialect.name == 'postgresql':
+        for table in TENANT_TABLES:
+            op.execute(f'DROP POLICY IF EXISTS tenant_isolation_{table} ON {table}')
+
+    if 'portal_messages' in tables:
+        op.drop_index('ix_portal_messages_created_at', table_name='portal_messages')
+        op.drop_index('ix_portal_messages_participant_id', table_name='portal_messages')
+        op.drop_index('ix_portal_messages_tx_id', table_name='portal_messages')
+        op.drop_index('ix_portal_messages_org_id', table_name='portal_messages')
+        op.drop_table('portal_messages')
+
+    if 'client_portal_access' in tables:
+        op.drop_index('ix_client_portal_access_token', table_name='client_portal_access')
+        op.drop_index('ix_client_portal_access_participant_id', table_name='client_portal_access')
+        op.drop_index('ix_client_portal_access_tx_id', table_name='client_portal_access')
+        op.drop_index('ix_client_portal_access_org_id', table_name='client_portal_access')
+        op.drop_table('client_portal_access')

--- a/models.py
+++ b/models.py
@@ -2534,6 +2534,7 @@ class Notification(db.Model):
         'task_reminder': 'Task Reminders',
         'company_update': 'Company Updates',
         'magic_inbox': 'Magic Inbox',
+        'portal': 'Client Portal',
     }
 
     def mark_read(self):
@@ -2740,3 +2741,103 @@ class ActivationEvent(db.Model):
 
     def __repr__(self):
         return f'<ActivationEvent {self.event} org={self.organization_id} user={self.user_id}>'
+
+
+# =============================================================================
+# CLIENT PORTAL (passwordless, per-seller "magic link" transaction portal)
+# =============================================================================
+
+class ClientPortalAccess(db.Model):
+    """A private, revocable magic link that lets one transaction participant
+    (a seller) view their own transaction in the client portal.
+
+    Auth is the token itself: a long, url-safe random string. There is no
+    password and no User account. The link can be rotated or revoked by the
+    agent at any time. One row per participant per transaction.
+    """
+    __tablename__ = 'client_portal_access'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id',
+                               ondelete='CASCADE'), nullable=False, index=True)
+    participant_id = db.Column(db.Integer, db.ForeignKey('transaction_participants.id',
+                               ondelete='CASCADE'), nullable=False, index=True)
+
+    # The secret in the URL. ~43 chars from token_urlsafe(32).
+    token = db.Column(db.String(64), unique=True, nullable=False, index=True)
+
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    revoked_at = db.Column(db.DateTime, nullable=True)
+    last_viewed_at = db.Column(db.DateTime, nullable=True)
+    view_count = db.Column(db.Integer, nullable=False, default=0)
+
+    transaction = db.relationship('Transaction', backref=db.backref(
+        'portal_access_links', lazy='dynamic', cascade='all, delete-orphan'))
+    participant = db.relationship('TransactionParticipant', backref=db.backref(
+        'portal_access', lazy='dynamic', cascade='all, delete-orphan'))
+
+    @staticmethod
+    def generate_token():
+        """Cryptographically secure, url-safe token (~43 chars)."""
+        return secrets.token_urlsafe(32)
+
+    def record_view(self):
+        self.view_count = (self.view_count or 0) + 1
+        self.last_viewed_at = datetime.utcnow()
+
+    def __repr__(self):
+        return (f'<ClientPortalAccess {self.id} tx={self.transaction_id} '
+                f'participant={self.participant_id} active={self.is_active}>')
+
+
+class PortalMessage(db.Model):
+    """A note shown in the client portal. Powers two things with one model:
+
+    - kind='update': an agent-posted status note ("This week's update").
+    - kind='message': a two-way message between the agent and the client.
+
+    Scoped to a single participant + transaction so each seller sees only
+    their own thread.
+    """
+    __tablename__ = 'portal_messages'
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id',
+                               ondelete='CASCADE'), nullable=False, index=True)
+    participant_id = db.Column(db.Integer, db.ForeignKey('transaction_participants.id',
+                               ondelete='CASCADE'), nullable=False, index=True)
+
+    # 'agent' | 'client'
+    sender = db.Column(db.String(20), nullable=False, default='agent', index=True)
+    # 'update' | 'message'
+    kind = db.Column(db.String(20), nullable=False, default='message', index=True)
+
+    body = db.Column(db.Text, nullable=False)
+    # Supabase path when a client attaches a requested file to a message.
+    attachment_path = db.Column(db.String(500), nullable=True)
+    attachment_name = db.Column(db.String(255), nullable=True)
+
+    # Which agent authored an agent-side message/update (null for client).
+    author_user_id = db.Column(db.Integer, db.ForeignKey('user.id',
+                               ondelete='SET NULL'), nullable=True)
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+    read_by_agent_at = db.Column(db.DateTime, nullable=True)
+    read_by_client_at = db.Column(db.DateTime, nullable=True)
+
+    transaction = db.relationship('Transaction', backref=db.backref(
+        'portal_messages', lazy='dynamic', cascade='all, delete-orphan',
+        order_by='PortalMessage.created_at.desc()'))
+    author = db.relationship('User', foreign_keys=[author_user_id])
+
+    SENDERS = {'agent', 'client'}
+    KINDS = {'update', 'message'}
+
+    def __repr__(self):
+        return (f'<PortalMessage {self.id} tx={self.transaction_id} '
+                f'sender={self.sender} kind={self.kind}>')

--- a/routes/portal.py
+++ b/routes/portal.py
@@ -1,0 +1,220 @@
+"""Client portal — passwordless, per-seller transaction portal.
+
+Every route is authenticated by a long, unguessable token in the URL that maps
+to a single ClientPortalAccess row. There is no User session. The token's org
+is resolved first (the access table carries no RLS, like the Magic Inbox user
+lookup), then a connection-scoped RLS context is set for all tenant queries and
+reset in teardown.
+"""
+from __future__ import annotations
+
+import logging
+from functools import wraps
+
+from flask import (
+    Blueprint, render_template, abort, request, redirect, url_for,
+    flash, g, jsonify,
+)
+from sqlalchemy import text
+
+from models import db, ClientPortalAccess, PortalMessage
+from services.portal_service import build_portal_context, SELLER_ROLES
+
+logger = logging.getLogger(__name__)
+
+portal_bp = Blueprint('portal', __name__, url_prefix='/portal')
+
+
+# --------------------------------------------------------------------------
+# RLS org context (connection-scoped; reset in teardown). Mirrors the
+# Magic Inbox webhook pattern since there is no authenticated user here.
+# --------------------------------------------------------------------------
+
+def _set_portal_org_context(org_id: int) -> None:
+    try:
+        db.session.execute(
+            text("SELECT set_config('app.current_org_id', :org_id, false)"),
+            {'org_id': str(org_id)},
+        )
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+@portal_bp.teardown_request
+def _reset_portal_org_context(exc=None):
+    try:
+        db.session.execute(text('RESET app.current_org_id'))
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------
+# access decorator
+# --------------------------------------------------------------------------
+
+def portal_access(view):
+    """Resolve and authorize the portal token, then set RLS context.
+
+    Stashes the ClientPortalAccess row on ``g.portal`` and passes it to the
+    view as the first argument.
+    """
+    @wraps(view)
+    def wrapper(token, *args, **kwargs):
+        access = ClientPortalAccess.query.filter_by(
+            token=token, is_active=True).first()
+        if not access:
+            return render_template('portal/invalid.html'), 404
+
+        _set_portal_org_context(access.organization_id)
+
+        tx = access.transaction
+        participant = access.participant
+        if (tx is None or participant is None
+                or participant.transaction_id != tx.id
+                or (participant.role or '') not in SELLER_ROLES):
+            return render_template('portal/invalid.html'), 404
+
+        g.portal = access
+        return view(access, *args, **kwargs)
+
+    return wrapper
+
+
+# --------------------------------------------------------------------------
+# routes
+# --------------------------------------------------------------------------
+
+@portal_bp.route('/<token>')
+@portal_access
+def home(access):
+    """The seller's portal: status tracker + everything they care about."""
+    try:
+        access.record_view()
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+    ctx = build_portal_context(access)
+    return render_template('portal/show.html', token=access.token, **ctx)
+
+
+@portal_bp.route('/<token>/document/<int:doc_id>/view')
+@portal_access
+def view_document(access, doc_id):
+    """Redirect to a short-lived signed URL for a completed document the
+    seller was a party to."""
+    from models import TransactionDocument
+    from services.supabase_storage import get_transaction_document_url
+
+    doc = TransactionDocument.query.filter_by(
+        id=doc_id, transaction_id=access.transaction_id).first()
+    email = (access.participant.display_email or '').strip().lower()
+    if not doc or doc.status != 'signed' or not doc.signed_file_path:
+        abort(404)
+
+    # Must be a signer on the doc (or an unsigner-tracked completed doc).
+    sigs = doc.signatures.all()
+    if sigs and not any((s.signer_email or '').strip().lower() == email for s in sigs):
+        abort(403)
+
+    try:
+        signed_url = get_transaction_document_url(doc.signed_file_path, expires_in=3600)
+    except Exception:
+        logger.exception('Portal: failed to sign document URL for doc %s', doc_id)
+        signed_url = None
+    if not signed_url:
+        abort(404)
+    return redirect(signed_url)
+
+
+@portal_bp.route('/<token>/sign/<int:doc_id>')
+@portal_access
+def sign_document(access, doc_id):
+    """Embedded DocuSeal signing page for a document awaiting the seller."""
+    from models import TransactionDocument
+
+    doc = TransactionDocument.query.filter_by(
+        id=doc_id, transaction_id=access.transaction_id).first()
+    email = (access.participant.display_email or '').strip().lower()
+    if not doc:
+        abort(404)
+
+    sigs = doc.signatures.all()
+    mine = [s for s in sigs
+            if (s.signer_email or '').strip().lower() == email
+            and s.status in ('sent', 'viewed')]
+    if not mine or not mine[0].docuseal_submitter_slug:
+        abort(404)
+
+    embed_src = f'https://docuseal.com/s/{mine[0].docuseal_submitter_slug}'
+    ctx = build_portal_context(access)
+    doc_name = doc.template_name or (doc.template_slug or 'Document').replace('-', ' ').title()
+    return render_template(
+        'portal/sign.html',
+        token=access.token,
+        embed_src=embed_src,
+        doc_name=doc_name,
+        agent=ctx['agent'],
+        property=ctx['property'],
+    )
+
+
+@portal_bp.route('/<token>/message', methods=['POST'])
+@portal_access
+def post_message(access):
+    """Light action: the seller sends a note to their agent."""
+    body = (request.form.get('body') or '').strip()
+    if not body:
+        flash('Please write a message before sending.', 'error')
+        return redirect(url_for('portal.home', token=access.token) + '#talk')
+    if len(body) > 4000:
+        body = body[:4000]
+
+    msg = PortalMessage(
+        organization_id=access.organization_id,
+        transaction_id=access.transaction_id,
+        participant_id=access.participant_id,
+        sender='client',
+        kind='message',
+        body=body,
+    )
+    db.session.add(msg)
+    db.session.commit()
+
+    # Notify the agent in-app (best-effort; never block the seller's action).
+    try:
+        _notify_agent_of_message(access, body)
+    except Exception:
+        logger.exception('Portal: failed to notify agent of client message.')
+
+    flash('Message sent to your agent.', 'success')
+    return redirect(url_for('portal.home', token=access.token) + '#talk')
+
+
+def _notify_agent_of_message(access, body):
+    from services.notification_service import create_notification
+
+    tx = access.transaction
+    agent = getattr(tx, 'created_by', None)
+    if not agent:
+        return
+    sender = access.participant.name or 'Your client'
+    preview = (body[:120] + '…') if len(body) > 120 else body
+    create_notification(
+        user_id=agent.id,
+        organization_id=access.organization_id,
+        category='portal',
+        title=f'Portal message from {sender}',
+        body=preview,
+        icon='fa-comment',
+        action_url=url_for('transactions.view_transaction', id=tx.id),
+        respect_preference=False,
+    )

--- a/routes/transactions/__init__.py
+++ b/routes/transactions/__init__.py
@@ -37,3 +37,4 @@ from . import signing
 from . import download
 from . import docuseal_admin
 from . import history
+from . import portal_admin

--- a/routes/transactions/portal_admin.py
+++ b/routes/transactions/portal_admin.py
@@ -1,0 +1,160 @@
+"""Agent-side management of client portal links for a transaction.
+
+Lets the agent generate, copy, rotate, and revoke the private seller portal
+link from the transaction detail page. All endpoints are agent-authenticated
+and org-scoped; the portal itself (token-authenticated) lives in routes/portal.py.
+"""
+from flask import abort, jsonify, request, url_for
+from flask_login import current_user, login_required
+
+from models import (
+    ClientPortalAccess,
+    Transaction,
+    TransactionParticipant,
+    db,
+)
+from . import transactions_bp
+from .decorators import transactions_required
+
+SELLER_ROLES = ('seller', 'co_seller')
+
+
+def _can_manage_transaction(transaction):
+    return (
+        transaction.created_by_id == current_user.id
+        or getattr(current_user, 'role', None) == 'admin'
+        or getattr(current_user, 'org_role', None) in ('admin', 'owner')
+    )
+
+
+def _get_transaction(id):
+    transaction = Transaction.query.filter_by(
+        id=id, organization_id=current_user.organization_id,
+    ).first_or_404()
+    if not _can_manage_transaction(transaction):
+        abort(403)
+    return transaction
+
+
+def _link_url(access):
+    return url_for('portal.home', token=access.token, _external=True)
+
+
+def _serialize(participant, access):
+    return {
+        'participant_id': participant.id,
+        'name': participant.name or (
+            f'{participant.contact.first_name} {participant.contact.last_name}'.strip()
+            if participant.contact else 'Seller'),
+        'role': participant.role,
+        'email': participant.display_email,
+        'has_link': access is not None,
+        'access_id': access.id if access else None,
+        'url': _link_url(access) if access else None,
+        'view_count': access.view_count if access else 0,
+        'last_viewed': (
+            access.last_viewed_at.strftime('%b %d, %Y')
+            if access and access.last_viewed_at else None),
+    }
+
+
+def _seller_participants(transaction):
+    return TransactionParticipant.query.filter(
+        TransactionParticipant.transaction_id == transaction.id,
+        TransactionParticipant.organization_id == current_user.organization_id,
+        TransactionParticipant.role.in_(SELLER_ROLES),
+    ).all()
+
+
+def _active_link_for(transaction, participant_id):
+    return ClientPortalAccess.query.filter_by(
+        transaction_id=transaction.id,
+        participant_id=participant_id,
+        is_active=True,
+    ).first()
+
+
+@transactions_bp.route('/<int:id>/portal/status')
+@login_required
+@transactions_required
+def portal_status(id):
+    """List seller participants and their active portal links."""
+    transaction = _get_transaction(id)
+    rows = []
+    for participant in _seller_participants(transaction):
+        access = _active_link_for(transaction, participant.id)
+        rows.append(_serialize(participant, access))
+    return jsonify({'success': True, 'sellers': rows})
+
+
+@transactions_bp.route('/<int:id>/portal/create', methods=['POST'])
+@login_required
+@transactions_required
+def portal_create_link(id):
+    """Create (or return the existing) active portal link for a seller."""
+    transaction = _get_transaction(id)
+    data = request.get_json(silent=True) or request.form
+    try:
+        participant_id = int(data.get('participant_id'))
+    except (TypeError, ValueError):
+        return jsonify({'success': False, 'error': 'Missing participant.'}), 400
+
+    participant = TransactionParticipant.query.filter_by(
+        id=participant_id,
+        transaction_id=transaction.id,
+        organization_id=current_user.organization_id,
+    ).first()
+    if not participant or participant.role not in SELLER_ROLES:
+        return jsonify({'success': False, 'error': 'Not a seller on this transaction.'}), 400
+
+    access = _active_link_for(transaction, participant.id)
+    if not access:
+        access = ClientPortalAccess(
+            organization_id=current_user.organization_id,
+            transaction_id=transaction.id,
+            participant_id=participant.id,
+            token=ClientPortalAccess.generate_token(),
+            is_active=True,
+        )
+        db.session.add(access)
+        db.session.commit()
+
+    return jsonify({'success': True, 'link': _serialize(participant, access)})
+
+
+@transactions_bp.route('/<int:id>/portal/<int:access_id>/rotate', methods=['POST'])
+@login_required
+@transactions_required
+def portal_rotate_link(id, access_id):
+    """Issue a fresh token, invalidating the old link."""
+    transaction = _get_transaction(id)
+    access = ClientPortalAccess.query.filter_by(
+        id=access_id,
+        transaction_id=transaction.id,
+        organization_id=current_user.organization_id,
+    ).first_or_404()
+    access.token = ClientPortalAccess.generate_token()
+    access.is_active = True
+    access.revoked_at = None
+    access.view_count = 0
+    access.last_viewed_at = None
+    db.session.commit()
+    return jsonify({'success': True, 'link': _serialize(access.participant, access)})
+
+
+@transactions_bp.route('/<int:id>/portal/<int:access_id>/revoke', methods=['POST'])
+@login_required
+@transactions_required
+def portal_revoke_link(id, access_id):
+    """Turn off a portal link. The seller's URL stops working immediately."""
+    from datetime import datetime
+    transaction = _get_transaction(id)
+    access = ClientPortalAccess.query.filter_by(
+        id=access_id,
+        transaction_id=transaction.id,
+        organization_id=current_user.organization_id,
+    ).first_or_404()
+    access.is_active = False
+    access.revoked_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({'success': True, 'participant_id': access.participant_id})

--- a/services/portal_service.py
+++ b/services/portal_service.py
@@ -1,0 +1,602 @@
+"""Client portal view-model builder.
+
+Assembles a single, client-safe projection of a seller's transaction for the
+passwordless portal. Everything the portal template needs is computed here so
+the route stays thin and the template never reaches into agent-only data.
+
+Design rules:
+- Only expose what a seller should see (no internal agent notes, no other
+  parties' contact PII, no commission breakdowns beyond net proceeds).
+- Degrade gracefully: every section renders even when its data is absent.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, date
+
+logger = logging.getLogger(__name__)
+
+SELLER_ROLES = {'seller', 'co_seller'}
+
+# The seller's journey, in order. Each stage maps to data we already store.
+STAGE_DEFS = [
+    ('preparing', 'Getting ready', 'fa-clipboard-check'),
+    ('active', 'Live on the market', 'fa-house'),
+    ('showings', 'Showings & feedback', 'fa-users'),
+    ('offers', 'Reviewing offers', 'fa-file-signature'),
+    ('under_contract', 'Under contract', 'fa-handshake'),
+    ('closing', 'Closing', 'fa-key'),
+    ('closed', 'Sold', 'fa-champagne-glasses'),
+]
+
+# The big editorial sentence shown for the current stage.
+STAGE_STATEMENTS = {
+    'preparing': 'Getting your home ready',
+    'active': 'Live on the market',
+    'showings': 'Buyers are touring your home',
+    'offers': 'Reviewing your offers',
+    'under_contract': 'Under contract',
+    'closing': 'Headed to the closing table',
+    'closed': 'Sold',
+}
+
+ACTIVE_OFFER_STATUSES = {'new', 'reviewing', 'needs_review', 'countered'}
+
+INTEREST_LABELS = {
+    'high': 'Very interested',
+    'medium': 'Somewhat interested',
+    'low': 'Low interest',
+    'none': 'Not interested',
+}
+
+
+# --------------------------------------------------------------------------
+# small formatting helpers
+# --------------------------------------------------------------------------
+
+def _money(value, cents=False):
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if cents:
+        num = num / 100.0
+    return f'${num:,.0f}'
+
+
+def _as_date(value):
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return None
+
+
+def _day(value):
+    d = _as_date(value)
+    return d.strftime('%b %-d') if d else None
+
+
+def _full_day(value):
+    d = _as_date(value)
+    return d.strftime('%A, %B %-d, %Y') if d else None
+
+
+def _initials(first, last):
+    a = (first or '').strip()
+    b = (last or '').strip()
+    out = (a[:1] + b[:1]).upper()
+    return out or 'AG'
+
+
+# --------------------------------------------------------------------------
+# main builder
+# --------------------------------------------------------------------------
+
+def build_portal_context(access):
+    """Build the full client-safe view model from a ClientPortalAccess row."""
+    tx = access.transaction
+    participant = access.participant
+
+    profile = getattr(tx, 'seller_listing_profile', None)
+
+    seller_first = _participant_first_name(participant)
+
+    ctx = {
+        'access': access,
+        'transaction': tx,
+        'participant': participant,
+        'seller_first_name': seller_first,
+        'property': _property_block(tx),
+        'agent': _agent_block(tx),
+        'headline': _headline_block(tx, profile),
+        'updated_label': _updated_label(tx),
+    }
+
+    stages, current_index = _build_stages(tx, profile)
+    ctx['stages'] = stages
+    ctx['current_stage_index'] = current_index
+    ctx['current_stage'] = stages[current_index] if stages else None
+    ctx['headline_statement'] = STAGE_STATEMENTS.get(
+        stages[current_index]['key'] if stages else 'active', 'Live on the market')
+    # Fraction of the journey complete, for the progress rail fill.
+    last = max(len(stages) - 1, 1)
+    ctx['progress_pct'] = round(current_index / last * 100)
+
+    ctx['showings'] = _showings_block(tx)
+    ctx['offers'] = _offers_block(tx)
+    ctx['milestones'] = _milestones_block(tx)
+    ctx['documents'] = _documents_block(tx, participant)
+    ctx['price_changes'] = _price_changes_block(tx)
+    ctx['net_proceeds'] = _net_proceeds_block(tx)
+    ctx['updates'] = _updates_block(tx, participant)
+
+    return ctx
+
+
+def _participant_first_name(participant):
+    if participant.contact and participant.contact.first_name:
+        return participant.contact.first_name
+    name = (participant.name or '').strip()
+    if name:
+        return name.split()[0]
+    return 'there'
+
+
+def _property_block(tx):
+    parts = [p for p in [tx.city, tx.state] if p]
+    locality = ', '.join(parts)
+    if tx.zip_code:
+        locality = f'{locality} {tx.zip_code}'.strip()
+    return {
+        'street': tx.street_address or 'Your property',
+        'locality': locality,
+        'full_address': getattr(tx, 'full_address', None) or tx.street_address,
+        'city': tx.city,
+        'state': tx.state,
+        'zip_code': tx.zip_code,
+    }
+
+
+def _agent_block(tx):
+    agent = getattr(tx, 'created_by', None)
+    org = getattr(tx, 'organization', None) or (agent.organization if agent else None)
+    if not agent:
+        return {
+            'name': (org.name if org else 'Your agent'),
+            'initials': 'AG',
+            'phone': None, 'email': None,
+            'brokerage': org.name if org else None,
+        }
+    full = f'{agent.first_name} {agent.last_name}'.strip()
+    return {
+        'name': full or agent.username,
+        'initials': _initials(agent.first_name, agent.last_name),
+        'phone': agent.phone,
+        'email': agent.email,
+        'brokerage': org.name if org else None,
+        'license_number': agent.license_number,
+    }
+
+
+def _headline_block(tx, profile):
+    list_price = None
+    if profile and profile.current_list_price:
+        list_price = profile.current_list_price
+    original_price = profile.original_list_price if profile else None
+
+    # Days on market: prefer go_live_date, else listing start, else first-active.
+    dom_start = None
+    if profile and profile.go_live_date:
+        dom_start = _as_date(profile.go_live_date)
+    days_on_market = None
+    if dom_start and tx.status in ('active', 'under_contract', 'closed'):
+        days_on_market = max((date.today() - dom_start).days, 0)
+
+    return {
+        'list_price': _money(list_price),
+        'list_price_raw': float(list_price) if list_price else None,
+        'original_price': _money(original_price) if original_price else None,
+        'price_reduced': bool(original_price and list_price and float(original_price) > float(list_price)),
+        'days_on_market': days_on_market,
+        'mls_number': profile.mls_number if profile else None,
+        'status': tx.status,
+        'status_label': _status_label(tx.status),
+    }
+
+
+def _status_label(status):
+    return {
+        'preparing_to_list': 'Preparing to list',
+        'active': 'Active on the market',
+        'under_contract': 'Under contract',
+        'closed': 'Sold',
+        'cancelled': 'Listing paused',
+    }.get(status, (status or '').replace('_', ' ').title())
+
+
+def _updated_label(tx):
+    dt = getattr(tx, 'updated_at', None) or getattr(tx, 'created_at', None)
+    if not dt:
+        return None
+    return dt
+
+
+# --------------------------------------------------------------------------
+# pizza tracker
+# --------------------------------------------------------------------------
+
+def _build_stages(tx, profile):
+    status = tx.status
+    primary_contract = _primary_contract(tx)
+    has_offers = tx.seller_offers.count() > 0 if hasattr(tx.seller_offers, 'count') else False
+    has_showings = tx.seller_showings.count() > 0 if hasattr(tx.seller_showings, 'count') else False
+
+    # Resolve the current stage index from the macro status + signals.
+    if status == 'closed':
+        current = 6
+    elif status == 'under_contract':
+        current = 5 if _in_closing_window(primary_contract) else 4
+    elif status == 'active':
+        if has_offers:
+            current = 3
+        elif has_showings:
+            current = 2
+        else:
+            current = 1
+    elif status == 'cancelled':
+        current = 1
+    else:  # preparing_to_list / unknown
+        current = 0
+
+    # Dates for each stage where we have them.
+    go_live = _as_date(profile.go_live_date) if profile else None
+    first_showing = _first_showing_date(tx)
+    first_offer = _first_offer_date(tx)
+    effective = _as_date(primary_contract.effective_date) if primary_contract else None
+    closing = _as_date(primary_contract.closing_date) if primary_contract else None
+    closed_on = _as_date(getattr(tx, 'actual_close_date', None))
+    stage_dates = {
+        'preparing': _as_date(getattr(tx, 'created_at', None)),
+        'active': go_live,
+        'showings': first_showing,
+        'offers': first_offer,
+        'under_contract': effective,
+        'closing': closing,
+        'closed': closed_on or closing,
+    }
+
+    stages = []
+    for idx, (key, label, icon) in enumerate(STAGE_DEFS):
+        if idx < current:
+            state = 'done'
+        elif idx == current:
+            state = 'current'
+        else:
+            state = 'upcoming'
+        stages.append({
+            'key': key,
+            'label': label,
+            'icon': icon,
+            'state': state,
+            'date': _day(stage_dates.get(key)),
+            'index': idx,
+        })
+    return stages, current
+
+
+def _in_closing_window(contract):
+    if not contract or not contract.closing_date:
+        return False
+    closing = _as_date(contract.closing_date)
+    if not closing:
+        return False
+    return (closing - date.today()).days <= 14
+
+
+def _primary_contract(tx):
+    try:
+        return tx.seller_accepted_contracts.filter_by(
+            position='primary', status='active').first() \
+            or tx.seller_accepted_contracts.filter_by(position='primary').first() \
+            or tx.seller_accepted_contracts.first()
+    except Exception:
+        return None
+
+
+def _first_showing_date(tx):
+    try:
+        s = tx.seller_showings.order_by('scheduled_start_at').first()
+        return _as_date(s.scheduled_start_at) if s else None
+    except Exception:
+        return None
+
+
+def _first_offer_date(tx):
+    try:
+        o = tx.seller_offers.order_by('created_at').first()
+        return _as_date(o.created_at) if o else None
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------
+# showings & feedback
+# --------------------------------------------------------------------------
+
+def _showings_block(tx):
+    try:
+        from models import SellerShowing
+        showings = tx.seller_showings.order_by(
+            SellerShowing.scheduled_start_at.desc()
+        ).all()
+    except Exception:
+        try:
+            showings = sorted(
+                tx.seller_showings.all(),
+                key=lambda s: s.scheduled_start_at or datetime.min,
+                reverse=True,
+            )
+        except Exception:
+            showings = []
+
+    now = datetime.utcnow()
+    week_ago = now.timestamp() - 7 * 86400
+    items = []
+    with_feedback = 0
+    this_week = 0
+    interest_counts = {'high': 0, 'medium': 0, 'low': 0, 'none': 0}
+
+    for s in showings:
+        start = s.scheduled_start_at
+        has_fb = bool(getattr(s, 'feedback_received_at', None) or getattr(s, 'feedback_notes', None)
+                      or getattr(s, 'feedback_interest_level', None))
+        if has_fb:
+            with_feedback += 1
+        if start and start.timestamp() >= week_ago:
+            this_week += 1
+        lvl = getattr(s, 'feedback_interest_level', None)
+        if lvl in interest_counts:
+            interest_counts[lvl] += 1
+        items.append({
+            'date': start.strftime('%a, %b %-d') if start else 'Scheduled',
+            'time': start.strftime('%-I:%M %p') if start else None,
+            'status': (s.status or 'scheduled').replace('_', ' ').title(),
+            'agent_brokerage': getattr(s, 'showing_agent_brokerage', None),
+            'has_feedback': has_fb,
+            'interest': INTEREST_LABELS.get(lvl) if lvl else None,
+            'interest_level': lvl,
+            'feedback_notes': getattr(s, 'feedback_notes', None),
+            'price_opinion': getattr(s, 'feedback_price_opinion', None),
+        })
+
+    return {
+        'items': items,
+        'total': len(items),
+        'this_week': this_week,
+        'with_feedback': with_feedback,
+        'interest_counts': interest_counts,
+    }
+
+
+# --------------------------------------------------------------------------
+# offers
+# --------------------------------------------------------------------------
+
+def _offers_block(tx):
+    try:
+        from services.seller_workflow import offer_urgency
+    except Exception:
+        offer_urgency = None
+
+    try:
+        offers = tx.seller_offers.order_by('created_at').all()
+    except Exception:
+        offers = []
+
+    items = []
+    active_count = 0
+    for idx, o in enumerate(offers, start=1):
+        is_active = (o.status in ACTIVE_OFFER_STATUSES)
+        if is_active:
+            active_count += 1
+        urgency = None
+        if offer_urgency:
+            try:
+                urgency = offer_urgency(o)
+            except Exception:
+                urgency = None
+        items.append({
+            'label': f'Offer {idx}',
+            'price': _money(o.offer_price),
+            'price_raw': float(o.offer_price) if o.offer_price else None,
+            'financing': (o.financing_type or '').replace('_', ' ').title() or None,
+            'earnest': _money(getattr(o, 'earnest_money', None)),
+            'option_days': getattr(o, 'option_period_days', None),
+            'close_date': _day(getattr(o, 'proposed_close_date', None)),
+            'status': _offer_status_label(o.status),
+            'status_key': o.status,
+            'is_active': is_active,
+            'is_accepted': o.status in ('accepted_primary', 'accepted_backup'),
+            'urgency': urgency,
+            'net_to_seller': _money(getattr(o, 'net_to_seller_estimate', None)),
+        })
+
+    return {
+        'items': items,
+        'total': len(items),
+        'active_count': active_count,
+        'has_accepted': any(i['is_accepted'] for i in items),
+    }
+
+
+def _offer_status_label(status):
+    return {
+        'new': 'New',
+        'needs_review': 'In review',
+        'reviewing': 'In review',
+        'countered': 'Countered',
+        'accepted_primary': 'Accepted',
+        'accepted_backup': 'Accepted (backup)',
+        'declined': 'Declined',
+        'withdrawn': 'Withdrawn',
+        'expired': 'Expired',
+    }.get(status, (status or '').replace('_', ' ').title())
+
+
+# --------------------------------------------------------------------------
+# milestones (under contract)
+# --------------------------------------------------------------------------
+
+def _milestones_block(tx):
+    contract = _primary_contract(tx)
+    if not contract:
+        return {'items': [], 'next': None}
+    try:
+        milestones = contract.milestones.order_by('due_at').all()
+    except Exception:
+        try:
+            milestones = sorted(contract.milestones.all(),
+                                key=lambda m: (m.due_at or datetime.max))
+        except Exception:
+            milestones = []
+
+    today = date.today()
+    items = []
+    next_item = None
+    for m in milestones:
+        due = _as_date(m.due_at)
+        status = m.status or 'not_started'
+        done = status == 'completed'
+        na = status == 'not_applicable'
+        # Derive due_soon/overdue client-side (server stores these manually only).
+        derived = status
+        if not done and not na and due:
+            delta = (due - today).days
+            if delta < 0:
+                derived = 'overdue'
+            elif delta <= 5:
+                derived = 'due_soon'
+        item = {
+            'title': m.title,
+            'due': _full_day(m.due_at),
+            'due_short': _day(m.due_at),
+            'status': derived,
+            'done': done,
+            'not_applicable': na,
+        }
+        items.append(item)
+        if next_item is None and not done and not na and due and due >= today:
+            next_item = item
+
+    return {'items': items, 'next': next_item}
+
+
+# --------------------------------------------------------------------------
+# documents
+# --------------------------------------------------------------------------
+
+def _documents_block(tx, participant):
+    email = (participant.display_email or '').strip().lower()
+    needs = []
+    completed = []
+    try:
+        docs = tx.documents.all()
+    except Exception:
+        docs = []
+
+    for doc in docs:
+        try:
+            sigs = doc.signatures.all()
+        except Exception:
+            sigs = []
+        mine = [s for s in sigs if (s.signer_email or '').strip().lower() == email]
+        name = doc.template_name or (doc.template_slug or 'Document').replace('-', ' ').title()
+
+        if doc.status == 'signed':
+            # Only show completed docs the client was a party to (or all signed
+            # docs on their transaction if we can't tell).
+            if mine or not sigs:
+                completed.append({
+                    'name': name,
+                    'doc_id': doc.id,
+                    'signed_on': _day(getattr(doc, 'signed_at', None)),
+                    'can_view': bool(getattr(doc, 'signed_file_path', None)),
+                })
+        elif doc.status == 'sent' and mine:
+            pending = [s for s in mine if s.status in ('sent', 'viewed')]
+            if pending:
+                slug = pending[0].docuseal_submitter_slug
+                needs.append({
+                    'name': name,
+                    'doc_id': doc.id,
+                    'submitter_slug': slug,
+                    'sign_url': f'https://docuseal.com/s/{slug}' if slug else None,
+                    'viewed': any(s.status == 'viewed' for s in pending),
+                })
+
+    return {
+        'needs_signature': needs,
+        'completed': completed,
+        'needs_count': len(needs),
+        'completed_count': len(completed),
+    }
+
+
+# --------------------------------------------------------------------------
+# price changes / net proceeds / updates
+# --------------------------------------------------------------------------
+
+def _price_changes_block(tx):
+    try:
+        changes = tx.seller_price_changes.order_by('changed_at').all()
+    except Exception:
+        changes = []
+    out = []
+    for c in changes:
+        out.append({
+            'old': _money(c.old_price),
+            'new': _money(c.new_price),
+            'date': _day(getattr(c, 'changed_at', None)),
+            'reason': c.reason,
+        })
+    return out
+
+
+def _net_proceeds_block(tx):
+    # Closed: use the closing summary's final net. Under contract: the accepted
+    # offer's estimate. Either way this is a number the seller should see.
+    contract = _primary_contract(tx)
+    if contract:
+        summary = getattr(contract, 'closing_summary', None)
+        if summary and summary.final_net_proceeds:
+            return {'label': 'Net proceeds', 'value': _money(summary.final_net_proceeds), 'estimate': False}
+        offer = getattr(contract, 'offer', None)
+        if offer and getattr(offer, 'net_to_seller_estimate', None):
+            return {'label': 'Estimated net proceeds', 'value': _money(offer.net_to_seller_estimate), 'estimate': True}
+    return None
+
+
+def _updates_block(tx, participant):
+    try:
+        from models import PortalMessage
+        msgs = PortalMessage.query.filter_by(
+            transaction_id=tx.id,
+            participant_id=participant.id,
+            kind='update',
+        ).order_by(PortalMessage.created_at.desc()).limit(10).all()
+    except Exception:
+        msgs = []
+    out = []
+    for m in msgs:
+        author = getattr(m, 'author', None)
+        out.append({
+            'body': m.body,
+            'date': _day(getattr(m, 'created_at', None)),
+            'author': (f'{author.first_name}' if author else 'Your agent'),
+        })
+    return out

--- a/static/css/portal.css
+++ b/static/css/portal.css
@@ -1,0 +1,472 @@
+/* =========================================================================
+   Origen Client Portal
+   A clean, app-style private dashboard for one listing. System type, a light
+   neutral page, white bordered cards with clear section headers, and the
+   shared orange accent. Structured and scannable, not decorative.
+   Mobile-first. Prefix: .pp-
+   ========================================================================= */
+
+:root {
+  /* Neutral app surfaces — cool slate, aligned with the CRM shell */
+  --pp-page:      #f4f5f7;
+  --pp-surface:   #ffffff;
+  --pp-surface-2: #f8fafc;
+  --pp-ink:       #0f172a;
+  --pp-ink-2:     #334155;
+  --pp-muted:     #64748b;
+  --pp-faint:     #94a3b8;
+  --pp-line:      #e6e8ec;
+  --pp-line-2:    #dde0e6;
+  --pp-dark:      #0f172a;
+
+  /* Brand orange */
+  --pp-accent:      #f97316;
+  --pp-accent-deep: #ea580c;
+  --pp-accent-soft: #fff3e9;
+  --pp-accent-ring: rgba(249, 115, 22, 0.18);
+
+  --pp-green:      #16a34a;
+  --pp-green-soft: #e9f7ee;
+
+  /* 4pt-based spacing scale */
+  --s1: 4px;  --s2: 8px;  --s3: 12px; --s4: 16px;
+  --s5: 20px; --s6: 28px; --s7: 40px; --s8: 64px;
+
+  --radius:    12px;
+  --radius-sm: 9px;
+
+  --pp-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
+             "Helvetica Neue", Arial, sans-serif;
+
+  --pp-maxw: 760px;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body.pp {
+  font-family: var(--pp-sans);
+  background: var(--pp-page);
+  color: var(--pp-ink);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.pp a { color: inherit; text-decoration: none; }
+.pp button { font-family: inherit; }
+.pp ::selection { background: var(--pp-accent); color: #fff; }
+
+/* A clean bold sans for headline moments (was a serif display) */
+.pp-display {
+  font-family: var(--pp-sans);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ------------------------------------------------------------- masthead */
+
+.pp-bar {
+  position: sticky; top: 0; z-index: 40;
+  background: color-mix(in srgb, var(--pp-surface) 88%, transparent);
+  backdrop-filter: saturate(140%) blur(12px);
+  -webkit-backdrop-filter: saturate(140%) blur(12px);
+  border-bottom: 1px solid var(--pp-line);
+  padding-top: env(safe-area-inset-top);
+}
+.pp-bar__inner {
+  max-width: var(--pp-maxw); margin: 0 auto;
+  padding: 13px var(--s5);
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+}
+.pp-brand {
+  font-size: 12px; font-weight: 700; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--pp-ink);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pp-bar__links { display: flex; gap: var(--s2); flex: none; }
+.pp-link {
+  font-size: 13px; font-weight: 600;
+  color: var(--pp-ink-2);
+  padding: 6px 12px; border-radius: 8px;
+  border: 1px solid var(--pp-line-2);
+  background: var(--pp-surface);
+  transition: border-color .15s ease, color .15s ease, background .15s ease;
+}
+.pp-link:hover { color: var(--pp-ink); border-color: var(--pp-faint); background: var(--pp-surface-2); }
+
+/* --------------------------------------------------------------- shell */
+
+.pp-doc { max-width: var(--pp-maxw); margin: 0 auto; padding: var(--s5) var(--s4) var(--s8); }
+
+.pp-eyebrow {
+  font-size: 11px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--pp-muted);
+}
+
+/* ----------------------------------------------------------------- hero */
+
+.pp-hero {
+  background: var(--pp-surface);
+  border: 1px solid var(--pp-line);
+  border-radius: var(--radius);
+  padding: var(--s6);
+}
+.pp-hero__addr {
+  font-size: clamp(26px, 6vw, 36px);
+  line-height: 1.08;
+  margin: var(--s2) 0 0;
+  color: var(--pp-ink);
+}
+.pp-hero__loc { margin-top: var(--s2); font-size: 14px; color: var(--pp-muted); }
+
+.pp-status {
+  display: inline-flex; align-items: center; gap: 8px;
+  margin-top: var(--s4);
+  font-size: 13px; font-weight: 700; letter-spacing: .02em;
+  color: var(--pp-accent-deep);
+}
+.pp-live {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--pp-accent); position: relative; flex: none;
+}
+.pp-live--sold { background: var(--pp-green); }
+.pp-live--paused { background: var(--pp-faint); }
+@media (prefers-reduced-motion: no-preference) {
+  .pp-live::after {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: inherit; animation: pp-ping 2.6s cubic-bezier(.2,.6,.3,1) infinite;
+  }
+  @keyframes pp-ping { 0% { transform: scale(1); opacity: .5; }
+    70%,100% { transform: scale(2.6); opacity: 0; } }
+}
+
+.pp-specs {
+  display: flex; flex-direction: column;
+  margin-top: var(--s5);
+  border-top: 1px solid var(--pp-line);
+  padding-top: var(--s5);
+}
+.pp-spec { display: flex; flex-direction: column; min-width: 0; }
+.pp-spec + .pp-spec {
+  margin-top: var(--s4); padding-top: var(--s4);
+  border-top: 1px solid var(--pp-line);
+}
+@media (min-width: 480px) {
+  .pp-specs { flex-direction: row; align-items: flex-start; }
+  .pp-spec { padding-right: var(--s6); }
+  .pp-spec + .pp-spec {
+    margin-top: 0; padding-top: 0; border-top: 0;
+    padding-left: var(--s6); border-left: 1px solid var(--pp-line);
+  }
+}
+.pp-spec__v {
+  font-size: 24px; font-weight: 700; letter-spacing: -0.02em;
+  color: var(--pp-ink); font-variant-numeric: tabular-nums;
+}
+.pp-spec__v .pp-was {
+  font-size: 13px; font-weight: 500; color: var(--pp-faint);
+  text-decoration: line-through; margin-left: 7px; letter-spacing: 0;
+}
+.pp-spec__l {
+  font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
+  color: var(--pp-muted); margin-top: 5px; font-weight: 650;
+}
+
+/* --------------------------------------------------------------- section */
+
+.pp-sec {
+  margin-top: var(--s4);
+  background: var(--pp-surface);
+  border: 1px solid var(--pp-line);
+  border-radius: var(--radius);
+  padding: var(--s5) var(--s6);
+}
+.pp-sec > .pp-eyebrow { display: block; margin-bottom: var(--s1); }
+.pp-sec__head {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+}
+.pp-sec__title {
+  font-size: 18px; font-weight: 650; letter-spacing: -0.01em;
+  margin: 0; color: var(--pp-ink);
+}
+.pp-sec .pp-eyebrow + .pp-sec__title { margin-top: 2px; }
+.pp-sec__count {
+  font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--pp-muted); font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+
+/* Emphasised "action needed" section */
+.pp-sec--action {
+  background: var(--pp-accent-soft);
+  border-color: color-mix(in srgb, var(--pp-accent) 26%, transparent);
+}
+
+/* --------------------------------------------------------------- tracker */
+
+.pp-statement {
+  font-size: 17px; font-weight: 600; line-height: 1.35;
+  letter-spacing: -0.005em;
+  margin: 4px 0 0; color: var(--pp-ink);
+}
+.pp-track-meta {
+  margin-top: var(--s3); font-size: 12px; color: var(--pp-muted);
+  letter-spacing: .01em; font-variant-numeric: tabular-nums;
+}
+.pp-track-meta b { color: var(--pp-accent-deep); font-weight: 700; }
+
+.pp-rail { position: relative; height: 3px; border-radius: 3px;
+  background: var(--pp-line-2);
+  margin: var(--s5) 0 var(--s6); }
+.pp-rail__fill {
+  position: absolute; left: 0; top: 0; height: 100%; width: 100%;
+  border-radius: 3px;
+  background: var(--pp-accent); transform-origin: left center;
+  transform: scaleX(var(--p, 0));
+}
+@media (prefers-reduced-motion: no-preference) {
+  .pp-rail__fill { animation: pp-fill 1s .2s cubic-bezier(.22,.61,.36,1) both; }
+  @keyframes pp-fill { from { transform: scaleX(0); } to { transform: scaleX(var(--p,0)); } }
+}
+.pp-rail__tick {
+  position: absolute; top: 50%; width: 9px; height: 9px; border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--pp-surface); border: 2px solid var(--pp-line-2);
+}
+.pp-rail__tick.is-done { background: var(--pp-accent); border-color: var(--pp-accent); }
+.pp-rail__tick.is-current {
+  width: 14px; height: 14px; background: var(--pp-accent);
+  border-color: var(--pp-surface); box-shadow: 0 0 0 3px var(--pp-accent);
+}
+
+.pp-stages { list-style: none; margin: 0; padding: 0; }
+.pp-stage {
+  display: flex; align-items: center; gap: var(--s3);
+  padding: 12px 0; border-top: 1px solid var(--pp-line);
+}
+.pp-stage:first-child { border-top: 0; }
+.pp-stage__dot {
+  width: 8px; height: 8px; border-radius: 50%; flex: none;
+  background: var(--pp-faint);
+}
+.pp-stage.is-done .pp-stage__dot { background: var(--pp-accent); }
+.pp-stage.is-current .pp-stage__dot {
+  background: var(--pp-accent); box-shadow: 0 0 0 3px var(--pp-accent-ring);
+}
+.pp-stage__name { font-size: 15px; font-weight: 500; color: var(--pp-ink-2); }
+.pp-stage.is-current .pp-stage__name { color: var(--pp-ink); font-weight: 650; }
+.pp-stage.is-upcoming .pp-stage__name { color: var(--pp-faint); font-weight: 450; }
+.pp-stage__here {
+  display: inline-block;
+  font-size: 10px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--pp-accent-deep); margin-left: 10px;
+  vertical-align: middle;
+}
+.pp-stage__date {
+  margin-left: auto; font-size: 12.5px; color: var(--pp-muted);
+  font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+
+/* --------------------------------------------------------- sign / action */
+
+.pp-action {
+  margin-top: var(--s4); padding: var(--s4) var(--s5);
+  background: var(--pp-surface); border: 1px solid color-mix(in srgb, var(--pp-accent) 24%, transparent);
+  border-radius: var(--radius-sm);
+}
+.pp-action:first-of-type { margin-top: 0; }
+.pp-action + .pp-action { margin-top: var(--s3); }
+.pp-action__row { display: flex; align-items: center; gap: var(--s4); flex-wrap: wrap; }
+.pp-action__main { flex: 1; min-width: 0; }
+.pp-action__title { font-weight: 650; font-size: 15px; color: var(--pp-ink); }
+.pp-action__sub { font-size: 13px; color: var(--pp-accent-deep); margin-top: 2px; }
+
+/* --------------------------------------------------------- showings */
+
+.pp-bigstat { font-size: 15px; color: var(--pp-ink-2); margin-top: var(--s3); }
+.pp-bigstat b { color: var(--pp-ink); font-weight: 700; }
+
+.pp-quote {
+  margin: 0; padding: var(--s4) var(--s5);
+  background: var(--pp-surface-2);
+  border: 1px solid var(--pp-line);
+  border-radius: var(--radius-sm);
+}
+.pp-quote + .pp-quote { margin-top: var(--s3); }
+.pp-quote__text {
+  font-size: 15px; line-height: 1.6; color: var(--pp-ink);
+}
+.pp-quote__by {
+  margin-top: var(--s3); padding-top: var(--s3);
+  border-top: 1px solid var(--pp-line);
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 4px var(--s4); flex-wrap: wrap;
+  font-size: 12px; color: var(--pp-muted); font-weight: 550;
+}
+.pp-quote__by > span:first-child { min-width: 0; }
+.pp-int {
+  flex: none; white-space: nowrap;
+  font-weight: 700; letter-spacing: .06em; text-transform: uppercase; font-size: 11px;
+}
+.pp-int--high { color: var(--pp-green); }
+.pp-int--medium { color: var(--pp-ink-2); }
+.pp-int--low, .pp-int--none { color: var(--pp-faint); }
+
+.pp-line-item {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+  padding: var(--s3) 0; border-top: 1px solid var(--pp-line);
+}
+.pp-line-item:first-of-type { border-top: 0; }
+.pp-li__date { font-weight: 600; font-size: 14px; color: var(--pp-ink); }
+.pp-li__sub { font-size: 12.5px; color: var(--pp-muted); margin-top: 2px; }
+
+/* --------------------------------------------------------- offers */
+
+.pp-offer {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+  padding: var(--s4) 0; border-top: 1px solid var(--pp-line);
+}
+.pp-offer:first-of-type { border-top: 0; }
+.pp-offer__price { font-size: 20px; font-weight: 700; letter-spacing: -0.02em;
+  color: var(--pp-ink); font-variant-numeric: tabular-nums; }
+.pp-offer__terms { font-size: 12.5px; color: var(--pp-muted); margin-top: 3px; }
+.pp-label {
+  font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--pp-muted); white-space: nowrap;
+}
+.pp-label--accent { color: var(--pp-accent-deep); }
+.pp-label--green  { color: var(--pp-green); }
+
+/* --------------------------------------------------------- proceeds (dark) */
+
+.pp-proceeds {
+  margin-top: var(--s4); padding: var(--s6);
+  background: var(--pp-dark); color: #f8fafc;
+  border-radius: var(--radius);
+}
+.pp-proceeds__l {
+  font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  color: color-mix(in srgb, #f8fafc 60%, transparent);
+}
+.pp-proceeds__v {
+  font-weight: 700; font-size: clamp(32px, 9vw, 46px);
+  line-height: 1.05; margin-top: var(--s2); letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+.pp-proceeds__note {
+  margin-top: var(--s3); font-size: 12.5px;
+  color: color-mix(in srgb, #f8fafc 60%, transparent);
+}
+
+/* --------------------------------------------------------- documents */
+
+.pp-doc-item {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+  padding: var(--s3) 0; border-top: 1px solid var(--pp-line);
+}
+.pp-doc-item:first-of-type { border-top: 0; }
+.pp-doc-name { font-weight: 600; font-size: 14px; color: var(--pp-ink); }
+.pp-doc-sub { font-size: 12.5px; color: var(--pp-muted); margin-top: 2px; }
+
+/* --------------------------------------------------------- updates */
+
+.pp-update { padding: var(--s4) 0; border-top: 1px solid var(--pp-line); }
+.pp-update:first-of-type { border-top: 0; }
+.pp-update__meta { font-size: 11.5px; text-transform: uppercase; letter-spacing: .06em;
+  color: var(--pp-muted); font-weight: 650; }
+.pp-update__body { margin-top: var(--s2); font-size: 14.5px; line-height: 1.55;
+  color: var(--pp-ink-2); white-space: pre-wrap; }
+
+/* --------------------------------------------------------- compose */
+
+.pp-compose { margin-top: var(--s4); }
+.pp-textarea {
+  width: 100%; resize: vertical; min-height: 104px;
+  font-family: inherit; font-size: 15px; color: var(--pp-ink);
+  padding: var(--s3) var(--s4); border-radius: var(--radius-sm);
+  background: var(--pp-surface); border: 1px solid var(--pp-line-2);
+  margin-bottom: var(--s3); line-height: 1.5;
+}
+.pp-textarea::placeholder { color: var(--pp-faint); }
+.pp-textarea:focus { outline: none; border-color: var(--pp-accent);
+  box-shadow: 0 0 0 3px var(--pp-accent-ring); }
+
+/* --------------------------------------------------------- buttons */
+
+.pp-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-size: 14px; font-weight: 650;
+  padding: 10px 18px; border-radius: var(--radius-sm); border: 1px solid transparent;
+  cursor: pointer; transition: background .15s ease, border-color .15s ease, transform .12s ease;
+}
+.pp-btn:active { transform: scale(.99); }
+.pp-btn--block { width: 100%; }
+.pp-btn--primary { background: var(--pp-accent); color: #fff; }
+.pp-btn--primary:hover { background: var(--pp-accent-deep); }
+.pp-btn--ink { background: var(--pp-dark); color: #fff; }
+.pp-btn--ink:hover { background: #1e293b; }
+.pp-btn--ghost { background: var(--pp-surface); color: var(--pp-ink);
+  border-color: var(--pp-line-2); }
+.pp-btn--ghost:hover { border-color: var(--pp-faint); background: var(--pp-surface-2); }
+.pp-btn--sm { padding: 8px 13px; font-size: 13px; }
+
+/* --------------------------------------------------------- empty */
+
+.pp-empty { padding: var(--s4) 0; }
+.pp-empty p { margin: 0; font-size: 14px; color: var(--pp-muted); line-height: 1.5; }
+
+/* --------------------------------------------------------- footer */
+
+.pp-foot { margin-top: var(--s6); padding: var(--s5) var(--s6);
+  text-align: center; }
+.pp-foot__agent { font-size: 14px; color: var(--pp-ink-2); }
+.pp-foot__agent b { font-weight: 650; color: var(--pp-ink); }
+.pp-foot__contact { margin-top: var(--s2); font-size: 13px; color: var(--pp-muted); }
+.pp-foot__note { margin-top: var(--s4); font-size: 12px; color: var(--pp-faint);
+  line-height: 1.5; }
+.pp-foot__brand { margin-top: var(--s3); font-size: 11px; font-weight: 700;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--pp-muted); }
+
+/* --------------------------------------------------------- flash */
+
+.pp-flash { max-width: var(--pp-maxw); margin: var(--s4) auto 0; padding: 0 var(--s4); }
+.pp-flash__item {
+  border-radius: var(--radius-sm); padding: 11px 15px; font-size: 14px; font-weight: 550;
+  display: flex; align-items: center; gap: 10px;
+  background: var(--pp-surface); border: 1px solid var(--pp-line-2);
+}
+.pp-flash__item.success { color: var(--pp-green); border-color: color-mix(in srgb, var(--pp-green) 30%, transparent); background: var(--pp-green-soft); }
+.pp-flash__item.error { color: var(--pp-accent-deep); border-color: color-mix(in srgb, var(--pp-accent) 30%, transparent); background: var(--pp-accent-soft); }
+
+/* --------------------------------------------------------- reveal */
+
+@media (prefers-reduced-motion: no-preference) {
+  .pp-reveal { opacity: 0; transform: translateY(10px);
+    animation: pp-rise .5s cubic-bezier(.16,.7,.3,1) forwards; }
+  @keyframes pp-rise { to { opacity: 1; transform: none; } }
+}
+
+/* --------------------------------------------------------- sign page */
+
+.pp-sign-wrap { max-width: 960px; margin: 0 auto; padding: var(--s5) var(--s4); }
+.pp-back { display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px; font-weight: 600;
+  color: var(--pp-muted); margin-bottom: var(--s4); }
+.pp-back:hover { color: var(--pp-ink); }
+.pp-sign-title { font-size: clamp(22px, 5vw, 28px); line-height: 1.15;
+  letter-spacing: -0.02em; margin: 0 0 4px; font-weight: 700; color: var(--pp-ink); }
+.pp-note { font-size: 14px; color: var(--pp-muted); margin: 0; }
+.pp-sign-frame { background: #fff; border: 1px solid var(--pp-line-2);
+  border-radius: var(--radius); overflow: hidden; }
+
+/* --------------------------------------------------------- invalid */
+
+.pp-center { min-height: 100vh; min-height: 100dvh; display: grid; place-items: center;
+  padding: var(--s6); text-align: center; }
+.pp-center__box { max-width: 400px; background: var(--pp-surface);
+  border: 1px solid var(--pp-line); border-radius: var(--radius); padding: var(--s7) var(--s6); }
+.pp-center__mark { font-size: 40px; color: var(--pp-faint); margin-bottom: var(--s3); }
+.pp-center h1 { font-weight: 700; font-size: 22px;
+  margin: 0 0 var(--s2); letter-spacing: -0.01em; color: var(--pp-ink); }
+.pp-center p { color: var(--pp-muted); font-size: 14.5px; margin: 0; line-height: 1.55; }

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="#f4f5f7">
+    <meta name="robots" content="noindex, nofollow">
+    <title>{% block title %}Your listing{% endblock %}</title>
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/fontawesome/css/all.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/portal.css') }}">
+    {% block head_extra %}{% endblock %}
+</head>
+<body class="pp">
+    {% block body %}{% endblock %}
+
+    <script>
+      // Masthead hairline appears only once you leave the top.
+      (function () {
+        var bar = document.querySelector('[data-bar]');
+        if (bar) {
+          var onScroll = function () {
+            bar.classList.toggle('is-stuck', window.scrollY > 8);
+          };
+          onScroll();
+          window.addEventListener('scroll', onScroll, { passive: true });
+        }
+        // Staggered reveal — gentle, slow, reduced-motion aware.
+        if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+        document.querySelectorAll('[data-reveal]').forEach(function (el, i) {
+          el.classList.add('pp-reveal');
+          el.style.animationDelay = Math.min(i * 90, 720) + 'ms';
+        });
+      })();
+    </script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/portal/invalid.html
+++ b/templates/portal/invalid.html
@@ -1,0 +1,12 @@
+{% extends "portal/base.html" %}
+{% block title %}Link unavailable{% endblock %}
+
+{% block body %}
+<div class="pp-center">
+  <div class="pp-center__box">
+    <div class="pp-center__mark">&hellip;</div>
+    <h1>This link isn&rsquo;t active</h1>
+    <p>It may have expired or been turned off. Reach out to your agent and they can send you a fresh one.</p>
+  </div>
+</div>
+{% endblock %}

--- a/templates/portal/show.html
+++ b/templates/portal/show.html
@@ -1,0 +1,292 @@
+{% extends "portal/base.html" %}
+{% block title %}{{ property.street }}{% endblock %}
+
+{% block body %}
+<header class="pp-bar" data-bar>
+  <div class="pp-bar__inner">
+    <div class="pp-brand">{{ agent.brokerage or 'Origen' }}</div>
+    <nav class="pp-bar__links">
+      {% if agent.phone %}<a class="pp-link" href="tel:{{ agent.phone }}">Call</a>
+      <a class="pp-link" href="sms:{{ agent.phone }}">Text</a>{% endif %}
+      {% if agent.email %}<a class="pp-link" href="mailto:{{ agent.email }}">Email</a>{% endif %}
+    </nav>
+  </div>
+</header>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  <div class="pp-flash">
+    {% for category, message in messages %}
+      <div class="pp-flash__item {{ category }}">
+        <i class="fas {{ 'fa-circle-check' if category == 'success' else 'fa-circle-exclamation' }}"></i>
+        <span>{{ message }}</span>
+      </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endwith %}
+
+<main class="pp-doc">
+
+  {# ----------------------------------------------------------------- hero #}
+  <section class="pp-hero" data-reveal>
+    <div class="pp-eyebrow">{{ property.locality or 'Your listing' }}{% if headline.mls_number %} &middot; MLS {{ headline.mls_number }}{% endif %}</div>
+    <h1 class="pp-display pp-hero__addr">{{ property.street }}</h1>
+
+    <div class="pp-status">
+      {% if headline.status == 'closed' %}<span class="pp-live pp-live--sold"></span>
+      {% elif headline.status == 'cancelled' %}<span class="pp-live pp-live--paused"></span>
+      {% else %}<span class="pp-live"></span>{% endif %}
+      {{ headline.status_label }}
+    </div>
+
+    {% if headline.list_price or headline.days_on_market is not none %}
+    <div class="pp-specs">
+      {% if headline.list_price %}
+      <div class="pp-spec">
+        <div class="pp-spec__v">{{ headline.list_price }}{% if headline.price_reduced %}<span class="pp-was">{{ headline.original_price }}</span>{% endif %}</div>
+        <div class="pp-spec__l">{{ 'Sold price' if headline.status == 'closed' else 'List price' }}</div>
+      </div>
+      {% endif %}
+      {% if headline.days_on_market is not none %}
+      <div class="pp-spec">
+        <div class="pp-spec__v">{{ headline.days_on_market }}</div>
+        <div class="pp-spec__l">Days listed</div>
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+  </section>
+
+  {# -------------------------------------------------------------- tracker #}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-eyebrow">Where we are</div>
+    <h2 class="pp-display pp-statement">{{ headline_statement }}</h2>
+    {% if current_stage %}
+    <div class="pp-track-meta">Step <b>{{ current_stage.index + 1 }}</b> of {{ stages|length }}</div>
+    {% endif %}
+
+    <div class="pp-rail">
+      <div class="pp-rail__fill" style="--p: {{ '%.4f'|format(progress_pct / 100) }};"></div>
+      {% for stage in stages %}
+      <span class="pp-rail__tick is-{{ stage.state }}"
+            style="left: {{ '%.2f'|format(loop.index0 / (stages|length - 1) * 100) }}%;"></span>
+      {% endfor %}
+    </div>
+
+    <ol class="pp-stages">
+      {% for stage in stages %}
+      <li class="pp-stage is-{{ stage.state }}">
+        <span class="pp-stage__dot"></span>
+        <span class="pp-stage__name">{{ stage.label }}{% if stage.state == 'current' %}<span class="pp-stage__here">You are here</span>{% endif %}</span>
+        {% if stage.date %}<span class="pp-stage__date">{{ stage.date }}</span>{% endif %}
+      </li>
+      {% endfor %}
+    </ol>
+  </section>
+
+  {# --------------------------------------------------- needs signature #}
+  {% if documents.needs_signature %}
+  <section class="pp-sec pp-sec--action" data-reveal>
+    <div class="pp-sec__head">
+      <div>
+        <div class="pp-eyebrow">Action needed</div>
+        <h2 class="pp-sec__title">Ready for your signature</h2>
+      </div>
+      <span class="pp-sec__count">{{ documents.needs_count }}</span>
+    </div>
+    {% for doc in documents.needs_signature %}
+    <div class="pp-action">
+      <div class="pp-action__row">
+        <div class="pp-action__main">
+          <div class="pp-action__title">{{ doc.name }}</div>
+          <div class="pp-action__sub">{{ 'Opened — not yet signed' if doc.viewed else 'Waiting for you' }}</div>
+        </div>
+        {% if doc.submitter_slug %}
+        <a class="pp-btn pp-btn--primary pp-btn--sm" href="{{ url_for('portal.sign_document', token=token, doc_id=doc.doc_id) }}">
+          <i class="fas fa-signature"></i> Review &amp; sign
+        </a>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  {# ----------------------------------------------- showings & feedback #}
+  {% if headline.status in ['active', 'under_contract', 'closed'] %}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-eyebrow">Interest</div>
+    <h2 class="pp-sec__title">Showings &amp; feedback</h2>
+    {% if showings.total %}
+      <div class="pp-bigstat">
+        <b>{{ showings.total }}</b> showing{{ '' if showings.total == 1 else 's' }}{% if showings.this_week %} &middot; <b>{{ showings.this_week }}</b> this week{% endif %}{% if showings.with_feedback %} &middot; <b>{{ showings.with_feedback }}</b> shared feedback{% endif %}
+      </div>
+
+      {% set quotes = showings['items'] | selectattr('feedback_notes') | list %}
+      {% if quotes %}
+        <div style="margin-top: var(--s5);">
+        {% for s in quotes[:5] %}
+        <blockquote class="pp-quote">
+          <div class="pp-quote__text">&ldquo;{{ s.feedback_notes }}&rdquo;</div>
+          <div class="pp-quote__by">
+            <span>{{ s.agent_brokerage or 'Buyer' }} &middot; {{ s.date }}</span>
+            {% if s.interest_level %}<span class="pp-int pp-int--{{ s.interest_level }}">{{ s.interest }}</span>{% endif %}
+          </div>
+        </blockquote>
+        {% endfor %}
+        </div>
+      {% else %}
+        <div style="margin-top: var(--s5);">
+        {% for s in showings['items'][:6] %}
+        <div class="pp-line-item">
+          <div>
+            <div class="pp-li__date">{{ s.date }}{% if s.time %} &middot; {{ s.time }}{% endif %}</div>
+            <div class="pp-li__sub">{{ s.agent_brokerage or 'Buyer showing' }}</div>
+          </div>
+          {% if s.interest_level %}<span class="pp-int pp-int--{{ s.interest_level }}" style="font-size:11.5px;">{{ s.interest }}</span>{% endif %}
+        </div>
+        {% endfor %}
+        </div>
+      {% endif %}
+    {% else %}
+      <div class="pp-empty"><p>No showings yet. As buyers tour your home, their visits and feedback will appear here.</p></div>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  {# ----------------------------------------------------------- offers #}
+  {% if offers.total %}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-sec__head">
+      <div>
+        <div class="pp-eyebrow">On the table</div>
+        <h2 class="pp-sec__title">Offers</h2>
+      </div>
+      <span class="pp-sec__count">{{ offers.active_count }} active</span>
+    </div>
+    <div style="margin-top: var(--s4);">
+    {% for o in offers['items'] %}
+    <div class="pp-offer">
+      <div>
+        <div class="pp-offer__price">{{ o.price or o.label }}</div>
+        <div class="pp-offer__terms">
+          {% if o.financing %}{{ o.financing }}{% endif %}
+          {% if o.close_date %} &middot; close {{ o.close_date }}{% endif %}
+          {% if o.option_days %} &middot; {{ o.option_days }}-day option{% endif %}
+        </div>
+      </div>
+      <span class="pp-label {% if o.is_accepted %}pp-label--green{% elif o.is_active %}pp-label--accent{% endif %}">{{ o.status }}</span>
+    </div>
+    {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# --------------------------------------------------- road to closing #}
+  {% if milestones['items'] %}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-eyebrow">Toward closing</div>
+    <h2 class="pp-sec__title">What happens next</h2>
+    {% if milestones.next %}
+    <div class="pp-bigstat" style="margin-top: var(--s3);">Next: <b>{{ milestones.next.title }}</b>{% if milestones.next.due_short %} &middot; {{ milestones.next.due_short }}{% endif %}</div>
+    {% endif %}
+    <div style="margin-top: var(--s5);">
+    {% for m in milestones['items'] %}
+    <div class="pp-line-item">
+      <div>
+        <div class="pp-li__date" {% if m.done or m.not_applicable %}style="color:var(--pp-muted);font-weight:550;"{% endif %}>{{ m.title }}</div>
+        {% if m.due_short %}<div class="pp-li__sub">{{ m.due_short }}</div>{% endif %}
+      </div>
+      {% if m.done %}<span class="pp-label pp-label--green">Done</span>
+      {% elif m.not_applicable %}<span class="pp-label">N/A</span>
+      {% elif m.status == 'overdue' %}<span class="pp-label pp-label--accent">Overdue</span>
+      {% elif m.status == 'due_soon' %}<span class="pp-label pp-label--accent">Due soon</span>
+      {% else %}<span class="pp-label">Upcoming</span>{% endif %}
+    </div>
+    {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# -------------------------------------------------------- net proceeds #}
+  {% if net_proceeds %}
+  <section data-reveal>
+    <div class="pp-proceeds">
+      <div class="pp-proceeds__l">{{ net_proceeds.label }}</div>
+      <div class="pp-proceeds__v">{{ net_proceeds.value }}</div>
+      {% if net_proceeds.estimate %}<div class="pp-proceeds__note">An estimate — final figures are confirmed at closing.</div>{% endif %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# ---------------------------------------------------- your documents #}
+  {% if documents.completed %}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-sec__head">
+      <div>
+        <div class="pp-eyebrow">On file</div>
+        <h2 class="pp-sec__title">Your documents</h2>
+      </div>
+      <span class="pp-sec__count">{{ documents.completed_count }}</span>
+    </div>
+    <div style="margin-top: var(--s4);">
+    {% for doc in documents.completed %}
+    <div class="pp-doc-item">
+      <div>
+        <div class="pp-doc-name">{{ doc.name }}</div>
+        <div class="pp-doc-sub">{% if doc.signed_on %}Signed {{ doc.signed_on }}{% else %}Completed{% endif %}</div>
+      </div>
+      {% if doc.can_view %}
+      <a class="pp-btn pp-btn--ghost pp-btn--sm" href="{{ url_for('portal.view_document', token=token, doc_id=doc.doc_id) }}" target="_blank" rel="noopener">
+        <i class="fas fa-arrow-up-right-from-square"></i> View
+      </a>
+      {% else %}<span class="pp-label pp-label--green">Signed</span>{% endif %}
+    </div>
+    {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# -------------------------------------------------------- updates #}
+  {% if updates %}
+  <section class="pp-sec" data-reveal>
+    <div class="pp-eyebrow">From {{ agent.name.split(' ')[0] }}</div>
+    <h2 class="pp-sec__title">Latest updates</h2>
+    <div style="margin-top: var(--s4);">
+    {% for u in updates %}
+    <div class="pp-update">
+      <div class="pp-update__meta">{{ u.author }}{% if u.date %} &middot; {{ u.date }}{% endif %}</div>
+      <div class="pp-update__body">{{ u.body }}</div>
+    </div>
+    {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# ----------------------------------------------------- talk to agent #}
+  <section class="pp-sec" id="talk" data-reveal>
+    <div class="pp-eyebrow">Questions?</div>
+    <h2 class="pp-sec__title">Send {{ agent.name.split(' ')[0] }} a note</h2>
+    <form class="pp-compose" method="POST" action="{{ url_for('portal.post_message', token=token) }}">
+      <textarea class="pp-textarea" name="body" placeholder="Type your message&hellip;" maxlength="4000" required></textarea>
+      <button type="submit" class="pp-btn pp-btn--ink pp-btn--block">
+        <i class="fas fa-paper-plane"></i> Send to {{ agent.name.split(' ')[0] }}
+      </button>
+    </form>
+  </section>
+
+  {# -------------------------------------------------------------- footer #}
+  <footer class="pp-foot">
+    <div class="pp-foot__agent">Represented by <b>{{ agent.name }}</b></div>
+    {% if agent.phone or agent.email %}
+    <div class="pp-foot__contact">
+      {% if agent.phone %}{{ agent.phone }}{% endif %}{% if agent.phone and agent.email %} &middot; {% endif %}{% if agent.email %}{{ agent.email }}{% endif %}
+    </div>
+    {% endif %}
+    <div class="pp-foot__note">This page is private to you and updates on its own as things move.</div>
+    <div class="pp-foot__brand">{{ agent.brokerage or 'Origen' }}</div>
+  </footer>
+
+</main>
+{% endblock %}

--- a/templates/portal/sign.html
+++ b/templates/portal/sign.html
@@ -1,0 +1,28 @@
+{% extends "portal/base.html" %}
+{% block title %}Sign {{ doc_name }}{% endblock %}
+
+{% block head_extra %}
+<script src="https://cdn.docuseal.com/js/form.js"></script>
+{% endblock %}
+
+{% block body %}
+<header class="pp-bar is-stuck" data-bar>
+  <div class="pp-bar__inner">
+    <div class="pp-brand">{{ agent.brokerage or 'Origen' }}</div>
+  </div>
+</header>
+
+<div class="pp-sign-wrap">
+  <a class="pp-back" href="{{ url_for('portal.home', token=token) }}"><i class="fas fa-arrow-left"></i> Back to your listing</a>
+  <h1 class="pp-sign-title">{{ doc_name }}</h1>
+  <div class="pp-note" style="margin-bottom: var(--s5);">{{ property.street }}</div>
+  <div class="pp-sign-frame">
+    <docuseal-form
+      data-src="{{ embed_src }}"
+      data-with-title="false"
+      data-logo=""
+      data-completed-redirect-url="{{ url_for('portal.home', token=token, _external=True) }}">
+    </docuseal-form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -353,6 +353,19 @@
                     </div>
                 </section>
 
+                {# ----- Client portal link ----- #}
+                <section class="crm-surface scroll-mt-28" id="client-portal-card"
+                         data-portal-card data-transaction-id="{{ transaction.id }}">
+                    <div class="crm-surface-header">
+                        {{ section_header('Client portal', 'A private, live status page your seller can check anytime — no login required.') }}
+                    </div>
+                    <div class="crm-surface-body">
+                        <div data-portal-list class="space-y-3">
+                            <div class="text-sm text-slate-500">Loading…</div>
+                        </div>
+                    </div>
+                </section>
+
                 {# ----- Seller command workspace ----- #}
                 <section class="crm-surface" id="seller-workspace">
                     <div class="crm-surface-header">
@@ -3377,4 +3390,137 @@
 <script src="{{ url_for('static', filename='js/transaction_rentcast.js') }}"></script>
 <script src="{{ url_for('static', filename='js/transaction_uploads.js') }}"></script>
 <script src="{{ url_for('static', filename='js/transaction_doc_actions.js') }}"></script>
+
+<script>
+// ----- Client portal link management (agent-side) -----
+(function () {
+    const card = document.querySelector('[data-portal-card]');
+    if (!card) return;
+    const txId = card.dataset.transactionId;
+    const base = `/transactions/${txId}/portal`;
+    const list = card.querySelector('[data-portal-list]');
+
+    const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
+
+    async function api(url, method) {
+        const res = await fetch(url, {
+            method: method || 'GET',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+        });
+        return res.json();
+    }
+
+    function roleLabel(role) {
+        return role === 'co_seller' ? 'Co-seller' : 'Seller';
+    }
+
+    function row(s) {
+        const meta = s.has_link
+            ? `${s.view_count} view${s.view_count === 1 ? '' : 's'}${s.last_viewed ? ' · last opened ' + esc(s.last_viewed) : ' · not opened yet'}`
+            : 'No link yet';
+        const head = `
+            <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                    <div class="text-sm font-semibold text-slate-900">${esc(s.name)}</div>
+                    <div class="text-xs text-slate-500">${roleLabel(s.role)} · ${esc(meta)}</div>
+                </div>
+            </div>`;
+        let body;
+        if (s.has_link) {
+            body = `
+                <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <input type="text" readonly value="${esc(s.url)}"
+                           class="crm-input flex-1 text-xs" data-portal-url
+                           onclick="this.select()">
+                    <div class="flex gap-2">
+                        <button type="button" class="crm-btn crm-btn-primary" data-act="copy" data-url="${esc(s.url)}">
+                            <i class="fas fa-copy text-xs"></i> Copy
+                        </button>
+                        <button type="button" class="crm-btn crm-btn-secondary" data-act="rotate" data-access="${s.access_id}" title="Issue a new link and disable the old one">
+                            <i class="fas fa-rotate text-xs"></i>
+                        </button>
+                        <button type="button" class="crm-btn crm-btn-danger" data-act="revoke" data-access="${s.access_id}" title="Turn off this link">
+                            <i class="fas fa-ban text-xs"></i>
+                        </button>
+                    </div>
+                </div>`;
+        } else {
+            const disabled = s.email ? '' : 'disabled';
+            const note = s.email ? '' : '<div class="mt-1 text-xs text-amber-600">Add an email to this seller first.</div>';
+            body = `
+                <div class="mt-3">
+                    <button type="button" class="crm-btn crm-btn-primary" data-act="create" data-participant="${s.participant_id}" ${disabled}>
+                        <i class="fas fa-link text-xs"></i> Generate portal link
+                    </button>
+                    ${note}
+                </div>`;
+        }
+        return `<div class="rounded-md border border-slate-200 p-4" data-portal-row="${s.participant_id}">${head}${body}</div>`;
+    }
+
+    function render(sellers) {
+        if (!sellers || !sellers.length) {
+            list.innerHTML = '<div class="text-sm text-slate-500">Add a seller participant to this transaction to share a client portal.</div>';
+            return;
+        }
+        list.innerHTML = sellers.map(row).join('');
+    }
+
+    async function load() {
+        try {
+            const data = await api(`${base}/status`);
+            if (data.success) render(data.sellers);
+            else list.innerHTML = '<div class="text-sm text-red-600">Could not load portal status.</div>';
+        } catch (e) {
+            list.innerHTML = '<div class="text-sm text-red-600">Could not load portal status.</div>';
+        }
+    }
+
+    list.addEventListener('click', async (e) => {
+        const btn = e.target.closest('button[data-act]');
+        if (!btn) return;
+        const act = btn.dataset.act;
+
+        if (act === 'copy') {
+            const url = btn.dataset.url;
+            try {
+                await navigator.clipboard.writeText(url);
+            } catch (_) {
+                const input = btn.closest('[data-portal-row]').querySelector('[data-portal-url]');
+                if (input) { input.select(); document.execCommand('copy'); }
+            }
+            const label = btn.innerHTML;
+            btn.innerHTML = '<i class="fas fa-check text-xs"></i> Copied';
+            setTimeout(() => { btn.innerHTML = label; }, 1600);
+            return;
+        }
+
+        btn.disabled = true;
+        try {
+            if (act === 'create') {
+                await fetch(`${base}/create`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ participant_id: btn.dataset.participant }),
+                });
+            } else if (act === 'rotate') {
+                if (!confirm('Issue a new link? The current link will stop working.')) { btn.disabled = false; return; }
+                await api(`${base}/${btn.dataset.access}/rotate`, 'POST');
+            } else if (act === 'revoke') {
+                if (!confirm('Turn off this portal link? The seller will no longer be able to open it.')) { btn.disabled = false; return; }
+                await api(`${base}/${btn.dataset.access}/revoke`, 'POST');
+            }
+            await load();
+        } catch (_) {
+            btn.disabled = false;
+        }
+    });
+
+    load();
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Adds a **passwordless seller client portal**: a token-authenticated, per-listing microsite where sellers see their transaction at a glance — status tracker, showings & feedback, offers, closing milestones, documents to sign/download, estimated net proceeds, and a note form to message their agent.
- Token resolves the org first, then sets a connection-scoped RLS context (mirrors the Magic Inbox pattern); no user session. Only seller-safe data is projected via `services/portal_service.py`.
- Agents manage portal access from the transaction detail page (`routes/transactions/portal_admin.py`).
- Ships a clean, **app-style UI** (`static/css/portal.css`): system type, white bordered section cards on a light surface, the shared orange accent, sleek colored status labels (no badge pills), boxed feedback cards, and a responsive hero stats row.

## Changes
- New: `routes/portal.py`, `routes/transactions/portal_admin.py`, `services/portal_service.py`, `static/css/portal.css`, `templates/portal/{base,show,sign,invalid}.html`, migration `add_client_portal_tables.py`
- Modified: `app.py` (register blueprint), `models.py` (portal models), `routes/transactions/__init__.py`, `templates/transactions/detail.html` (admin UI)

## Test plan
- [ ] Run migration: `python3 scripts/manage_db.py upgrade`
- [ ] Generate a portal link from a seller transaction's detail page
- [ ] Visit the token URL: verify status tracker, showings/feedback, offers, milestones, documents, net proceeds render and degrade gracefully when empty
- [ ] Verify an invalid/inactive token shows the unavailable page
- [ ] Sign a pending document via the embedded DocuSeal flow and confirm redirect back
- [ ] Send a note and confirm the agent receives an in-app notification
- [ ] Check responsive layout on mobile (hero stats stack cleanly; feedback cards are roomy)

Made with [Cursor](https://cursor.com)