### PR TITLE
fix: client portal migration boolean default Postgres-safe

### DIFF
--- a/migrations/versions/add_client_portal_tables.py
+++ b/migrations/versions/add_client_portal_tables.py
@@ -39,7 +39,7 @@ def upgrade():
             sa.Column('participant_id', sa.Integer(), nullable=False),
             sa.Column('token', sa.String(length=64), nullable=False),
             sa.Column('is_active', sa.Boolean(), nullable=False,
-                      server_default=sa.text('1')),
+                      server_default=sa.true()),
             sa.Column('created_at', sa.DateTime(), nullable=False,
                       server_default=sa.text('CURRENT_TIMESTAMP')),
             sa.Column('revoked_at', sa.DateTime(), nullable=True),


### PR DESCRIPTION
## Summary
- Fixes the seller client portal migration (`add_client_portal_tables`) failing on **PostgreSQL/Supabase** in production, which caused **"Could not load portal status."** on the transaction detail page.
- `client_portal_access.is_active` used `server_default=sa.text('1')`. Postgres rejects `DEFAULT 1` on a boolean column (`column "is_active" is of type boolean but default expression is of type integer`), so the table was never created in prod. SQLite accepted it, so it passed locally.
- Switched to `sa.true()`, which renders `true` on Postgres and `1` on SQLite.

## Why re-running is safe
The migration guards each table with `if '...' not in tables:`, and the prior failed run rolled back its transaction without advancing the Alembic version. After this fix, the release step (`python3 scripts/manage_db.py upgrade`) creates the missing tables cleanly.

## Test plan
- [ ] Deploy to Railway; confirm the `release` migration step succeeds
- [ ] `python3 scripts/manage_db.py status` shows head `add_client_portal_tables`
- [ ] Verify `client_portal_access` and `portal_messages` tables exist in Supabase
- [ ] Open a seller transaction detail page in prod; the portal panel loads (no "Could not load portal status.")
- [ ] Generate a portal link and confirm the seller page renders

Made with [Cursor](https://cursor.com)