### PR TITLE
feat: make B.O.B. Telegram useful in the field

### DIFF
--- a/jobs/bob_telegram_reply.py
+++ b/jobs/bob_telegram_reply.py
@@ -11,9 +11,15 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def process_telegram_message_job(*, org_id: int, channel_id: int,
-                                 text: str,
-                                 telegram_message_id: str | None = None) -> None:
+def process_telegram_message_job(
+    *,
+    org_id: int,
+    channel_id: int,
+    text: str,
+    telegram_message_id: str | None = None,
+    voice_file_id: str | None = None,
+    voice_duration_seconds: int | None = None,
+) -> None:
     from app import app
     from jobs.base import set_job_org_context
     from services.messaging.conversation import handle_inbound_message
@@ -26,6 +32,8 @@ def process_telegram_message_job(*, org_id: int, channel_id: int,
                 org_id=org_id,
                 text=text,
                 telegram_message_id=telegram_message_id,
+                voice_file_id=voice_file_id,
+                voice_duration_seconds=voice_duration_seconds,
             )
         except Exception:
             logger.exception(

--- a/jobs/daily_briefing.py
+++ b/jobs/daily_briefing.py
@@ -87,6 +87,7 @@ def prewarm_daily_briefings(active_within_days: int = 7):
                 db.session.add(row)
             db.session.commit()
             generated += 1
+            _maybe_telegram_briefing_nudge(user, content)
         except Exception as e:
             failed += 1
             logger.exception(f"Prewarm failed for user {user.id}: {e}")
@@ -106,6 +107,28 @@ def prewarm_daily_briefings(active_within_days: int = 7):
         f"skipped={skipped} failed={failed}"
     )
     return {"generated": generated, "skipped": skipped, "failed": failed}
+
+
+def _maybe_telegram_briefing_nudge(user, content: dict) -> None:
+    """Best-effort Telegram push; never fails the prewarm."""
+    try:
+        import os
+        from services.messaging.binding import get_active_channel
+        from services.messaging.outbound import notify_daily_briefing
+
+        if get_active_channel(user.id) is None:
+            return
+        base = (os.environ.get('APP_BASE_URL')
+                or 'https://www.origentechnolog.com').rstrip('/')
+        notify_daily_briefing(
+            user,
+            content,
+            action_url=f'{base}/briefing',
+        )
+    except Exception:
+        logger.exception(
+            'Telegram daily briefing nudge failed for user %s', user.id,
+        )
 
 
 def run_daily_briefing_prewarm():

