### PR TITLE
fix: landing logo scale + modern red accent on marketing/auth

### DIFF
--- a/static/css/am_skin.css
+++ b/static/css/am_skin.css
@@ -1006,6 +1006,12 @@ html.am-skin {
   --focus: rgba(250, 88, 106, 0.28);
   --shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
 }
+html.am-skin[data-theme="dark"] {
+  --brand-orange: #fa586a;
+}
+html.am-skin[data-theme="light"] {
+  --brand-orange: #fa243c;
+}
 
 /* ── Orange Tailwind utilities → Apple accent ─────────────── */
 html.am-skin .text-orange-400,
@@ -1318,11 +1324,33 @@ html.am-skin #planContent li {
 
 /* ── Auth pages ───────────────────────────────────────────── */
 html.am-skin .login-page,
-html.am-skin .register-page {
+html.am-skin .register-page,
+html.am-skin .register-panel {
   font-family: var(--font-sans) !important;
   background: var(--canvas) !important;
   background-image: none !important;
   color: var(--ink) !important;
+}
+/* Pin marketing/auth red utilities to the same accent as the app */
+html.am-skin .text-red-400,
+html.am-skin .text-red-500,
+html.am-skin .text-red-600,
+html.am-skin .text-red-700,
+html.am-skin .hover\:text-red-500:hover,
+html.am-skin .hover\:text-red-600:hover,
+html.am-skin .hover\:text-red-700:hover {
+  color: var(--accent-ink) !important;
+}
+html.am-skin .border-red-500,
+html.am-skin .border-red-600 {
+  border-color: var(--accent) !important;
+}
+html.am-skin .from-red-400 { --tw-gradient-from: #ff6b7a var(--tw-gradient-from-position) !important; }
+html.am-skin .to-rose-400 { --tw-gradient-to: #fa586a var(--tw-gradient-to-position) !important; }
+html.am-skin .from-red-500\/20 { --tw-gradient-from: rgb(250 36 60 / 0.2) var(--tw-gradient-from-position) !important; }
+html.am-skin .from-rose-500\/10 { --tw-gradient-from: rgb(250 88 106 / 0.1) var(--tw-gradient-from-position) !important; }
+html.am-skin .toc-link:hover {
+  color: var(--accent-ink) !important;
 }
 html.am-skin .login-page .card,
 html.am-skin .register-page .premium-card,

--- a/static/css/am_skin.css
+++ b/static/css/am_skin.css
@@ -1360,23 +1360,76 @@ html.am-skin .card {
   box-shadow: none !important;
   border-radius: 18px !important;
 }
+/* Soft left rail — paper-2, never pure black (was crushing contrast) */
 html.am-skin .login-page .left,
 html.am-skin .register-page .left {
-  background: #000000 !important;
-  background-image: none !important;
-}
-html.am-skin[data-theme="light"] .login-page .left,
-html.am-skin[data-theme="light"] .register-page .left {
-  background: #1c1c1e !important;
+  background-color: var(--paper-2) !important;
+  background-image: radial-gradient(ellipse at 0% 0%, var(--accent-soft) 0%, transparent 55%) !important;
+  color: var(--ink) !important;
+  border-right: 0.5px solid var(--hairline) !important;
 }
 html.am-skin .login-page .left::before,
 html.am-skin .register-page .left::before {
   background: var(--accent) !important;
   background-image: none !important;
 }
+html.am-skin .login-page .left-muted,
+html.am-skin .register-page .left-muted {
+  color: var(--ink-3) !important;
+}
+html.am-skin .login-page .left-title,
+html.am-skin .login-page .left .font-semibold,
+html.am-skin .login-page .left .font-extrabold {
+  color: var(--ink) !important;
+}
+html.am-skin .login-page .left-chip {
+  background: var(--accent-soft) !important;
+  color: var(--accent-ink) !important;
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent) !important;
+}
+html.am-skin .login-page .left-icon {
+  background: var(--paper) !important;
+  border-color: var(--hairline) !important;
+  color: var(--accent) !important;
+}
+html.am-skin .login-page .input,
+html.am-skin .login-page .icon-btn {
+  background: var(--paper) !important;
+  border-color: var(--hairline) !important;
+  color: var(--ink) !important;
+}
+html.am-skin .login-page .input:focus {
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 4px var(--accent-soft) !important;
+}
+html.am-skin .login-page .btn {
+  background: var(--am-key-bg) !important;
+  color: #fff !important;
+  box-shadow: none !important;
+}
+html.am-skin .login-page .btn:hover {
+  background: var(--am-key-pressed) !important;
+}
+html.am-skin .login-page .kicker,
+html.am-skin .login-page .subtitle,
+html.am-skin .login-page .label,
+html.am-skin .login-page .title {
+  color: var(--ink) !important;
+}
+html.am-skin .login-page .subtitle,
+html.am-skin .login-page .kicker {
+  color: var(--ink-3) !important;
+}
 html.am-skin .login-page a,
 html.am-skin .register-page a {
   color: var(--accent-ink) !important;
+}
+@media (max-width: 1024px) {
+  html.am-skin .login-page .left,
+  html.am-skin .register-page .left {
+    border-right: none !important;
+    border-bottom: 0.5px solid var(--hairline) !important;
+  }
 }
 
 /* ── Shared CRM primitives polish ─────────────────────────── */

--- a/templates/auth/accept_invite.html
+++ b/templates/auth/accept_invite.html
@@ -27,7 +27,7 @@
     .invite-orb.orb-2 {
         width: 220px;
         height: 220px;
-        background: rgba(249, 115, 22, 0.15);
+        background: rgba(250, 36, 60, 0.15);
         bottom: -70px;
         left: -70px;
     }
@@ -104,7 +104,7 @@
 
     <div class="w-full max-w-2xl relative z-10">
         <div class="invite-card rounded-2xl overflow-hidden">
-            <div class="bg-gradient-to-r from-[#2d3e50] via-[#3d5a73] to-[#f97316] text-white px-8 py-6">
+            <div class="bg-gradient-to-r from-[#1c1c1e] via-[#2c2c2e] to-[#fa243c] text-white px-8 py-6">
                 <div class="flex flex-wrap items-center justify-between gap-4">
                     <div class="flex items-center gap-4">
                         <div class="w-12 h-12 rounded-xl bg-white/15 flex items-center justify-center">

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -3,55 +3,57 @@
 
 {% block content %}
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
   :root{
-    --brand-navy: #2d3e50;
-    --brand-navy-2: #1a2634;
     --brand-orange: #fa243c;
-
-    --bg: #f8fafc;
+    --bg: #f4f4f4;
     --panel: #ffffff;
-    --text: #0f172a;
-    --muted: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 16px 40px rgba(15, 23, 42, 0.10);
-
-    --focus: rgba(45, 62, 80, 0.18);
+    --panel-soft: #f0f0f0;
+    --text: rgba(0, 0, 0, 0.88);
+    --muted: rgba(0, 0, 0, 0.56);
+    --border: rgba(0, 0, 0, 0.10);
+    --shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+    --focus: rgba(250, 36, 60, 0.18);
+    --accent-soft: rgba(214, 0, 23, 0.1);
   }
 
   .login-page{
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background:
-      radial-gradient(1100px 550px at 10% 0%, rgba(250,36,60,.06), transparent 60%),
-      radial-gradient(900px 520px at 100% 40%, rgba(45,62,80,.07), transparent 55%),
-      var(--bg);
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
   }
 
-  .shell{ width: 100%; max-width: 940px; }
+  .shell{ width: 100%; max-width: 920px; }
 
   .card{
     background: var(--panel);
-    border: 1px solid rgba(15, 23, 42, 0.07);
+    border: 1px solid var(--border);
     box-shadow: var(--shadow);
     border-radius: 18px;
     overflow: hidden;
   }
 
-  /* Left panel */
+  /* Left panel — soft surface, same ink as the form (no black cave) */
   .left{
-    background: linear-gradient(180deg, var(--brand-navy) 0%, var(--brand-navy-2) 100%);
-    color: rgba(255,255,255,.92);
+    background:
+      radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.07) 0%, transparent 55%),
+      var(--panel-soft);
+    color: var(--text);
     position: relative;
+    border-right: 1px solid var(--border);
   }
   .left::before{
     content:'';
     position:absolute;
     top:0; left:0; right:0;
-    height: 3px;
-    background: linear-gradient(90deg, var(--brand-orange), rgba(250,36,60,.55));
+    height: 2px;
+    background: var(--brand-orange);
   }
