### PR TITLE
feat: create CRM contacts from Telegram photos like Magic Inbox

### DIFF
--- a/jobs/bob_telegram_reply.py
+++ b/jobs/bob_telegram_reply.py
@@ -19,6 +19,7 @@ def process_telegram_message_job(
     telegram_message_id: str | None = None,
     voice_file_id: str | None = None,
     voice_duration_seconds: int | None = None,
+    photo_file_id: str | None = None,
 ) -> None:
     from app import app
     from jobs.base import set_job_org_context
@@ -34,6 +35,7 @@ def process_telegram_message_job(
                 telegram_message_id=telegram_message_id,
                 voice_file_id=voice_file_id,
                 voice_duration_seconds=voice_duration_seconds,
+                photo_file_id=photo_file_id,
             )
         except Exception:
             logger.exception(

--- a/routes/bob_telegram.py
+++ b/routes/bob_telegram.py
@@ -140,6 +140,7 @@ def _handle_message_update(message: dict, update_id: str) -> None:
     voice = message.get('voice') or message.get('audio') or {}
     voice_file_id = voice.get('file_id') if isinstance(voice, dict) else None
     voice_duration = voice.get('duration') if isinstance(voice, dict) else None
+    photo_file_id = _largest_photo_file_id(message)
     if external_id is None or chat_id is None:
         return
 
@@ -164,11 +165,12 @@ def _handle_message_update(message: dict, update_id: str) -> None:
         )
         return
 
-    if not text_body and not voice_file_id:
+    if not text_body and not voice_file_id and not photo_file_id:
         get_transport().send_text(
             channel.chat_id,
-            "I can take a text message or a voice note. "
-            "Photos, stickers, and files aren't supported yet.\n\n--BOB",
+            "I can take a text message, a voice note, or a photo of a "
+            "business card / email / contact screenshot. "
+            "Stickers and other files aren't supported yet.\n\n--BOB",
         )
         return
 
@@ -181,6 +183,7 @@ def _handle_message_update(message: dict, update_id: str) -> None:
         voice_duration_seconds=(
             int(voice_duration) if voice_duration is not None else None
         ),
+        photo_file_id=photo_file_id,
     )
 
 
