### PR TITLE
fix: leftover landing slop and register red

### DIFF
--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -264,7 +264,7 @@
                 </h1>
                 
                 <p class="text-xl text-slate-300 leading-relaxed max-w-lg">
-                    No credit card. The free tier stays free. You can be in within a couple of minutes. Unlimited contacts, in an all-in-one CRM for agents.
+                    No credit card. The free tier stays free. You can be in within a couple of minutes. Up to 10,000 contacts, in an all-in-one CRM for agents.
                 </p>
             </div>
             
@@ -276,7 +276,7 @@
                     </div>
                     <div>
                         <h3 class="text-white font-semibold text-lg">Smart Contact Management</h3>
-                        <p class="text-slate-400 text-sm mt-1">Unlimited contacts with groups, notes, and activity tracking</p>
+                        <p class="text-slate-400 text-sm mt-1">Up to 10,000 contacts with groups, notes, and activity tracking</p>
                     </div>
                 </div>
                 
@@ -348,7 +348,7 @@
                     
                     <!-- Benefits -->
                     <div class="flex items-center justify-center gap-6 mb-8 text-sm text-slate-500">
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Unlimited Contacts</span>
+                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>10k contacts</span>
                         <span class="text-slate-300">·</span>
                         <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Instant Access</span>
                         <span class="text-slate-300">·</span>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -35,10 +35,6 @@
         0%, 100% { opacity: 0.4; }
         50% { opacity: 0.8; }
     }
