### PR TITLE
fix: purge controlling-contract rows before transaction delete

### DIFF
--- a/models.py
+++ b/models.py
@@ -1544,7 +1544,11 @@ class SellerContractDocument(db.Model):
     accepted_contract = db.relationship(
         'SellerAcceptedContract',
         foreign_keys=[accepted_contract_id],
-        backref=db.backref('contract_documents', lazy='dynamic'),
+        backref=db.backref(
+            'contract_documents',
+            lazy='dynamic',
+            cascade='all, delete-orphan',
+        ),
     )
     document = db.relationship('TransactionDocument', foreign_keys=[transaction_document_id])
     created_by = db.relationship('User', foreign_keys=[created_by_id])

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -1201,63 +1201,16 @@ def delete_transaction(id):
         # Log deletion before actually deleting
         audit_service.log_transaction_deleted(transaction_id, address)
 
-        # BOB VTC rows use NOT NULL FKs. SQLite often skips DB ON DELETE CASCADE,
-        # and ORM nullify-on-delete then raises IntegrityError. Purge first.
-        from models import (
-            CommunicationDeliveryAttempt,
-            DocumentExtractionRun,
-            DocumentReviewReport,
-            ExtractedField,
-            SellerCommissionTerms,
-            TransactionChangeProposal,
-            TransactionCommunication,
-        )
+        # BOB VTC rows use NOT NULL FKs. ORM nullify-on-delete raises
+        # NotNullViolation on Postgres (seller_contract_documents etc.).
+        from services.transaction_helpers import purge_transaction_dependent_rows
 
-        SellerCommissionTerms.query.filter_by(
-            transaction_id=transaction_id,
-        ).delete(synchronize_session=False)
+        purge_transaction_dependent_rows(transaction_id)
 
-        review_q = DocumentReviewReport.query.filter_by(transaction_id=transaction_id)
-        review_q.delete(synchronize_session=False)
-
-        proposal_q = TransactionChangeProposal.query.filter_by(transaction_id=transaction_id)
-        proposal_q.delete(synchronize_session=False)
-
-        comm_ids = [
-            row[0] for row in
-            db.session.query(TransactionCommunication.id)
-            .filter_by(transaction_id=transaction_id)
-            .all()
-        ]
-        if comm_ids:
-            CommunicationDeliveryAttempt.query.filter(
-                CommunicationDeliveryAttempt.communication_id.in_(comm_ids)
-            ).delete(synchronize_session=False)
-            TransactionCommunication.query.filter(
-                TransactionCommunication.id.in_(comm_ids)
-            ).delete(synchronize_session=False)
-
-        run_ids = [
-            row[0] for row in
-            db.session.query(DocumentExtractionRun.id)
-            .filter_by(transaction_id=transaction_id)
-            .all()
-        ]
-        if run_ids:
-            ExtractedField.query.filter(
-                ExtractedField.extraction_run_id.in_(run_ids)
-            ).delete(synchronize_session=False)
-            DocumentExtractionRun.query.filter(
-                DocumentExtractionRun.id.in_(run_ids)
-            ).delete(synchronize_session=False)
-
-        # Delete the transaction - cascade will handle:
-        # - TransactionParticipants (cascade='all, delete-orphan')
-        # - TransactionDocuments (cascade='all, delete-orphan')
-        #   - DocumentSignatures (cascade='all, delete-orphan' via TransactionDocument)
+        # Remaining ORM cascades: participants, documents/signatures,
+        # listing profile, showings, price changes.
         db.session.delete(transaction)
         db.session.commit()
-
         flash(f'Transaction for "{address}" has been deleted.', 'success')
         return redirect(url_for('transactions.list_transactions'))
         

--- a/services/transaction_helpers.py
+++ b/services/transaction_helpers.py
@@ -729,3 +729,181 @@ def build_contract_terms(transaction, accepted_contract=None, documents=None):
     data['_sources'] = sources
     data['_completeness'] = _compute_contract_completeness(data)
     return data
