### PR TITLE
docs: add CRM Analytics skill for retention diagnosis

### DIFF
--- a/.cursor/skills/crm-analytics/SKILL.md
+++ b/.cursor/skills/crm-analytics/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: crm-analytics
+description: >-
+  Runs Origen CRM retention and activation analytics using PostHog MCP,
+  Supabase activation_events, Railway cron health, and the retention playbook.
+  Use when the user says CRM Analytics, asks why users are not staying, requests
+  activation/retention metrics, D1/D7 return, lifecycle email volume, churn
+  reasons, funnel drop-off, or the next product change to ship for retention.
+---
+
+# CRM Analytics
+
+Jarvis retention brief for Origen TechnolOG. North star: **retain users after signup**. Measurement exists only to choose the next product change.
+
+Canonical playbook: `documentation/activation_analytics.md`. Event catalog, HogQL, and Railway details: [reference.md](reference.md).
+
+## When invoked
+
+Default window: last 14 days (use 24h / 7d if the user specifies). Produce a brief, not a data dump.
+
+1. **Data health** — event volume + Railway cron status
+2. **Funnel + return** — activation and D1/D7
+3. **Email / auth loop** — welcome + lifecycle send/click + login failures
+4. **Stages + reasons** — retention stages, friction, churn_reason
+5. **Verdict** — largest loss + one ship recommendation
+
+## Tool routing
+
+| Need | Source |
+|---|---|
+| Trends, funnels, retention, HogQL | PostHog MCP (`user-posthog`) — project **526258** |
+| Operational truth / email send log | Supabase CRM `activation_events` (project `ikdcpkuwpaejbgyapzhr`) |
+| Cron last run / next run | Railway CLI (`railway status`, service logs) |
+| Platform numbers | `python scripts/activation_report.py` (prod env) |
+
+PostHog dashboard: [New-user retention](https://us.posthog.com/project/526258/dashboard/1898511)
+
+Discover PostHog tools with `GetMcpTools` / `search` before calling. Prefer `query-funnel`, `query-retention`, `query-trends` when they fit; use `execute-sql` for multi-event / stage / email breakdowns.
+
+## Metric truth (do not violate)
+
+- Unit of analysis: **user**, not org
+- Customer cohort: active orgs, `is_platform_admin=false`
+- **Activated:** ≥1 contact + ≥1 dated task subtype `Follow-up` / `Follow Up`
+- Eligible denominators only (age ≥ 24h for 24h activation; age ≥ 7d for D2–D7)
+- UTC day boundaries for sessions
+- Opaque IDs only (`user_<id>`). Never request or echo PII from PostHog
+- Autocapture is off; only allowlisted events count
+
+## Standard run (copy progress)
+
+```
+CRM Analytics
+- [ ] 1. Data health (PostHog volume + Railway crons)
+- [ ] 2. Activation funnel + D1/D7
+- [ ] 3. Email + auth loop (24h or requested window)
+- [ ] 4. Stages + friction/churn reasons
+- [ ] 5. Verdict + one product change
+```
+
+### 1. Data health
+
+PostHog: event counts for the retention event set (see reference). Flag zeros on expected events after deploy.
+
+Railway (linked project `scintillating-encouragement` / production):
+
+- **Activation Lifecycle Cron** — hourly `python jobs/activation_lifecycle.py`
+- **Retention Analytics Cron** — daily `python jobs/retention_analytics.py`
+- **Task Reminder Cron** — unrelated to activation; ignore unless asked
+
+Missing canvas edges on Task Reminder are cosmetic (plain env vars, not `${{refs}}`).
+
+### 2. Activation + return
+
+- Funnel: `account_created` → `dashboard_viewed` → `activation_path_selected` → `contact_created` → `follow_up_created` → `activation_completed` (24h window)
+- Retention: `account_created` → returning `session_started` (Day, ~8 intervals)
+- Abandonment: `activation_abandoned` breakdown by `last_step`
+- Meaningful return: `meaningful_action` after signup
+
+### 3. Email + auth (activation jobs)
+
+From PostHog and/or Supabase `activation_events`:
+
+| Event | Meaning |
+|---|---|
+| `welcome_email_sent` / `welcome_email_failed` / `welcome_email_clicked` | Signup welcome |
+| `lifecycle_message_sent` | Hourly nudge (`event_data.stage`) |
+| `lifecycle_message_clicked` | Nudge CTA click (stage-aware) |
+| `email_delivered` / `email_bounced` / `email_dropped` / `email_deferred` | SendGrid webhook |
+| `login_failed` / `password_reset_*` | Auth-blocked return |
+
+Lifecycle stages: `no_contact_2h`, `no_follow_up_24h`, `stalled_3d` (max 3 sends/user, stops when activated).
+
+For "emails sent last 24h", query `lifecycle_message_sent` + `welcome_email_sent` by stage/time. Summarize counts by stage; name users only if asked and only via DB (not PostHog).
+
+### 4. Stages + reasons
+
+- Person `retention_stage` distribution
+- `retention_stage_changed` transitions
+- `friction_response`, `churn_reason` (direct "why")
+
+### 5. Verdict
+
+End with:
+
+1. **Largest loss** (stage or step) with numbers
+2. **Confidence** (direct reason vs correlation)
+3. **One ship** from the signal→action table in the playbook / reference
+4. Link the PostHog dashboard
+
+Do not recommend more paths, longer onboarding, or more lifecycle mail when deliverability/auth is the blocker.
+
+## Output format
+
+```markdown
+## CRM Analytics (window)
+
+**Headline:** one sentence
+
+### Data health
+- PostHog volume / gaps
+- Cron status
+
+### Activation & return
+- Funnel / D1 / D7 / abandon hot spot
+
+### Email & auth
+- Welcome + lifecycle sends/clicks (by stage)
+- Login failures if material
+
+### Stages & reasons
+- Stage mix; top friction/churn reasons
+
+### Ship next
+- One change + why (signal→action)
+```
+
+Stay Jarvis: concise, competent, one sharp line max. Prefer canvas only if the user wants a heavy visual artifact.
+
+## Privacy
+
+- No names/emails/phones/notes/brokerage in PostHog queries or briefs
+- Replay only for register / zero-contact cohorts, masked
+- Treat `activation_events` as internal ops data; redact emails unless the user explicitly needs recipient detail

--- a/.cursor/skills/crm-analytics/reference.md
+++ b/.cursor/skills/crm-analytics/reference.md
@@ -1,0 +1,146 @@
+# CRM Analytics reference
+
+Companion to [SKILL.md](SKILL.md). Full prose playbook: `documentation/activation_analytics.md`.
+
+## PostHog
+
+- Org: Origen TechnolOG
+- Project: Default project **526258**
+- Dashboard: [New-user retention](https://us.posthog.com/project/526258/dashboard/1898511)
+- Insights on that dashboard: Activation funnel (24h), D1/D7 retention, abandon by last step, login failures + welcome clicks
+
+## Railway (production)
+
+Project: `scintillating-encouragement` (`f64a9388-3778-45e6-9755-97b41a746a1c`)
+
+| Service | Schedule (UTC) | Command |
+|---|---|---|
+| Activation Lifecycle Cron | `0 * * * *` | `python jobs/activation_lifecycle.py` |
+| Retention Analytics Cron | `0 15 * * *` | `python jobs/retention_analytics.py` |
+| Task Reminder Cron | `0 14 * * *` | `python jobs/task_reminder.py` (not activation) |
+
+Lifecycle template env: `SENDGRID_ACTIVATION_LIFECYCLE_TEMPLATE_ID=d-9f6eaf6cb88340e2b6cdfcf6375b68ca`  
+SendGrid template name: **OGT: Activation Lifecycle Nudge**
+
+## Supabase
+
+CRM project: `ikdcpkuwpaejbgyapzhr`  
+Table: `activation_events` (`event`, `event_data` JSON, `user_id`, `organization_id`, `created_at`)
+
+Example — lifecycle emails last 24h:
+
+```sql
+SELECT event,
+       event_data->>'stage' AS stage,
+       count(*) AS n
+FROM activation_events
+WHERE created_at >= now() - interval '24 hours'
+  AND event IN (
+    'lifecycle_message_sent',
+    'lifecycle_message_clicked',
+    'welcome_email_sent',
+    'welcome_email_failed',
+    'welcome_email_clicked'
+  )
+GROUP BY 1, 2
+ORDER BY 1, 2;
+```
+
+## Retention stages
+
+`activation_observing`, `unactivated_no_path`, `unactivated_path_stalled`,
+`unactivated_returning`, `activated_observing`, `activated_retained`,
+`activated_idle`, `established_active`, `established_at_risk`,
+`established_dormant`
+
+## Core events
+
+**Funnel / return:** `account_created`, `dashboard_viewed`, `activation_path_selected`, `contact_created`, `follow_up_created`, `activation_completed`, `session_started`, `meaningful_action`, `activation_abandoned`, `activation_step_viewed`, `nav_away_during_activation`
+
+**Email / auth:** `welcome_email_sent`, `welcome_email_failed`, `welcome_email_clicked`, `lifecycle_message_sent`, `lifecycle_message_clicked`, `email_delivered`, `email_bounced`, `email_dropped`, `email_deferred`, `login_failed`, `login_succeeded`, `password_reset_requested`, `password_reset_completed`
+
+**Reasons / stages:** `friction_response`, `churn_reason`, `retention_stage_changed`, `retention_baseline_snapshot`
+
+**Paths:** `csv_import_*`, `inbox_address_copied`, `inbound_message_received`, `inbound_processing_failed`, `surface_viewed`, `feature_gate_hit`
+
+## First HogQL checks
+
+```sql
+SELECT event, count(), uniq(person_id)
+FROM events
+WHERE timestamp >= now() - INTERVAL 14 DAY
+  AND event IN (
+    'account_created', 'dashboard_viewed', 'activation_path_selected',
+    'contact_created', 'follow_up_created', 'activation_completed',
+    'session_started', 'meaningful_action', 'activation_abandoned',
+    'welcome_email_sent', 'welcome_email_clicked', 'lifecycle_message_sent',
+    'lifecycle_message_clicked', 'login_failed',
+    'friction_response', 'churn_reason', 'retention_stage_changed'
+  )
+GROUP BY event
+ORDER BY count() DESC
+```
+
+```sql
+SELECT
+  properties.retention_stage AS stage,
+  count() AS users
+FROM persons
+WHERE properties.retention_stage IS NOT NULL
+GROUP BY stage
+ORDER BY users DESC
+```
+
+```sql
+SELECT
+  properties.stage AS stage,
+  count() AS sends,
+  uniq(person_id) AS users
+FROM events
+WHERE timestamp >= now() - INTERVAL 1 DAY
+  AND event = 'lifecycle_message_sent'
+GROUP BY stage
+ORDER BY sends DESC
+```
+
+(If `properties.stage` is empty, check `properties.event_data.stage` or mirror shape from a sample row.)
+
+## Lifecycle email copy map
+
+| stage | Subject (approx) | CTA |
+|---|---|---|
+| `no_contact_2h` | Add one contact to get started | Add a contact |
+| `no_follow_up_24h` | Schedule your next follow-up | Schedule follow-up |
+| `stalled_3d` | Stuck on setup? | Open my dashboard (+ churn reason links) |
+
+## Signal → action
+
+| Dominant signal | Ship this | Do not do |
+|---|---|---|
+| No path selected | Simplify chooser to one primary CTA | Add more paths |
+| Abandon at contact step | Fewer fields / clearer mobile UX | Add optional fields |
+| Abandon at follow-up step | Stronger Tomorrow default | Custom date as default |
+| Submit failures | Fix the dominant `error_code` | Blame the user |
+| CSV failures | Fix mapper/preview for that code | Force only manual |
+| Inbox copy, zero contacts | Improve inbox instructions or bury path | Lead welcome with inbox |
+| Welcome delivered, low click | Rewrite subject/CTA | Longer email |
+| Bounce/drop/defer | Fix deliverability | More lifecycle mail |
+| Auth-blocked returns | Clearer login/recovery | Blame product value |
+| Activated then idle | Today surface + due-day loop | More signup ads |
+| Direct `unclear_value` | Show payoff earlier | Feature tour |
+| Direct `no_time` / `too_much_setup` | Shorten path, preserve progress | Longer onboarding |
+
+Cadence: every 5–10 eligible new users → one `activation_experience_version` change → remeasure.
+
+## Targets (initial)
+
+- 60% start a path
+- 40% activate in 24h
+- 25% meaningful work on days 2–7
+
+## Local scripts
+
+```bash
+python scripts/activation_report.py
+python scripts/retention_baseline.py   # one-time; idempotent
+```


### PR DESCRIPTION
## Summary
- Adds project skill `.cursor/skills/crm-analytics/` so asking for **CRM Analytics** runs the retention playbook: data health, funnel/D1–D7, lifecycle email volume, stages/reasons, and one ship recommendation.
- Includes a concise reference for PostHog project 526258, Railway crons, Supabase `activation_events` queries, and the signal→action table.

## Test plan
- [ ] Reload Cursor / confirm skill appears for this repo
- [ ] Ask: "CRM Analytics" and confirm Jarvis follows the skill checklist
- [ ] Spot-check that PostHog dashboard + Railway cron names in the skill match production


Made with [Cursor](https://cursor.com)