### PR TITLE
feat: show typing dots while B.O.B. composes a Telegram reply

### DIFF
--- a/services/messaging/__init__.py
+++ b/services/messaging/__init__.py
@@ -10,6 +10,7 @@ from services.messaging.telegram import (
     TelegramTransport,
     get_transport,
     markdown_to_telegram_html,
+    show_typing,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     'TelegramTransport',
     'get_transport',
     'markdown_to_telegram_html',
+    'show_typing',
 ]

--- a/services/messaging/base.py
+++ b/services/messaging/base.py
@@ -65,3 +65,10 @@ class MessagingTransport(Protocol):
     ) -> dict:
         """Acknowledge a button tap so the client stops spinning."""
         ...
+
+    def send_activity(self, chat_id: str) -> dict:
+        """Signal that a reply is being composed (typing dots, etc.).
+
+        Best-effort and cosmetic. Channels without the concept may no-op.
+        """
+        ...

--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -30,7 +30,7 @@ from services.bob_tools import (
 from services.bob_tools.registry import dispatch as bob_dispatch
 from services.messaging.base import ChoiceOption
 from services.messaging.prompt import TELEGRAM_SYSTEM_PROMPT
-from services.messaging.telegram import get_transport
+from services.messaging.telegram import get_transport, show_typing
 
 logger = logging.getLogger(__name__)
 
@@ -125,12 +125,13 @@ def handle_inbound_message(
     _persist_message(conversation, 'user', text)
 
     ctx = BobContext.from_user(user, surface=SURFACE, timezone=_user_tz(user))
-    reply_text, pending, undoable = _run_tool_loop(
-        user=user,
-        ctx=ctx,
-        conversation=conversation,
-        user_text=text,
-    )
+    with show_typing(transport, channel.chat_id):
+        reply_text, pending, undoable = _run_tool_loop(
+            user=user,
+            ctx=ctx,
+            conversation=conversation,
+            user_text=text,
+        )
 
     if pending is not None:
         channel.pending_action_id = pending['action_id']

--- a/services/messaging/telegram.py
+++ b/services/messaging/telegram.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import html
 import logging
 import re
+import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Optional, Sequence
 from urllib.parse import urljoin
@@ -26,6 +28,12 @@ SOFT_CHUNK_LENGTH = 3800
 
 # Back off on Telegram's own rate limits. The per-chat floor is ~1 msg/sec.
 MAX_RETRIES = 3
+
+# Telegram drops the typing indicator after ~5s, so refresh under that while
+# the model works. Give up after a bounded run so a wedged turn cannot leave
+# the dots spinning forever.
+TYPING_REFRESH_SECONDS = 4
+MAX_TYPING_SECONDS = 90
 
 
 class TelegramError(RuntimeError):
@@ -192,6 +200,12 @@ class TelegramTransport:
             payload['text'] = text[:200]
         return self._call('answerCallbackQuery', payload)
 
+    def send_activity(self, chat_id: str) -> dict:
+        return self._call('sendChatAction', {
+            'chat_id': chat_id,
+            'action': 'typing',
+        })
+
     def set_webhook(
         self,
         url: str,
@@ -308,6 +322,7 @@ class FakeTransport:
     sent: list[dict] = field(default_factory=list)
     edited: list[dict] = field(default_factory=list)
     answered: list[dict] = field(default_factory=list)
+    activity: list[dict] = field(default_factory=list)
     _next_message_id: int = 1
 
     def send_text(
@@ -381,6 +396,42 @@ class FakeTransport:
         }
         self.answered.append(record)
         return {'ok': True}
+
+    def send_activity(self, chat_id: str) -> dict:
+        self.activity.append({'chat_id': str(chat_id)})
+        return {'ok': True}
+
+
+@contextmanager
+def show_typing(transport: Any, chat_id: str):
+    """Keep the typing indicator alive for the duration of the block.
+
+    Purely cosmetic, so every failure is swallowed — a dropped indicator must
+    never cost the agent their answer. The refresh runs on a daemon thread and
+    is stopped before the caller sends anything, so the two never share the
+    HTTP session concurrently.
+    """
+    stop = threading.Event()
+
+    def refresh():
+        deadline = time.monotonic() + MAX_TYPING_SECONDS
+        while not stop.is_set() and time.monotonic() < deadline:
+            try:
+                transport.send_activity(chat_id)
+            except Exception as exc:  # noqa: BLE001 - cosmetic only
+                logger.debug('Telegram typing indicator stopped: %s', exc)
+                return
+            stop.wait(TYPING_REFRESH_SECONDS)
+
+    thread = threading.Thread(
+        target=refresh, name='telegram-typing', daemon=True,
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=2)
 
 
 _transport_override: Optional[Any] = None

--- a/tests/test_bob_telegram.py
+++ b/tests/test_bob_telegram.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
@@ -501,6 +502,65 @@ class TestToolLoopContract:
         sent = ' '.join(m['text'] for m in _fake_transport.sent)
         assert 'Something went wrong' not in sent
         assert 'contacts' in sent
+
+
+class TestTypingIndicator:
+    def test_typing_is_sent_while_thinking_and_stops_after(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        def slow_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+            time.sleep(0.3)
+            yield ('text', 'Two contacts.')
+
+        with app.app_context():
+            with patch(
+                'services.messaging.telegram.TYPING_REFRESH_SECONDS', 0.05,
+            ), patch(
+                'services.messaging.conversation.run_tool_conversation',
+                slow_run,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='How many contacts do I have?',
+                    telegram_message_id='501',
+                )
+
+        # Refreshed rather than sent once, so the dots survive a long turn.
+        assert len(_fake_transport.activity) > 1
+        assert all(
+            a['chat_id'] == linked_channel['chat_id']
+            for a in _fake_transport.activity
+        )
+        # The refresh thread must not outlive the turn.
+        before = len(_fake_transport.activity)
+        time.sleep(0.3)
+        assert len(_fake_transport.activity) == before
+
+    def test_typing_failure_does_not_break_the_reply(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        def boom(chat_id):
+            raise RuntimeError('telegram down')
+
+        def fake_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+            yield ('text', 'Two contacts.')
+
+        with app.app_context():
+            with patch.object(_fake_transport, 'send_activity', boom), patch(
+                'services.messaging.conversation.run_tool_conversation',
+                fake_run,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='How many contacts do I have?',
+                    telegram_message_id='502',
+                )
+
+        assert any(
+            'Two contacts.' in m['text'] for m in _fake_transport.sent
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Telegram turns take 4-8 seconds while the model works, with no signal that B.O.B. heard you. This sends `sendChatAction: typing` so the dots appear.
- The indicator expires after ~5s on Telegram's side, so a single call would drop off mid-turn. A daemon thread refreshes it under that interval and is stopped before the reply is sent, so the refresh and the send never touch the HTTP session at the same time.
- Cosmetic by design: every failure is swallowed so a Telegram hiccup can't cost the agent their answer, and a 90s ceiling keeps a wedged turn from leaving the dots spinning.
- `send_activity` is on the shared `MessagingTransport` interface, so a future SMS or WhatsApp adapter can no-op it rather than special-case the caller.

## Test plan

- [x] `pytest tests/test_bob_telegram.py` — 20 passed
- [x] New test asserts the indicator refreshes (more than one call) and that the thread stops when the turn ends
- [x] New test asserts a failing indicator still delivers the reply
- [ ] After deploy: send the bot a question and confirm the dots show while it thinks

Made with [Cursor](https://cursor.com)