### PR TITLE
feat: record what B.O.B. changed in the notification bell

### DIFF
--- a/migrations/versions/add_bob_action_notification.py
+++ b/migrations/versions/add_bob_action_notification.py
@@ -1,0 +1,57 @@
+"""Link B.O.B. actions to the notification that announced them.
+
+Lets an undo retract the bell entry instead of leaving the agent with a record
+of a change that no longer exists.
+
+Revision ID: add_bob_action_notif
+Revises: add_bob_telegram
+Create Date: 2026-07-29
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_bob_action_notif'
+down_revision = 'add_bob_telegram'
+branch_labels = None
+depends_on = None
+
+TABLE = 'bob_actions'
+COLUMN = 'notification_id'
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    if TABLE not in set(inspector.get_table_names()):
+        return
+    if COLUMN in {c['name'] for c in inspector.get_columns(TABLE)}:
+        return
+
+    op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
+    op.create_index(
+        f'ix_{TABLE}_{COLUMN}', TABLE, [COLUMN], unique=False,
+    )
+
+    # SQLite cannot add a foreign key to an existing table, and local dev does
+    # not need one for correctness here.
+    if conn.dialect.name == 'postgresql':
+        op.create_foreign_key(
+            f'fk_{TABLE}_{COLUMN}', TABLE, 'notifications',
+            [COLUMN], ['id'], ondelete='SET NULL',
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    if TABLE not in set(inspector.get_table_names()):
+        return
+    if COLUMN not in {c['name'] for c in inspector.get_columns(TABLE)}:
+        return
+
+    if conn.dialect.name == 'postgresql':
+        op.drop_constraint(f'fk_{TABLE}_{COLUMN}', TABLE, type_='foreignkey')
+    op.drop_index(f'ix_{TABLE}_{COLUMN}', table_name=TABLE)
+    op.drop_column(TABLE, COLUMN)

--- a/models.py
+++ b/models.py
@@ -2224,6 +2224,12 @@ class BobAction(db.Model):
     error = db.Column(db.Text, nullable=True)
     surface = db.Column(db.String(32), nullable=False, default='bob_chat')
 
+    # The bell entry this action was folded into, so an undo can retract it.
+    notification_id = db.Column(db.Integer,
+                                db.ForeignKey('notifications.id',
+                                              ondelete='SET NULL'),
+                                nullable=True, index=True)
+
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow,
                            index=True)
     executed_at = db.Column(db.DateTime, nullable=True)
@@ -2770,6 +2776,7 @@ class Notification(db.Model):
         'company_update': 'Company Updates',
         'magic_inbox': 'Magic Inbox',
         'portal': 'Client Portal',
+        'bob_action': 'B.O.B. Changes',
     }
 
     def mark_read(self):

--- a/routes/ai_chat.py
+++ b/routes/ai_chat.py
@@ -15,6 +15,8 @@ from services.bob_tools import (
     reject_action,
     undo_action,
 )
+from services.bob_tools.notifications import ActionCollector
+from services.bob_tools.notifications import flush as flush_action_notification
 from sqlalchemy import or_, func
 from tier_config.tier_limits import get_tier_defaults
 import logging
@@ -637,10 +639,12 @@ def chat_stream():
         def generate():
             """Yield SSE events for text, tool activity, and confirmations."""
             full_response = ""
+            collector = ActionCollector()
 
             def execute_tool(name, arguments):
                 result = bob_dispatch(
                     name, arguments, bob_ctx, conversation_id=conversation_id,
+                    collector=collector,
                 )
                 return result.for_model(), result.for_client()
 
@@ -685,6 +689,8 @@ def chat_stream():
                 )
                 full_response += message
                 yield f"data: {_sse_escape(message)}\n\n"
+
+            flush_action_notification(collector, bob_ctx)
 
             yield f"data: [DONE]\n\n"
             # Client accumulates during the stream; trailer is optional metadata.

--- a/services/bob_tools/notifications.py
+++ b/services/bob_tools/notifications.py
@@ -1,0 +1,174 @@
+"""In-app notifications for the changes B.O.B. makes on an agent's behalf.
+
+A chat turn scrolls away and a Telegram thread gets buried, so the bell is the
+one place an agent will still find "what did B.O.B. change?" tomorrow.
+
+Grouped per request rather than per tool call: one sentence can trigger three
+writes, and three separate bells for one instruction reads as noise.
+"""
+from __future__ import annotations
+
+import logging
+
+from models import BobAction, db
+from services.bob_tools.context import BobContext
+from services.notification_service import create_notification
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = 'bob_action'
+ICON = 'fa-robot'
+
+# How the agent would describe where they asked, not our internal surface key.
+SURFACE_LABELS = {
+    'bob_chat': 'chat',
+    'bob_telegram': 'Telegram',
+}
+
+MAX_LISTED = 4
+
+
+class ActionCollector:
+    """Gathers the writes from one request so they notify together.
+
+    Passed explicitly through ``dispatch`` rather than kept in module state, so
+    two concurrent turns can never pour into each other's notification.
+    """
+
+    def __init__(self):
+        self._entries: list[tuple[BobAction, str | None]] = []
+
+    def add(self, action: BobAction, result) -> None:
+        self._entries.append((action, getattr(result, 'record_url', None)))
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    @property
+    def entries(self) -> list:
+        return list(self._entries)
+
+
+def notify_actions(entries: list, ctx: BobContext):
+    """Create one notification covering everything B.O.B. just changed.
+
+    Never raises: a bell that fails to ring must not roll back real CRM work
+    that already succeeded.
+    """
+    live = [
+        (action, url) for action, url in entries
+        if action is not None and action.status == BobAction.STATUS_EXECUTED
+    ]
+    if not live:
+        return None
+
+    try:
+        notif = create_notification(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            category=CATEGORY,
+            title=_title(live),
+            body=_body(live, ctx),
+            icon=ICON,
+            action_url=_action_url(live),
+        )
+        if notif is not None:
+            for action, _ in live:
+                action.notification_id = notif.id
+            db.session.commit()
+        return notif
+    except Exception:
+        db.session.rollback()
+        logger.exception('B.O.B. action notification failed user=%s', ctx.user_id)
+        return None
+
+
+def flush(collector: ActionCollector | None, ctx: BobContext):
+    """Emit the notification for a finished turn, if anything was written."""
+    if collector is None or not len(collector):
+        return None
+    return notify_actions(collector.entries, ctx)
+
+
+def forget_action(action: BobAction) -> None:
+    """Drop the notification for an undone action.
+
+    Leaving "B.O.B. created Cooper Blake" in the bell after the agent undid it
+    would be a lie, and its link would 404. A grouped notification only goes
+    when every action it covered has been undone.
+    """
+    notification_id = getattr(action, 'notification_id', None)
+    if not notification_id:
+        return
+
+    try:
+        from models import Notification
+
+        # Confirm the row is still the notification we announced. Postgres
+        # nulls the reference on delete, but a stale pointer must never let an
+        # undo remove some unrelated entry from the agent's bell.
+        notif = db.session.get(Notification, notification_id)
+        if (notif is None
+                or notif.user_id != action.user_id
+                or notif.category != CATEGORY):
+            action.notification_id = None
+            db.session.commit()
+            return
+
+        siblings = BobAction.query.filter_by(
+            notification_id=notification_id,
+            user_id=action.user_id,
+        ).all()
+        if any(s.status != BobAction.STATUS_UNDONE for s in siblings):
+            return
+
+        db.session.delete(notif)
+        for sibling in siblings:
+            sibling.notification_id = None
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('B.O.B. notification cleanup failed action=%s', action.id)
+
+
+# ---------------------------------------------------------------------------
+# Copy
+# ---------------------------------------------------------------------------
+
+def _title(live: list) -> str:
+    if len(live) == 1:
+        return f'B.O.B. {_lower_first(_summary(live[0][0]))}'[:200]
+    return f'B.O.B. made {len(live)} changes'
+
+
+def _body(live: list, ctx: BobContext) -> str:
+    where = SURFACE_LABELS.get(ctx.surface, 'B.O.B.')
+    if len(live) == 1:
+        return f'Asked in {where}.'
+
+    parts = [_summary(action) for action, _ in live[:MAX_LISTED]]
+    remaining = len(live) - len(parts)
+    if remaining > 0:
+        parts.append(f'and {remaining} more')
+    return f"{' · '.join(parts)} — asked in {where}."
+
+
+def _action_url(live: list) -> str | None:
+    for _, url in live:
+        # Guard the type: a non-string here would only surface as a failed
+        # INSERT at the very end of an otherwise successful turn.
+        if url and isinstance(url, str):
+            return url
+    return None
+
+
+def _summary(action: BobAction) -> str:
+    return (action.summary or action.tool_name.replace('_', ' ')).strip()
+
+
+def _lower_first(text: str) -> str:
+    if not text:
+        return text
+    # Only the leading capital, so "Created Cooper Blake" reads as a sentence
+    # while an acronym or a proper noun keeps its shape.
+    return text[0].lower() + text[1:]

--- a/services/bob_tools/registry.py
+++ b/services/bob_tools/registry.py
@@ -27,6 +27,7 @@ from services.bob_tools import interactions as interaction_tools
 from services.bob_tools import tasks as task_tools
 from services.bob_tools import todos as todo_tools
 from services.bob_tools.common import ToolError
+from services.bob_tools.notifications import forget_action, notify_actions
 from services.bob_tools.context import (
     RISK_HIGH_WRITE,
     RISK_LOW_WRITE,
@@ -750,7 +751,8 @@ def sanitize_arguments(tool: Tool, raw_args: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 def dispatch(name: str, raw_args: dict, ctx: BobContext, *,
-             conversation_id: int | None = None) -> ToolResult:
+             conversation_id: int | None = None,
+             collector=None) -> ToolResult:
     """Run one tool call under the confirmation and audit policy.
 
     Never raises: every failure becomes a ToolResult the model can read and
