### PR TITLE
chore: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Keep deps current without PR spam:
+# - weekly checks
+# - group all updates per ecosystem into one PR
+# - cap open Dependabot PRs
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 1
+    groups:
+      python-test-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with grouped weekly pip/npm updates and monthly GitHub Actions updates
- Caps open PRs so Dependabot stays useful without spamming the board
- Repo security alerts + automated security fixes are already enabled via GitHub settings

## Test plan
- [ ] Confirm Dependabot appears under Insights → Dependency graph / Dependabot after merge
- [ ] Expect first grouped update PRs within about a day of the next scheduled check (or after GitHub picks up the config)

Made with [Cursor](https://cursor.com)