+
+
+def purge_transaction_dependent_rows(transaction_id: int) -> None:
+    """Bulk-delete dependent rows before removing a transaction.
+
+    Several VTC tables use NOT NULL FKs. SQLAlchemy's default relationship
+    behavior nullifies those FKs on parent delete, which fails on Postgres.
+    Call this before ``db.session.delete(transaction)``.
+    """
+    from models import (
+        CommunicationDeliveryAttempt,
+        DocumentExtractionRun,
+        DocumentReviewReport,
+        ExtractedField,
+        NotificationDelivery,
+        NotificationEvent,
+        SellerAcceptedContract,
+        SellerClosingSummary,
+        SellerCommissionTerms,
+        SellerContractAmendment,
+        SellerContractAmendmentVersion,
+        SellerContractDocument,
+        SellerContractMilestone,
+        SellerContractTermination,
+        SellerOffer,
+        SellerOfferActivity,
+        SellerOfferDocument,
+        SellerOfferVersion,
+        TransactionAssignment,
+        TransactionChangeProposal,
+        TransactionCommunication,
+        TransactionRequirement,
+        TransactionRequirementDependency,
+        TransactionRequirementEvent,
+        TransactionRequirementEvidence,
+        db,
+    )
+
+    def _ids(model):
+        return [
+            row[0]
+            for row in db.session.query(model.id).filter_by(
+                transaction_id=transaction_id,
+            ).all()
+        ]
+
+    # --- Notifications / reviews / proposals / comms / extraction ---
+    event_ids = [
+        row[0]
+        for row in db.session.query(NotificationEvent.id).filter_by(
+            related_transaction_id=transaction_id,
+        ).all()
+    ]
+    if event_ids:
+        NotificationDelivery.query.filter(
+            NotificationDelivery.event_id.in_(event_ids),
+        ).delete(synchronize_session=False)
+        NotificationEvent.query.filter(
+            NotificationEvent.id.in_(event_ids),
+        ).delete(synchronize_session=False)
+
+    DocumentReviewReport.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    TransactionChangeProposal.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+
+    comm_ids = _ids(TransactionCommunication)
+    if comm_ids:
+        CommunicationDeliveryAttempt.query.filter(
+            CommunicationDeliveryAttempt.communication_id.in_(comm_ids),
+        ).delete(synchronize_session=False)
+        TransactionCommunication.query.filter(
+            TransactionCommunication.id.in_(comm_ids),
+        ).delete(synchronize_session=False)
+
+    run_ids = _ids(DocumentExtractionRun)
+    if run_ids:
+        ExtractedField.query.filter(
+            ExtractedField.extraction_run_id.in_(run_ids),
+        ).delete(synchronize_session=False)
+        DocumentExtractionRun.query.filter(
+            DocumentExtractionRun.id.in_(run_ids),
+        ).delete(synchronize_session=False)
+
+    SellerCommissionTerms.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+
+    # --- Requirements (evidence/events before parent) ---
+    req_ids = _ids(TransactionRequirement)
+    if req_ids:
+        TransactionRequirementEvidence.query.filter(
+            TransactionRequirementEvidence.requirement_id.in_(req_ids),
+        ).delete(synchronize_session=False)
+        TransactionRequirementEvent.query.filter(
+            TransactionRequirementEvent.requirement_id.in_(req_ids),
+        ).delete(synchronize_session=False)
+        TransactionRequirementDependency.query.filter(
+            db.or_(
+                TransactionRequirementDependency.requirement_id.in_(req_ids),
+                TransactionRequirementDependency.blocks_requirement_id.in_(req_ids),
+            ),
+        ).delete(synchronize_session=False)
+        # Clear milestone FK before milestones go away.
+        TransactionRequirement.query.filter(
+            TransactionRequirement.id.in_(req_ids),
+        ).update(
+            {TransactionRequirement.source_milestone_id: None},
+            synchronize_session=False,
+        )
+        TransactionRequirement.query.filter(
+            TransactionRequirement.id.in_(req_ids),
+        ).delete(synchronize_session=False)
+
+    # --- Controlling contract package (NOT NULL accepted_contract_id) ---
+    SellerContractDocument.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerClosingSummary.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerContractTermination.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerContractAmendmentVersion.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerContractAmendment.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerContractMilestone.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+
+    # --- Offers (break version pointers, then children, then parents) ---
+    offer_ids = _ids(SellerOffer)
+    if offer_ids:
+        SellerOffer.query.filter(
+            SellerOffer.id.in_(offer_ids),
+        ).update(
+            {
+                SellerOffer.current_version_id: None,
+                SellerOffer.accepted_version_id: None,
+                SellerOffer.replacement_offer_id: None,
+            },
+            synchronize_session=False,
+        )
+    SellerAcceptedContract.query.filter_by(
+        transaction_id=transaction_id,
+    ).update(
+        {
+            SellerAcceptedContract.offer_id: None,
+            SellerAcceptedContract.accepted_version_id: None,
+        },
+        synchronize_session=False,
+    )
+    SellerOfferDocument.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerOfferActivity.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerOfferVersion.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    SellerAcceptedContract.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)
+    if offer_ids:
+        SellerOffer.query.filter(
+            SellerOffer.id.in_(offer_ids),
+        ).delete(synchronize_session=False)
+
+    TransactionAssignment.query.filter_by(
+        transaction_id=transaction_id,
+    ).delete(synchronize_session=False)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -135,6 +135,77 @@ class TestTransactionDelete:
             assert Transaction.query.get(tx_id) is None
             assert SellerCommissionTerms.query.get(terms_id) is None
 