@@ -784,6 +786,8 @@ def dispatch(name: str, raw_args: dict, ctx: BobContext, *,
         if result.ok:
             action = _record_executed_action(tool, args, result, ctx,
                                             conversation_id=conversation_id)
+            if collector is not None:
+                collector.add(action, result)
             if tool.undo is not None and result.undoable:
                 result.action_id = action.id
             else:
@@ -843,6 +847,10 @@ def confirm_action(action_id: int, ctx: BobContext) -> ToolResult:
     action.result = _undo_payload(result)
     db.session.commit()
 
+    # A confirmation is its own moment, so it notifies on its own rather than
+    # waiting for a turn that already ended.
+    notify_actions([(action, result.record_url)], ctx)
+
     if tool.undo is not None and result.undoable:
         result.action_id = action.id
     else:
@@ -892,6 +900,7 @@ def undo_action(action_id: int, ctx: BobContext) -> ToolResult:
 
     action.status = BobAction.STATUS_UNDONE
     db.session.commit()
+    forget_action(action)
     return ToolResult.success(summary=summary, data={'undone': True})
 
 

--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -27,6 +27,8 @@ from services.bob_tools import (
     reject_action,
     undo_action,
 )
+from services.bob_tools.notifications import ActionCollector
+from services.bob_tools.notifications import flush as flush_action_notification
 from services.bob_tools.registry import dispatch as bob_dispatch
 from services.messaging.base import ChoiceOption
 from services.messaging.prompt import TELEGRAM_SYSTEM_PROMPT
@@ -271,11 +273,13 @@ def _run_tool_loop(
     pending: Optional[dict] = None
     undoable_action_id: Optional[int] = None
     text_parts: list[str] = []
+    collector = ActionCollector()
 
     def execute_tool(name: str, args: dict) -> tuple[dict, dict]:
         nonlocal pending, undoable_action_id
         result = bob_dispatch(
             name, args, ctx, conversation_id=conversation.id,
+            collector=collector,
         )
         if result.requires_confirmation and result.action_id:
             pending = {
@@ -308,6 +312,8 @@ def _run_tool_loop(
         text_parts.append(
             "Something went wrong on my end. Try that again in a moment."
         )
+
+    flush_action_notification(collector, ctx)
 
     reply = ''.join(text_parts).strip()
     if not reply:

--- a/templates/notifications/settings.html
+++ b/templates/notifications/settings.html
@@ -47,6 +47,10 @@
                             <p class="mt-1 text-xs" style="color: var(--ink-3); line-height: 1.45;">
                                 Get notified when your team posts a company update.
                             </p>
+                            {% elif cat_key == 'bob_action' %}
+                            <p class="mt-1 text-xs" style="color: var(--ink-3); line-height: 1.45;">
+                                Keep a record of what B.O.B. changed for you, in chat or Telegram.
+                            </p>
                             {% endif %}
                         </div>
                         <div class="flex justify-center">

--- a/tests/test_bob_notifications.py
+++ b/tests/test_bob_notifications.py
@@ -15,7 +15,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from models import BobAction, Notification, db
+from models import BobAction, Contact, Interaction, Notification, Task, db
 from services.bob_tools import BobContext, dispatch, undo_action
 from services.bob_tools.notifications import (
     CATEGORY,
@@ -46,6 +46,11 @@ def ctx_telegram(seed):
     )
 
 
+# Every contact these tests create uses this first name, so cleanup can find
+# them without threading ids through each test.
+SCRATCH_FIRST_NAME = 'Nora'
+
+
 @pytest.fixture(autouse=True)
 def _clean_notifications(app, seed):
     """Isolate counts from any other test file that drove B.O.B."""
@@ -60,6 +65,26 @@ def _wipe(app):
         # pointing at a deleted notification would collide with the next one.
         BobAction.query.delete()
         Notification.query.filter_by(category=CATEGORY).delete()
+
+        # The contacts these tests create own interactions and tasks. Left
+        # behind, they break unrelated files later in the session, because the
+        # SQLite test database is shared for the whole run.
+        scratch = Contact.query.filter_by(
+            first_name=SCRATCH_FIRST_NAME,
+        ).all()
+        if scratch:
+            ids = [c.id for c in scratch]
+            Interaction.query.filter(
+                Interaction.contact_id.in_(ids),
+            ).delete(synchronize_session=False)
+            Task.query.filter(
+                Task.contact_id.in_(ids),
+            ).delete(synchronize_session=False)
+            for contact in scratch:
+                contact.groups = []
+            db.session.flush()
+            for contact in scratch:
+                db.session.delete(contact)
         db.session.commit()
 
 
@@ -74,7 +99,7 @@ def _bob_notifications(user_id):
 
 def _new_contact(ctx, collector, last_name='Notify'):
     return dispatch('create_contact', {
-        'first_name': 'Nora', 'last_name': last_name,
+        'first_name': SCRATCH_FIRST_NAME, 'last_name': last_name,
         'email': f'nora.{last_name.lower()}@test.com',
         'group_names': ['Buyers'],
     }, ctx, collector=collector)
@@ -235,8 +260,11 @@ class TestConfirmedActions:
         from services.bob_tools import confirm_action
 
         with app.app_context():
+            created = _new_contact(ctx_owner_a, None, last_name='Confirmed')
+            assert _bob_notifications(seed['owner_a']) == []
+
             pending = dispatch('update_contact', {
-                'contact_id': seed['contact_a'],
+                'contact_id': created.data['contact']['contact_id'],
                 'fields': {'city': 'Katy'},
             }, ctx_owner_a)
             assert pending.requires_confirmation is True

--- a/tests/test_bob_notifications.py
+++ b/tests/test_bob_notifications.py
@@ -1,0 +1,250 @@
+"""Tests for the bell record of what B.O.B. changed.
+
+Covers grouping per request, B.O.B. attribution, surface wording, undo
+retraction, preference opt-out, and that reads never notify.
+
+Run with: python -m pytest tests/test_bob_notifications.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models import BobAction, Notification, db
+from services.bob_tools import BobContext, dispatch, undo_action
+from services.bob_tools.notifications import (
+    CATEGORY,
+    ActionCollector,
+    flush,
+)
+from services.notification_service import set_preference
+
+
+@pytest.fixture()
+def ctx_owner_a(seed):
+    return BobContext(
+        user_id=seed['owner_a'],
+        organization_id=seed['org_a'],
+        org_role='owner',
+        is_org_admin=True,
+    )
+
+
+@pytest.fixture()
+def ctx_telegram(seed):
+    return BobContext(
+        user_id=seed['owner_a'],
+        organization_id=seed['org_a'],
+        org_role='owner',
+        is_org_admin=True,
+        surface='bob_telegram',
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_notifications(app, seed):
+    """Isolate counts from any other test file that drove B.O.B."""
+    _wipe(app)
+    yield
+    _wipe(app)
+
+
+def _wipe(app):
+    with app.app_context():
+        # Actions go too. SQLite recycles row ids, so a leftover action still
+        # pointing at a deleted notification would collide with the next one.
+        BobAction.query.delete()
+        Notification.query.filter_by(category=CATEGORY).delete()
+        db.session.commit()
+
+
+def _bob_notifications(user_id):
+    return (
+        Notification.query
+        .filter_by(user_id=user_id, category=CATEGORY)
+        .order_by(Notification.created_at.desc())
+        .all()
+    )
+
+
+def _new_contact(ctx, collector, last_name='Notify'):
+    return dispatch('create_contact', {
+        'first_name': 'Nora', 'last_name': last_name,
+        'email': f'nora.{last_name.lower()}@test.com',
+        'group_names': ['Buyers'],
+    }, ctx, collector=collector)
+
+
+class TestGrouping:
+    def test_one_request_with_one_write_makes_one_notification(
+            self, app, seed, ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            _new_contact(ctx_owner_a, collector)
+            flush(collector, ctx_owner_a)
+
+            notifs = _bob_notifications(seed['owner_a'])
+            assert len(notifs) == 1
+            assert notifs[0].title.startswith('B.O.B.')
+
+    def test_several_writes_in_one_request_collapse_into_one(
+            self, app, seed, ctx_owner_a):
+        """Three bells for one sentence would read as noise."""
+        with app.app_context():
+            collector = ActionCollector()
+            created = _new_contact(ctx_owner_a, collector, last_name='Grouped')
+            contact_id = created.data['contact']['contact_id']
+            dispatch('append_contact_note', {
+                'contact_id': contact_id, 'note': 'Met at open house',
+            }, ctx_owner_a, collector=collector)
+            dispatch('log_interaction', {
+                'contact_id': contact_id, 'type': 'call',
+            }, ctx_owner_a, collector=collector)
+            flush(collector, ctx_owner_a)
+
+            notifs = _bob_notifications(seed['owner_a'])
+            assert len(notifs) == 1
+            assert '3 changes' in notifs[0].title
+
+    def test_reads_never_notify(self, app, seed, ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            dispatch('get_agenda', {}, ctx_owner_a, collector=collector)
+            dispatch('search_contacts', {'query': 'Jane'}, ctx_owner_a,
+                     collector=collector)
+            flush(collector, ctx_owner_a)
+
+            assert _bob_notifications(seed['owner_a']) == []
+
+    def test_a_failed_write_does_not_notify(self, app, seed, ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            result = dispatch('append_contact_note', {
+                'contact_id': seed['contact_b'], 'note': 'nope',
+            }, ctx_owner_a, collector=collector)
+            flush(collector, ctx_owner_a)
+
+            assert result.ok is False
+            assert _bob_notifications(seed['owner_a']) == []
+
+
+class TestAttribution:
+    def test_names_bob_and_the_surface(self, app, seed, ctx_telegram):
+        with app.app_context():
+            collector = ActionCollector()
+            _new_contact(ctx_telegram, collector, last_name='Telegram')
+            flush(collector, ctx_telegram)
+
+            notif = _bob_notifications(seed['owner_a'])[0]
+            assert 'B.O.B.' in notif.title
+            assert 'Telegram' in notif.body
+
+    def test_chat_surface_is_named_too(self, app, seed, ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            _new_contact(ctx_owner_a, collector, last_name='Chat')
+            flush(collector, ctx_owner_a)
+
+            notif = _bob_notifications(seed['owner_a'])[0]
+            assert 'chat' in notif.body
+
+    def test_links_to_the_record_when_there_is_one(self, app, seed,
+                                                   ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            result = _new_contact(ctx_owner_a, collector, last_name='Linked')
+            flush(collector, ctx_owner_a)
+
+            notif = _bob_notifications(seed['owner_a'])[0]
+            if result.record_url:
+                assert notif.action_url == result.record_url
+
+
+class TestUndo:
+    def test_undo_retracts_the_notification(self, app, seed, ctx_owner_a):
+        """A bell saying B.O.B. created something it just removed is a lie."""
+        with app.app_context():
+            collector = ActionCollector()
+            result = _new_contact(ctx_owner_a, collector, last_name='Undone')
+            flush(collector, ctx_owner_a)
+            assert len(_bob_notifications(seed['owner_a'])) == 1
+
+            undo = undo_action(result.action_id, ctx_owner_a)
+
+            assert undo.ok is True
+            assert _bob_notifications(seed['owner_a']) == []
+
+    def test_grouped_notification_survives_a_partial_undo(self, app, seed,
+                                                          ctx_owner_a):
+        with app.app_context():
+            collector = ActionCollector()
+            created = _new_contact(ctx_owner_a, collector, last_name='Partial')
+            contact_id = created.data['contact']['contact_id']
+            logged = dispatch('log_interaction', {
+                'contact_id': contact_id, 'type': 'call',
+            }, ctx_owner_a, collector=collector)
+            flush(collector, ctx_owner_a)
+            assert len(_bob_notifications(seed['owner_a'])) == 1
+
+            undo_action(logged.action_id, ctx_owner_a)
+
+            # The contact still exists, so the record must stay.
+            assert len(_bob_notifications(seed['owner_a'])) == 1
+
+
+class TestPreferences:
+    def test_opting_out_silences_the_category(self, app, seed, ctx_owner_a):
+        with app.app_context():
+            set_preference(seed['owner_a'], seed['org_a'], CATEGORY,
+                           in_app=False)
+
+            collector = ActionCollector()
+            _new_contact(ctx_owner_a, collector, last_name='Muted')
+            flush(collector, ctx_owner_a)
+
+            assert _bob_notifications(seed['owner_a']) == []
+
+            set_preference(seed['owner_a'], seed['org_a'], CATEGORY,
+                           in_app=True)
+
+    def test_write_still_succeeds_when_muted(self, app, seed, ctx_owner_a):
+        """The bell is a side effect and must never gate real CRM work."""
+        with app.app_context():
+            set_preference(seed['owner_a'], seed['org_a'], CATEGORY,
+                           in_app=False)
+
+            collector = ActionCollector()
+            result = _new_contact(ctx_owner_a, collector, last_name='Silent')
+            flush(collector, ctx_owner_a)
+
+            assert result.ok is True
+
+            set_preference(seed['owner_a'], seed['org_a'], CATEGORY,
+                           in_app=True)
+
+
+class TestConfirmedActions:
+    def test_a_confirmed_change_notifies_on_its_own(self, app, seed,
+                                                    ctx_owner_a):
+        """Confirming is its own moment, after the turn already ended."""
+        from services.bob_tools import confirm_action
+
+        with app.app_context():
+            pending = dispatch('update_contact', {
+                'contact_id': seed['contact_a'],
+                'fields': {'city': 'Katy'},
+            }, ctx_owner_a)
+            assert pending.requires_confirmation is True
+            assert _bob_notifications(seed['owner_a']) == []
+
+            confirmed = confirm_action(pending.action_id, ctx_owner_a)
+
+            assert confirmed.ok is True
+            notifs = _bob_notifications(seed['owner_a'])
+            assert len(notifs) == 1
+            assert 'B.O.B.' in notifs[0].title


### PR DESCRIPTION
## Summary

- A chat turn scrolls away and a Telegram thread gets buried, so there was no trace an agent would stumble across later of what B.O.B. changed for them. Executed writes now create an in-app notification, clearly attributed to B.O.B. and naming where it was asked ("Asked in Telegram").
- **Grouped per request, not per tool call.** "Add Cooper to Family and update his commission" is three writes; three separate bells for one instruction reads as noise. One notification says "B.O.B. made 3 changes" and lists them.
- **Undo retracts it.** Leaving "B.O.B. created Cooper Blake" in the bell after the agent undid it would be a lie, and its link would 404. A grouped entry only goes when every action it covered was undone.
- Confirmed high-risk actions notify on their own, since confirming happens after the turn already ended.
- New `bob_action` notification category, so agents can mute it from notification settings like any other.

## Safety

The bell is a side effect and never gates real work: notification failures are logged and swallowed, with a test asserting the write still succeeds when the category is muted. Reads never notify, and neither do failed writes.

`forget_action` re-verifies the notification still belongs to that user and category before deleting, so a stale reference can't retract an unrelated entry.

## Migration

Adds nullable `bob_actions.notification_id` (`add_bob_action_notif`, down_revision `add_bob_telegram`, confirmed single head). Verified upgrade, re-run idempotency, and downgrade.

## Test plan

- [x] `pytest tests/test_bob_tools.py tests/test_bob_telegram.py tests/test_bob_notifications.py tests/test_org_feature_flags.py` — 172 passed
- [x] New tests: grouping, reads/failures not notifying, B.O.B. + surface attribution, undo retraction, partial-undo keeping the entry, preference opt-out, confirmed actions
- [ ] After deploy: ask B.O.B. in Telegram to create a contact, confirm the bell entry names B.O.B. and Telegram

Made with [Cursor](https://cursor.com)