-  .left-muted{ color: rgba(255,255,255,.74); }
+  .left-muted{ color: var(--muted); }
+  .left-title{
+    color: var(--text);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
   .left-chip{
     display:inline-flex;
     align-items:center;
@@ -60,8 +62,9 @@
     font-weight: 700;
     padding: 6px 10px;
     border-radius: 9999px;
-    background: rgba(255,255,255,.10);
-    border: 1px solid rgba(255,255,255,.14);
+    background: var(--accent-soft);
+    color: var(--brand-orange);
+    border: 1px solid rgba(250, 36, 60, 0.16);
   }
   .left-bullet{
     display:flex;
@@ -71,23 +74,25 @@
   .left-icon{
     width: 34px;
     height: 34px;
-    border-radius: 12px;
-    background: rgba(255,255,255,.10);
+    border-radius: 10px;
+    background: var(--panel);
+    border: 1px solid var(--border);
     display:flex;
     align-items:center;
     justify-content:center;
     flex-shrink:0;
+    color: var(--brand-orange);
   }
 
   /* Form */
-  .kicker{ font-size: 13px; font-weight: 700; color: #334155; }
+  .kicker{ font-size: 12px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
   .title{ font-size: 24px; font-weight: 800; color: var(--text); letter-spacing: -0.02em; }
   .subtitle{ font-size: 14px; color: var(--muted); }
 
   .label{
     font-size: 13px;
     font-weight: 600;
-    color: #334155;
+    color: var(--text);
     margin-bottom: 6px;
     display: block;
   }
@@ -96,17 +101,17 @@
     height: 46px;
     border-radius: 12px;
     border: 1px solid var(--border);
-    background: #fff;
+    background: var(--panel);
     padding: 0 14px;
     font-size: 15px;
     width: 100%;
     color: var(--text);
     transition: border-color .15s ease, box-shadow .15s ease, background .15s ease;
   }
-  .input::placeholder{ color: #94a3b8; }
+  .input::placeholder{ color: rgba(0,0,0,0.35); }
   .input:focus{
     outline: none;
-    border-color: rgba(45,62,80,.55);
+    border-color: var(--brand-orange);
     box-shadow: 0 0 0 4px var(--focus);
   }
 
@@ -116,50 +121,49 @@
     font-size: 13px;
     text-decoration: none;
   }
-  .hint-link:hover{ color: #334155; }
+  .hint-link:hover{ color: var(--brand-orange); }
 
   .btn{
     height: 46px;
     border-radius: 12px;
     width: 100%;
-    background: var(--brand-navy);
+    background: #d60017;
     color: #fff;
     font-weight: 700;
     font-size: 15px;
-    transition: transform .08s ease, box-shadow .18s ease, background .18s ease;
+    transition: background .15s ease, box-shadow .18s ease;
   }
   .btn:hover{
-    background: #243243;
-    box-shadow: 0 10px 18px rgba(45,62,80,.22);
+    background: #b00014;
+    box-shadow: 0 8px 20px rgba(214, 0, 23, 0.28);
   }
-  .btn:active{ transform: translateY(1px); }
+  .btn:active{ background: #980012; }
 
-  .divider{ height: 1px; background: rgba(15, 23, 42, 0.08); }
+  .divider{ height: 1px; background: var(--border); }
 
   .icon-btn{
     border: 1px solid var(--border);
-    background: #fff;
+    background: var(--panel);
     height: 46px;
     width: 46px;
     border-radius: 12px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: #64748b;
+    color: var(--muted);
     transition: background .15s ease, border-color .15s ease, color .15s ease;
   }
   .icon-btn:hover{
-    background: #f8fafc;
-    border-color: #cbd5e1;
-    color: #334155;
+    background: var(--panel-soft);
+    border-color: rgba(0,0,0,0.16);
+    color: var(--text);
   }
 
-  /* Status banners (tight, professional) */
   .banner{
     border-radius: 14px;
     padding: 14px 16px;
-    border: 1px solid rgba(15,23,42,.10);
-    background: #fff;
+    border: 1px solid var(--border);
+    background: var(--panel);
   }
   .banner-warning{
     background: #fffbeb;
@@ -170,51 +174,49 @@
     border-color: #f87171;
   }
   .banner-neutral{
-    background: #f1f5f9;
-    border-color: #cbd5e1;
+    background: var(--panel-soft);
+    border-color: var(--border);
   }
   .banner-title{
     font-weight: 800;
-    color: #0f172a;
+    color: var(--text);
     margin-bottom: 2px;
   }
   .banner-text{
-    color: #334155;
+    color: var(--muted);
     font-size: 13px;
   }
 
-  /* small footer links */
   .footer-link{
     font-size: 13px;
     font-weight: 600;
-    color: #475569;
+    color: var(--brand-orange);
     text-decoration: none;
   }
-  .footer-link:hover{ color: var(--brand-navy); }
+  .footer-link:hover{ text-decoration: underline; text-underline-offset: 3px; }
 
-  /* Support link (under button) */
   .support-row{
     margin-top: 10px;
     font-size: 13px;
-    color: #64748b;
+    color: var(--muted);
     display: flex;
     justify-content: center;
     gap: 6px;
   }
   .support-action{
-    color: var(--brand-navy);
+    color: var(--brand-orange);
     font-weight: 700;
     text-decoration: none;
   }
   .support-action:hover{
-    color: #1f2d3d;
     text-decoration: underline;
     text-underline-offset: 3px;
   }
 
   @media (max-width: 1024px){
     .left{
-      border-bottom: 1px solid rgba(255,255,255,.10);
+      border-right: none;
+      border-bottom: 1px solid var(--border);
     }
   }
 </style>
@@ -307,26 +309,20 @@
     <div class="card">
       <div class="grid grid-cols-1 lg:grid-cols-2">
 
-        <!-- Left: Product context (not salesy) -->
+        <!-- Left: Product context -->
         <div class="left p-8 lg:p-10 flex flex-col justify-between">
           <div>
             <div class="flex items-center gap-3">
-              <div class="w-12 h-12 rounded-xl bg-white/10 flex items-center justify-center">
-                {{ brand_logo(size_class='crm-brand-logo-wrap--h9 crm-brand-logo-wrap--on-dark', width=164, height=36) }}
-              </div>
-              <div>
-                <div class="text-lg font-extrabold tracking-tight">Origen TechnolOG</div>
-                <div class="text-sm left-muted">Client management for real estate teams</div>
-              </div>
+              {{ brand_logo(size_class='crm-brand-logo-wrap--h9', width=164, height=36) }}
             </div>
 
             <div class="mt-8">
               <div class="left-chip">
-                <i class="fas fa-lock" style="color: rgba(250,36,60,.95)"></i>
+                <i class="fas fa-lock"></i>
                 Secure sign-in
               </div>
 
-              <h1 class="mt-4 text-2xl lg:text-3xl font-extrabold leading-tight tracking-tight">
+              <h1 class="left-title mt-4 text-2xl lg:text-3xl leading-tight">
                 Sign in to continue.
               </h1>
 
@@ -338,7 +334,7 @@
             <div class="mt-8 space-y-4">
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-address-book" style="color: rgba(250,36,60,.95)"></i>
+                  <i class="fas fa-address-book"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Contacts & groups</div>
@@ -348,7 +344,7 @@
 
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-tasks" style="color: rgba(250,36,60,.95)"></i>
+                  <i class="fas fa-tasks"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Tasks & reminders</div>
@@ -358,7 +354,7 @@
 
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-calendar-check" style="color: rgba(250,36,60,.95)"></i>
+                  <i class="fas fa-calendar-check"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Google integration</div>
@@ -369,7 +365,7 @@
           </div>
 
           <div class="mt-10 text-xs left-muted flex items-center gap-2">
-            <i class="fas fa-shield-alt" style="color: rgba(16,185,129,.95)"></i>
+            <i class="fas fa-shield-alt" style="color: #248a3d"></i>
             256-bit SSL encryption · Your data stays private
           </div>
         </div>

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -8,7 +8,7 @@
   :root{
     --brand-navy: #2d3e50;
     --brand-navy-2: #1a2634;
-    --brand-orange: #f97316;
+    --brand-orange: #fa243c;
 
     --bg: #f8fafc;
     --panel: #ffffff;
@@ -23,7 +23,7 @@
   .login-page{
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     background:
-      radial-gradient(1100px 550px at 10% 0%, rgba(249,115,22,.06), transparent 60%),
+      radial-gradient(1100px 550px at 10% 0%, rgba(250,36,60,.06), transparent 60%),
       radial-gradient(900px 520px at 100% 40%, rgba(45,62,80,.07), transparent 55%),
       var(--bg);
   }
@@ -49,7 +49,7 @@
     position:absolute;
     top:0; left:0; right:0;
     height: 3px;
-    background: linear-gradient(90deg, var(--brand-orange), rgba(249,115,22,.55));
+    background: linear-gradient(90deg, var(--brand-orange), rgba(250,36,60,.55));
   }
   .left-muted{ color: rgba(255,255,255,.74); }
   .left-chip{
@@ -322,7 +322,7 @@
 
             <div class="mt-8">
               <div class="left-chip">
-                <i class="fas fa-lock" style="color: rgba(249,115,22,.95)"></i>
+                <i class="fas fa-lock" style="color: rgba(250,36,60,.95)"></i>
                 Secure sign-in
               </div>
 
@@ -338,7 +338,7 @@
             <div class="mt-8 space-y-4">
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-address-book" style="color: rgba(249,115,22,.95)"></i>
+                  <i class="fas fa-address-book" style="color: rgba(250,36,60,.95)"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Contacts & groups</div>
@@ -348,7 +348,7 @@
 
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-tasks" style="color: rgba(249,115,22,.95)"></i>
+                  <i class="fas fa-tasks" style="color: rgba(250,36,60,.95)"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Tasks & reminders</div>
@@ -358,7 +358,7 @@
 
               <div class="left-bullet">
                 <div class="left-icon">
-                  <i class="fas fa-calendar-check" style="color: rgba(249,115,22,.95)"></i>
+                  <i class="fas fa-calendar-check" style="color: rgba(250,36,60,.95)"></i>
                 </div>
                 <div>
                   <div class="font-semibold text-sm">Google integration</div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -26,8 +26,8 @@
         50% { opacity: 0.8; }
     }
     @keyframes glow {
-        0%, 100% { box-shadow: 0 0 20px rgba(249, 115, 22, 0.3); }
-        50% { box-shadow: 0 0 40px rgba(249, 115, 22, 0.5); }
+        0%, 100% { box-shadow: 0 0 20px rgba(250, 36, 60, 0.3); }
+        50% { box-shadow: 0 0 40px rgba(250, 36, 60, 0.5); }
     }
     
     .register-panel {
@@ -56,7 +56,7 @@
     /* Right panel background */
     .right-bg {
         background: 
-            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
+            radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.03) 0%, transparent 50%),
             radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
             linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
     }
@@ -168,7 +168,7 @@
     /* Accent line */
     .accent-line {
         height: 4px;
-        background: linear-gradient(90deg, #f97316, #eab308, #f97316);
+        background: linear-gradient(90deg, #fa243c, #ff6b7a, #fa243c);
         background-size: 200% 100%;
         animation: shimmer 3s linear infinite;
     }
@@ -183,7 +183,7 @@
     .orb-1 {
         width: 200px;
         height: 200px;
-        background: rgba(249, 115, 22, 0.15);
+        background: rgba(250, 36, 60, 0.15);
         top: -50px;
         right: -50px;
     }
@@ -207,7 +207,7 @@
         color: #64748b;
     }
     .benefit-badge i {
-        color: #f97316;
+        color: #fa243c;
         margin-right: 6px;
     }
     
@@ -238,8 +238,8 @@
         <div class="absolute inset-0 hero-pattern"></div>
         
         <!-- Gradient overlays -->
-        <div class="absolute top-0 right-0 w-96 h-96 bg-gradient-to-bl from-orange-500/20 to-transparent rounded-full blur-3xl"></div>
-        <div class="absolute bottom-0 left-0 w-80 h-80 bg-gradient-to-tr from-amber-500/10 to-transparent rounded-full blur-3xl"></div>
+        <div class="absolute top-0 right-0 w-96 h-96 bg-gradient-to-bl from-red-500/20 to-transparent rounded-full blur-3xl"></div>
+        <div class="absolute bottom-0 left-0 w-80 h-80 bg-gradient-to-tr from-rose-500/10 to-transparent rounded-full blur-3xl"></div>
         
         <!-- Content -->
         <div class="relative z-10 flex flex-col justify-between p-12 xl:p-16 w-full">
@@ -253,7 +253,7 @@
                 
                 <h1 class="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
                     Grow Your Real Estate<br>
-                    <span class="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-amber-400">Business Today</span>
+                    <span class="text-transparent bg-clip-text bg-gradient-to-r from-red-400 to-rose-400">Business Today</span>
                 </h1>
                 
                 <p class="text-xl text-slate-300 leading-relaxed max-w-lg">
@@ -335,11 +335,11 @@
                     
                     <!-- Benefits -->
                     <div class="flex items-center justify-center gap-6 mb-8 text-sm text-slate-500">
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Unlimited Contacts</span>
+                        <span class="flex items-center"><i class="fas fa-check text-red-500 mr-2"></i>Unlimited Contacts</span>
                         <span class="text-slate-300">·</span>
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Instant Access</span>
+                        <span class="flex items-center"><i class="fas fa-check text-red-500 mr-2"></i>Instant Access</span>
                         <span class="text-slate-300">·</span>
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Secure</span>
+                        <span class="flex items-center"><i class="fas fa-check text-red-500 mr-2"></i>Secure</span>
                     </div>
                     
                     <form method="POST" action="{{ url_for('auth.register') }}" class="space-y-4"
@@ -441,7 +441,7 @@
             <div class="text-center mt-8">
             <p class="text-slate-600">
                 Already have an account?
-                    <a href="{{ url_for('auth.login') }}" class="font-semibold text-[#2d3e50] hover:text-orange-600 transition-colors ml-1">
+                    <a href="{{ url_for('auth.login') }}" class="font-semibold text-[#2d3e50] hover:text-red-600 transition-colors ml-1">
                         Sign in <i class="fas fa-arrow-right text-xs ml-1"></i>
                 </a>
             </p>

--- a/templates/auth/registration_status.html
+++ b/templates/auth/registration_status.html
@@ -38,7 +38,7 @@
     /* Background */
     .status-bg {
         background: 
-            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
+            radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.03) 0%, transparent 50%),
             radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
             linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
     }
@@ -53,7 +53,7 @@
     .orb-1 {
         width: 250px;
         height: 250px;
-        background: rgba(249, 115, 22, 0.12);
+        background: rgba(250, 36, 60, 0.12);
         top: -80px;
         right: -80px;
     }
@@ -81,7 +81,7 @@
     /* Accent line */
     .accent-line {
         height: 4px;
-        background: linear-gradient(90deg, #f97316, #eab308, #f97316);
+        background: linear-gradient(90deg, #fa243c, #ff6b7a, #fa243c);
         background-size: 200% 100%;
         animation: shimmer 3s linear infinite;
     }

--- a/templates/auth/reset_password.html
+++ b/templates/auth/reset_password.html
@@ -30,7 +30,7 @@
     /* Background */
     .reset-bg {
         background: 
-            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
+            radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.03) 0%, transparent 50%),
             radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
             linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
     }
@@ -45,7 +45,7 @@
     .orb-1 {
         width: 250px;
         height: 250px;
-        background: rgba(249, 115, 22, 0.12);
+        background: rgba(250, 36, 60, 0.12);
         top: -80px;
         right: -80px;
     }
@@ -81,7 +81,7 @@
     /* Accent line */
     .accent-line {
         height: 4px;
-        background: linear-gradient(90deg, #f97316, #eab308, #f97316);
+        background: linear-gradient(90deg, #fa243c, #ff6b7a, #fa243c);
         background-size: 200% 100%;
         animation: shimmer 3s linear infinite;
     }

--- a/templates/auth/reset_request.html
+++ b/templates/auth/reset_request.html
@@ -30,7 +30,7 @@
     /* Background */
     .reset-bg {
         background: 
-            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
+            radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.03) 0%, transparent 50%),
             radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
             linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
     }
@@ -45,7 +45,7 @@
     .orb-1 {
         width: 250px;
         height: 250px;
-        background: rgba(249, 115, 22, 0.12);
+        background: rgba(250, 36, 60, 0.12);
         top: -80px;
         right: -80px;
     }
@@ -81,7 +81,7 @@
     /* Accent line */
     .accent-line {
         height: 4px;
-        background: linear-gradient(90deg, #f97316, #eab308, #f97316);
+        background: linear-gradient(90deg, #fa243c, #ff6b7a, #fa243c);
         background-size: 200% 100%;
         animation: shimmer 3s linear infinite;
     }

--- a/templates/auth/terms_privacy.html
+++ b/templates/auth/terms_privacy.html
@@ -12,7 +12,7 @@
         transition: all 0.2s ease;
     }
     .toc-link:hover {
-        color: #f97316;
+        color: #fa243c;
         padding-left: 8px;
     }
 </style>
@@ -37,7 +37,7 @@
                 <h2 class="text-2xl font-bold mb-4">Quick Navigation</h2>
                 <div class="grid md:grid-cols-2 gap-4 text-sm">
                     <div>
-                        <h3 class="font-semibold text-orange-400 mb-2">Terms of Service</h3>
+                        <h3 class="font-semibold text-red-400 mb-2">Terms of Service</h3>
                         <ul class="space-y-2 text-slate-300">
                             <li><a href="#tos-acceptance" class="toc-link block">1. Acceptance of Terms</a></li>
                             <li><a href="#tos-service" class="toc-link block">2. Service Description</a></li>
@@ -50,7 +50,7 @@
                         </ul>
                     </div>
                     <div>
-                        <h3 class="font-semibold text-orange-400 mb-2">Privacy Policy</h3>
+                        <h3 class="font-semibold text-red-400 mb-2">Privacy Policy</h3>
                         <ul class="space-y-2 text-slate-300">
                             <li><a href="#privacy-intro" class="toc-link block">1. Introduction</a></li>
                             <li><a href="#privacy-collection" class="toc-link block">2. Information We Collect</a></li>
@@ -70,7 +70,7 @@
                 
                 <!-- ========== TERMS OF SERVICE ========== -->
                 <section class="mb-16">
-                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-orange-500">Terms of Service</h2>
+                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-red-500">Terms of Service</h2>
                     
                     <!-- Section 1 -->
                     <div id="tos-acceptance" class="legal-section mb-8">
@@ -220,7 +220,7 @@
 
                 <!-- ========== PRIVACY POLICY ========== -->
                 <section>
-                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-orange-500">Privacy Policy</h2>
+                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-red-500">Privacy Policy</h2>
                     
                     <!-- Section 1 -->
                     <div id="privacy-intro" class="legal-section mb-8">
@@ -406,8 +406,8 @@
                     <h3 class="text-2xl font-bold text-slate-900 mb-4">Contact Us</h3>
                     <p class="text-slate-700 mb-4">If you have questions about these Terms of Service or Privacy Policy, or wish to exercise your privacy rights, please contact us:</p>
                     <div class="space-y-2 text-slate-700">
-                        <p><strong>Email:</strong> <a href="mailto:info@origentechnolog.com" class="text-orange-600 hover:text-orange-700">info@origentechnolog.com</a></p>
-                        <p><strong>Website:</strong> <a href="{{ url_for('main.landing') }}" class="text-orange-600 hover:text-orange-700">{{ request.host }}</a></p>
+                        <p><strong>Email:</strong> <a href="mailto:info@origentechnolog.com" class="text-red-600 hover:text-red-700">info@origentechnolog.com</a></p>
+                        <p><strong>Website:</strong> <a href="{{ url_for('main.landing') }}" class="text-red-600 hover:text-red-700">{{ request.host }}</a></p>
                         <p class="text-sm text-slate-500 mt-4">We will respond to your inquiry within 30 days.</p>
                     </div>
                 </div>
@@ -416,7 +416,7 @@
 
         <!-- Back to Top -->
         <div class="text-center mt-8">
-            <a href="#" class="inline-flex items-center text-slate-600 hover:text-orange-600 transition-colors">
+            <a href="#" class="inline-flex items-center text-slate-600 hover:text-red-600 transition-colors">
                 <i class="fas fa-arrow-up mr-2"></i>
                 Back to Top
             </a>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -207,7 +207,7 @@
             <div class="flex items-center justify-between h-16 md:h-20">
                 <!-- Logo -->
                 <a href="/" class="flex items-center">
-                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-20 md:h-24 w-auto object-contain" width="365" height="80" />
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
                 </a>
                 
                 <!-- Desktop Nav Links -->
@@ -989,7 +989,7 @@
                 <!-- Logo -->
                 <div class="flex items-center">
                     {# Footer sits on a dark band — use the light-on-dark mark. #}
-                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-28 w-auto object-contain" width="511" height="112" />
+                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
                 </div>
                 
                 <!-- Links -->

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -40,22 +40,22 @@
                             900: '#102a43',
                         },
                         accent: {
-                            50: '#fff7ed',
-                            100: '#ffedd5',
-                            200: '#fed7aa',
-                            300: '#fdba74',
-                            400: '#fb923c',
-                            500: '#f97316',
-                            600: '#ea580c',
-                            700: '#c2410c',
+                            50: '#fff1f2',
+                            100: '#ffe0e3',
+                            200: '#ffc1c8',
+                            300: '#ff9aa5',
+                            400: '#ff6b7a',
+                            500: '#fa243c',
+                            600: '#d60017',
+                            700: '#b00014',
                         },
                         warm: {
-                            50: '#fefce8',
-                            100: '#fef9c3',
-                            200: '#fef08a',
-                            300: '#fde047',
-                            400: '#facc15',
-                            500: '#eab308',
+                            50: '#fff1f2',
+                            100: '#ffe0e3',
+                            200: '#ffc1c8',
+                            300: '#ff9aa5',
+                            400: '#ff6b7a',
+                            500: '#fa243c',
                         }
                     }
                 }
@@ -106,7 +106,7 @@
         .hero-bg {
             background-color: #f8fafc;
             background-image: 
-                radial-gradient(ellipse at 20% 0%, rgba(249, 115, 22, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 20% 0%, rgba(250, 36, 60, 0.08) 0%, transparent 50%),
                 radial-gradient(ellipse at 80% 100%, rgba(36, 59, 83, 0.06) 0%, transparent 50%),
                 url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23334e68' fill-opacity='0.03'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
         }
@@ -143,7 +143,7 @@
         }
         .btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 12px 24px -8px rgba(249, 115, 22, 0.4);
+            box-shadow: 0 12px 24px -8px rgba(250, 36, 60, 0.4);
         }
         
         /* Feature card hover */
@@ -575,7 +575,7 @@
                 <!-- Feature 4: AI Tools -->
                 <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden">
                     <span class="feature-badge badge-free">Free</span>
-                    <div class="w-14 h-14 bg-gradient-to-br from-accent-500 to-amber-500 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-accent-500/20">
+                    <div class="w-14 h-14 bg-gradient-to-br from-accent-500 to-accent-700 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-accent-500/20">
                         <i class="fas fa-brain text-white text-xl"></i>
                     </div>
                     <h3 class="text-xl font-bold text-brand-900 mb-3">AI-Powered B.O.B.</h3>
@@ -680,7 +680,7 @@
                     <div class="relative text-center">
                         <!-- Step number -->
                         <div class="relative inline-flex items-center justify-center w-32 h-32 mb-6">
-                            <div class="absolute inset-0 bg-gradient-to-br from-accent-100 to-orange-100 rounded-full"></div>
+                            <div class="absolute inset-0 bg-gradient-to-br from-accent-100 to-accent-200 rounded-full"></div>
                             <div class="relative w-20 h-20 bg-gradient-to-br from-accent-500 to-accent-600 rounded-2xl flex items-center justify-center shadow-xl">
                                 <i class="fas fa-tasks text-white text-2xl"></i>
                             </div>
@@ -841,7 +841,7 @@
                         </li>
                         
                         <!-- B.O.B. AI Chat Highlight -->
-                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-gradient-to-r from-amber-50 via-white to-orange-50 border border-amber-100">
+                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-gradient-to-r from-accent-50 via-white to-accent-50 border border-accent-100">
                             <div class="flex-shrink-0 mt-0.5">
                                 <i class="fas fa-brain text-accent-500"></i>
                             </div>
@@ -953,7 +953,7 @@
     
     
     <!-- ========== FINAL CTA SECTION ========== -->
-    <section class="bg-gradient-to-br from-accent-500 via-accent-600 to-amber-500 py-20 md:py-28 relative overflow-hidden">
+    <section class="bg-gradient-to-br from-accent-500 via-accent-600 to-accent-700 py-20 md:py-28 relative overflow-hidden">
         <!-- Background pattern -->
         <div class="absolute inset-0 opacity-10">
             <div class="absolute top-0 left-0 w-96 h-96 bg-white rounded-full -translate-x-1/2 -translate-y-1/2"></div>


### PR DESCRIPTION
## Summary
- Shrinks landing header/footer logos to fit nav chrome (`h-8` / `md:h-10`).
- Retints the landing page accent scale from orange to the app’s modern red (`#fa243c` / `#d60017`).
- Updates login, register, forgot/reset password, registration status, accept invite, and terms pages so hardcoded orange accents match the same red.
- Tightens `am_skin` auth remaps so red utilities and brand tokens stay theme-aware.

## Test plan
- [ ] Open `/` — CTAs, hero highlight, and bottom band should read red (not orange); logos sized to the nav
- [ ] `/auth/login` — accent line, icon chips, and links use app red
- [ ] `/auth/register` — left panel glow, checks, and accent line match
- [ ] Forgot password + reset password pages — soft glow / accent line red
- [ ] Terms & Privacy — TOC hover and section borders red
- [ ] Toggle light/dark on an auth page and confirm accent still tracks the skin