@@ -253,7 +256,7 @@ def _handle_start(text_body: str, *, external_id: str, chat_id: str,
     transport.send_choice(
         chat_id,
         "Linked. Ask me about your contacts or tasks anytime, "
-        "or send a voice note from the field.\n\n"
+        "send a voice note, or photo a business card.\n\n"
         "Try one of these, or just type.\n\n--BOB",
         [
             ChoiceOption(label="Today's plate", callback_data='cmd:today'),
@@ -277,6 +280,21 @@ def _annotate_update(update_id: str, channel: AgentMessagingChannel) -> None:
         db.session.commit()
     except Exception:
         db.session.rollback()
+
+
+def _largest_photo_file_id(message: dict) -> str | None:
+    """Telegram sends photo sizes ascending; the last entry is the largest."""
+    photos = message.get('photo')
+    if isinstance(photos, list) and photos:
+        file_id = (photos[-1] or {}).get('file_id')
+        return str(file_id) if file_id else None
+
+    # Image sent as a document (e.g. from Files).
+    document = message.get('document') or {}
+    mime = (document.get('mime_type') or '').lower()
+    if mime.startswith('image/') and document.get('file_id'):
+        return str(document['file_id'])
+    return None
 
 
 def _org_allows_telegram(organization_id: int) -> bool:

--- a/services/bob_tools/contacts.py
+++ b/services/bob_tools/contacts.py
@@ -341,11 +341,24 @@ def create_contact(args: dict, ctx: BobContext) -> ToolResult:
     _record_contact_created(ctx, user)
 
     name = f'{first_name} {last_name}'.strip()
+    saved_groups = [g.name for g in contact.groups if g.is_active]
     result = ToolResult.success(
         summary=f'Created contact {name}',
         data={
             'created': True,
             'contact': contact_summary(contact),
+            'saved': {
+                'first_name': contact.first_name,
+                'last_name': contact.last_name,
+                'email': contact.email,
+                'phone': contact.phone,
+                'street_address': contact.street_address,
+                'city': contact.city,
+                'state': contact.state,
+                'zip_code': contact.zip_code,
+                'notes': contact.notes,
+                'groups': saved_groups,
+            },
             'groups_not_found': missing_groups,
         },
         undoable=True,

--- a/services/inbound_payload.py
+++ b/services/inbound_payload.py
@@ -170,7 +170,7 @@ def normalize_sendgrid_payload(form: dict, files: dict | None = None,
             if len(image_blocks) >= MAX_IMAGES:
                 skipped_images += 1
                 continue
-            block = _image_to_base64_jpeg(raw_bytes)
+            block = image_to_base64_jpeg(raw_bytes)
             if block:
                 image_blocks.append(block)
             else:
@@ -364,11 +364,12 @@ def _truncate_csv(data: bytes) -> tuple[str, int, int, bool]:
     return out, total, len(keep), truncated
 
 
-def _image_to_base64_jpeg(data: bytes) -> str | None:
+def image_to_base64_jpeg(data: bytes) -> str | None:
     """Downscale and re-encode an image to JPEG/base64 for the vision model.
 
     Returns None if the image can't be loaded (corrupted, weird format).
     HEIC support depends on the runtime; we try and silently skip on failure.
+    Public so Telegram B.O.B. can reuse the same prep as Magic Inbox.
     """
     try:
         from PIL import Image
@@ -401,6 +402,10 @@ def _image_to_base64_jpeg(data: bytes) -> str | None:
     buf = io.BytesIO()
     img.save(buf, format='JPEG', quality=82, optimize=True)
     return base64.b64encode(buf.getvalue()).decode('ascii')
+
+
+# Back-compat alias for older call sites / tests.
+_image_to_base64_jpeg = image_to_base64_jpeg
 
 
 def _summarize_kind(kinds: set[str], *, has_text: bool, has_image: bool) -> str:

--- a/services/messaging/conversation.py
+++ b/services/messaging/conversation.py
@@ -35,6 +35,18 @@ from services.bob_tools.notifications import ActionCollector
 from services.bob_tools.notifications import flush as flush_action_notification
 from services.bob_tools.registry import dispatch as bob_dispatch
 from services.messaging.base import ChoiceOption
+from services.messaging.photo_contacts import (
+    PhotoContactError,
+    confirm_photo_contacts,
+    create_contacts_now,
+    create_pending_photo_action,
+    download_telegram_photo,
+    extract_contact_candidates,
+    format_candidate_preview,
+    format_saved_contacts,
+    is_photo_pending_action,
+    wants_create_contact,
+)
 from services.messaging.prompt import TELEGRAM_SYSTEM_PROMPT
 from services.messaging.telegram import get_transport, show_typing
 from services.messaging.voice import VoiceTranscriptionError, transcribe_telegram_voice
@@ -86,8 +98,9 @@ def handle_inbound_message(
     telegram_message_id: Optional[str] = None,
     voice_file_id: Optional[str] = None,
     voice_duration_seconds: Optional[int] = None,
+    photo_file_id: Optional[str] = None,
 ) -> None:
-    """Process a text or voice message from a linked agent."""
+    """Process a text, voice, or photo message from a linked agent."""
     channel = _load_channel(channel_id, org_id)
     if channel is None:
         return
@@ -103,6 +116,16 @@ def handle_inbound_message(
     transport = get_transport()
     from_voice = False
     working_text = (text or '').strip()
+
+    if photo_file_id:
+        _handle_photo_message(
+            channel=channel,
+            user=user,
+            transport=transport,
+            photo_file_id=photo_file_id,
+            caption=working_text,
+        )
+        return
 
     if voice_file_id and not working_text:
         try:
@@ -263,16 +286,67 @@ def handle_callback_query(
             pass
 
     if verb == 'confirm':
-        result = confirm_action(action_id, ctx)
-        channel.pending_action_id = None
-        db.session.commit()
-        outcome = result.summary if result.ok else (result.error or 'Could not confirm.')
-        transport.answer_callback(callback_query_id, text='Confirmed' if result.ok else 'Failed')
-        body = f"{'Confirmed. ' if result.ok else ''}{outcome}"
-        body = _append_record_links(body, [result.record_url])
+        action = BobAction.query.filter_by(
+            id=action_id,
+            organization_id=user.organization_id,
+            user_id=user.id,
+        ).first()
+        undoable = None
+        record_urls: list[str] = []
+        if action is not None and is_photo_pending_action(action):
+            result, created = confirm_photo_contacts(action, ctx)
+            channel.pending_action_id = None
+            db.session.commit()
+            transport.answer_callback(
+                callback_query_id,
+                text='Saved' if result.ok else 'Failed',
+            )
+            if result.ok and created:
+                body = format_saved_contacts(created)
+                undoable = result.action_id
+                record_urls = [
+                    f'/contact/{c.id}' for c in created
+                ]
+            else:
+                body = result.summary if result.ok else (
+                    result.error or 'Could not confirm.'
+                )
+        else:
+            result = confirm_action(action_id, ctx)
+            channel.pending_action_id = None
+            db.session.commit()
+            transport.answer_callback(
+                callback_query_id,
+                text='Confirmed' if result.ok else 'Failed',
+            )
+            if result.ok and (result.data or {}).get('created'):
+                body = _format_create_confirm_body(result)
+                undoable = result.action_id if result.undoable else None
+            else:
+                body = (
+                    f"{'Confirmed. ' if result.ok else ''}"
+                    f"{result.summary if result.ok else (result.error or 'Could not confirm.')}"
+                )
+            if result.record_url:
+                record_urls = [result.record_url]
+
+        body = _append_record_links(body, record_urls)
         body = _ensure_bob_signoff(body)
+        options = []
+        if undoable is not None:
+            options.append(ChoiceOption(
+                label='Undo', callback_data=f'undo:{undoable}',
+            ))
         if message_id:
+            # editMessageText cannot add a new keyboard reliably after clear;
+            # edit the body, then send Undo as a follow-up if needed.
             transport.edit_message(channel.chat_id, message_id, body)
+            if options:
+                transport.send_choice(
+                    channel.chat_id, 'Changed your mind?', options,
+                )
+        elif options:
+            transport.send_choice(channel.chat_id, body, options)
         else:
             transport.send_text(channel.chat_id, body)
         return
@@ -389,6 +463,7 @@ def _run_tool_loop(
     undoable_action_id: Optional[int] = None
     disambiguation: Optional[list[dict]] = None
     record_urls: list[str] = []
+    created_saved: list[dict] = []
     text_parts: list[str] = []
     collector = ActionCollector()
 
@@ -411,6 +486,14 @@ def _run_tool_loop(
                 pending['record_url'] = result.record_url
         elif result.ok and result.undoable and result.action_id:
             undoable_action_id = result.action_id
+
+        if (
+            name == 'create_contact'
+            and result.ok
+            and (result.data or {}).get('created')
+            and isinstance((result.data or {}).get('saved'), dict)
+        ):
+            created_saved.append(result.data['saved'])
 
         if name == 'search_contacts' and result.ok and pending is None:
             contacts = (result.data or {}).get('contacts') or []
@@ -457,6 +540,22 @@ def _run_tool_loop(
             reply = 'A few people match. Tap the right one:'
         else:
             reply = "Done."
+
+    if created_saved and pending is None:
+        from services.messaging.photo_contacts import display_name, format_fields
+        blocks = []
+        for saved in created_saved:
+            name = display_name(saved)
+            fields = format_fields(saved, skip_name=True)
+            block = f'**{name}**'
+            if fields:
+                block += f'\n{fields}'
+            blocks.append(block)
+        saved_block = 'Saved to your CRM:\n\n' + '\n\n'.join(blocks)
+        # Prefer the structured dump over a vague model summary.
+        if 'Saved to your CRM' not in reply:
+            reply = saved_block
+
     reply = _ensure_bob_signoff(reply)
     return reply, pending, undoable_action_id, disambiguation, record_urls
 
@@ -547,19 +646,141 @@ def _starter_options() -> list[ChoiceOption]:
     ]
 
 
+def _handle_photo_message(
+    *,
+    channel: AgentMessagingChannel,
+    user: User,
+    transport: Any,
+    photo_file_id: str,
+    caption: str,
+) -> None:
+    """Extract contact info from a photo (Magic Inbox vision path)."""
+    try:
+        _bump_daily_count(channel)
+    except RateLimitExceeded as exc:
+        transport.send_text(channel.chat_id, f"{exc.message}\n\n--BOB")
+        return
+
+    conversation = _get_or_create_conversation(user)
+    user_line = caption.strip() if caption.strip() else '[photo]'
+    _persist_message(conversation, 'user', user_line)
+
+    ctx = BobContext.from_user(user, surface=SURFACE, timezone=_user_tz(user))
+    try:
+        with show_typing(transport, channel.chat_id):
+            image_bytes = download_telegram_photo(transport, photo_file_id)
+            candidates = extract_contact_candidates(
+                image_bytes, caption=caption, user=user,
+            )
+    except PhotoContactError as exc:
+        body = _ensure_bob_signoff(exc.message)
+        transport.send_text(channel.chat_id, body)
+        _persist_message(conversation, 'assistant', body)
+        return
+    except Exception:
+        logger.exception('Telegram photo turn crashed channel=%s', channel.id)
+        body = _ensure_bob_signoff(
+            "Couldn't read that photo. Try again, or type the contact details."
+        )
+        transport.send_text(channel.chat_id, body)
+        _persist_message(conversation, 'assistant', body)
+        return
+
+    if not candidates:
+        body = _ensure_bob_signoff(
+            "I didn't find usable contact info in that photo. "
+            "Try a clearer shot of the card or email, or type the details."
+        )
+        transport.send_text(channel.chat_id, body)
+        _persist_message(conversation, 'assistant', body)
+        return
+
+    if wants_create_contact(caption):
+        with show_typing(transport, channel.chat_id):
+            body, created, undoable, record_urls = create_contacts_now(
+                ctx=ctx,
+                candidates=candidates,
+                conversation_id=conversation.id,
+            )
+        body = _append_record_links(body, record_urls)
+        body = _ensure_bob_signoff(body)
+        options = []
+        if undoable is not None:
+            options.append(ChoiceOption(
+                label='Undo', callback_data=f'undo:{undoable}',
+            ))
+        if options:
+            transport.send_choice(channel.chat_id, body, options)
+        else:
+            transport.send_text(channel.chat_id, body)
+        _persist_message(conversation, 'assistant', body)
+        return
+
+    # Ask before creating — same Confirm/Cancel pattern as risky writes.
+    preview = format_candidate_preview(candidates)
+    action = create_pending_photo_action(
+        ctx=ctx,
+        candidates=candidates,
+        conversation_id=conversation.id,
+    )
+    channel.pending_action_id = action.id
+    db.session.commit()
+    body = _ensure_bob_signoff(preview)
+    transport.send_choice(
+        channel.chat_id,
+        body,
+        [
+            ChoiceOption(
+                label='Create contact' if len(candidates) == 1 else 'Create all',
+                callback_data=f'confirm:{action.id}',
+                style='primary',
+            ),
+            ChoiceOption(
+                label='Cancel',
+                callback_data=f'reject:{action.id}',
+            ),
+        ],
+    )
+    _persist_message(conversation, 'assistant', body)
+
+
+def _format_create_confirm_body(result) -> str:
+    """Prefer the full saved field list after a contact create confirm."""
+    saved = (result.data or {}).get('saved')
+    if isinstance(saved, dict) and saved:
+        from services.messaging.photo_contacts import display_name, format_fields
+        name = display_name(saved)
+        fields = format_fields(saved, skip_name=True)
+        body = f'Saved to your CRM:\n\n**{name}**'
+        if fields:
+            body += f'\n{fields}'
+        return body
+
+    contact_id = None
+    contact_data = (result.data or {}).get('contact') or {}
+    if isinstance(contact_data, dict):
+        contact_id = contact_data.get('contact_id')
+    contact_id = contact_id or (result.data or {}).get('undo_target_id')
+    if contact_id:
+        contact = db.session.get(Contact, int(contact_id))
+        if contact is not None:
+            return format_saved_contacts([contact])
+    return result.summary or 'Saved.'
+
+
 def _help_text(user: User) -> str:
     name = user.first_name or 'there'
     return (
         f"Hey {name}. I am B.O.B. in your CRM.\n\n"
-        "Text me, or send a voice note. I can:\n"
+        "Text me, send a voice note, or photo a business card / email. I can:\n"
         "- Show today's agenda and overdue tasks\n"
         "- Look up contacts and counts by city or group\n"
         "- Log calls, texts, notes, and follow-ups\n"
-        "- Add contacts and create tasks\n\n"
+        "- Add contacts (including from photos) and create tasks\n\n"
         "Try:\n"
         "- What's on my plate today?\n"
         "- Log a call with Sarah and follow up Friday\n"
-        "- How many contacts in Houston?\n\n"
+        "- Photo a card with caption: create this contact\n\n"
         "Commands: /today  /overdue  /help  /undo  /stop\n"
         "Risky edits and deletes show a Confirm button first.\n"
         "When a few people match a name, tap the right one.\n\n"

--- a/services/messaging/photo_contacts.py
+++ b/services/messaging/photo_contacts.py
@@ -1,0 +1,512 @@
+"""Telegram photo → contact extraction for B.O.B.
+
+Reuses Magic Inbox's vision extraction (``generate_contact_extraction``) and
+image prep (``image_to_base64_jpeg``). Telegram decides whether to ask before
+creating or to create immediately when the caption/text is a clear save ask.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from models import BobAction, Contact, User, db
+from services.ai_service import generate_contact_extraction
+from services.bob_tools.context import BobContext, ToolResult
+from services.bob_tools.registry import (
+    CONFIRMATION_TTL_MINUTES,
+    dispatch as bob_dispatch,
+)
+from services.inbound_payload import image_to_base64_jpeg
+from utils import format_phone_number
+
+logger = logging.getLogger(__name__)
+
+MAX_PHOTO_BYTES = 10 * 1024 * 1024
+MAX_CANDIDATES = 5
+PHOTO_SOURCE = 'telegram_photo'
+
+# Caption/text that means "just save it" rather than "show me what you see".
+_CREATE_INTENT_RE = re.compile(
+    r'(?i)\b('
+    r'create(\s+(this|the|a|my))?\s+contact'
+    r'|add(\s+(this|the|a|my))?\s+contact'
+    r'|save(\s+(this|the|a|my))?\s+contact'
+    r'|add(\s+(them|him|her|this|these))?\s+to\s+(my\s+)?(crm|contacts?)'
+    r'|save(\s+(them|him|her|this|these))?\s+to\s+(my\s+)?(crm|contacts?)'
+    r'|new\s+contact'
+    r'|put\s+(this|them|him|her)\s+in\s+(my\s+)?(crm|contacts?)'
+    r')\b'
+)
+
+
+class PhotoContactError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+def wants_create_contact(text: str) -> bool:
+    """True when the agent already asked to create/save a contact."""
+    return bool(_CREATE_INTENT_RE.search(text or ''))
+
+
+def download_telegram_photo(transport: Any, file_id: str) -> bytes:
+    try:
+        meta = transport.get_file(file_id)
+    except Exception as exc:
+        logger.warning('Telegram getFile for photo failed: %s', exc)
+        raise PhotoContactError(
+            "Couldn't download that photo. Try again."
+        ) from exc
+
+    file_path = (meta or {}).get('file_path') or ''
+    file_size = int((meta or {}).get('file_size') or 0)
+    if file_size and file_size > MAX_PHOTO_BYTES:
+        raise PhotoContactError(
+            'That photo is too large. Try a clearer crop or a smaller image.'
+        )
+    if not file_path:
+        raise PhotoContactError("Couldn't find that photo file. Try again.")
+
+    try:
+        data = transport.download_file(file_path)
+    except Exception as exc:
+        logger.warning('Telegram photo download failed: %s', exc)
+        raise PhotoContactError(
+            "Couldn't download that photo. Try again."
+        ) from exc
+
+    if not data:
+        raise PhotoContactError('That photo looked empty.')
+    if len(data) > MAX_PHOTO_BYTES:
+        raise PhotoContactError(
+            'That photo is too large. Try a clearer crop or a smaller image.'
+        )
+    return data
+
+
+def extract_contact_candidates(
+    image_bytes: bytes,
+    *,
+    caption: str = '',
+    user: User,
+) -> list[dict]:
+    """Run Magic Inbox extraction on one photo and return usable candidates."""
+    b64 = image_to_base64_jpeg(image_bytes)
+    if not b64:
+        raise PhotoContactError(
+            "Couldn't read that image. Try a clearer photo of the card or email."
+        )
+
+    try:
+        result = generate_contact_extraction(
+            text=caption or '',
+            image_blocks=[b64],
+        )
+    except Exception as exc:
+        logger.warning('Telegram photo extraction failed: %s', exc)
+        raise PhotoContactError(
+            "Couldn't pull contact info from that photo. Try again, or type the details."
+        ) from exc
+
+    raw = result.get('contacts') or []
+    if not isinstance(raw, list):
+        return []
+
+    user_email = (getattr(user, 'email', None) or '').strip().lower()
+    candidates: list[dict] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        normalized = _normalize_candidate(entry, user_email=user_email)
+        if normalized is not None:
+            candidates.append(normalized)
+        if len(candidates) >= MAX_CANDIDATES:
+            break
+    return candidates
+
+
+def candidate_to_create_args(candidate: dict) -> dict:
+    """Shape a candidate for ``create_contact``."""
+    notes = (candidate.get('notes') or '').strip()
+    provenance = 'Added via Telegram photo.'
+    if notes:
+        notes = f'{notes}\n\n{provenance}'
+    else:
+        notes = provenance
+
+    args = {
+        'first_name': candidate['first_name'],
+        'last_name': candidate.get('last_name') or '',
+        'email': candidate.get('email'),
+        'phone': candidate.get('phone'),
+        'street_address': candidate.get('street_address'),
+        'city': candidate.get('city'),
+        'state': candidate.get('state'),
+        'zip_code': candidate.get('zip_code'),
+        'notes': notes,
+    }
+    group_name = candidate.get('group_name')
+    if group_name:
+        args['group_names'] = [group_name]
+    return {k: v for k, v in args.items() if v not in (None, '', [])}
+
+
+def format_candidate_preview(candidates: list[dict]) -> str:
+    """Human-readable preview of what B.O.B. read from the photo."""
+    if not candidates:
+        return "I didn't find usable contact info in that photo."
+
+    if len(candidates) == 1:
+        lines = ['Found this contact info:', '', _format_fields(candidates[0])]
+        lines.extend([
+            '',
+            'Create this contact in your CRM?',
+        ])
+        return '\n'.join(lines)
+
+    lines = [f'Found {len(candidates)} people in that photo:', '']
+    for i, candidate in enumerate(candidates, start=1):
+        name = _display_name(candidate)
+        lines.append(f'**{i}. {name}**')
+        lines.append(_format_fields(candidate, skip_name=True))
+        lines.append('')
+    lines.append('Create all of them in your CRM?')
+    return '\n'.join(lines).rstrip()
+
+
+def format_saved_contact(contact: Contact) -> str:
+    """Everything B.O.B. persisted on the contact row."""
+    groups = [
+        g.name for g in (contact.groups or [])
+        if getattr(g, 'is_active', True)
+    ]
+    fields = {
+        'first_name': contact.first_name,
+        'last_name': contact.last_name,
+        'email': contact.email,
+        'phone': contact.phone,
+        'street_address': contact.street_address,
+        'city': contact.city,
+        'state': contact.state,
+        'zip_code': contact.zip_code,
+        'notes': contact.notes,
+        'groups': groups,
+    }
+    name = _display_name(fields)
+    body = _format_fields(fields, skip_name=True)
+    return f'**{name}**\n{body}' if body else f'**{name}**'
+
+
+def format_saved_contacts(contacts: list[Contact]) -> str:
+    if not contacts:
+        return 'No contacts were saved.'
+    if len(contacts) == 1:
+        return 'Saved to your CRM:\n\n' + format_saved_contact(contacts[0])
+    chunks = ['Saved to your CRM:', '']
+    for contact in contacts:
+        chunks.append(format_saved_contact(contact))
+        chunks.append('')
+    return '\n'.join(chunks).rstrip()
+
+
+def create_pending_photo_action(
+    *,
+    ctx: BobContext,
+    candidates: list[dict],
+    conversation_id: Optional[int] = None,
+) -> BobAction:
+    """Store extracted create args as a pending BobAction for Confirm/Cancel."""
+    contacts_args = [candidate_to_create_args(c) for c in candidates]
+    preview = {
+        'source': PHOTO_SOURCE,
+        'batch': True,
+        'count': len(contacts_args),
+        'contacts': candidates,
+        'summary': (
+            f'Create {len(contacts_args)} contact(s) from photo'
+            if len(contacts_args) != 1
+            else f"Create contact {_display_name(candidates[0])}"
+        ),
+    }
+    # First contact args stay at top level so a generic confirm still works
+    # for the single-contact case; batch confirm reads arguments['contacts'].
+    arguments = {'contacts': contacts_args}
+    if len(contacts_args) == 1:
+        arguments.update(contacts_args[0])
+
+    action = BobAction(
+        organization_id=ctx.organization_id,
+        user_id=ctx.user_id,
+        conversation_id=conversation_id,
+        tool_name='create_contact',
+        arguments=arguments,
+        preview=preview,
+        status=BobAction.STATUS_PENDING,
+        summary=preview['summary'][:300],
+        surface=ctx.surface,
+        expires_at=datetime.utcnow() + timedelta(minutes=CONFIRMATION_TTL_MINUTES),
+    )
+    db.session.add(action)
+    db.session.commit()
+    return action
+
+
+def is_photo_pending_action(action: BobAction) -> bool:
+    preview = action.preview or {}
+    return preview.get('source') == PHOTO_SOURCE
+
+
+def confirm_photo_contacts(action: BobAction, ctx: BobContext) -> tuple[ToolResult, list[Contact]]:
+    """Execute a photo pending action (one or many creates)."""
+    loaded = BobAction.query.filter_by(
+        id=action.id,
+        organization_id=ctx.organization_id,
+        user_id=ctx.user_id,
+    ).first()
+    if loaded is None:
+        return ToolResult.failure('That pending action was not found.'), []
+    if loaded.status != BobAction.STATUS_PENDING:
+        return ToolResult.failure(
+            f'That action was already {loaded.status}.'
+        ), []
+    if loaded.is_expired:
+        loaded.status = BobAction.STATUS_EXPIRED
+        db.session.commit()
+        return ToolResult.failure(
+            'That confirmation expired. Send the photo again if you still want it.'
+        ), []
+
+    batch = (loaded.arguments or {}).get('contacts')
+    if not isinstance(batch, list) or not batch:
+        from services.bob_tools import confirm_action
+        result = confirm_action(loaded.id, ctx)
+        return result, _contacts_from_create_result(result)
+
+    created: list[Contact] = []
+    duplicates: list[str] = []
+    errors: list[str] = []
+    last_undoable_id: Optional[int] = None
+    record_urls: list[str] = []
+
+    for args in batch:
+        if not isinstance(args, dict):
+            continue
+        result = bob_dispatch(
+            'create_contact', args, ctx,
+            conversation_id=loaded.conversation_id,
+        )
+        if result.ok and (result.data or {}).get('created'):
+            created.extend(_contacts_from_create_result(result))
+            if result.undoable and result.action_id:
+                last_undoable_id = result.action_id
+            if result.record_url:
+                record_urls.append(result.record_url)
+        elif result.ok and (result.data or {}).get('reason') == 'duplicate':
+            existing = (result.data or {}).get('existing_contact') or {}
+            duplicates.append(existing.get('name') or result.summary)
+        else:
+            errors.append(result.error or result.summary)
+
+    loaded.status = BobAction.STATUS_EXECUTED
+    loaded.executed_at = datetime.utcnow()
+    db.session.commit()
+
+    if not created and duplicates and not errors:
+        return ToolResult.success(
+            summary='Already in your CRM: ' + ', '.join(duplicates),
+            data={'created': False, 'duplicates': duplicates},
+        ), []
+
+    if not created:
+        return ToolResult.failure(
+            errors[0] if errors else 'Could not create those contacts.'
+        ), []
+
+    summary = format_saved_contacts(created)
+    if duplicates:
+        summary += '\n\nAlready in CRM: ' + ', '.join(duplicates)
+    return ToolResult.success(
+        summary=summary,
+        data={
+            'created': True,
+            'count': len(created),
+            'contact_ids': [c.id for c in created],
+        },
+        undoable=last_undoable_id is not None,
+        action_id=last_undoable_id,
+        record_url=record_urls[0] if len(record_urls) == 1 else None,
+    ), created
+
+
+def create_contacts_now(
+    *,
+    ctx: BobContext,
+    candidates: list[dict],
+    conversation_id: Optional[int] = None,
+) -> tuple[str, list[Contact], Optional[int], list[str]]:
+    """Create immediately (create-intent path). Returns body, contacts, undo id, urls."""
+    created: list[Contact] = []
+    duplicates: list[str] = []
+    errors: list[str] = []
+    undoable_id: Optional[int] = None
+    record_urls: list[str] = []
+
+    for candidate in candidates:
+        args = candidate_to_create_args(candidate)
+        result = bob_dispatch(
+            'create_contact', args, ctx, conversation_id=conversation_id,
+        )
+        if result.ok and (result.data or {}).get('created'):
+            contacts = _contacts_from_create_result(result)
+            created.extend(contacts)
+            if result.undoable and result.action_id:
+                undoable_id = result.action_id
+            if result.record_url:
+                record_urls.append(result.record_url)
+        elif result.ok and (result.data or {}).get('reason') == 'duplicate':
+            existing = (result.data or {}).get('existing_contact') or {}
+            duplicates.append(existing.get('name') or result.summary)
+        else:
+            errors.append(result.error or result.summary)
+
+    if created:
+        body = format_saved_contacts(created)
+        if duplicates:
+            body += '\n\nAlready in CRM: ' + ', '.join(duplicates)
+        return body, created, undoable_id, record_urls
+
+    if duplicates and not errors:
+        return (
+            'Already in your CRM: ' + ', '.join(duplicates),
+            [],
+            None,
+            [],
+        )
+
+    return (
+        errors[0] if errors else 'Could not create a contact from that photo.',
+        [],
+        None,
+        [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _normalize_candidate(entry: dict, *, user_email: str) -> Optional[dict]:
+    confidence = (entry.get('confidence') or 'low').lower()
+    first = _title_case_name(entry.get('first_name'))
+    last = _title_case_name(entry.get('last_name'))
+    email = _normalize_email(entry.get('email'))
+    phone = _normalize_phone(entry.get('phone'))
+
+    # create_contact requires first_name — promote last-only cards.
+    if not first and last:
+        first, last = last, ''
+
+    has_name = bool(first)
+    has_signal = bool(email or phone)
+    if not has_name:
+        return None
+    if not has_signal and confidence == 'low':
+        return None
+    if email and user_email and email == user_email:
+        return None
+
+    return {
+        'first_name': first,
+        'last_name': last,
+        'email': email,
+        'phone': phone,
+        'street_address': (entry.get('street_address') or '').strip() or None,
+        'city': (entry.get('city') or '').strip() or None,
+        'state': (entry.get('state') or '').strip() or None,
+        'zip_code': (entry.get('zip_code') or '').strip() or None,
+        'notes': (entry.get('notes') or '').strip() or None,
+        'group_name': (entry.get('group_name') or '').strip() or None,
+        'confidence': confidence,
+    }
+
+
+def _normalize_email(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    cleaned = str(raw).strip().lower()
+    return cleaned or None
+
+
+def _normalize_phone(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    return format_phone_number(raw)
+
+
+def _title_case_name(raw: str | None) -> str:
+    if not raw:
+        return ''
+    return ' '.join(part.capitalize() for part in str(raw).strip().split())
+
+
+def display_name(fields: dict) -> str:
+    return (
+        f"{fields.get('first_name') or ''} {fields.get('last_name') or ''}"
+    ).strip() or 'Contact'
+
+
+# Back-compat for internal callers.
+_display_name = display_name
+
+
+_FIELD_LABELS = (
+    ('first_name', 'First name'),
+    ('last_name', 'Last name'),
+    ('email', 'Email'),
+    ('phone', 'Phone'),
+    ('street_address', 'Address'),
+    ('city', 'City'),
+    ('state', 'State'),
+    ('zip_code', 'ZIP'),
+    ('notes', 'Notes'),
+    ('groups', 'Groups'),
+    ('group_name', 'Group'),
+)
+
+
+def format_fields(fields: dict, *, skip_name: bool = False) -> str:
+    lines = []
+    for key, label in _FIELD_LABELS:
+        if skip_name and key in ('first_name', 'last_name'):
+            continue
+        value = fields.get(key)
+        if value in (None, '', [], ()):
+            continue
+        if isinstance(value, (list, tuple)):
+            value = ', '.join(str(v) for v in value if v)
+            if not value:
+                continue
+        # Keep notes readable but bounded for chat.
+        text = str(value).strip()
+        if key == 'notes' and len(text) > 400:
+            text = text[:397].rstrip() + '...'
+        lines.append(f'- **{label}:** {text}')
+    return '\n'.join(lines)
+
+
+_format_fields = format_fields
+
+
+def _contacts_from_create_result(result: ToolResult) -> list[Contact]:
+    data = result.data or {}
+    contact_id = None
+    if isinstance(data.get('contact'), dict):
+        contact_id = data['contact'].get('contact_id')
+    contact_id = contact_id or data.get('undo_target_id')
+    if not contact_id:
+        return []
+    contact = db.session.get(Contact, int(contact_id))
+    return [contact] if contact is not None else []

--- a/services/messaging/prompt.py
+++ b/services/messaging/prompt.py
@@ -25,6 +25,7 @@ Reply shape:
 - No markdown tables. No # headers. Use **bold** sparingly for names or key facts, and `backticks` for values.
 - Close with "--BOB".
 - The agent may send a voice note. Treat the transcript as their typed message.
+- Photos of business cards, emails, or contact screenshots are handled before you see them. When you create a contact yourself, list every field you saved.
 - When several contacts match, name them briefly. Tap buttons may appear under your reply so they can pick one.
 
 STRICT SCOPE (NON-NEGOTIABLE):

--- a/services/messaging/queue.py
+++ b/services/messaging/queue.py
@@ -22,6 +22,7 @@ def enqueue_telegram_message(
     telegram_message_id: str | None = None,
     voice_file_id: str | None = None,
     voice_duration_seconds: int | None = None,
+    photo_file_id: str | None = None,
 ) -> None:
     _enqueue(
         'jobs.bob_telegram_reply.process_telegram_message_job',
@@ -31,6 +32,7 @@ def enqueue_telegram_message(
         telegram_message_id=telegram_message_id,
         voice_file_id=voice_file_id,
         voice_duration_seconds=voice_duration_seconds,
+        photo_file_id=photo_file_id,
     )
 
 

--- a/tests/test_bob_telegram.py
+++ b/tests/test_bob_telegram.py
@@ -640,13 +640,13 @@ class TestVoiceAndMedia:
                 'message_id': 9,
                 'from': {'id': int(linked_channel['external_id'])},
                 'chat': {'id': int(linked_channel['chat_id'])},
-                'photo': [{'file_id': 'photo-1'}],
+                'sticker': {'file_id': 'sticker-1'},
             },
         }
         with patch('routes.bob_telegram.enqueue_telegram_message') as enq:
             assert _webhook(client, payload).status_code == 200
             enq.assert_not_called()
-        assert any('voice note' in m['text'] for m in _fake_transport.sent)
+        assert any('business card' in m['text'] for m in _fake_transport.sent)
 
     def test_voice_message_is_enqueued_with_file_id(
         self, app, seed, linked_channel, _fake_transport,
@@ -668,6 +668,30 @@ class TestVoiceAndMedia:
             assert kwargs['voice_file_id'] == 'AwVOICE'
             assert kwargs['voice_duration_seconds'] == 6
             assert kwargs['text'] == ''
+
+    def test_photo_message_is_enqueued_with_largest_file_id(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        client = app.test_client()
+        payload = {
+            'update_id': 9003,
+            'message': {
+                'message_id': 11,
+                'from': {'id': int(linked_channel['external_id'])},
+                'chat': {'id': int(linked_channel['chat_id'])},
+                'caption': 'create this contact',
+                'photo': [
+                    {'file_id': 'small', 'width': 90, 'height': 90},
+                    {'file_id': 'large', 'width': 800, 'height': 800},
+                ],
+            },
+        }
+        with patch('routes.bob_telegram.enqueue_telegram_message') as enq:
+            assert _webhook(client, payload).status_code == 200
+            enq.assert_called_once()
+            kwargs = enq.call_args.kwargs
+            assert kwargs['photo_file_id'] == 'large'
+            assert kwargs['text'] == 'create this contact'
 
 
 class TestCommandsAndDisambiguation:
@@ -817,3 +841,162 @@ class TestDeepLinksAndLocalDay:
             first = _get_or_create_conversation(user)
             second = _get_or_create_conversation(user)
             assert first.id == second.id
+
+
+# ---------------------------------------------------------------------------
+# Photo → contact (Magic Inbox extraction)
+# ---------------------------------------------------------------------------
+
+_PHOTO_CANDIDATE = {
+    'first_name': 'Casey',
+    'last_name': 'Card',
+    'email': 'casey.card@example.com',
+    'phone': '(832) 555-0199',
+    'street_address': '100 Main St',
+    'city': 'Houston',
+    'state': 'TX',
+    'zip_code': '77002',
+    'notes': 'Acme Realty',
+    'group_name': None,
+    'confidence': 'high',
+}
+
+
+class TestPhotoContacts:
+    def test_photo_without_create_intent_asks_before_saving(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.download_telegram_photo',
+                return_value=b'fake-image-bytes',
+            ), patch(
+                'services.messaging.conversation.extract_contact_candidates',
+                return_value=[dict(_PHOTO_CANDIDATE)],
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='',
+                    photo_file_id='photo-ask',
+                    telegram_message_id='700',
+                )
+
+            channel = db.session.get(
+                AgentMessagingChannel, linked_channel['id'],
+            )
+            assert channel.pending_action_id is not None
+            action = db.session.get(BobAction, channel.pending_action_id)
+            assert action is not None
+            assert action.status == BobAction.STATUS_PENDING
+            assert (action.preview or {}).get('source') == 'telegram_photo'
+
+        choice_msgs = [m for m in _fake_transport.sent if m.get('options')]
+        assert choice_msgs
+        labels = [opt.label for opt in choice_msgs[0]['options']]
+        assert 'Create contact' in labels
+        assert 'Cancel' in labels
+        assert 'Casey' in choice_msgs[0]['text']
+        assert 'casey.card@example.com' in choice_msgs[0]['text']
+
+    def test_photo_with_create_intent_saves_and_lists_fields(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.download_telegram_photo',
+                return_value=b'fake-image-bytes',
+            ), patch(
+                'services.messaging.conversation.extract_contact_candidates',
+                return_value=[dict(_PHOTO_CANDIDATE)],
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='Create this contact please',
+                    photo_file_id='photo-create',
+                    telegram_message_id='701',
+                )
+
+            from models import Contact
+            contact = Contact.query.filter_by(
+                user_id=seed['agent_a'],
+                email='casey.card@example.com',
+            ).first()
+            assert contact is not None
+            contact_id = contact.id
+            # Cleanup
+            contact.groups.clear()
+            db.session.delete(contact)
+            BobAction.query.filter_by(
+                user_id=seed['agent_a'], surface='bob_telegram',
+            ).delete()
+            db.session.commit()
+
+        sent = ' '.join(m['text'] for m in _fake_transport.sent)
+        assert 'Saved to your CRM' in sent
+        assert 'Casey Card' in sent
+        assert 'casey.card@example.com' in sent
+        assert '(832) 555-0199' in sent
+        assert f'https://example.test/contact/{contact_id}' in sent
+        # Undo button for the create
+        assert any(m.get('options') for m in _fake_transport.sent)
+
+    def test_photo_confirm_creates_and_returns_saved_fields(
+        self, app, seed, linked_channel, _fake_transport,
+    ):
+        with app.app_context():
+            with patch(
+                'services.messaging.conversation.download_telegram_photo',
+                return_value=b'fake-image-bytes',
+            ), patch(
+                'services.messaging.conversation.extract_contact_candidates',
+                return_value=[dict(_PHOTO_CANDIDATE, email='confirm.card@example.com')],
+            ):
+                handle_inbound_message(
+                    channel_id=linked_channel['id'],
+                    org_id=seed['org_a'],
+                    text='',
+                    photo_file_id='photo-confirm',
+                    telegram_message_id='702',
+                )
+
+            channel = db.session.get(
+                AgentMessagingChannel, linked_channel['id'],
+            )
+            action_id = channel.pending_action_id
+            assert action_id
+
+            handle_callback_query(
+                channel_id=linked_channel['id'],
+                org_id=seed['org_a'],
+                callback_query_id='cb-photo',
+                data=f'confirm:{action_id}',
+                message_id='80',
+            )
+
+            from models import Contact
+            contact = Contact.query.filter_by(
+                user_id=seed['agent_a'],
+                email='confirm.card@example.com',
+            ).first()
+            assert contact is not None
+            contact.groups.clear()
+            db.session.delete(contact)
+            BobAction.query.filter_by(
+                user_id=seed['agent_a'], surface='bob_telegram',
+            ).delete()
+            db.session.commit()
+
+        edited = ' '.join(m['text'] for m in _fake_transport.edited)
+        assert 'Saved to your CRM' in edited
+        assert 'Casey Card' in edited
+        assert 'confirm.card@example.com' in edited
+
+    def test_wants_create_contact_phrases(self):
+        from services.messaging.photo_contacts import wants_create_contact
+        assert wants_create_contact('create this contact')
+        assert wants_create_contact('Please add this to my CRM')
+        assert wants_create_contact('save contact')
+        assert not wants_create_contact('')
+        assert not wants_create_contact('what do you see here?')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Telegram B.O.B. can now turn photos of business cards, emails, and contact screenshots into CRM contacts — same vision extraction path as Magic Inbox (`generate_contact_extraction` + JPEG prep).

## Behavior

| Agent action | B.O.B. response |
|---|---|
| Sends a photo with contact info | Shows extracted fields + **Create contact** / **Cancel** |
| Captions with “create this contact” / “add to my CRM” / similar | Creates immediately, then lists everything saved |
| After any create (photo or text tool) | Replies with every persisted field + Open link + Undo when available |

## Implementation

- New `services/messaging/photo_contacts.py` — download, extract, preview, pending confirm, create-now
- Webhook accepts `photo` (largest size) and image `document`s; stickers still get a polite refusal
- Pending photo creates reuse `BobAction` + Confirm/Cancel buttons
- `create_contact` tool results now include a `saved` field dump for full replies
- Magic Inbox image helper exposed as `image_to_base64_jpeg`

## Test plan

- [x] `pytest tests/test_bob_telegram.py` + create_contact tool tests
- [ ] Send a business-card photo with no caption → Confirm/Cancel prompt
- [ ] Tap Create → contact saved, full field list + Open link
- [ ] Send photo with caption `create this contact` → saved without extra confirm
- [ ] Send a sticker → unsupported hint (not photo path)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbd4e-adf2-721c-8914-d078835f7cf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbd4e-adf2-721c-8914-d078835f7cf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