-    @keyframes glow {
-        0%, 100% { box-shadow: 0 0 20px rgba(250, 36, 60, 0.3); }
-        50% { box-shadow: 0 0 40px rgba(250, 36, 60, 0.5); }
-    }
     
     .register-panel {
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -66,7 +62,7 @@
     /* Right panel background */
     .right-bg {
         background: 
-            radial-gradient(ellipse at 0% 0%, rgba(250, 36, 60, 0.03) 0%, transparent 50%),
+            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
             radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
             linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
     }
@@ -193,7 +189,7 @@
     .orb-1 {
         width: 200px;
         height: 200px;
-        background: rgba(250, 36, 60, 0.15);
+        background: rgba(234, 88, 12, 0.15);
         top: -50px;
         right: -50px;
     }
@@ -290,7 +286,7 @@
                     </div>
                     <div>
                         <h3 class="text-white font-semibold text-lg">Task & Follow-up System</h3>
-                        <p class="text-slate-400 text-sm mt-1">Never miss a follow-up with built-in task management and reminders</p>
+                        <p class="text-slate-400 text-sm mt-1">Due dates and email reminders for follow-up tasks</p>
                     </div>
                 </div>
                 

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -348,7 +348,7 @@
                     
                     <!-- Benefits -->
                     <div class="flex items-center justify-center gap-6 mb-8 text-sm text-slate-500">
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>10k contacts</span>
+                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Up to 10,000 contacts</span>
                         <span class="text-slate-300">·</span>
                         <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Instant Access</span>
                         <span class="text-slate-300">·</span>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -594,7 +594,7 @@
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Unlimited contacts
+                            Up to 10,000 contacts
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
@@ -711,12 +711,12 @@
                     </div>
                     <h3 class="text-xl font-bold text-brand-900 mb-3">AI-Powered B.O.B.</h3>
                     <p class="text-brand-600 mb-4">
-                        Meet B.O.B., your Business Optimization Buddy. Ask for real estate advice, email drafts, and suggestions. You get 10 messages a day on the free tier.
+                        Meet B.O.B., your Business Optimization Buddy. Ask for real estate advice, email drafts, and suggestions. You get 25 messages a day on the free tier.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            AI chat assistant (10/day free)
+                            AI chat assistant (25/day free)
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-lock text-brand-300"></i>
@@ -929,7 +929,7 @@
                         </li>
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
-                            Unlimited contacts
+                            Up to 10,000 contacts
                         </li>
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
@@ -979,7 +979,7 @@
                             <div class="flex-1">
                                 <span class="font-semibold text-brand-800">B.O.B. AI Assistant</span>
                                 <div class="text-xs text-brand-600 mt-1">
-                                    10 messages/day included free
+                                    25 messages/day included free
                                 </div>
                             </div>
                         </li>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -623,7 +623,7 @@
                     </div>
                     <h3 class="text-xl font-bold text-brand-900 mb-3">Task Automation</h3>
                     <p class="text-brand-600 mb-4">
-                        Set due dates and get email reminders for follow-up tasks.
+                        Set a due date and a reminder. The follow-up stays on your list.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -546,11 +546,10 @@
     </section>
     
     
-    <!-- ========== SOCIAL PROOF BAR ========== -->
+    <!-- ========== PRODUCT BAR ========== -->
     <section class="bg-brand-900 py-6">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex flex-col md:flex-row items-center justify-center gap-4 md:gap-12 text-center">
-                <span class="text-brand-300 text-sm font-medium">Trusted by real estate professionals</span>
                 <div class="flex items-center gap-8 text-brand-400">
                     <div class="flex items-center gap-2">
                         <i class="fas fa-shield-alt text-accent-400"></i>
@@ -580,7 +579,7 @@
                     EVERYTHING YOU NEED
                 </span>
                 <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-900 mb-4">
-                    Great businesses don't just happen
+                    What's on the free tier
                 </h2>
                 <p class="text-lg text-brand-600 max-w-2xl mx-auto">
                     Contact management and task automation are on the free tier. Pro features are on the way.
@@ -624,7 +623,7 @@
                     </div>
                     <h3 class="text-xl font-bold text-brand-900 mb-3">Task Automation</h3>
                     <p class="text-brand-600 mb-4">
-                        Never miss a follow-up again. Smart task reminders and scheduling keep you on top of every opportunity.
+                        Set due dates and get email reminders for follow-up tasks.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
@@ -831,7 +830,7 @@
                         
                         <h3 class="text-xl font-bold text-brand-900 mb-3">Stay organized</h3>
                         <p class="text-brand-600 leading-relaxed">
-                            Create tasks, set reminders, and never miss a follow-up. Stay on top of every opportunity.
+                            Add a task, pick a due date, and get an email reminder.
                         </p>
                     </div>
                 </div>
@@ -1140,15 +1139,15 @@
         
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
             <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
-                Ready to grow your business?
+                Ready to try it?
             </h2>
             <p class="text-xl text-white/90 mb-10 max-w-2xl mx-auto">
-                Join real estate professionals who are closing more deals with Origen TechnolOG. Start free today.
+                Create an account when you're ready. No card.
             </p>
             
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
                 <a href="{{ url_for('auth.register') }}" class="inline-flex items-center justify-center gap-2 px-10 py-4 bg-white text-accent-600 font-bold text-lg rounded-xl shadow-xl hover:shadow-2xl hover:-translate-y-1 transition-all">
-                    Get Started Free
+                    Start Free
                     <i class="fas fa-arrow-right"></i>
                 </a>
                 <button onclick="openContactUsModal('landing')" class="inline-flex items-center justify-center gap-2 px-10 py-4 bg-transparent text-white font-semibold text-lg rounded-xl border-2 border-white/40 hover:bg-white/10 transition-all">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -51,50 +51,42 @@
           "mainEntity": [
             {
               "@type": "Question",
-              "name": "Is the free tier actually free?",
+              "name": "What does the free plan include?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Yes. It stays free. You do not need a card to start."
+                "text": "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day."
               }
             },
             {
               "@type": "Question",
-              "name": "Will you charge me later for what I get today?",
+              "name": "Do I need a credit card?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "No. What is free now stays free. Extra features later will be paid. Nothing paid is for sale today."
+                "text": "No. You can start without one. What's on the free plan stays free. Extra features later will be paid. Nothing paid is for sale today."
               }
             },
             {
               "@type": "Question",
-              "name": "How long to set up?",
+              "name": "How long does it take to get started?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "The site says about two minutes."
+                "text": "Setup takes about two minutes."
               }
             },
             {
               "@type": "Question",
-              "name": "What do I get on free?",
+              "name": "Is this built for real estate agents?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "You get one user, unlimited contacts, tasks, a dashboard, Gmail send, Google Calendar task sync, and B.O.B. with 10 messages a day."
+                "text": "Yes. Contacts, follow-ups, and tasks are set up the way agents actually work, not as a generic CRM."
               }
             },
             {
               "@type": "Question",
-              "name": "Is this Follow Up Boss or HubSpot?",
+              "name": "What is B.O.B.?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "No. Those are paid or generic. This is a real estate CRM. Free tier, no card."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Is this origentech.com or Origin CRM?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "No. This is Origen TechnolOG at origentechnolog.com. It is not Origen Tech, Origen-Tech, or Origin CRM."
+                "text": "B.O.B. is the built-in assistant. On the free plan you get 25 messages a day for drafts and questions about your work."
               }
             }
           ]
