### PR TITLE
fix: return both tool payloads so B.O.B. can reply on Telegram

### DIFF
--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -271,7 +271,7 @@ def _run_tool_loop(
     undoable_action_id: Optional[int] = None
     text_parts: list[str] = []
 
-    def execute_tool(name: str, args: dict) -> dict:
+    def execute_tool(name: str, args: dict) -> tuple[dict, dict]:
         nonlocal pending, undoable_action_id
         result = bob_dispatch(
             name, args, ctx, conversation_id=conversation.id,
@@ -285,7 +285,7 @@ def _run_tool_loop(
             }
         elif result.ok and result.undoable and result.action_id:
             undoable_action_id = result.action_id
-        return result.for_model()
+        return result.for_model(), result.for_client()
 
     try:
         for event, payload in run_tool_conversation(

--- a/tests/test_bob_telegram.py
+++ b/tests/test_bob_telegram.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -447,7 +447,9 @@ class TestIsolationAndLimits:
                 AgentMessagingChannel, linked_channel['id'],
             )
             channel.daily_count = PER_USER_DAILY_LIMIT
-            channel.daily_count_date = datetime.utcnow().date()
+            # Must match the local date _bump_daily_count compares against,
+            # or the counter resets instead of tripping.
+            channel.daily_count_date = date.today()
             db.session.commit()
 
             with pytest.raises(RateLimitExceeded):
@@ -455,6 +457,50 @@ class TestIsolationAndLimits:
 
             channel.daily_count = 0
             db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Disabled channel silence
+# ---------------------------------------------------------------------------
+
+class TestToolLoopContract:
+    """The tool loop only runs with a live model, so pin its contract here.
+
+    ``ai_service.run_tool_conversation`` unpacks ``execute_tool`` into
+    ``(payload, meta)``. A callback returning a bare dict blows up at runtime
+    with "too many values to unpack" and the agent just sees a generic error.
+    """
+
+    def test_execute_tool_returns_model_and_client_payloads(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        captured = {}
+
+        def fake_run_tool_conversation(
+            *, system_prompt, messages, tools, execute_tool, **kwargs
+        ):
+            payload, meta = execute_tool('count_contacts', {})
+            captured['payload'] = payload
+            captured['meta'] = meta
+            yield ('text', f"You have {payload.get('count')} contacts.")
+
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.run_tool_conversation',
+                fake_run_tool_conversation,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='How many contacts do I have?',
+                    telegram_message_id='500',
+                )
+
+        assert isinstance(captured['payload'], dict)
+        assert isinstance(captured['meta'], dict)
+        sent = ' '.join(m['text'] for m in _fake_transport.sent)
+        assert 'Something went wrong' not in sent
+        assert 'contacts' in sent
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Telegram turns that called any tool crashed with `ValueError: too many values to unpack (expected 2)`. `ai_service.run_tool_conversation` unpacks the `execute_tool` callback into `(payload, meta)`, but the Telegram version returned only `result.for_model()`. The agent saw "Something went wrong on my end" for every real question.
- Adds a regression test that drives a full inbound turn through a stand-in model, which is the only way to exercise the tool loop without live OpenAI. Verified it fails with the old code and passes with the fix.
- Pins the daily rate-limit test to the local date `_bump_daily_count` compares against. It was seeding the UTC date, so it failed locally after ~7pm Central when the counter reset instead of tripping.

## Test plan

- [x] `pytest tests/test_bob_telegram.py` — 18 passed
- [x] Confirmed the new test fails without the one-line fix
- [ ] After deploy: message the bot "how many contacts do I have?" and confirm a real answer comes back

Made with [Cursor](https://cursor.com)