### PR TITLE
chore: ignore Vite/Tailwind major Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,10 +32,23 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 2
+    # Tailwind v4 / Vite 8+ need a deliberate migration (PostCSS plugin split, etc).
+    # Keep Dependabot on patch/minor only for the frontend build toolchain.
+    ignore:
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@tailwindcss/*"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "tailwindcss"
+          - "vite"
+          - "@tailwindcss/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Ignore semver-major updates for `vite`, `tailwindcss`, and `@tailwindcss/*`
- Exclude those packages from the grouped npm Dependabot PR so a future major cannot piggyback on safer bumps again (as in #292)

## Test plan
- [x] Confirm #292 is closed
- [ ] After merge, Dependabot should not reopen a Vite 8 / Tailwind 4 group bump

Made with [Cursor](https://cursor.com)