+    def test_delete_with_controlling_contract_documents(self, app, seed, owner_a_client):
+        """Contract package rows must be deleted — not nullified — on Postgres."""
+        from models import (
+            SellerAcceptedContract,
+            SellerContractDocument,
+            Transaction,
+            TransactionDocument,
+            db,
+        )
+
+        with app.app_context():
+            tx = Transaction(
+                organization_id=seed['org_a'],
+                created_by_id=seed['owner_a'],
+                transaction_type_id=seed['tx_type_a'],
+                street_address='Delete Contract Docs St',
+                city='Austin',
+                state='TX',
+                status='under_contract',
+            )
+            db.session.add(tx)
+            db.session.flush()
+            doc = TransactionDocument(
+                organization_id=seed['org_a'],
+                transaction_id=tx.id,
+                template_slug='seller-accepted-contract',
+                template_name='Executed Contract',
+                status='signed',
+                signed_file_path='test/executed.pdf',
+            )
+            db.session.add(doc)
+            db.session.flush()
+            contract = SellerAcceptedContract(
+                organization_id=seed['org_a'],
+                transaction_id=tx.id,
+                created_by_id=seed['owner_a'],
+                position='primary',
+                status='active',
+            )
+            db.session.add(contract)
+            db.session.flush()
+            link = SellerContractDocument(
+                organization_id=seed['org_a'],
+                transaction_id=tx.id,
+                accepted_contract_id=contract.id,
+                transaction_document_id=doc.id,
+                created_by_id=seed['owner_a'],
+                document_type='final_acceptance',
+                display_name='Executed Contract',
+                is_primary_contract_document=True,
+            )
+            db.session.add(link)
+            db.session.commit()
+            tx_id = tx.id
+            contract_id = contract.id
+            link_id = link.id
+            doc_id = doc.id
+
+        resp = owner_a_client.post(
+            f'/transactions/{tx_id}/delete',
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303), resp.get_data(as_text=True)
+        assert b'Error deleting transaction' not in (resp.data or b'')
+
+        with app.app_context():
+            assert Transaction.query.get(tx_id) is None
+            assert SellerAcceptedContract.query.get(contract_id) is None
+            assert SellerContractDocument.query.get(link_id) is None
+            assert TransactionDocument.query.get(doc_id) is None
+
 
 class TestTransactionStatusAPI:
     """Status update API."""


### PR DESCRIPTION
ORM was nullifying seller_contract_documents.accepted_contract_id on delete, which Postgres rejects (NOT NULL). Bulk-delete VTC dependents first, and cascade contract_documents from the accepted contract.