@@ -1095,36 +1087,30 @@
     <section id="faq" class="bg-[#f4f4f4] py-20 md:py-28">
         <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="mb-10">
-                <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-3">Questions people ask</h2>
-                <p class="text-brand-600">Straight answers. No pitch.</p>
+                <h2 class="text-3xl sm:text-4xl font-bold text-brand-900">Common questions</h2>
             </div>
             <div class="landing-faq">
                 <details>
-                    <summary>Is the free tier actually free?</summary>
-                    <p class="faq-answer">Yes. It stays free. You do not need a card to start.</p>
+                    <summary>What does the free plan include?</summary>
+                    <p class="faq-answer">One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.</p>
                 </details>
                 <details>
-                    <summary>Will you charge me later for what I get today?</summary>
-                    <p class="faq-answer">No. What is free now stays free. Extra features later will be paid. Nothing paid is for sale today.</p>
+                    <summary>Do I need a credit card?</summary>
+                    <p class="faq-answer">No. You can start without one. What's on the free plan stays free. Extra features later will be paid. Nothing paid is for sale today.</p>
                 </details>
                 <details>
-                    <summary>How long to set up?</summary>
-                    <p class="faq-answer">The site says about two minutes.</p>
+                    <summary>How long does it take to get started?</summary>
+                    <p class="faq-answer">Setup takes about two minutes.</p>
                 </details>
                 <details>
-                    <summary>What do I get on free?</summary>
-                    <p class="faq-answer">You get one user, unlimited contacts, tasks, a dashboard, Gmail send, Google Calendar task sync, and B.O.B. with 10 messages a day.</p>
+                    <summary>Is this built for real estate agents?</summary>
+                    <p class="faq-answer">Yes. Contacts, follow-ups, and tasks are set up the way agents actually work, not as a generic CRM.</p>
                 </details>
                 <details>
-                    <summary>Is this Follow Up Boss or HubSpot?</summary>
-                    <p class="faq-answer">No. Those are paid or generic. This is a real estate CRM. Free tier, no card.</p>
-                </details>
-                <details>
-                    <summary>Is this origentech.com or Origin CRM?</summary>
-                    <p class="faq-answer">No. This is Origen TechnolOG at origentechnolog.com. It is not Origen Tech, Origen-Tech, or Origin CRM.</p>
+                    <summary>What is B.O.B.?</summary>
+                    <p class="faq-answer">B.O.B. is the built-in assistant. On the free plan you get 25 messages a day for drafts and questions about your work.</p>
                 </details>
             </div>
-            <p class="mt-10 text-sm text-brand-500">Origen TechnolOG (origentechnolog.com) is not Origen Tech, Origen-Tech, or Origin CRM.</p>
         </div>
     </section>
     

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -39,7 +39,7 @@ class TestLandingLeftoverCopy:
         assert "What's on the free tier" in LANDING
         assert "Ready to try it?" in LANDING
         assert "Create an account when you're ready. No card." in LANDING
