### PR TITLE
feat: public /free-real-estate-crm page

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -431,6 +431,12 @@ def landing():
     return render_template('landing.html', current_year=datetime.now().year)
 
 
+@main_bp.route('/free-real-estate-crm')
+def free_real_estate_crm():
+    """Public page for the free real estate CRM offer. Always 200, even if logged in."""
+    return render_template('free_real_estate_crm.html', current_year=datetime.now().year)
+
+
 # =============================================================================
 # CONTACTS LIST (Authenticated)
 # =============================================================================

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -17,3 +17,4 @@ Origen TechnolOG is a free CRM for real estate agents. Use it to organize contac
 - https://www.origentechnolog.com/register
 - https://www.origentechnolog.com/login
 - https://www.origentechnolog.com/terms-privacy
+- https://www.origentechnolog.com/free-real-estate-crm

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -12,4 +12,7 @@
   <url>
     <loc>https://www.origentechnolog.com/terms-privacy</loc>
   </url>
+  <url>
+    <loc>https://www.origentechnolog.com/free-real-estate-crm</loc>
+  </url>
 </urlset>

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -1,0 +1,372 @@
+{% from "components/seo_meta.html" import public_seo %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Free real estate CRM | Origen TechnolOG</title>
+    {{ public_seo(
+        title="Free real estate CRM | Origen TechnolOG",
+        description="Built for agents, by agents. The free tier stays free. No card. About two minutes.",
+        canonical=app_base_url ~ "/free-real-estate-crm"
+    ) }}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": "{{ app_base_url }}/#organization",
+          "name": "Origen TechnolOG",
+          "url": "{{ app_base_url }}/",
+          "logo": "{{ app_base_url }}/static/images/logo_og_dark.png"
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "{{ app_base_url }}/free-real-estate-crm#software",
+          "name": "Origen TechnolOG",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web",
+          "isAccessibleForFree": true,
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+          },
+          "description": "Built for agents, by agents. The free tier stays free. No card. About two minutes.",
+          "url": "{{ app_base_url }}/free-real-estate-crm",
+          "publisher": { "@id": "{{ app_base_url }}/#organization" }
+        },
+        {
+          "@type": "FAQPage",
+          "@id": "{{ app_base_url }}/free-real-estate-crm#faq",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "What does the free tier include?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "One user, up to 10,000 contacts, and 25 B.O.B. messages a day. You can send email through Gmail and sync tasks to Google Calendar."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Do I need a credit card?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "No. Setup takes about two minutes."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Can I buy Pro today?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "No. Paid features come later. Nothing paid is for sale today."
+              }
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['DM Sans', 'system-ui', 'sans-serif'],
+                    },
+                    colors: {
+                        brand: {
+                            50: '#f0f4f8',
+                            100: '#d9e2ec',
+                            200: '#bcccdc',
+                            300: '#9fb3c8',
+                            400: '#829ab1',
+                            500: '#627d98',
+                            600: '#486581',
+                            700: '#334e68',
+                            800: '#243b53',
+                            900: '#102a43',
+                        },
+                        accent: {
+                            50: '#fff7ed',
+                            100: '#ffedd5',
+                            200: '#fed7aa',
+                            300: '#fdba74',
+                            400: '#fb923c',
+                            500: '#f97316',
+                            600: '#ea580c',
+                            700: '#c2410c',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .hero-bg {
+            background-color: #f8fafc;
+            background-image:
+                radial-gradient(ellipse at 20% 0%, rgba(249, 115, 22, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 100%, rgba(36, 59, 83, 0.06) 0%, transparent 50%),
+                url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23334e68' fill-opacity='0.03'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+        .nav-blur {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        .btn-primary {
+            position: relative;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px -8px rgba(249, 115, 22, 0.4);
+        }
+        .mobile-menu {
+            transform: translateX(100%);
+            transition: transform 0.3s ease;
+        }
+        .mobile-menu.open {
+            transform: translateX(0);
+        }
+        .landing-faq {
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+        .landing-faq details {
+            border-bottom: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq details:first-of-type {
+            border-top: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq summary {
+            list-style: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1.15rem 0;
+            font-size: 1.05rem;
+            font-weight: 600;
+            color: #102a43;
+        }
+        .landing-faq summary::-webkit-details-marker {
+            display: none;
+        }
+        .landing-faq summary::after {
+            content: '';
+            width: 10px;
+            height: 10px;
+            flex-shrink: 0;
+            border-right: 1.5px solid #627d98;
+            border-bottom: 1.5px solid #627d98;
+            transform: rotate(45deg);
+            margin-top: -4px;
+        }
+        .landing-faq details[open] summary {
+            color: #ea580c;
+        }
+        .landing-faq details[open] summary::after {
+            border-color: #f97316;
+            transform: rotate(225deg);
+            margin-top: 4px;
+        }
+        .landing-faq .faq-answer {
+            padding: 0 0 1.15rem;
+            color: #486581;
+            font-size: 1rem;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+
+<body class="font-sans antialiased text-brand-800">
+
+    <nav class="fixed top-0 left-0 right-0 z-50 nav-blur bg-white/90 border-b border-brand-100/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 md:h-20">
+                <a href="{{ url_for('main.landing') }}" class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </a>
+
+                <div class="hidden md:flex items-center gap-8">
+                    <a href="{{ url_for('main.landing') }}#features" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Pricing</a>
+                </div>
+
+                <div class="hidden md:flex items-center gap-4">
+                    <a href="{{ url_for('auth.login') }}" class="text-brand-700 hover:text-brand-900 font-semibold transition-colors">
+                        Log In
+                    </a>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                        <i class="fas fa-arrow-right text-sm"></i>
+                    </a>
+                </div>
+
+                <button id="mobileMenuBtn" class="md:hidden p-2 text-brand-700 hover:text-brand-900">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </div>
+
+        <div id="mobileMenuOverlay" class="fixed inset-0 bg-black/50 z-40 md:hidden opacity-0 pointer-events-none transition-opacity duration-300"></div>
+
+        <div id="mobileMenu" class="mobile-menu fixed top-0 right-0 w-80 h-screen md:hidden z-50" style="background-color: #ffffff;">
+            <div class="p-6 h-full bg-white">
+                <button id="closeMobileMenu" class="absolute top-4 right-4 p-2 text-brand-600 hover:text-brand-900 z-10">
+                    <i class="fas fa-times text-xl"></i>
+                </button>
+
+                <div class="mt-12 space-y-6">
+                    <a href="{{ url_for('main.landing') }}#features" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="block text-lg font-medium text-brand-700 hover:text-accent-500">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Pricing</a>
+
+                    <hr class="border-brand-100">
+
+                    <a href="{{ url_for('auth.login') }}" class="block text-lg font-semibold text-brand-800">Log In</a>
+                    <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-bg pt-24 md:pt-32 pb-16 md:pb-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
+                    A real estate CRM you can start tonight.
+                </h1>
+                <p class="text-lg sm:text-xl text-brand-600 mb-8">
+                    Built for agents, by agents. The free tier stays free. No card. About two minutes.
+                </p>
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section class="bg-white py-16 md:py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl space-y-10">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">What's on the free tier</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        The free tier is one user, up to 10,000 contacts, and 25 B.O.B. messages a day. Load your database, then put a due date on the next call so it isn't stuck in your notes app. Gmail send and Google Calendar task sync are included.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Built for real estate agents, by real estate agents.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">What other CRMs publish</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Follow Up Boss is $69 per user after a trial. Wise Agent is $49 after a trial. Sierra is $299.95 and up. BoldTrail and Lofty are quote-only. Here it's $0 to start, and you don't need a card.
+                    </p>
+                </div>
+
+                <p class="text-lg text-brand-600 leading-relaxed">
+                    Paid features come later. Nothing paid is for sale today. Pro is coming soon.
+                </p>
+
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section id="faq" class="bg-[#f4f4f4] py-16 md:py-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-10">Common questions</h2>
+            <div class="landing-faq">
+                <details>
+                    <summary>What does the free tier include?</summary>
+                    <p class="faq-answer">One user, up to 10,000 contacts, and 25 B.O.B. messages a day. You can send email through Gmail and sync tasks to Google Calendar.</p>
+                </details>
+                <details>
+                    <summary>Do I need a credit card?</summary>
+                    <p class="faq-answer">No. Setup takes about two minutes.</p>
+                </details>
+                <details>
+                    <summary>Can I buy Pro today?</summary>
+                    <p class="faq-answer">No. Paid features come later. Nothing paid is for sale today.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <footer class="bg-brand-900 py-12">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col md:flex-row items-center justify-between gap-6">
+                <div class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </div>
+
+                <div class="flex items-center gap-6 text-brand-400 text-sm">
+                    <a href="{{ url_for('auth.login') }}" class="hover:text-white transition-colors">Login</a>
+                    <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
+                    <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
+                    <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                </div>
+
+                <div class="text-brand-500 text-sm">
+                    &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+        const closeMobileMenu = document.getElementById('closeMobileMenu');
+        const mobileMenu = document.getElementById('mobileMenu');
+        const mobileMenuOverlay = document.getElementById('mobileMenuOverlay');
+
+        function openMobileMenu() {
+            mobileMenu.classList.add('open');
+            mobileMenuOverlay.classList.remove('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.add('opacity-100');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeMobileMenuFn() {
+            mobileMenu.classList.remove('open');
+            mobileMenuOverlay.classList.add('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.remove('opacity-100');
+            document.body.style.overflow = '';
+        }
+
+        mobileMenuBtn.addEventListener('click', openMobileMenu);
+        closeMobileMenu.addEventListener('click', closeMobileMenuFn);
+        mobileMenuOverlay.addEventListener('click', closeMobileMenuFn);
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', closeMobileMenuFn);
+        });
+    </script>
+
+    {% include 'modals/contact_us_modal.html' %}
+
+</body>
+</html>

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -1,0 +1,207 @@
+"""Public /free-real-estate-crm page: route, SEO, sitemap, and copy guards."""
+import re
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from tier_config.tier_limits import get_tier_defaults
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = (ROOT / "templates" / "free_real_estate_crm.html").read_text()
+LANDING = (ROOT / "templates" / "landing.html").read_text()
+SITEMAP = ROOT / "static" / "sitemap.xml"
+FREE_LIMITS = get_tier_defaults("free")
+
+PAGE_PATH = "/free-real-estate-crm"
+TITLE = "Free real estate CRM | Origen TechnolOG"
+H1 = "A real estate CRM you can start tonight."
+LEAD = "Built for agents, by agents. The free tier stays free. No card. About two minutes."
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+ALLOWED_SITEMAP_PATHS = {
+    "/",
+    "/register",
+    "/login",
+    "/terms-privacy",
+    PAGE_PATH,
+}
+BLOCKED_SEO_PATHS = (
+    "/pricing",
+    "/about",
+    "/blog",
+    "/help",
+    "/features",
+    "/contact",
+)
+BANNED_SLOP = (
+    "unlock",
+    "empower",
+    "elevate",
+    "seamless",
+    "seamlessly",
+    "revolutionize",
+    "transform",
+    "supercharge",
+    "robust",
+    "comprehensive",
+    "all-in-one solution",
+    "take your business to the next level",
+    "designed for your success",
+    "focus on what matters most",
+    "powerful platform",
+)
+FAQ_ITEMS = (
+    (
+        "What does the free tier include?",
+        "One user, up to 10,000 contacts, and 25 B.O.B. messages a day. You can send email through Gmail and sync tasks to Google Calendar.",
+    ),
+    (
+        "Do I need a credit card?",
+        "No. Setup takes about two minutes.",
+    ),
+    (
+        "Can I buy Pro today?",
+        "No. Paid features come later. Nothing paid is for sale today.",
+    ),
+)
+FAKE_SEO_QUESTIONS = (
+    "origentech",
+    "Is this HubSpot",
+    "Is this Follow Up Boss or HubSpot",
+    "Is this origentech.com or Origin CRM",
+)
+
+
+def _sitemap_paths():
+    tree = ET.parse(SITEMAP)
+    locs = [el.text or "" for el in tree.getroot().findall("sm:url/sm:loc", SITEMAP_NS)]
+    paths = []
+    for loc in locs:
+        path = loc.replace("https://www.origentechnolog.com", "", 1) or "/"
+        paths.append(path)
+    return paths
+
+
+def _visible_copy(html):
+    html = re.sub(r"<script\b[^>]*>.*?</script>", " ", html, flags=re.I | re.S)
+    html = re.sub(r"<style\b[^>]*>.*?</style>", " ", html, flags=re.I | re.S)
+    html = re.sub(r"<[^>]+>", " ", html)
+    return re.sub(r"\s+", " ", html)
+
+
+class TestFreeRealEstateCrmRoute:
+    def test_page_returns_200(self, client):
+        resp = client.get(PAGE_PATH)
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert H1 in html
+        assert 'href="/register"' in html
+
+    def test_logged_in_user_still_gets_200(self, owner_a_client):
+        resp = owner_a_client.get(PAGE_PATH)
+        assert resp.status_code == 200
+
+    def test_sitemap_includes_page_as_only_extra_url(self, client):
+        resp = client.get("/sitemap.xml")
+        assert resp.status_code == 200
+        paths = _sitemap_paths()
+        assert paths.count(PAGE_PATH) == 1
+        assert set(paths) == ALLOWED_SITEMAP_PATHS
+        for blocked in BLOCKED_SEO_PATHS:
+            assert blocked not in paths
+        assert "/dashboard" not in paths
+
+    def test_blocked_marketing_urls_are_not_built(self, client):
+        for path in BLOCKED_SEO_PATHS:
+            resp = client.get(path)
+            assert resp.status_code == 404, f"{path} should not be a public page"
+
+
+class TestFreeRealEstateCrmSeo:
+    def test_unique_title_canonical_and_og(self, client):
+        page = client.get(PAGE_PATH).get_data(as_text=True)
+        home = client.get("/").get_data(as_text=True)
+
+        assert f"<title>{TITLE}</title>" in page
+        assert 'rel="canonical" href="https://www.origentechnolog.com/free-real-estate-crm"' in page
+        assert 'property="og:title" content="Free real estate CRM | Origen TechnolOG"' in page
+        assert 'property="og:url" content="https://www.origentechnolog.com/free-real-estate-crm"' in page
+        assert 'property="og:description" content="Built for agents, by agents. The free tier stays free. No card. About two minutes."' in page
+
+        assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in home
+        assert 'rel="canonical" href="https://www.origentechnolog.com/"' in home
+        assert page.count("<title>") == 1
+        assert 'rel="canonical" href="https://www.origentechnolog.com/"' not in page
+        assert TITLE not in home
+
+    def test_software_application_json_ld_price_is_zero(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        assert '"@type": "SoftwareApplication"' in html
+        assert '"price": "0"' in html
+        assert '"priceCurrency": "USD"' in html
+        assert '"isAccessibleForFree": true' in html
+        assert '"url": "https://www.origentechnolog.com/free-real-estate-crm"' in html
+
+
+class TestFreeRealEstateCrmCopy:
+    def test_required_human_copy(self):
+        assert f"<title>{TITLE}</title>" in PAGE
+        assert H1 in PAGE
+        assert LEAD in PAGE
+        assert "Start Free" in PAGE
+        assert "url_for('auth.register')" in PAGE
+
+    def test_h1_is_the_human_line(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        match = re.search(r"<h1[^>]*>(.*?)</h1>", html, flags=re.S)
+        assert match is not None
+        h1 = re.sub(r"<[^>]+>", "", match.group(1))
+        h1 = re.sub(r"\s+", " ", h1).strip()
+        assert h1 == H1
+
+    def test_limits_match_repo(self):
+        assert FREE_LIMITS["max_users"] == 1
+        assert FREE_LIMITS["max_contacts"] == 10000
+        assert FREE_LIMITS["daily_ai_chat_messages"] == 25
+        visible = _visible_copy(PAGE)
+        assert "one user" in visible.lower()
+        assert "10,000 contacts" in visible
+        assert "25 B.O.B. messages a day" in visible
+        assert "Unlimited contacts" not in PAGE
+        assert "unlimited contacts" not in PAGE.lower()
+
+    def test_cta_goes_to_register(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        assert re.search(r'href="/register"[^>]*>\s*Start Free', html) is not None
+
+    def test_no_em_dashes(self):
+        assert "—" not in PAGE
+
+    def test_no_unlimited_contacts_or_never_paid_plan(self):
+        assert "Unlimited contacts" not in PAGE
+        assert "never be a paid plan" not in PAGE.lower()
+        assert "never be a paid" not in PAGE.lower()
+
+    def test_no_banned_slop(self):
+        lowered = _visible_copy(PAGE).lower()
+        for phrase in BANNED_SLOP:
+            assert phrase not in lowered
+
+    def test_faq_matches_json_ld_and_repo_limits(self):
+        assert '"@type": "FAQPage"' in PAGE
+        assert PAGE.count("<summary>") == 3
+        assert PAGE.count('"@type": "Question"') == 3
+        for question, answer in FAQ_ITEMS:
+            assert PAGE.count(question) == 2
+            assert PAGE.count(answer) == 2
+            assert f"<summary>{question}</summary>" in PAGE
+            assert f'<p class="faq-answer">{answer}</p>' in PAGE
+            assert f'"name": "{question}"' in PAGE
+            assert f'"text": "{answer}"' in PAGE
+        include_answer = FAQ_ITEMS[0][1]
+        assert "One user" in include_answer
+        assert "10,000 contacts" in include_answer
+        assert "25 B.O.B. messages a day" in include_answer
+
+    def test_no_fake_seo_questions(self):
+        for phrase in FAKE_SEO_QUESTIONS:
+            assert phrase.lower() not in PAGE.lower()

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -114,6 +114,17 @@ class TestFreeRealEstateCrmRoute:
             assert blocked not in paths
         assert "/dashboard" not in paths
 
+    def test_llms_txt_lists_the_page(self, client):
+        resp = client.get("/llms.txt")
+        assert resp.status_code == 200
+        text = resp.get_data(as_text=True)
+        assert "https://www.origentechnolog.com/free-real-estate-crm" in text
+        for blocked in BLOCKED_SEO_PATHS:
+            assert f"https://www.origentechnolog.com{blocked}" not in text
+        assert "https://www.origentechnolog.com/dashboard" not in text
+        assert "—" not in text
+        assert "Unlimited contacts" not in text
+
     def test_blocked_marketing_urls_are_not_built(self, client):
         for path in BLOCKED_SEO_PATHS:
             resp = client.get(path)

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -81,6 +81,10 @@ def _sitemap_paths():
     return paths
 
 
+def _app_base_url(app):
+    return (app.config.get("APP_BASE_URL") or "https://www.origentechnolog.com").rstrip("/")
+
+
 def _visible_copy(html):
     html = re.sub(r"<script\b[^>]*>.*?</script>", " ", html, flags=re.I | re.S)
     html = re.sub(r"<style\b[^>]*>.*?</style>", " ", html, flags=re.I | re.S)
@@ -117,29 +121,33 @@ class TestFreeRealEstateCrmRoute:
 
 
 class TestFreeRealEstateCrmSeo:
-    def test_unique_title_canonical_and_og(self, client):
+    def test_unique_title_canonical_and_og(self, app, client):
         page = client.get(PAGE_PATH).get_data(as_text=True)
         home = client.get("/").get_data(as_text=True)
+        base = _app_base_url(app)
+        page_url = f"{base}{PAGE_PATH}"
+        home_url = f"{base}/"
 
         assert f"<title>{TITLE}</title>" in page
-        assert 'rel="canonical" href="https://www.origentechnolog.com/free-real-estate-crm"' in page
+        assert f'rel="canonical" href="{page_url}"' in page
         assert 'property="og:title" content="Free real estate CRM | Origen TechnolOG"' in page
-        assert 'property="og:url" content="https://www.origentechnolog.com/free-real-estate-crm"' in page
+        assert f'property="og:url" content="{page_url}"' in page
         assert 'property="og:description" content="Built for agents, by agents. The free tier stays free. No card. About two minutes."' in page
 
         assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in home
-        assert 'rel="canonical" href="https://www.origentechnolog.com/"' in home
+        assert f'rel="canonical" href="{home_url}"' in home
         assert page.count("<title>") == 1
-        assert 'rel="canonical" href="https://www.origentechnolog.com/"' not in page
+        assert f'rel="canonical" href="{home_url}"' not in page
         assert TITLE not in home
 
-    def test_software_application_json_ld_price_is_zero(self, client):
+    def test_software_application_json_ld_price_is_zero(self, app, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
+        base = _app_base_url(app)
         assert '"@type": "SoftwareApplication"' in html
         assert '"price": "0"' in html
         assert '"priceCurrency": "USD"' in html
         assert '"isAccessibleForFree": true' in html
-        assert '"url": "https://www.origentechnolog.com/free-real-estate-crm"' in html
+        assert f'"url": "{base}{PAGE_PATH}"' in html
 
 
 class TestFreeRealEstateCrmCopy:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -37,6 +37,10 @@ class TestPublicRoutes:
         resp = client.get('/terms-privacy')
         assert resp.status_code == 200
 
+    def test_free_real_estate_crm(self, client, seed):
+        resp = client.get('/free-real-estate-crm')
+        assert resp.status_code == 200
+
     def test_reset_password_page(self, client, seed):
         resp = client.get('/reset_password')
         assert resp.status_code in (200, 302)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a short public page at `GET /free-real-estate-crm` for the free-tier offer. One extra sitemap URL. Does not add `/pricing`, `/about`, `/blog`, `/help`, `/features`, `/contact`, or an SEO `/dashboard`.

## What shipped
- Route always returns 200, including for logged-in users
- Title: `Free real estate CRM | Origen TechnolOG`
- H1: `A real estate CRM you can start tonight.`
- Lead and meta description: `Built for agents, by agents. The free tier stays free. No card. About two minutes.`
- CTA: Start Free → `/register`
- Limits from `tier_config/tier_limits.py`: 1 user, up to 10,000 contacts, 25 B.O.B. messages a day
- Reuses `public_seo` plus SoftwareApplication JSON-LD at price 0
- Optional FAQ with matching FAQPage JSON-LD
- One-line public-price compare (Follow Up Boss, Wise Agent, Sierra, BoldTrail, Lofty)
- Sitemap and `llms.txt` add only `https://www.origentechnolog.com/free-real-estate-crm`

## Copy constraints
- No invented features, stats, testimonials, or unlimited contacts
- No em dashes
- Does not claim there will never be a paid plan
- Pro coming soon is a note, not the CTA

## Tests
- `tests/test_free_real_estate_crm.py` covers 200, sitemap, llms.txt, unique title/canonical/OG, H1, repo limits, CTA, and copy guards
- SEO URL assertions use `APP_BASE_URL` so they pass after Telegram tests set `https://example.test` in CI
- Public route added to `tests/test_navigation.py`

Same PR, same branch. Not merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb865ed-1d37-4dfb-85e2-b1a4b1f43a96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb865ed-1d37-4dfb-85e2-b1a4b1f43a96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

