### PR TITLE
fix: hide activation onboarding for legacy users

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -674,6 +674,9 @@ def dashboard():
         'contact': first_contact,
         'follow_up': first_follow_up,
     }
+    show_activation_onboarding = not bool(
+        current_user.has_seen_dashboard_onboarding
+    )
     days_since_signup = (
         (datetime.utcnow() - current_user.created_at).days
         if current_user.created_at else 0
@@ -683,10 +686,12 @@ def dashboard():
         event=ActivationEvent.FRICTION_RESPONSE,
     ).first()
     show_friction = (
-        activation_state['mode'] != 'complete'
+        show_activation_onboarding
+        and activation_state['mode'] != 'complete'
+        and prior_friction is None
         and (
             request.args.get('friction') == '1'
-            or (days_since_signup >= 1 and prior_friction is None)
+            or days_since_signup >= 1
         )
     )
     # Only auto-complete for recent signups so legacy users do not pollute
@@ -1114,6 +1119,7 @@ def dashboard():
                          task_window_days=task_window_days,
                          now=now,
                          activation_state=activation_state,
+                         show_activation_onboarding=show_activation_onboarding,
                          show_friction=show_friction,
                          show_transactions=show_transactions,
                          transactions_by_status=transactions_by_status,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -66,7 +66,7 @@
 
 {% block content %}
 {% set total_deals = transactions_by_status.values()|map(attribute='count')|sum if show_transactions else 0 %}
-{% set is_first_run = activation_state.mode == 'start' %}
+{% set is_first_run = show_activation_onboarding and activation_state.mode == 'start' %}
 {% set _hour = now.hour if now is defined else 12 %}
 {% set greeting = 'Good morning' if _hour < 12 else ('Good afternoon' if _hour < 18 else 'Good evening') %}
 {% set first_name = current_user.first_name if current_user.is_authenticated else '' %}
@@ -549,7 +549,7 @@
             <div class="hidden p-5 sm:p-8" data-dashboard-page-target="activationSuccess"></div>
         </section>
         {% else %}
-        {% if activation_state.mode == 'follow_up' %}
+        {% if show_activation_onboarding and activation_state.mode == 'follow_up' %}
         <section class="crm-surface mb-6 overflow-hidden">
             <div class="border-b border-slate-200 px-5 py-5 sm:px-7">
                 <div class="crm-section-kicker">One step left</div>

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -130,6 +130,40 @@ def test_quick_activation_creates_contact_task_and_milestones(
             _cleanup_user(user_id)
 
 
+def test_baselined_user_does_not_see_activation_prompts(app, client, seed):
+    with app.app_context():
+        user = _new_user(
+            seed,
+            'activation_baselined',
+            created_at=datetime.utcnow() - timedelta(days=30),
+        )
+        user.has_seen_dashboard_onboarding = True
+        contact = Contact(
+            organization_id=user.organization_id,
+            user_id=user.id,
+            created_by_id=user.id,
+            first_name='Legacy',
+            last_name='Contact',
+        )
+        db.session.add(contact)
+        db.session.commit()
+        user_id = user.id
+
+    try:
+        client.post('/login', data={
+            'username': 'activation_baselined',
+            'password': 'password123',
+        })
+        dashboard = client.get('/dashboard?friction=1')
+        assert dashboard.status_code == 200
+        assert b'What stopped you from finishing setup?' not in dashboard.data
+        assert b'Give this relationship a next date.' not in dashboard.data
+        assert b'How do you want to start?' not in dashboard.data
+    finally:
+        with app.app_context():
+            _cleanup_user(user_id)
+
+
 def test_lifecycle_stops_for_activated_user(app, seed, monkeypatch):
     with app.app_context():
         user = _new_user(


### PR DESCRIPTION
## Summary
- honor the existing dashboard onboarding baseline flag for activation cards and friction surveys
- prevent old lifecycle URLs from forcing activation prompts for baselined users
- add regression coverage for legacy accounts with an unfinished follow-up

## Test plan
- [x] `pytest tests/test_activation.py`
- [x] verify all 34 existing production users have `has_seen_dashboard_onboarding = true`
- [ ] verify the production dashboard no longer shows activation prompts for a legacy account


Made with [Cursor](https://cursor.com)