-        assert "Set due dates and get email reminders for follow-up tasks." in LANDING
+        assert "Set a due date and a reminder. The follow-up stays on your list." in LANDING
         assert "Contacts and follow-up tasks in one CRM" not in LANDING
 
     def test_no_em_dashes_in_public_copy(self):

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -159,3 +159,8 @@ class TestRegisterLeftoverCopy:
     def test_register_orbs_use_brand_orange(self):
         assert "249, 115, 22" in REGISTER
         assert "234, 88, 12" in REGISTER
+
+    def test_register_does_not_claim_unlimited_contacts(self):
+        assert "unlimited contact" not in REGISTER.lower()
+        assert "Up to 10,000 contacts" in REGISTER
+        assert "10k contacts" in REGISTER

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -1,10 +1,13 @@
 """Guard public landing and register copy against leftover marketing slop."""
 from pathlib import Path
 
+from tier_config.tier_limits import get_tier_defaults
+
 
 ROOT = Path(__file__).resolve().parents[1]
 LANDING = (ROOT / "templates" / "landing.html").read_text()
 REGISTER = (ROOT / "templates" / "auth" / "register.html").read_text()
+FREE_LIMITS = get_tier_defaults("free")
 
 BANNED_LEFTOVERS = (
     "Trusted by real estate professionals",
@@ -15,13 +18,39 @@ BANNED_LEFTOVERS = (
     "Join real estate professionals who are closing more deals",
 )
 
-FAQ_QUESTIONS = (
+DELETED_FAQ = (
     "Is the free tier actually free?",
     "Will you charge me later for what I get today?",
     "How long to set up?",
     "What do I get on free?",
     "Is this Follow Up Boss or HubSpot?",
     "Is this origentech.com or Origin CRM?",
+    "Straight answers. No pitch.",
+    "Questions people ask",
+    "Origen TechnolOG (origentechnolog.com) is not Origen Tech, Origen-Tech, or Origin CRM.",
+)
+
+FAQ_ITEMS = (
+    (
+        "What does the free plan include?",
+        "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.",
+    ),
+    (
+        "Do I need a credit card?",
+        "No. You can start without one. What's on the free plan stays free. Extra features later will be paid. Nothing paid is for sale today.",
+    ),
+    (
+        "How long does it take to get started?",
+        "Setup takes about two minutes.",
+    ),
+    (
+        "Is this built for real estate agents?",
+        "Yes. Contacts, follow-ups, and tasks are set up the way agents actually work, not as a generic CRM.",
+    ),
+    (
+        "What is B.O.B.?",
+        "B.O.B. is the built-in assistant. On the free plan you get 25 messages a day for drafts and questions about your work.",
+    ),
 )
 
 
@@ -60,13 +89,35 @@ class TestLandingLeftoverCopy:
 
     def test_keeps_visible_faq_and_matching_json_ld(self):
         assert '"@type": "FAQPage"' in LANDING
-        for question in FAQ_QUESTIONS:
-            assert LANDING.count(question) >= 2
+        assert LANDING.count("<summary>") == 5
+        assert LANDING.count('"@type": "Question"') == 5
+        for question, answer in FAQ_ITEMS:
+            assert LANDING.count(question) == 2
+            assert LANDING.count(answer) == 2
             assert f"<summary>{question}</summary>" in LANDING
+            assert f'<p class="faq-answer">{answer}</p>' in LANDING
             assert f'"name": "{question}"' in LANDING
+            assert f'"text": "{answer}"' in LANDING
 
-    def test_keeps_disambiguation_and_foundation_title(self):
-        assert "Origen TechnolOG (origentechnolog.com) is not Origen Tech, Origen-Tech, or Origin CRM." in LANDING
+    def test_old_faq_copy_is_gone(self):
+        for phrase in DELETED_FAQ:
+            assert phrase not in LANDING
+
+    def test_faq_facts_match_product_limits(self):
+        assert FREE_LIMITS["max_users"] == 1
+        assert FREE_LIMITS["max_contacts"] == 10000
+        assert FREE_LIMITS["daily_ai_chat_messages"] == 25
+        include_answer = FAQ_ITEMS[0][1]
+        bob_answer = FAQ_ITEMS[4][1]
+        assert "One user" in include_answer
+        assert "10,000 contacts" in include_answer
+        assert "25 messages a day" in include_answer
+        assert "25 messages a day" in bob_answer
+        assert "10 messages a day" not in include_answer
+        assert "10 messages a day" not in bob_answer
+        assert "unlimited contacts" not in include_answer.lower()
+
+    def test_keeps_foundation_title(self):
         assert "Free Real Estate CRM | Origen TechnolOG" in LANDING
 
     def test_does_not_claim_there_will_never_be_a_paid_plan(self):

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -1,0 +1,88 @@
+"""Guard public landing and register copy against leftover marketing slop."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LANDING = (ROOT / "templates" / "landing.html").read_text()
+REGISTER = (ROOT / "templates" / "auth" / "register.html").read_text()
+
+BANNED_LEFTOVERS = (
+    "Trusted by real estate professionals",
+    "Great businesses don't just happen",
+    "Ready to grow your business?",
+    "Never miss a follow-up again",
+    "closing more deals",
+    "Join real estate professionals who are closing more deals",
+)
+
+FAQ_QUESTIONS = (
+    "Is the free tier actually free?",
+    "Will you charge me later for what I get today?",
+    "How long to set up?",
+    "What do I get on free?",
+    "Is this Follow Up Boss or HubSpot?",
+    "Is this origentech.com or Origin CRM?",
+)
+
+
+class TestLandingLeftoverCopy:
+    def test_banned_leftovers_are_gone(self):
+        for phrase in BANNED_LEFTOVERS:
+            assert phrase not in LANDING
+            assert phrase not in REGISTER
+
+    def test_banned_slogan_words_stay_gone(self):
+        assert "seamlessly" not in LANDING.lower()
+        assert "seamlessly" not in REGISTER.lower()
+
+    def test_exact_replacements_are_present(self):
+        assert "What's on the free tier" in LANDING
+        assert "Ready to try it?" in LANDING
+        assert "Create an account when you're ready. No card." in LANDING
+        assert "Set due dates and get email reminders for follow-up tasks." in LANDING
+        assert "Contacts and follow-up tasks in one CRM" not in LANDING
+
+    def test_no_em_dashes_in_public_copy(self):
+        assert "—" not in LANDING
+        assert "—" not in REGISTER
+
+    def test_keeps_homepage_h1(self):
+        assert "Your clients and follow-ups," in LANDING
+        assert "in one place." in LANDING
+
+    def test_keeps_start_free_cta(self):
+        assert "Start Free" in LANDING
+
+    def test_keeps_pro_coming_soon_and_pricing_tbd(self):
+        assert "Pro" in LANDING
+        assert "Coming Soon" in LANDING
+        assert "Pricing TBD" in LANDING
+
+    def test_keeps_visible_faq_and_matching_json_ld(self):
+        assert '"@type": "FAQPage"' in LANDING
+        for question in FAQ_QUESTIONS:
+            assert LANDING.count(question) >= 2
+            assert f"<summary>{question}</summary>" in LANDING
+            assert f'"name": "{question}"' in LANDING
+
+    def test_keeps_disambiguation_and_foundation_title(self):
+        assert "Origen TechnolOG (origentechnolog.com) is not Origen Tech, Origen-Tech, or Origin CRM." in LANDING
+        assert "Free Real Estate CRM | Origen TechnolOG" in LANDING
+
+    def test_does_not_claim_there_will_never_be_a_paid_plan(self):
+        assert "never be a paid" not in LANDING.lower()
+        assert "Extra features later will be paid" in LANDING
+
+
+class TestRegisterLeftoverCopy:
+    def test_keeps_register_h1(self):
+        assert "Create your account." in REGISTER
+
+    def test_register_red_leftover_is_gone(self):
+        assert "#fa243c" not in REGISTER
+        assert "250, 36, 60" not in REGISTER
+        assert "@keyframes glow" not in REGISTER
+
+    def test_register_orbs_use_brand_orange(self):
+        assert "249, 115, 22" in REGISTER
+        assert "234, 88, 12" in REGISTER

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -161,6 +161,7 @@ class TestRegisterLeftoverCopy:
         assert "234, 88, 12" in REGISTER
 
     def test_register_does_not_claim_unlimited_contacts(self):
-        assert "unlimited contact" not in REGISTER.lower()
+        assert "Unlimited contacts" not in REGISTER
+        assert "unlimited contacts" not in REGISTER
+        assert "Unlimited Contacts" not in REGISTER
         assert "Up to 10,000 contacts" in REGISTER
-        assert "10k contacts" in REGISTER

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -128,6 +128,17 @@ class TestLandingLeftoverCopy:
         assert "25/day free" in LANDING
         assert "25 messages/day included free" in LANDING
 
+    def test_free_pricing_card_matches_product_limits(self):
+        start = LANDING.index("<!-- Free Plan -->")
+        end = LANDING.index("<!-- Pro Plan -->")
+        card = LANDING[start:end]
+        assert "1 user account" in card
+        assert "Up to 10,000 contacts" in card
+        assert "25 messages/day included free" in card
+        assert "Unlimited contacts" not in card
+        assert "10 messages" not in card
+        assert "10/day" not in card
+
     def test_keeps_foundation_title(self):
         assert "Free Real Estate CRM | Origen TechnolOG" in LANDING
 

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -117,6 +117,17 @@ class TestLandingLeftoverCopy:
         assert "10 messages a day" not in bob_answer
         assert "unlimited contacts" not in include_answer.lower()
 
+    def test_landing_does_not_claim_old_free_limits(self):
+        assert "Unlimited contacts" not in LANDING
+        assert "unlimited contacts" not in LANDING
+        assert "10 messages a day" not in LANDING
+        assert "10 messages/day" not in LANDING
+        assert "10/day free" not in LANDING
+        assert "Up to 10,000 contacts" in LANDING
+        assert "25 messages a day" in LANDING
+        assert "25/day free" in LANDING
+        assert "25 messages/day included free" in LANDING
+
     def test_keeps_foundation_title(self):
         assert "Free Real Estate CRM | Origen TechnolOG" in LANDING
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #304 (already on main as `180d5f9`). Does not revert it. One PR. Do not merge.

QA leftover slogans stay replaced. Homepage FAQ is rewritten from scratch. Landing and register free-tier facts now match `tier_limits.py`.

## Product facts

`tier_config/tier_limits.py`: one user, 10,000 contacts, 25 B.O.B. messages a day.

Visible landing copy uses those numbers in FAQ, FAQPage JSON-LD, feature cards, and the free pricing card.

Register no longer says unlimited contacts. All three lines now match landing:
- `Up to 10,000 contacts, in an all-in-one CRM for agents.`
- `Up to 10,000 contacts with groups, notes, and activity tracking`
- Badge: `Up to 10,000 contacts`

Tests fail if `Unlimited contacts` or `Unlimited Contacts` return on `landing.html` or `register.html`.

## FAQ rewrite

Heading is `Common questions`. Five Qs only. No brand-disambiguation line.

## Leftover slogans (unchanged)

- Trust-bar claim deleted
- H2: What's on the free tier
- CTA: Ready to try it? / Create an account when you're ready. No card.
- Task card: Set a due date and a reminder. The follow-up stays on your list.
- Register `#fa243c` → brand orange

## Kept

- Homepage H1
- Register H1: Create your account.
- Pro / Coming Soon / Pricing TBD
- CTA Start Free
- Foundation title/meta
- No new routes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ebc9c87-1b0c-4c3f-8471-cc7308975f98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ebc9c87-1b0c-4c3f-8471-cc7308975f98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

