### PR TITLE
fix: run db migrations in Railway web start command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
-release: python3 scripts/manage_db.py upgrade
-web: gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500
+# Railway does not support Heroku-style `release:` phases, and this Procfile
+# overrides the start command in nixpacks.toml — so migrations must run as
+# part of the web process command itself.
+web: python3 scripts/manage_db.py upgrade && gunicorn app:app --bind 0.0.0.0:5011 --workers 2 --timeout 120 --log-level warning --max-requests 10000 --max-requests-jitter 500


### PR DESCRIPTION
## Summary
- The `release:` line in the Procfile is Heroku syntax that Railway ignores, and the `web:` line overrides the `nixpacks.toml` start command — so `manage_db.py upgrade` never ran on deploy. This is why PR #253's migration had to be applied manually.
- Chains the upgrade into the `web:` command so schema and code always ship together. If a migration fails, the deploy fails instead of booting mismatched code (`manage_db.py` exits 1 on error).

## Test plan
- [x] No-op when DB is already at head (verified locally; alembic upgrade to head does nothing)
- [ ] Post-merge: Railway deploy logs show "Database upgraded successfully!" before gunicorn boot

Made with [Cursor](https://cursor.com)