--- a/models.py
+++ b/models.py
@@ -2773,6 +2773,7 @@ class Notification(db.Model):
     # Rows older than 90 days are safe to prune via a periodic job.
     CATEGORIES = {
         'task_reminder': 'Task Reminders',
+        'daily_briefing': 'Daily Briefing',
         'company_update': 'Company Updates',
         'magic_inbox': 'Magic Inbox',
         'portal': 'Client Portal',

--- a/routes/ai_chat.py
+++ b/routes/ai_chat.py
@@ -144,17 +144,23 @@ def get_rate_limit_message():
 
 --BOB"""
 
-SYSTEM_PROMPT = """You are B.O.B. (Business Optimization Buddy), an experienced real estate professional with deep expertise in the Houston market and HAR (Houston Association of REALTORS®) procedures. Think of yourself as a knowledgeable, supportive colleague who's always ready to share insights and practical advice.
+SYSTEM_PROMPT = """You are B.O.B. (Business Optimization Buddy), a sharp Houston real estate ops partner with deep HAR (Houston Association of REALTORS®) knowledge. You sit beside the agent, not above them. You've been through enough deals to know what matters and what is noise.
 
-Communication Style:
-- Be direct and genuine - skip phrases like "I hope this message finds you well"
-- Keep a professional tone without being overly formal
-- Use natural language and contractions
-- Acknowledge mistakes directly without over-apologizing
-- Skip unnecessary words that don't add value
-- Find the middle ground between casual and corporate
+Voice:
+- Sound like a competent desk partner: calm, clear, lightly dry when it fits. Never cartoonish, never chipper.
+- Lead with the answer or the next step. Warmth comes from being useful, not from cheerleading.
+- Use contractions. Vary sentence length. Short is fine.
+- Have a point of view when it helps ("I'd call her before noon" beats "You might consider reaching out"). Soften if the agent pushes back.
+- Occasional dry understatement is fine. Forced jokes, slang piles, and pep-talk energy are not.
+- Skip corporate filler: "I hope this finds you well", "Happy to help!", "Great question!", "Absolutely!", "Certainly!".
+- Acknowledge mistakes in one plain line. No over-apologizing.
 - NEVER use em dashes (—) or en dashes (–). Use a period or comma instead.
 - When drafting texts/emails for clients, sound human and ready to send, not like marketing copy.
+
+Name usage:
+- You know the agent's first name. Do NOT open every reply with it, and do not sprinkle it through the message.
+- Use their name rarely: a first greeting in a new conversation, or once when you need real emphasis (bad news, a firm redirect, a personal nudge).
+- Default is no name. Back-to-back replies almost never need it.
 
 Your background includes:
 - 15+ years of real estate experience in Houston
@@ -163,13 +169,10 @@ Your background includes:
 - Expert negotiation and client relationship skills
 - Experience with both residential and commercial properties
 
-When interacting with agents:
-- Be professional but personable
-- Share real-world examples and practical experiences
-- Provide actionable advice based on industry best practices
-- Focus on solving real estate challenges first, mentioning CRM features only when naturally relevant
-- Address agents by their first name
-- Keep conversations efficient but friendly
+How you work with agents:
+- Solve the real estate problem first. Mention CRM features only when they naturally help.
+- Share practical examples when they sharpen the advice, not as padding.
+- Keep conversations efficient. Friendly without being soft.
 - Close all conversations with "--BOB"
 
 Your expertise covers:
@@ -187,9 +190,7 @@ When giving advice:
 - Keep it concise but complete
 - Address urgent matters directly
 - Draw from real estate best practices and market knowledge
-- Share practical tips that have worked in similar situations
 - Consider both immediate needs and long-term strategy
-- Be supportive while staying professional
 - Suggest CRM features only when they naturally fit the conversation
 
 FORMATTING RULES (follow exactly):
@@ -251,7 +252,8 @@ Out of scope (refuse):
 How to refuse:
 - Do NOT answer the off-topic request, even partially. Do not hedge with a "but here's a quick answer."
 - Give one short, polite sentence stating you only help with real estate, then offer a relevant real estate direction.
-- Example (use the agent's first name): "That's outside what I do - I only help with real estate. Want me to help with a listing, a client follow-up, or pricing instead?"
+- Example: "That's outside what I do - I only help with real estate. Want a hand with a listing, a client follow-up, or pricing instead?"
+- Do not use the agent's name in a routine refusal.
 - Always still close with "--BOB".
 
 If a request mixes real estate with an off-topic ask, answer only the real estate part and decline the rest. When in doubt about whether something is real estate, decline.
@@ -362,7 +364,7 @@ def chat():
         # Prepare the context message with agent info
         context_message = f"""
 # Agent Context
-- **Name**: {current_user.first_name} {current_user.last_name}
+- **Name**: {current_user.first_name} {current_user.last_name} (first name: use rarely, per Name usage rules)
 - **Email**: {current_user.email}
 - **Role**: {current_user.role}
 - **Current View**: {current_url}
@@ -556,7 +558,7 @@ def chat_stream():
         # Prepare the context message with agent info
         context_message = f"""
 # Agent Context
-- **Name**: {current_user.first_name} {current_user.last_name}
+- **Name**: {current_user.first_name} {current_user.last_name} (first name: use rarely, per Name usage rules)
 - **Email**: {current_user.email}
 - **Role**: {current_user.role}
 - **Current View**: {current_url}

--- a/routes/bob_telegram.py
+++ b/routes/bob_telegram.py
@@ -136,7 +136,10 @@ def _handle_message_update(message: dict, update_id: str) -> None:
     chat = message.get('chat') or {}
     external_id = from_user.get('id')
     chat_id = chat.get('id')
-    text_body = (message.get('text') or '').strip()
+    text_body = (message.get('text') or message.get('caption') or '').strip()
+    voice = message.get('voice') or message.get('audio') or {}
+    voice_file_id = voice.get('file_id') if isinstance(voice, dict) else None
+    voice_duration = voice.get('duration') if isinstance(voice, dict) else None
     if external_id is None or chat_id is None:
         return
 
@@ -161,11 +164,23 @@ def _handle_message_update(message: dict, update_id: str) -> None:
         )
         return
 
+    if not text_body and not voice_file_id:
+        get_transport().send_text(
+            channel.chat_id,
+            "I can take a text message or a voice note. "
+            "Photos, stickers, and files aren't supported yet.\n\n--BOB",
+        )
+        return
+
     enqueue_telegram_message(
         org_id=channel.organization_id,
         channel_id=channel.id,
         text=text_body,
         telegram_message_id=str(message.get('message_id') or ''),
+        voice_file_id=voice_file_id,
+        voice_duration_seconds=(
+            int(voice_duration) if voice_duration is not None else None
+        ),
     )
 
 
@@ -234,10 +249,17 @@ def _handle_start(text_body: str, *, external_id: str, chat_id: str,
 
     _set_webhook_org_context(channel.organization_id)
     _annotate_update(update_id, channel)
-    transport.send_text(
+    from services.messaging.base import ChoiceOption
+    transport.send_choice(
         chat_id,
-        "Linked. Ask me about your contacts or tasks anytime. "
-        "Send /help for ideas.\n\n--BOB",
+        "Linked. Ask me about your contacts or tasks anytime, "
+        "or send a voice note from the field.\n\n"
+        "Try one of these, or just type.\n\n--BOB",
+        [
+            ChoiceOption(label="Today's plate", callback_data='cmd:today'),
+            ChoiceOption(label='Overdue', callback_data='cmd:overdue'),
+            ChoiceOption(label='Help', callback_data='cmd:help'),
+        ],
     )
 
 
@@ -332,7 +354,10 @@ def register_webhook():
 
     url = f'{base.rstrip("/")}/webhooks/telegram/{path}'
     try:
-        TelegramTransport(token).set_webhook(url, secret_token=secret)
+        transport = TelegramTransport(token)
+        transport.set_webhook(url, secret_token=secret)
+        from services.messaging.telegram import BOT_COMMANDS
+        transport.set_my_commands(BOT_COMMANDS)
     except Exception as exc:
         logger.exception('setWebhook failed')
         flash(f'Webhook registration failed: {exc}', 'error')

--- a/scripts/register_telegram_webhook.py
+++ b/scripts/register_telegram_webhook.py
@@ -35,11 +35,15 @@ def main() -> int:
     url = f'{base}/webhooks/telegram/{path}'
     # Import after dotenv so Config is not required.
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from services.messaging.telegram import TelegramTransport
+    from services.messaging.telegram import BOT_COMMANDS, TelegramTransport
 
-    result = TelegramTransport(token).set_webhook(url, secret_token=secret)
+    transport = TelegramTransport(token)
+    result = transport.set_webhook(url, secret_token=secret)
     print(f'Registered webhook: {url}')
     print(result)
+    commands_result = transport.set_my_commands(BOT_COMMANDS)
+    print(f'Registered {len(BOT_COMMANDS)} bot commands')
+    print(commands_result)
     return 0
 
 

--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -264,9 +264,10 @@ def _run_tool_loop(
     messages = _history_messages(conversation)
     messages.append({'role': 'user', 'content': user_text})
 
+    first_name = user.first_name or 'there'
     system = (
         TELEGRAM_SYSTEM_PROMPT
-        + f"\n\nAgent first name: {user.first_name or 'there'}."
+        + f"\n\nAgent first name (use rarely, per Name usage rules): {first_name}."
         + f"\nToday (agent local): {ctx.today().isoformat()}."
     )
 

--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -8,14 +8,18 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+from flask import current_app
 
 from models import (
     AgentMessagingChannel,
     BobAction,
     ChatConversation,
     ChatMessage,
+    Contact,
     User,
     db,
 )
@@ -33,6 +37,7 @@ from services.bob_tools.registry import dispatch as bob_dispatch
 from services.messaging.base import ChoiceOption
 from services.messaging.prompt import TELEGRAM_SYSTEM_PROMPT
 from services.messaging.telegram import get_transport, show_typing
+from services.messaging.voice import VoiceTranscriptionError, transcribe_telegram_voice
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +50,20 @@ CHANNEL_NAME = 'telegram'
 PER_USER_DAILY_LIMIT = 100
 PER_ORG_DAILY_LIMIT = 500
 
-_CALLBACK_RE = re.compile(
-    r'^(confirm|reject|undo):(\d+)$'
-)
+# Contact picker: enough options to be useful, few enough for one keyboard row
+# wrap without drowning the agent.
+MAX_DISAMBIGUATION_OPTIONS = 6
+
+_CALLBACK_RE = re.compile(r'^(confirm|reject|undo):(\d+)$')
+_PICK_RE = re.compile(r'^pick:c:(\d+)$')
+_CMD_CALLBACK_RE = re.compile(r'^cmd:(today|overdue|help)$')
 _COMMAND_RE = re.compile(r'^/([a-zA-Z_]+)(?:@\S+)?(?:\s+(.*))?$')
+
+# Slash commands that expand into a normal user turn (not meta-commands).
+COMMAND_PROMPTS = {
+    'today': "What's on my plate today?",
+    'overdue': 'What tasks am I overdue on?',
+}
 
 
 class RateLimitExceeded(Exception):
@@ -69,8 +84,10 @@ def handle_inbound_message(
     org_id: int,
     text: str,
     telegram_message_id: Optional[str] = None,
+    voice_file_id: Optional[str] = None,
+    voice_duration_seconds: Optional[int] = None,
 ) -> None:
-    """Process a text message from a linked agent."""
+    """Process a text or voice message from a linked agent."""
     channel = _load_channel(channel_id, org_id)
     if channel is None:
         return
@@ -84,7 +101,37 @@ def handle_inbound_message(
         return
 
     transport = get_transport()
-    command = _parse_command(text)
+    from_voice = False
+    working_text = (text or '').strip()
+
+    if voice_file_id and not working_text:
+        try:
+            with show_typing(transport, channel.chat_id):
+                working_text = transcribe_telegram_voice(
+                    transport,
+                    voice_file_id,
+                    duration_seconds=voice_duration_seconds,
+                )
+            from_voice = True
+        except VoiceTranscriptionError as exc:
+            transport.send_text(channel.chat_id, f"{exc.message}\n\n--BOB")
+            return
+        except Exception:
+            logger.exception('Voice transcription crashed channel=%s', channel_id)
+            transport.send_text(
+                channel.chat_id,
+                "Couldn't catch that. Try again or type it.\n\n--BOB",
+            )
+            return
+
+    if not working_text:
+        transport.send_text(
+            channel.chat_id,
+            "I can take a text message or a voice note.\n\n--BOB",
+        )
+        return
+
+    command = _parse_command(working_text)
 
     if command == 'stop':
         from services.messaging.binding import disconnect_channel
@@ -97,10 +144,7 @@ def handle_inbound_message(
         return
 
     if command == 'help':
-        transport.send_text(
-            channel.chat_id,
-            _help_text(user),
-        )
+        transport.send_text(channel.chat_id, _help_text(user))
         return
 
     if command == 'undo':
@@ -109,13 +153,19 @@ def handle_inbound_message(
 
     if command == 'start':
         # Binding is handled in the webhook before enqueue. A bare /start from
-        # an already-linked user just gets a greeting.
-        transport.send_text(
+        # an already-linked user just gets a greeting + starters.
+        transport.send_choice(
             channel.chat_id,
             f"Already linked, {user.first_name or 'there'}. "
-            f"Ask me about your contacts or tasks anytime.\n\n--BOB",
+            "Ask me about your contacts or tasks anytime, "
+            "or send a voice note.\n\n--BOB",
+            _starter_options(),
         )
         return
+
+    if command in COMMAND_PROMPTS:
+        working_text = COMMAND_PROMPTS[command]
+        from_voice = False
 
     try:
         _bump_daily_count(channel)
@@ -123,17 +173,160 @@ def handle_inbound_message(
         transport.send_text(channel.chat_id, f"{exc.message}\n\n--BOB")
         return
 
-    conversation = _get_or_create_conversation(user)
-    _persist_message(conversation, 'user', text)
+    if from_voice:
+        # Show what Whisper heard so the agent can catch a bad transcript
+        # before confirming a write.
+        heard = working_text if len(working_text) <= 280 else working_text[:277] + '...'
+        transport.send_text(channel.chat_id, f'Heard: "{heard}"')
 
+    conversation = _get_or_create_conversation(user)
+    _persist_message(conversation, 'user', working_text)
+
+    _run_and_reply(
+        channel=channel,
+        user=user,
+        conversation=conversation,
+        user_text=working_text,
+        transport=transport,
+    )
+
+
+def handle_callback_query(
+    *,
+    channel_id: int,
+    org_id: int,
+    callback_query_id: str,
+    data: str,
+    message_id: Optional[str],
+) -> None:
+    """Process Confirm / Cancel / Undo / pick / starter button taps."""
+    channel = _load_channel(channel_id, org_id)
+    if channel is None:
+        return
+
+    user = User.query.filter_by(
+        id=channel.user_id, organization_id=org_id,
+    ).first()
+    if user is None:
+        return
+
+    transport = get_transport()
+    raw = (data or '').strip()
+
+    cmd_match = _CMD_CALLBACK_RE.match(raw)
+    if cmd_match is not None:
+        transport.answer_callback(callback_query_id, text='On it')
+        verb = cmd_match.group(1)
+        if verb == 'help':
+            if message_id:
+                transport.edit_message(
+                    channel.chat_id, message_id, _help_text(user),
+                )
+            else:
+                transport.send_text(channel.chat_id, _help_text(user))
+            return
+        handle_inbound_message(
+            channel_id=channel_id,
+            org_id=org_id,
+            text=f'/{verb}',
+        )
+        return
+
+    pick_match = _PICK_RE.match(raw)
+    if pick_match is not None:
+        _handle_pick_contact(
+            channel=channel,
+            user=user,
+            transport=transport,
+            callback_query_id=callback_query_id,
+            contact_id=int(pick_match.group(1)),
+            message_id=message_id,
+        )
+        return
+
+    match = _CALLBACK_RE.match(raw)
+    if match is None:
+        transport.answer_callback(callback_query_id, text='Unknown action')
+        return
+
+    verb, action_id_str = match.group(1), match.group(2)
+    action_id = int(action_id_str)
+    ctx = BobContext.from_user(user, surface=SURFACE, timezone=_user_tz(user))
+
+    # Never trust the callback payload for identity — confirm_action already
+    # scopes by user_id + organization_id, but we also refuse early if the
+    # pending pointer on the channel does not match (except for undo).
+    if verb in ('confirm', 'reject'):
+        if channel.pending_action_id not in (None, action_id):
+            # Stale button from an older preview; still allow if the action
+            # itself is pending and owned by this user.
+            pass
+
+    if verb == 'confirm':
+        result = confirm_action(action_id, ctx)
+        channel.pending_action_id = None
+        db.session.commit()
+        outcome = result.summary if result.ok else (result.error or 'Could not confirm.')
+        transport.answer_callback(callback_query_id, text='Confirmed' if result.ok else 'Failed')
+        body = f"{'Confirmed. ' if result.ok else ''}{outcome}"
+        body = _append_record_links(body, [result.record_url])
+        body = _ensure_bob_signoff(body)
+        if message_id:
+            transport.edit_message(channel.chat_id, message_id, body)
+        else:
+            transport.send_text(channel.chat_id, body)
+        return
+
+    if verb == 'reject':
+        result = reject_action(action_id, ctx)
+        channel.pending_action_id = None
+        db.session.commit()
+        transport.answer_callback(callback_query_id, text='Cancelled')
+        body = _ensure_bob_signoff(f"Cancelled. {result.summary}")
+        if message_id:
+            transport.edit_message(channel.chat_id, message_id, body)
+        else:
+            transport.send_text(channel.chat_id, body)
+        return
+
+    if verb == 'undo':
+        result = undo_action(action_id, ctx)
+        transport.answer_callback(
+            callback_query_id,
+            text='Undone' if result.ok else 'Could not undo',
+        )
+        body = _ensure_bob_signoff(
+            (result.summary if result.ok else result.error) or 'Could not undo.'
+        )
+        if message_id:
+            transport.edit_message(channel.chat_id, message_id, body)
+        else:
+            transport.send_text(channel.chat_id, body)
+        return
+
+
+# ---------------------------------------------------------------------------
+# Tool loop + reply rendering
+# ---------------------------------------------------------------------------
+
+def _run_and_reply(
+    *,
+    channel: AgentMessagingChannel,
+    user: User,
+    conversation: ChatConversation,
+    user_text: str,
+    transport: Any,
+) -> None:
     ctx = BobContext.from_user(user, surface=SURFACE, timezone=_user_tz(user))
     with show_typing(transport, channel.chat_id):
-        reply_text, pending, undoable = _run_tool_loop(
+        reply_text, pending, undoable, disambiguation, record_urls = _run_tool_loop(
             user=user,
             ctx=ctx,
             conversation=conversation,
-            user_text=text,
+            user_text=user_text,
         )
+
+    reply_text = _append_record_links(reply_text, record_urls)
 
     if pending is not None:
         channel.pending_action_id = pending['action_id']
@@ -158,7 +351,9 @@ def handle_inbound_message(
         _persist_message(conversation, 'assistant', preview_body)
         return
 
-    options = []
+    options: list[ChoiceOption] = []
+    if disambiguation:
+        options.extend(_disambiguation_options(disambiguation))
     if undoable is not None:
         options.append(ChoiceOption(
             label='Undo',
@@ -172,95 +367,14 @@ def handle_inbound_message(
     _persist_message(conversation, 'assistant', reply_text)
 
 
-def handle_callback_query(
-    *,
-    channel_id: int,
-    org_id: int,
-    callback_query_id: str,
-    data: str,
-    message_id: Optional[str],
-) -> None:
-    """Process a Confirm / Cancel / Undo button tap."""
-    channel = _load_channel(channel_id, org_id)
-    if channel is None:
-        return
-
-    user = User.query.filter_by(
-        id=channel.user_id, organization_id=org_id,
-    ).first()
-    if user is None:
-        return
-
-    transport = get_transport()
-    match = _CALLBACK_RE.match((data or '').strip())
-    if match is None:
-        transport.answer_callback(callback_query_id, text='Unknown action')
-        return
-
-    verb, action_id_str = match.group(1), match.group(2)
-    action_id = int(action_id_str)
-    ctx = BobContext.from_user(user, surface=SURFACE, timezone=_user_tz(user))
-
-    # Never trust the callback payload for identity — confirm_action already
-    # scopes by user_id + organization_id, but we also refuse early if the
-    # pending pointer on the channel does not match (except for undo).
-    if verb in ('confirm', 'reject'):
-        if channel.pending_action_id not in (None, action_id):
-            # Stale button from an older preview; still allow if the action
-            # itself is pending and owned by this user.
-            pass
-
-    if verb == 'confirm':
-        result = confirm_action(action_id, ctx)
-        channel.pending_action_id = None
-        db.session.commit()
-        outcome = result.summary if result.ok else (result.error or 'Could not confirm.')
-        transport.answer_callback(callback_query_id, text='Confirmed' if result.ok else 'Failed')
-        body = f"{'Confirmed. ' if result.ok else ''}{outcome}\n\n--BOB"
-        if message_id:
-            transport.edit_message(channel.chat_id, message_id, body)
-        else:
-            transport.send_text(channel.chat_id, body)
-        return
-
-    if verb == 'reject':
-        result = reject_action(action_id, ctx)
-        channel.pending_action_id = None
-        db.session.commit()
-        transport.answer_callback(callback_query_id, text='Cancelled')
-        body = f"Cancelled. {result.summary}\n\n--BOB"
-        if message_id:
-            transport.edit_message(channel.chat_id, message_id, body)
-        else:
-            transport.send_text(channel.chat_id, body)
-        return
-
-    if verb == 'undo':
-        result = undo_action(action_id, ctx)
-        transport.answer_callback(
-            callback_query_id,
-            text='Undone' if result.ok else 'Could not undo',
-        )
-        body = f"{result.summary if result.ok else result.error}\n\n--BOB"
-        if message_id:
-            transport.edit_message(channel.chat_id, message_id, body)
-        else:
-            transport.send_text(channel.chat_id, body)
-        return
-
-
-# ---------------------------------------------------------------------------
-# Tool loop
-# ---------------------------------------------------------------------------
-
 def _run_tool_loop(
     *,
     user: User,
     ctx: BobContext,
     conversation: ChatConversation,
     user_text: str,
-) -> tuple[str, Optional[dict], Optional[int]]:
-    """Returns (reply_text, pending_preview_or_None, undoable_action_id_or_None)."""
+) -> tuple[str, Optional[dict], Optional[int], Optional[list[dict]], list[str]]:
+    """Returns reply, pending, undoable id, disambiguation contacts, record urls."""
     messages = _history_messages(conversation)
     messages.append({'role': 'user', 'content': user_text})
 
@@ -273,15 +387,19 @@ def _run_tool_loop(
 
     pending: Optional[dict] = None
     undoable_action_id: Optional[int] = None
+    disambiguation: Optional[list[dict]] = None
+    record_urls: list[str] = []
     text_parts: list[str] = []
     collector = ActionCollector()
 
     def execute_tool(name: str, args: dict) -> tuple[dict, dict]:
-        nonlocal pending, undoable_action_id
+        nonlocal pending, undoable_action_id, disambiguation
         result = bob_dispatch(
             name, args, ctx, conversation_id=conversation.id,
             collector=collector,
         )
+        if result.record_url:
+            record_urls.append(result.record_url)
         if result.requires_confirmation and result.action_id:
             pending = {
                 'action_id': result.action_id,
@@ -289,8 +407,18 @@ def _run_tool_loop(
                 'summary': result.summary,
                 'preview': (result.data or {}).get('preview') or result.data,
             }
+            if result.record_url:
+                pending['record_url'] = result.record_url
         elif result.ok and result.undoable and result.action_id:
             undoable_action_id = result.action_id
+
+        if name == 'search_contacts' and result.ok and pending is None:
+            contacts = (result.data or {}).get('contacts') or []
+            if 2 <= len(contacts) <= MAX_DISAMBIGUATION_OPTIONS:
+                disambiguation = contacts
+            else:
+                disambiguation = None
+
         return result.for_model(), result.for_client()
 
     try:
@@ -316,15 +444,76 @@ def _run_tool_loop(
 
     flush_action_notification(collector, ctx)
 
+    # If a write landed, the agent already resolved the contact. Don't also
+    # pile on picker buttons.
+    if pending is not None or undoable_action_id is not None:
+        disambiguation = None
+
     reply = ''.join(text_parts).strip()
     if not reply:
         if pending is not None:
             reply = pending['summary']
+        elif disambiguation:
+            reply = 'A few people match. Tap the right one:'
         else:
             reply = "Done."
-    if not reply.rstrip().endswith('--BOB'):
-        reply = reply.rstrip() + '\n\n--BOB'
-    return reply, pending, undoable_action_id
+    reply = _ensure_bob_signoff(reply)
+    return reply, pending, undoable_action_id, disambiguation, record_urls
+
+
+def _handle_pick_contact(
+    *,
+    channel: AgentMessagingChannel,
+    user: User,
+    transport: Any,
+    callback_query_id: str,
+    contact_id: int,
+    message_id: Optional[str],
+) -> None:
+    """Continue the prior turn with a tapped contact_id."""
+    contact = Contact.query.filter_by(
+        id=contact_id,
+        organization_id=user.organization_id,
+    ).first()
+    if contact is None:
+        transport.answer_callback(callback_query_id, text='Not found')
+        return
+
+    # Agents only pick among contacts they can already see.
+    if contact.user_id != user.id and getattr(user, 'org_role', None) not in (
+        'owner', 'admin',
+    ):
+        transport.answer_callback(callback_query_id, text='Not available')
+        return
+
+    name = f'{contact.first_name} {contact.last_name}'.strip()
+    transport.answer_callback(callback_query_id, text=name[:200] or 'Selected')
+    if message_id:
+        try:
+            transport.edit_message(
+                channel.chat_id,
+                message_id,
+                f'Using **{name}**.',
+            )
+        except Exception:
+            logger.debug('Could not edit disambiguation message', exc_info=True)
+
+    followup = f'Use contact_id {contact.id} ({name}).'
+    try:
+        _bump_daily_count(channel)
+    except RateLimitExceeded as exc:
+        transport.send_text(channel.chat_id, f"{exc.message}\n\n--BOB")
+        return
+
+    conversation = _get_or_create_conversation(user)
+    _persist_message(conversation, 'user', followup)
+    _run_and_reply(
+        channel=channel,
+        user=user,
+        conversation=conversation,
+        user_text=followup,
+        transport=transport,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,17 +539,30 @@ def _parse_command(text: str) -> Optional[str]:
     return match.group(1).lower()
 
 
+def _starter_options() -> list[ChoiceOption]:
+    return [
+        ChoiceOption(label="Today's plate", callback_data='cmd:today'),
+        ChoiceOption(label='Overdue', callback_data='cmd:overdue'),
+        ChoiceOption(label='Help', callback_data='cmd:help'),
+    ]
+
+
 def _help_text(user: User) -> str:
     name = user.first_name or 'there'
     return (
         f"Hey {name}. I am B.O.B. in your CRM.\n\n"
-        "Ask me things like:\n"
+        "Text me, or send a voice note. I can:\n"
+        "- Show today's agenda and overdue tasks\n"
+        "- Look up contacts and counts by city or group\n"
+        "- Log calls, texts, notes, and follow-ups\n"
+        "- Add contacts and create tasks\n\n"
+        "Try:\n"
         "- What's on my plate today?\n"
-        "- How many contacts in Houston?\n"
         "- Log a call with Sarah and follow up Friday\n"
-        "- Add a note to @someone\n\n"
-        "Risky changes (edits and deletes) show a Confirm button first.\n"
-        "Commands: /help  /undo  /stop\n\n"
+        "- How many contacts in Houston?\n\n"
+        "Commands: /today  /overdue  /help  /undo  /stop\n"
+        "Risky edits and deletes show a Confirm button first.\n"
+        "When a few people match a name, tap the right one.\n\n"
         "--BOB"
     )
 
@@ -385,7 +587,7 @@ def _handle_undo_command(channel, user, transport) -> None:
         return
     result = undo_action(action.id, ctx)
     body = (result.summary if result.ok else result.error) or 'Could not undo.'
-    transport.send_text(channel.chat_id, f"{body}\n\n--BOB")
+    transport.send_text(channel.chat_id, _ensure_bob_signoff(body))
 
 
 def _format_pending_preview(pending: dict, model_text: str) -> str:
@@ -396,24 +598,79 @@ def _format_pending_preview(pending: dict, model_text: str) -> str:
         summary = preview.get('summary') or pending.get('summary')
         if summary and summary not in model_text:
             lines.append(summary)
+    record_url = pending.get('record_url')
+    if record_url:
+        linked = _append_record_links('', [record_url]).strip()
+        if linked:
+            lines.append(linked)
     lines.append('')
     lines.append('Tap Confirm to apply, or Cancel to leave it alone.')
-    if not any(part.strip().endswith('--BOB') for part in lines):
-        lines.append('')
-        lines.append('--BOB')
-    return '\n'.join(lines)
+    return _ensure_bob_signoff('\n'.join(lines))
+
+
+def _disambiguation_options(contacts: list[dict]) -> list[ChoiceOption]:
+    options: list[ChoiceOption] = []
+    for contact in contacts[:MAX_DISAMBIGUATION_OPTIONS]:
+        contact_id = contact.get('contact_id')
+        if contact_id is None:
+            continue
+        name = (contact.get('name') or f'Contact {contact_id}').strip()
+        label = name[:64]
+        options.append(ChoiceOption(
+            label=label,
+            callback_data=f'pick:c:{int(contact_id)}',
+        ))
+    return options
+
+
+def _app_base_url() -> str:
+    try:
+        return (current_app.config.get('APP_BASE_URL') or '').rstrip('/')
+    except RuntimeError:
+        return ''
+
+
+def _append_record_links(body: str, record_urls: list[Optional[str]]) -> str:
+    base = _app_base_url()
+    seen: list[str] = []
+    for path in record_urls:
+        if not path:
+            continue
+        full = path if str(path).startswith('http') else f'{base}{path}'
+        if not full or full in seen:
+            continue
+        seen.append(full)
+    if not seen:
+        return body
+
+    text = (body or '').rstrip()
+    if text.endswith('--BOB'):
+        text = text[: -len('--BOB')].rstrip()
+    link_block = '\n'.join(f'Open: {url}' for url in seen)
+    if link_block not in text:
+        text = f'{text}\n\n{link_block}' if text else link_block
+    return _ensure_bob_signoff(text)
+
+
+def _ensure_bob_signoff(body: str) -> str:
+    text = (body or '').rstrip()
+    if not text:
+        return '--BOB'
+    if text.endswith('--BOB'):
+        return text
+    return text + '\n\n--BOB'
 
 
 def _get_or_create_conversation(user: User) -> ChatConversation:
-    """Reuse today's open Telegram conversation, or start a new one."""
-    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    """Reuse today's open Telegram conversation (agent-local day), or start one."""
+    day_start = _local_day_start_utc(user)
     existing = (
         ChatConversation.query.filter_by(
             user_id=user.id,
             organization_id=user.organization_id,
             channel=CHANNEL_NAME,
         )
-        .filter(ChatConversation.updated_at >= today_start)
+        .filter(ChatConversation.updated_at >= day_start)
         .order_by(ChatConversation.updated_at.desc())
         .first()
     )
@@ -429,6 +686,18 @@ def _get_or_create_conversation(user: User) -> ChatConversation:
     db.session.add(conversation)
     db.session.commit()
     return conversation
+
+
+def _local_day_start_utc(user: User) -> datetime:
+    """UTC datetime for midnight at the start of the agent's local calendar day."""
+    tz_name = _user_tz(user)
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = ZoneInfo('America/Chicago')
+    local_now = datetime.now(tz)
+    local_midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return local_midnight.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def _persist_message(conversation: ChatConversation, role: str, content: str) -> None:

--- a/services/messaging/outbound.py
+++ b/services/messaging/outbound.py
@@ -92,6 +92,43 @@ def notify_task_reminder(user: User, summary_parts: list[str],
     return notify(user, 'task_reminder', '\n'.join(lines))
 
 
+def notify_daily_briefing(user: User, content: dict,
+                          *, action_url: Optional[str] = None) -> bool:
+    """Short morning nudge when today's Daily Briefing is ready."""
+    if not isinstance(content, dict):
+        return False
+
+    from feature_flags import org_has_feature
+    org = getattr(user, 'organization', None)
+    if org is not None and not org_has_feature('BOB_TELEGRAM', org):
+        return False
+
+    teaser = (content.get('teaser') or '').strip()
+    priorities = content.get('priorities') or []
+    lines = ['Morning briefing', '']
+    if teaser:
+        lines.append(teaser)
+    else:
+        lines.append("Today's Daily Briefing is ready.")
+
+    shown = 0
+    for item in priorities:
+        if not isinstance(item, dict):
+            continue
+        title = (item.get('title') or item.get('why') or '').strip()
+        if not title:
+            continue
+        lines.append(f'- {title}')
+        shown += 1
+        if shown >= 3:
+            break
+
+    if action_url:
+        lines.extend(['', f'Open briefing: {action_url}'])
+    lines.extend(['', '--BOB'])
+    return notify(user, 'daily_briefing', '\n'.join(lines))
+
+
 def _in_quiet_hours(user: User) -> bool:
     tz_name = getattr(user, 'timezone', None) or 'America/Chicago'
     try:

--- a/services/messaging/prompt.py
+++ b/services/messaging/prompt.py
@@ -5,18 +5,28 @@ which renders as literal asterisks in a messaging client. This variant keeps the
 persona and CRM tool policy, and constrains length and formatting for chat.
 """
 
-TELEGRAM_SYSTEM_PROMPT = """You are B.O.B. (Business Optimization Buddy), an experienced real estate professional with deep expertise in the Houston market and HAR procedures. You are talking to the agent over Telegram, not the web chat.
+TELEGRAM_SYSTEM_PROMPT = """You are B.O.B. (Business Optimization Buddy), a sharp Houston real estate ops partner with deep HAR knowledge. You are talking to the agent over Telegram, not the web chat. You sit beside them, not above them.
 
-Communication style:
-- Be direct and genuine. Skip filler.
+Voice:
+- Competent desk partner: calm, clear, lightly dry when it fits. Never cartoonish or chipper.
+- Lead with the answer or next step. Warmth comes from being useful.
+- Contractions. Short messages. Vary rhythm.
+- Have a point of view when it helps. Soften if they push back.
+- Skip filler: "Happy to help!", "Great question!", "Absolutely!", "Certainly!".
+- NEVER use em dashes or en dashes. Use a period or comma instead.
+
+Name usage:
+- You may know the agent's first name. Do NOT use it in every reply.
+- Use it rarely: first hello in a new thread, or once for real emphasis.
+- Default is no name.
+
+Reply shape:
 - Keep replies short. Aim under a few short paragraphs. Offer a count and the top few items rather than dumping a long list.
 - No markdown tables. No # headers. Use **bold** sparingly for names or key facts, and `backticks` for values.
-- NEVER use em dashes or en dashes. Use a period or comma instead.
-- Address the agent by first name when you know it.
 - Close with "--BOB".
 
 STRICT SCOPE (NON-NEGOTIABLE):
-You ONLY help with real estate. Refuse anything off-topic in one short sentence, then offer a real-estate direction. Always still close with "--BOB".
+You ONLY help with real estate. Refuse anything off-topic in one short sentence, then offer a real-estate direction. Do not use their name in a routine refusal. Always still close with "--BOB".
 
 WORKING IN THE CRM (TOOLS):
 

--- a/services/messaging/prompt.py
+++ b/services/messaging/prompt.py
@@ -24,6 +24,8 @@ Reply shape:
 - Keep replies short. Aim under a few short paragraphs. Offer a count and the top few items rather than dumping a long list.
 - No markdown tables. No # headers. Use **bold** sparingly for names or key facts, and `backticks` for values.
 - Close with "--BOB".
+- The agent may send a voice note. Treat the transcript as their typed message.
+- When several contacts match, name them briefly. Tap buttons may appear under your reply so they can pick one.
 
 STRICT SCOPE (NON-NEGOTIABLE):
 You ONLY help with real estate. Refuse anything off-topic in one short sentence, then offer a real-estate direction. Do not use their name in a routine refusal. Always still close with "--BOB".

--- a/services/messaging/queue.py
+++ b/services/messaging/queue.py
@@ -14,14 +14,23 @@ logger = logging.getLogger(__name__)
 QUEUE_NAME = 'bob_telegram'
 
 
-def enqueue_telegram_message(*, org_id: int, channel_id: int, text: str,
-                             telegram_message_id: str | None = None) -> None:
+def enqueue_telegram_message(
+    *,
+    org_id: int,
+    channel_id: int,
+    text: str,
+    telegram_message_id: str | None = None,
+    voice_file_id: str | None = None,
+    voice_duration_seconds: int | None = None,
+) -> None:
     _enqueue(
         'jobs.bob_telegram_reply.process_telegram_message_job',
         org_id=org_id,
         channel_id=channel_id,
         text=text,
         telegram_message_id=telegram_message_id,
+        voice_file_id=voice_file_id,
+        voice_duration_seconds=voice_duration_seconds,
     )
 
 

--- a/services/messaging/telegram.py
+++ b/services/messaging/telegram.py
@@ -234,6 +234,37 @@ class TelegramTransport:
     def get_me(self) -> dict:
         return self._call('getMe', {})
 
+    def get_file(self, file_id: str) -> dict:
+        """Resolve a file_id to a Bot API file_path (and size)."""
+        return self._call('getFile', {'file_id': file_id})
+
+    def download_file(self, file_path: str) -> bytes:
+        """Download raw bytes for a path returned by getFile."""
+        url = f'{TELEGRAM_API_BASE}/file/bot{self.bot_token}/{file_path.lstrip("/")}'
+        try:
+            response = self._session.get(url, timeout=60)
+        except requests.RequestException as exc:
+            raise TelegramError('downloadFile', str(exc)) from exc
+        if response.status_code != 200:
+            raise TelegramError(
+                'downloadFile',
+                f'HTTP {response.status_code}',
+                status_code=response.status_code,
+            )
+        return response.content
+
+    def set_my_commands(self, commands: Sequence[dict[str, str]]) -> dict:
+        """Register the bot's / command menu (BotFather-style)."""
+        return self._call('setMyCommands', {
+            'commands': [
+                {
+                    'command': str(item['command']).lstrip('/')[:32],
+                    'description': str(item['description'])[:256],
+                }
+                for item in commands
+            ],
+        })
+
     def _call(self, method: str, payload: dict) -> dict:
         url = urljoin(self._base, method)
         for attempt in range(1, MAX_RETRIES + 1):
@@ -323,6 +354,9 @@ class FakeTransport:
     edited: list[dict] = field(default_factory=list)
     answered: list[dict] = field(default_factory=list)
     activity: list[dict] = field(default_factory=list)
+    files: dict[str, dict] = field(default_factory=dict)
+    file_bytes: dict[str, bytes] = field(default_factory=dict)
+    commands: list[dict] = field(default_factory=list)
     _next_message_id: int = 1
 
     def send_text(
@@ -400,6 +434,38 @@ class FakeTransport:
     def send_activity(self, chat_id: str) -> dict:
         self.activity.append({'chat_id': str(chat_id)})
         return {'ok': True}
+
+    def get_file(self, file_id: str) -> dict:
+        if file_id in self.files:
+            return dict(self.files[file_id])
+        return {
+            'file_id': file_id,
+            'file_path': f'voice/{file_id}.oga',
+            'file_size': len(self.file_bytes.get(file_id, b'')),
+        }
+
+    def download_file(self, file_path: str) -> bytes:
+        for file_id, meta in self.files.items():
+            if meta.get('file_path') == file_path:
+                return self.file_bytes.get(file_id, b'')
+        # Fall back: path ends with file_id.ext from get_file default.
+        name = file_path.rsplit('/', 1)[-1]
+        file_id = name.rsplit('.', 1)[0]
+        return self.file_bytes.get(file_id, b'')
+
+    def set_my_commands(self, commands: Sequence[dict[str, str]]) -> dict:
+        self.commands = list(commands)
+        return {'ok': True}
+
+
+# Commands shown in Telegram's "/" menu after setMyCommands.
+BOT_COMMANDS: tuple[dict[str, str], ...] = (
+    {'command': 'today', 'description': "What's on my plate today"},
+    {'command': 'overdue', 'description': 'Show overdue tasks'},
+    {'command': 'help', 'description': 'What I can help with'},
+    {'command': 'undo', 'description': 'Undo my last change'},
+    {'command': 'stop', 'description': 'Disconnect Telegram'},
+)
 
 
 @contextmanager

--- a/services/messaging/voice.py
+++ b/services/messaging/voice.py
@@ -1,0 +1,92 @@
+"""Telegram voice-note → text for B.O.B.
+
+Downloads the audio from Telegram and runs it through the same Whisper helper
+used for contact voice memos. The transcript then enters the normal tool loop
+as if the agent had typed it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Telegram voice notes are usually short; refuse monsters before paying Whisper.
+MAX_VOICE_BYTES = 10 * 1024 * 1024  # 10 MB
+MAX_VOICE_DURATION_SECONDS = 180
+
+
+class VoiceTranscriptionError(Exception):
+    """Raised when a voice note cannot be turned into usable text."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+def transcribe_telegram_voice(
+    transport: Any,
+    file_id: str,
+    *,
+    duration_seconds: Optional[int] = None,
+) -> str:
+    """Download a Telegram voice/audio file and return its transcript."""
+    if not file_id:
+        raise VoiceTranscriptionError('That voice note looked empty.')
+
+    if duration_seconds is not None and duration_seconds > MAX_VOICE_DURATION_SECONDS:
+        raise VoiceTranscriptionError(
+            f'Voice notes need to be under {MAX_VOICE_DURATION_SECONDS // 60} '
+            'minutes. Try a shorter one, or type it.'
+        )
+
+    try:
+        meta = transport.get_file(file_id)
+    except Exception as exc:
+        logger.warning('Telegram getFile failed: %s', exc)
+        raise VoiceTranscriptionError(
+            "Couldn't download that voice note. Try again or type it."
+        ) from exc
+
+    file_path = (meta or {}).get('file_path') or ''
+    file_size = (meta or {}).get('file_size') or 0
+    if file_size and int(file_size) > MAX_VOICE_BYTES:
+        raise VoiceTranscriptionError(
+            'That voice note is too large. Try a shorter one, or type it.'
+        )
+    if not file_path:
+        raise VoiceTranscriptionError(
+            "Couldn't find that voice note file. Try again or type it."
+        )
+
+    try:
+        audio_bytes = transport.download_file(file_path)
+    except Exception as exc:
+        logger.warning('Telegram file download failed: %s', exc)
+        raise VoiceTranscriptionError(
+            "Couldn't download that voice note. Try again or type it."
+        ) from exc
+
+    if not audio_bytes:
+        raise VoiceTranscriptionError('That voice note looked empty.')
+    if len(audio_bytes) > MAX_VOICE_BYTES:
+        raise VoiceTranscriptionError(
+            'That voice note is too large. Try a shorter one, or type it.'
+        )
+
+    filename = file_path.rsplit('/', 1)[-1] or 'voice.oga'
+    try:
+        from services.ai_service import transcribe_audio
+        text = transcribe_audio(audio_data=audio_bytes, filename=filename)
+    except Exception as exc:
+        logger.warning('Whisper failed for Telegram voice: %s', exc)
+        raise VoiceTranscriptionError(
+            "Couldn't catch that. Try again or type it."
+        ) from exc
+
+    text = (text or '').strip()
+    if not text:
+        raise VoiceTranscriptionError(
+            "Couldn't catch that. Try again or type it."
+        )
+    return text

--- a/templates/notifications/settings.html
+++ b/templates/notifications/settings.html
@@ -43,6 +43,10 @@
                             <p class="mt-1 text-xs" style="color: var(--ink-3); line-height: 1.45;">
                                 Get notified when tasks are due soon or overdue.
                             </p>
+                            {% elif cat_key == 'daily_briefing' %}
+                            <p class="mt-1 text-xs" style="color: var(--ink-3); line-height: 1.45;">
+                                Morning nudge when today's Daily Briefing is ready (Telegram).
+                            </p>
                             {% elif cat_key == 'company_update' %}
                             <p class="mt-1 text-xs" style="color: var(--ink-3); line-height: 1.45;">
                                 Get notified when your team posts a company update.

--- a/tests/test_bob_telegram.py
+++ b/tests/test_bob_telegram.py
@@ -575,3 +575,245 @@ class TestDisabledChannel:
             assert find_channel_by_external_id(
                 linked_channel['external_id']
             ) is None
+
+
+# ---------------------------------------------------------------------------
+# Voice notes, commands, disambiguation, deep links
+# ---------------------------------------------------------------------------
+
+class TestVoiceAndMedia:
+    def test_voice_note_is_transcribed_and_answered(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        def fake_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+            assert messages[-1]['content'] == 'What is on my plate today?'
+            yield ('text', 'Three things today.')
+
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.transcribe_telegram_voice',
+                return_value='What is on my plate today?',
+            ), patch(
+                'services.messaging.conversation.run_tool_conversation',
+                fake_run,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='',
+                    voice_file_id='voice-1',
+                    voice_duration_seconds=4,
+                    telegram_message_id='600',
+                )
+
+        texts = [m['text'] for m in _fake_transport.sent]
+        assert any(t.startswith('Heard:') for t in texts)
+        assert any('Three things today.' in t for t in texts)
+
+    def test_voice_transcription_failure_is_polite(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        from services.messaging.voice import VoiceTranscriptionError
+
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.transcribe_telegram_voice',
+                side_effect=VoiceTranscriptionError(
+                    "Couldn't catch that. Try again or type it."
+                ),
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='',
+                    voice_file_id='voice-bad',
+                    telegram_message_id='601',
+                )
+
+        assert any("Couldn't catch that" in m['text'] for m in _fake_transport.sent)
+
+    def test_unsupported_media_gets_a_hint(self, app, seed, linked_channel, _fake_transport):
+        client = app.test_client()
+        payload = {
+            'update_id': 9001,
+            'message': {
+                'message_id': 9,
+                'from': {'id': int(linked_channel['external_id'])},
+                'chat': {'id': int(linked_channel['chat_id'])},
+                'photo': [{'file_id': 'photo-1'}],
+            },
+        }
+        with patch('routes.bob_telegram.enqueue_telegram_message') as enq:
+            assert _webhook(client, payload).status_code == 200
+            enq.assert_not_called()
+        assert any('voice note' in m['text'] for m in _fake_transport.sent)
+
+    def test_voice_message_is_enqueued_with_file_id(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        client = app.test_client()
+        payload = {
+            'update_id': 9002,
+            'message': {
+                'message_id': 10,
+                'from': {'id': int(linked_channel['external_id'])},
+                'chat': {'id': int(linked_channel['chat_id'])},
+                'voice': {'file_id': 'AwVOICE', 'duration': 6},
+            },
+        }
+        with patch('routes.bob_telegram.enqueue_telegram_message') as enq:
+            assert _webhook(client, payload).status_code == 200
+            enq.assert_called_once()
+            kwargs = enq.call_args.kwargs
+            assert kwargs['voice_file_id'] == 'AwVOICE'
+            assert kwargs['voice_duration_seconds'] == 6
+            assert kwargs['text'] == ''
+
+
+class TestCommandsAndDisambiguation:
+    def test_today_command_expands_to_agenda_prompt(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        seen = {}
+
+        def fake_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+            seen['user'] = messages[-1]['content']
+            yield ('text', 'Agenda ready.')
+
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.run_tool_conversation',
+                fake_run,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='/today',
+                    telegram_message_id='610',
+                )
+
+        assert seen['user'] == "What's on my plate today?"
+        assert any('Agenda ready.' in m['text'] for m in _fake_transport.sent)
+
+    def test_search_with_multiple_matches_sends_pick_buttons(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        with app.app_context():
+            from models import Contact, ContactGroup
+            group = ContactGroup.query.filter_by(
+                user_id=seed['agent_a'], organization_id=seed['org_a'],
+            ).first()
+            created_ids = []
+            try:
+                for last in ('Alpha', 'Beta'):
+                    c = Contact(
+                        first_name='Sarah', last_name=last,
+                        user_id=seed['agent_a'],
+                        organization_id=seed['org_a'],
+                        email=f'sarah.{last.lower()}@example.com',
+                    )
+                    if group:
+                        c.groups.append(group)
+                    db.session.add(c)
+                    db.session.flush()
+                    created_ids.append(c.id)
+                db.session.commit()
+
+                def fake_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+                    execute_tool('search_contacts', {'query': 'Sarah'})
+                    yield ('text', 'Which Sarah did you mean?')
+
+                with patch(
+                    'services.messaging.conversation.run_tool_conversation',
+                    fake_run,
+                ):
+                    handle_inbound_message(
+                        channel_id=linked_channel['id'],
+                        org_id=seed['org_a'],
+                        text='Log a call with Sarah',
+                        telegram_message_id='611',
+                    )
+            finally:
+                for cid in created_ids:
+                    row = db.session.get(Contact, cid)
+                    if row is not None:
+                        row.groups.clear()
+                        db.session.delete(row)
+                db.session.commit()
+
+        choice_msgs = [m for m in _fake_transport.sent if m.get('options')]
+        assert choice_msgs
+        labels = [opt.label for opt in choice_msgs[0]['options']]
+        assert any('Sarah Alpha' in label for label in labels)
+        assert any('Sarah Beta' in label for label in labels)
+        callbacks = [opt.callback_data for opt in choice_msgs[0]['options']]
+        assert any(cb.startswith('pick:c:') for cb in callbacks)
+
+    def test_pick_contact_continues_the_turn(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        with app.app_context():
+            # contact_a2 is owned by agent_a (the linked Telegram user).
+            contact_id = seed['contact_a2']
+            seen = {}
+
+            def fake_run(*, system_prompt, messages, tools, execute_tool, **kwargs):
+                seen['user'] = messages[-1]['content']
+                yield ('text', f'Using contact {contact_id}.')
+
+            with patch(
+                'services.messaging.conversation.run_tool_conversation',
+                fake_run,
+            ):
+                handle_callback_query(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    callback_query_id='cb-pick',
+                    data=f'pick:c:{contact_id}',
+                    message_id='70',
+                )
+
+        assert f'contact_id {contact_id}' in seen['user']
+        assert _fake_transport.answered
+
+class TestDeepLinksAndLocalDay:
+    def test_reply_includes_absolute_record_link(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        from services.bob_tools.context import ToolResult
+
+        def run_with_tool(*, system_prompt, messages, tools, execute_tool, **kwargs):
+            execute_tool('add_note', {'contact_id': seed['contact_a'], 'note': 'hi'})
+            yield ('text', 'Note added.')
+
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.bob_dispatch',
+                return_value=ToolResult.success(
+                    summary='Note added',
+                    data={'contact_id': seed['contact_a']},
+                    record_url=f"/contact/{seed['contact_a']}",
+                ),
+            ), patch(
+                'services.messaging.conversation.run_tool_conversation',
+                run_with_tool,
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='Add a note to Jane',
+                    telegram_message_id='620',
+                )
+
+        sent = ' '.join(m['text'] for m in _fake_transport.sent)
+        assert f"https://example.test/contact/{seed['contact_a']}" in sent
+
+    def test_conversation_reuses_local_day_window(
+        self, app, seed, linked_channel,
+    ):
+        with app.app_context():
+            from services.messaging.conversation import _get_or_create_conversation
+            user = db.session.get(User, seed['agent_a'])
+            first = _get_or_create_conversation(user)
+            second = _get_or_create_conversation(user)
+            assert first.id == second.id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Turns B.O.B. on Telegram into a field tool: voice notes, tap-to-pick contacts, deep links back into the CRM, discoverable commands, and a morning briefing nudge.

**Depends on** [#274](https://github.com/cnichols1734/CRM/pull/274) (prompt voice + name usage). Please merge #274 first; this branch was cut from it. After #274 lands, this PR’s diff against `main` should show only the Telegram field UX commit.

## What’s in

- **Voice notes** — Telegram `voice`/`audio` → Whisper → normal tool loop. Shows `Heard: "..."` so bad transcripts are obvious before Confirm.
- **Unsupported media** — photos/stickers get a short “text or voice note” reply instead of silence.
- **Tap-to-pick contacts** — when `search_contacts` returns 2–6 matches, inline buttons let the agent pick; tap continues the prior turn.
- **Deep links** — replies/confirmations append `Open: {APP_BASE_URL}/contact/...` when tools return `record_url`.
- **Commands + menu** — `/today`, `/overdue`, richer `/help`; `setMyCommands` on webhook register; starter buttons after link.
- **Local-day continuity** — conversation window uses the agent’s timezone midnight, not UTC.
- **Morning briefing nudge** — after daily briefing prewarm, linked Telegram users can get a short digest (`daily_briefing` notification category).

## Deferred

- Multi-write undo/confirm for chained creates in one turn (still tracks the last undoable action).

## Test plan

- [x] `pytest tests/test_bob_telegram.py` (29 passed)
- [ ] Linked agent: send a voice note → see `Heard:` + a normal reply
- [ ] Ask about an ambiguous name → tap the right contact → action completes
- [ ] Create/log something → reply includes an Open link
- [ ] `/today` and `/overdue` work; `/` menu shows after re-registering the webhook
- [ ] Send a photo → polite unsupported hint
- [ ] Re-run webhook register so `setMyCommands` lands in prod
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbd4e-adf2-721c-8914-d078835f7cf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbd4e-adf2-721c-8914-d078835f7cf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

