### PR TITLE
feat: toggle org feature access from platform admin, clarify Telegram setup

### DIFF
--- a/feature_flags.py
+++ b/feature_flags.py
@@ -127,6 +127,94 @@ def org_has_feature(feature_name: str, org=None) -> bool:
     return TIER_FEATURES.get(tier, TIER_FEATURES['free']).get(feature_name, False)
 
 
+# Shown in the platform admin UI instead of raw SCREAMING_SNAKE keys.
+FEATURE_LABELS = {
+    'CONTACTS': 'Contacts',
+    'TASKS': 'Tasks',
+    'USER_TODOS': 'Personal to-dos',
+    'DASHBOARD': 'Dashboard',
+    'TEAM_UPDATES': 'Team updates',
+    'AI_CHAT': 'B.O.B. chat',
+    'AI_DAILY_TODO': 'B.O.B. daily to-do',
+    'AI_ACTION_PLAN': 'B.O.B. action plans',
+    'AI_TASK_SUGGESTIONS': 'B.O.B. task suggestions',
+    'BOB_TELEGRAM': 'B.O.B. on Telegram',
+    'TRANSACTIONS': 'Transactions',
+    'DOCUMENT_GENERATION': 'Document generation',
+    'MARKET_INSIGHTS': 'Market insights',
+    'MARKETING': 'Marketing',
+    'TAX_PROTEST': 'Tax protest',
+}
+
+
+def all_feature_names() -> list:
+    """Every known feature key, in a stable display order."""
+    names = []
+    for tier in ('enterprise', 'pro', 'free'):
+        for name in TIER_FEATURES.get(tier, {}):
+            if name not in names:
+                names.append(name)
+    return names
+
+
+def tier_default_for(feature_name: str, tier: Optional[str]) -> bool:
+    """What this feature would be if the org had no override."""
+    tier = tier or 'free'
+    return TIER_FEATURES.get(tier, TIER_FEATURES['free']).get(feature_name, False)
+
+
+def describe_org_features(org) -> list:
+    """Per-feature rows for the platform admin toggle UI.
+
+    Reports the tier default alongside the effective value so an admin can see
+    at a glance which flags are deliberate overrides rather than inherited.
+    """
+    overrides = org.feature_flags or {}
+    rows = []
+    for name in all_feature_names():
+        default = tier_default_for(name, org.subscription_tier)
+        overridden = name in overrides
+        rows.append({
+            'name': name,
+            'label': FEATURE_LABELS.get(name, name.replace('_', ' ').title()),
+            'tier_default': default,
+            'overridden': overridden,
+            'enabled': bool(overrides[name]) if overridden else default,
+            'locked': name in GLOBAL_FEATURE_OVERRIDES,
+            'locked_value': GLOBAL_FEATURE_OVERRIDES.get(name),
+        })
+    return rows
+
+
+def set_org_feature_overrides(org, desired: dict) -> dict:
+    """Persist only the flags that differ from the org's tier default.
+
+    Storing matches as explicit overrides would silently freeze the org against
+    future tier changes, so anything equal to the default is dropped instead.
+    Returns the new override dict. Caller commits.
+    """
+    overrides = {}
+    existing = org.feature_flags or {}
+    for name, enabled in desired.items():
+        if name in GLOBAL_FEATURE_OVERRIDES:
+            continue
+        if bool(enabled) != tier_default_for(name, org.subscription_tier):
+            overrides[name] = bool(enabled)
+
+    for name, enabled in existing.items():
+        if name in overrides:
+            continue
+        # A killswitch wins at read time and its toggle ships disabled, so keep
+        # the stored intent rather than reading an absent field as a real
+        # "off". Unmanaged keys (older or experimental flags) survive too.
+        if name in GLOBAL_FEATURE_OVERRIDES or name not in TIER_FEATURES['enterprise']:
+            overrides[name] = enabled
+
+    # JSON columns only track whole-value assignment, not in-place mutation.
+    org.feature_flags = overrides
+    return overrides
+
+
 def get_org_features(org=None) -> dict:
     """
     Get all feature flags for an organization.

--- a/routes/platform_admin.py
+++ b/routes/platform_admin.py
@@ -9,6 +9,11 @@ from flask_login import login_required, current_user
 from datetime import datetime
 from models import db, Organization, OrganizationMetrics, PlatformAuditLog, User
 from services.tenant_service import platform_admin_required, is_platform_admin
+from feature_flags import (
+    all_feature_names,
+    describe_org_features,
+    set_org_feature_overrides,
+)
 from sqlalchemy import func
 from tier_config.tier_limits import TIER_DEFAULTS, apply_tier_defaults
 
@@ -353,6 +358,7 @@ def view_org(org_id):
                           metrics=metrics,
                           owner_email=owner_email,
                           audit_logs=audit_logs,
+                          features=describe_org_features(org),
                           tier_defaults=TIER_DEFAULTS)
 
 
@@ -505,6 +511,42 @@ def update_org_limits(org_id):
     db.session.commit()
     
     flash(f'Limits updated for "{org.name}".', 'success')
+    return redirect(url_for('platform.view_org', org_id=org_id))
+
+
+@platform_bp.route('/orgs/<int:org_id>/update-features', methods=['POST'])
+@login_required
+@platform_admin_required
+def update_org_features(org_id):
+    """Turn individual features on or off for one organization."""
+    org = Organization.query.get_or_404(org_id)
+
+    old_flags = dict(org.feature_flags or {})
+    desired = {
+        name: request.form.get(f'feature_{name}') == 'on'
+        for name in all_feature_names()
+    }
+    new_flags = set_org_feature_overrides(org, desired)
+
+    if new_flags == old_flags:
+        flash('No feature changes to save.', 'info')
+        return redirect(url_for('platform.view_org', org_id=org_id))
+
+    changed = sorted(
+        set(old_flags) ^ set(new_flags)
+        | {k for k in set(old_flags) & set(new_flags) if old_flags[k] != new_flags[k]}
+    )
+    log_platform_action('features_changed', org.id, {
+        'org_name': org.name,
+        'tier': org.subscription_tier,
+        'changed': changed,
+        'old_overrides': old_flags,
+        'new_overrides': new_flags,
+    })
+
+    db.session.commit()
+
+    flash(f'Feature access updated for "{org.name}".', 'success')
     return redirect(url_for('platform.view_org', org_id=org_id))
 
 

--- a/templates/integrations/telegram.html
+++ b/templates/integrations/telegram.html
@@ -4,6 +4,24 @@
 {% block title %}Connect Telegram - Origen TechnolOG{% endblock %}
 {% block mobile_title %}Telegram{% endblock %}
 
+{% block head_scripts %}
+<style>
+    .setup-step {
+        flex: none;
+        width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 9999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #fff;
+        background: var(--accent);
+    }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="crm-page">
     <div class="crm-page__inner max-w-[640px]">
@@ -38,13 +56,39 @@
                     </form>
                 </div>
                 {% else %}
-                <div>
-                    <p class="text-sm" style="color: var(--ink-2); line-height: 1.55;">
-                        Scan the QR code with your phone, or open the link below.
-                        Telegram will ask you to start the bot. That one tap links
-                        this CRM account. The link expires in 15 minutes.
-                    </p>
-                </div>
+                {% if link_url %}
+                <ol class="space-y-4">
+                    <li class="flex gap-3">
+                        <span class="setup-step">1</span>
+                        <div class="min-w-0 pt-0.5">
+                            <p class="text-sm font-medium" style="color: var(--ink);">Install Telegram if you don't have it</p>
+                            <p class="mt-0.5 text-sm" style="color: var(--ink-3);">
+                                It's free. Any phone number works, and your number stays private from us.
+                            </p>
+                        </div>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="setup-step">2</span>
+                        <div class="min-w-0 pt-0.5">
+                            <p class="text-sm font-medium" style="color: var(--ink);">Open the bot</p>
+                            <p class="mt-0.5 text-sm" style="color: var(--ink-3);">
+                                Point your phone camera at the code below, or tap
+                                <span class="font-medium" style="color: var(--ink-2);">Open in Telegram</span>
+                                if you're already on your phone.
+                            </p>
+                        </div>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="setup-step">3</span>
+                        <div class="min-w-0 pt-0.5">
+                            <p class="text-sm font-medium" style="color: var(--ink);">Tap Start</p>
+                            <p class="mt-0.5 text-sm" style="color: var(--ink-3);">
+                                Telegram shows a blue Start button at the bottom. That one tap
+                                links your account and B.O.B. replies right away.
+                            </p>
+                        </div>
+                    </li>
+                </ol>
 
                 {% if qr_svg %}
                 <div class="flex justify-center">
@@ -52,10 +96,8 @@
                         {{ qr_svg }}
                     </div>
                 </div>
-                <p class="text-center text-xs" style="color: var(--ink-4);">Scan to open Telegram</p>
                 {% endif %}
 
-                {% if link_url %}
                 <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-center">
                     <a href="{{ link_url }}" target="_blank" rel="noopener"
                        class="crm-btn crm-btn-primary">
@@ -64,9 +106,14 @@
                     </a>
                     <a href="{{ url_for('bob_telegram.telegram_connect_page') }}"
                        class="crm-btn crm-btn-secondary">
-                        Refresh QR
+                        New code
                     </a>
                 </div>
+
+                <p class="text-center text-xs" style="color: var(--ink-4);">
+                    This code is yours alone and expires in 15 minutes. Tap
+                    <span class="font-medium">New code</span> if it stops working.
+                </p>
                 {% else %}
                 <p class="text-sm" style="color: var(--warn);">
                     Telegram is not fully configured on this server. Ask an admin

--- a/templates/platform_admin/org_detail.html
+++ b/templates/platform_admin/org_detail.html
@@ -222,6 +222,60 @@
                 {% endif %}
             </div>
 
+            <!-- Feature Access -->
+            <div class="admin-card p-6">
+                <h3 class="text-lg font-semibold text-slate-800 mb-1 flex items-center">
+                    <i class="fas fa-toggle-on text-slate-400 mr-2"></i>Feature Access
+                </h3>
+                <p class="text-sm text-slate-500 mb-4">
+                    Anything left matching the <span class="font-medium text-slate-600">{{ org.subscription_tier or 'free' }}</span>
+                    tier default stays inherited, so future tier changes still apply.
+                </p>
+
+                {% if org.is_platform_admin %}
+                <div class="rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 mb-4 text-sm text-blue-800">
+                    <i class="fas fa-info-circle mr-1"></i>
+                    This is the platform admin org, so every feature is on regardless of these toggles.
+                </div>
+                {% endif %}
+
+                <form action="{{ url_for('platform.update_org_features', org_id=org.id) }}" method="POST">
+                    <div class="divide-y divide-slate-100 border-t border-b border-slate-100">
+                        {% for feature in features %}
+                        <div class="flex items-center justify-between py-3">
+                            <div class="min-w-0 pr-4">
+                                <p class="text-sm font-medium text-slate-700">
+                                    {{ feature.label }}
+                                    {% if feature.overridden %}
+                                    <span class="ml-1.5 px-2 py-0.5 text-[11px] font-semibold rounded-full bg-orange-100 text-orange-800">Override</span>
+                                    {% endif %}
+                                    {% if feature.locked %}
+                                    <span class="ml-1.5 px-2 py-0.5 text-[11px] font-semibold rounded-full bg-slate-200 text-slate-700">Killswitch</span>
+                                    {% endif %}
+                                </p>
+                                <p class="text-xs text-slate-400 mt-0.5">
+                                    {% if feature.locked %}
+                                    Forced {{ 'on' if feature.locked_value else 'off' }} for every org in feature_flags.py
+                                    {% else %}
+                                    Tier default: {{ 'on' if feature.tier_default else 'off' }}
+                                    {% endif %}
+                                </p>
+                            </div>
+                            <label class="crm-toggle crm-toggle--accent shrink-0">
+                                <input type="checkbox" name="feature_{{ feature.name }}"
+                                       {% if feature.enabled %}checked{% endif %}
+                                       {% if feature.locked %}disabled{% endif %}>
+                                <span class="crm-toggle__track"><span class="crm-toggle__thumb"></span></span>
+                            </label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    <button type="submit" class="btn-admin-primary mt-4 px-4 py-2 rounded-lg text-sm font-medium">
+                        <i class="fas fa-save mr-1"></i>Save Feature Access
+                    </button>
+                </form>
+            </div>
+
             <!-- Audit Log -->
             <div class="admin-card p-6">
                 <h3 class="text-lg font-semibold text-slate-800 mb-4 flex items-center">

--- a/tests/test_org_feature_flags.py
+++ b/tests/test_org_feature_flags.py
@@ -1,0 +1,146 @@
+"""Tests for per-organization feature overrides.
+
+Covers the rules behind the platform admin toggle UI: overrides are only
+stored when they differ from the tier default, killswitched features are left
+alone, and unmanaged keys survive a save.
+
+Run with: python -m pytest tests/test_org_feature_flags.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from feature_flags import (
+    GLOBAL_FEATURE_OVERRIDES,
+    TIER_FEATURES,
+    all_feature_names,
+    describe_org_features,
+    org_has_feature,
+    set_org_feature_overrides,
+    tier_default_for,
+)
+from models import Organization, db
+
+
+@pytest.fixture()
+def org(app, seed):
+    """A plain pro-tier org with no overrides."""
+    with app.app_context():
+        record = db.session.get(Organization, seed['org_a'])
+        record.feature_flags = {}
+        db.session.commit()
+        yield record
+
+
+def _desired(org, **changes):
+    """Start from current effective values, then apply changes."""
+    current = {row['name']: row['enabled'] for row in describe_org_features(org)}
+    current.update(changes)
+    return current
+
+
+class TestOverrideStorage:
+    def test_enabling_a_feature_off_by_default_stores_an_override(self, app, org):
+        with app.app_context():
+            assert tier_default_for('BOB_TELEGRAM', org.subscription_tier) is False
+
+            flags = set_org_feature_overrides(org, _desired(org, BOB_TELEGRAM=True))
+            db.session.commit()
+
+            assert flags['BOB_TELEGRAM'] is True
+            assert org_has_feature('BOB_TELEGRAM', org) is True
+
+    def test_values_matching_the_tier_default_are_not_stored(self, app, org):
+        with app.app_context():
+            flags = set_org_feature_overrides(org, _desired(org))
+            db.session.commit()
+
+            # Every value equals its tier default, so nothing needs storing.
+            assert flags == {}
+
+    def test_turning_an_override_back_to_default_removes_it(self, app, org):
+        with app.app_context():
+            set_org_feature_overrides(org, _desired(org, BOB_TELEGRAM=True))
+            db.session.commit()
+            assert 'BOB_TELEGRAM' in org.feature_flags
+
+            set_org_feature_overrides(org, _desired(org, BOB_TELEGRAM=False))
+            db.session.commit()
+
+            assert 'BOB_TELEGRAM' not in org.feature_flags
+            assert org_has_feature('BOB_TELEGRAM', org) is False
+
+    def test_inherited_features_follow_a_tier_change(self, app, org):
+        """The point of not storing matches: tier upgrades still land."""
+        with app.app_context():
+            org.subscription_tier = 'free'
+            set_org_feature_overrides(org, _desired(org))
+            db.session.commit()
+            assert org_has_feature('TRANSACTIONS', org) is False
+
+            org.subscription_tier = 'pro'
+            db.session.commit()
+
+            assert org_has_feature('TRANSACTIONS', org) is True
+
+    def test_disabling_a_feature_the_tier_grants_stores_an_override(self, app, org):
+        with app.app_context():
+            assert org_has_feature('TRANSACTIONS', org) is True
+
+            flags = set_org_feature_overrides(org, _desired(org, TRANSACTIONS=False))
+            db.session.commit()
+
+            assert flags['TRANSACTIONS'] is False
+            assert org_has_feature('TRANSACTIONS', org) is False
+
+
+class TestEdgeCases:
+    def test_killswitched_feature_keeps_its_stored_intent(self, app, org):
+        """Its toggle ships disabled, so an absent field is not a real 'off'."""
+        killswitched = next(iter(GLOBAL_FEATURE_OVERRIDES))
+        with app.app_context():
+            org.feature_flags = {killswitched: True}
+            db.session.commit()
+
+            desired = _desired(org)
+            desired.pop(killswitched, None)
+            flags = set_org_feature_overrides(org, desired)
+            db.session.commit()
+
+            assert flags[killswitched] is True
+
+    def test_unmanaged_keys_survive_a_save(self, app, org):
+        with app.app_context():
+            org.feature_flags = {'SOME_LEGACY_FLAG': True}
+            db.session.commit()
+
+            flags = set_org_feature_overrides(org, _desired(org))
+            db.session.commit()
+
+            assert flags['SOME_LEGACY_FLAG'] is True
+
+
+class TestDescribeOrgFeatures:
+    def test_reports_every_known_feature(self, app, org):
+        with app.app_context():
+            rows = describe_org_features(org)
+            assert {row['name'] for row in rows} == set(all_feature_names())
+            assert set(TIER_FEATURES['enterprise']) <= {row['name'] for row in rows}
+
+    def test_marks_overrides_and_killswitches(self, app, org):
+        killswitched = next(iter(GLOBAL_FEATURE_OVERRIDES))
+        with app.app_context():
+            set_org_feature_overrides(org, _desired(org, BOB_TELEGRAM=True))
+            db.session.commit()
+
+            rows = {row['name']: row for row in describe_org_features(org)}
+
+            assert rows['BOB_TELEGRAM']['overridden'] is True
+            assert rows['BOB_TELEGRAM']['enabled'] is True
+            assert rows['TRANSACTIONS']['overridden'] is False
+            assert rows[killswitched]['locked'] is True


### PR DESCRIPTION
## Summary

- Enabling a feature for an org meant hand-editing the `feature_flags` JSON in the database, so B.O.B. on Telegram couldn't be rolled out to anyone without a developer. Adds a **Feature Access** card to `/platform/orgs/<id>` with a toggle per feature.
- Overrides are stored **only when they differ from the tier default**. Saving a value that matches the tier leaves it inherited, so the org still picks up future tier changes rather than being frozen at whatever happened to be true the day it was saved. There's a test for exactly that.
- Killswitched features (`GLOBAL_FEATURE_OVERRIDES`) render disabled and labelled, and keep any stored intent — a disabled checkbox doesn't submit, so an absent field must not be read as a deliberate "off".
- Every change is written to the platform audit log, matching `update_org_tier`.
- Separately: the Telegram connect page is now explicit numbered steps. The QR alone didn't tell an agent what to expect once Telegram opened, or that they need to tap Start.

## Notes

`BOB_TELEGRAM` still defaults to off on every tier. This just means you can flip it per org from the UI instead of the database.

## Test plan

- [x] `pytest tests/test_org_feature_flags.py tests/test_bob_telegram.py` — 29 passed
- [x] New tests cover: override stored only when it differs from tier, removal when set back to default, tier upgrade still landing on inherited features, killswitch intent preserved, unmanaged keys surviving a save
- [x] Verified `platform.update_org_features` resolves and both templates parse
- [ ] After deploy: open a customer org in platform admin, toggle B.O.B. on Telegram, confirm the row appears on that agent's profile

Made with [Cursor](https://cursor.com)