### PR TITLE
fix: raise toasts above chrome and unbreak public auth pages

### DIFF
--- a/static/css/am_skin.css
+++ b/static/css/am_skin.css
@@ -209,6 +209,27 @@ html.am-skin[data-theme="light"] .crm-sidebar {
   color: rgba(0, 0, 0, 0.88) !important;
 }
 
+/* Public auth: drop glass chrome so login/register are a plain working surface. */
+html.am-skin body.crm-auth-page {
+  background: #f4f4f4 !important;
+}
+html.am-skin body.crm-auth-page > header,
+html.am-skin body.crm-auth-page aside#sidebar.crm-sidebar {
+  display: none !important;
+}
+@media (min-width: 768px) {
+  html.am-skin body.crm-auth-page main#mainContent {
+    position: relative !important;
+    inset: auto !important;
+    background: #f4f4f4 !important;
+  }
+  html.am-skin body.crm-auth-page .content-wrapper {
+    padding-top: 0 !important;
+    padding-left: 0 !important;
+    background: #f4f4f4 !important;
+  }
+}
+
 /* Sidebar: exact AM floating glass panel over scrolling content */
 @media (min-width: 768px) {
   html.am-skin body.crm-shell > .flex.flex-1 {
@@ -804,11 +825,6 @@ html.am-skin .crm-search-results .crm-search-item.is-active {
   background: color-mix(in srgb, var(--ink) 8%, transparent) !important;
 }
 
-/* Flash toasts */
-html.am-skin .toast-message {
-  border-radius: 1000px !important;
-  font-size: 13px !important;
-}
 
 /* Mobile header on light skin — keep glass, not solid canvas */
 html.am-skin[data-theme="light"] header.bg-slate-950,
@@ -1438,19 +1454,14 @@ html.am-skin #planContent li {
 /* ── Auth pages ───────────────────────────────────────────── */
 html.am-skin .login-page,
 html.am-skin .register-page,
-html.am-skin .register-panel {
+html.am-skin .legal-page {
   font-family: var(--font-sans) !important;
   background: var(--canvas) !important;
   background-image: none !important;
   color: var(--ink) !important;
 }
-/* Auth/marketing brand accents use orange utilities + --accent tokens */
-html.am-skin .toc-link:hover {
-  color: var(--accent-ink) !important;
-}
 html.am-skin .login-page .card,
-html.am-skin .register-page .premium-card,
-html.am-skin .card {
+html.am-skin .register-page .card {
   background: var(--paper) !important;
   border: 0.5px solid var(--hairline) !important;
   box-shadow: none !important;
@@ -1475,50 +1486,102 @@ html.am-skin .register-page .left-muted {
 }
 html.am-skin .login-page .left-title,
 html.am-skin .login-page .left .font-semibold,
-html.am-skin .login-page .left .font-extrabold {
+html.am-skin .login-page .left .font-extrabold,
+html.am-skin .register-page .left-title,
+html.am-skin .register-page .left .font-semibold {
   color: var(--ink) !important;
 }
-html.am-skin .login-page .left-chip {
+html.am-skin .login-page .left-chip,
+html.am-skin .register-page .left-chip {
   background: var(--accent-soft) !important;
   color: var(--accent-ink) !important;
   border-color: color-mix(in srgb, var(--accent) 28%, transparent) !important;
 }
-html.am-skin .login-page .left-icon {
+html.am-skin .login-page .left-icon,
+html.am-skin .register-page .left-icon {
   background: var(--paper) !important;
   border-color: var(--hairline) !important;
   color: var(--accent) !important;
 }
 html.am-skin .login-page .input,
-html.am-skin .login-page .icon-btn {
+html.am-skin .login-page .icon-btn,
+html.am-skin .register-page .input {
   background: var(--paper) !important;
   border-color: var(--hairline) !important;
   color: var(--ink) !important;
 }
-html.am-skin .login-page .input:focus {
+html.am-skin .login-page .input:focus,
+html.am-skin .register-page .input:focus {
   border-color: var(--accent) !important;
   box-shadow: 0 0 0 4px var(--accent-soft) !important;
 }
-html.am-skin .login-page .btn {
+html.am-skin .login-page .btn,
+html.am-skin .register-page .btn {
   background: var(--am-key-bg) !important;
   color: #fff !important;
   box-shadow: none !important;
 }
-html.am-skin .login-page .btn:hover {
+html.am-skin .login-page .btn:hover,
+html.am-skin .register-page .btn:hover {
   background: var(--am-key-pressed) !important;
 }
 html.am-skin .login-page .kicker,
 html.am-skin .login-page .subtitle,
 html.am-skin .login-page .label,
-html.am-skin .login-page .title {
+html.am-skin .login-page .title,
+html.am-skin .register-page .kicker,
+html.am-skin .register-page .subtitle,
+html.am-skin .register-page .label,
+html.am-skin .register-page .title,
+html.am-skin .register-page .legal {
   color: var(--ink) !important;
 }
 html.am-skin .login-page .subtitle,
-html.am-skin .login-page .kicker {
+html.am-skin .login-page .kicker,
+html.am-skin .register-page .subtitle,
+html.am-skin .register-page .kicker,
+html.am-skin .register-page .legal {
   color: var(--ink-3) !important;
 }
 html.am-skin .login-page a,
 html.am-skin .register-page a {
   color: var(--accent-ink) !important;
+}
+
+html.am-skin .legal-page .legal-toc,
+html.am-skin .legal-page .legal-doc {
+  background: var(--paper) !important;
+  border-color: var(--hairline) !important;
+}
+html.am-skin .legal-page .legal-title,
+html.am-skin .legal-page .legal-h2,
+html.am-skin .legal-page .legal-h3,
+html.am-skin .legal-page .legal-toc a {
+  color: var(--ink) !important;
+}
+html.am-skin .legal-page .legal-copy {
+  color: var(--ink-2) !important;
+}
+html.am-skin .legal-page .legal-kicker,
+html.am-skin .legal-page .legal-meta,
+html.am-skin .legal-page .legal-home,
+html.am-skin .legal-page .legal-top,
+html.am-skin .legal-page .legal-toc h2 {
+  color: var(--ink-3) !important;
+}
+html.am-skin .legal-page .legal-toc h3,
+html.am-skin .legal-page .legal-toc a:hover,
+html.am-skin .legal-page .legal-home:hover,
+html.am-skin .legal-page .legal-top:hover,
+html.am-skin .legal-page .legal-callout a {
+  color: var(--accent-ink) !important;
+}
+html.am-skin .legal-page .legal-callout {
+  background: var(--paper-2) !important;
+  border-color: var(--hairline) !important;
+}
+html.am-skin .legal-page .legal-h2 {
+  border-bottom-color: var(--hairline) !important;
 }
 @media (max-width: 1024px) {
   html.am-skin .login-page .left,

--- a/static/css/crm_toast.css
+++ b/static/css/crm_toast.css
@@ -1,0 +1,135 @@
+/* Site-wide toasts. Sits above the glass topbar (z-index 60) and most
+   modals; stays below the loading overlay / BOB panel. */
+
+.crm-toast-region {
+  position: fixed;
+  top: max(0.625rem, env(safe-area-inset-top, 0px));
+  left: 0;
+  right: 0;
+  z-index: 400;
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.75rem;
+  pointer-events: none;
+}
+
+.crm-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  width: min(22.5rem, 100%);
+  padding: 0.625rem 0.5rem 0.625rem 0.625rem;
+  background: var(--paper, #2c2c2e);
+  color: var(--ink, hsla(0, 0%, 100%, 0.92));
+  border: 0.5px solid var(--hairline-strong, hsla(0, 0%, 100%, 0.16));
+  border-radius: 12px;
+  box-shadow:
+    0 12px 32px -16px rgba(0, 0, 0, 0.55),
+    0 2px 8px -4px rgba(0, 0, 0, 0.25);
+  font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif);
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.crm-toast.is-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.crm-toast.is-out {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.crm-toast__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0.0625rem;
+  border-radius: 6px;
+  font-size: 0.6875rem;
+  line-height: 1;
+}
+
+.crm-toast--success .crm-toast__icon {
+  background: var(--positive-soft, rgba(50, 215, 75, 0.16));
+  color: var(--positive, #32d74b);
+}
+
+.crm-toast--error .crm-toast__icon {
+  background: var(--danger-soft, rgba(255, 69, 58, 0.16));
+  color: var(--danger, #ff453a);
+}
+
+.crm-toast--warning .crm-toast__icon {
+  background: var(--warn-soft, rgba(255, 159, 10, 0.16));
+  color: var(--warn, #ff9f0a);
+}
+
+.crm-toast--info .crm-toast__icon {
+  background: color-mix(in srgb, var(--ink, #fff) 8%, transparent);
+  color: var(--ink-3, hsla(0, 0%, 100%, 0.64));
+}
+
+.crm-toast__message {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding-top: 0.125rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--ink, hsla(0, 0%, 100%, 0.92));
+}
+
+.crm-toast__close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0.0625rem;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-4, hsla(0, 0%, 100%, 0.4));
+  cursor: pointer;
+  font-size: 0.6875rem;
+  line-height: 1;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.crm-toast__close:hover {
+  background: color-mix(in srgb, var(--ink, #fff) 8%, transparent);
+  color: var(--ink-2, hsla(0, 0%, 100%, 0.8));
+}
+
+html[data-theme="light"] .crm-toast {
+  box-shadow:
+    0 10px 28px -14px rgba(0, 0, 0, 0.22),
+    0 2px 6px -3px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crm-toast {
+    transform: none;
+    transition: opacity 120ms ease;
+  }
+
+  .crm-toast.is-in,
+  .crm-toast.is-out {
+    transform: none;
+  }
+}

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -67,27 +67,23 @@
     }
     
     function showSessionExpiredToast() {
-        // Remove any existing session expired toasts
-        const existingToast = document.getElementById('session-expired-toast');
-        if (existingToast) {
-            existingToast.remove();
+        if (typeof window.showCrmToast === 'function') {
+            window.showCrmToast('Your session has expired. Redirecting to login...', 'warning', {
+                duration: 4000
+            });
+            return;
         }
-        
-        // Create toast notification
+        const existingToast = document.getElementById('session-expired-toast');
+        if (existingToast) existingToast.remove();
         const toast = document.createElement('div');
         toast.id = 'session-expired-toast';
-        toast.className = 'fixed top-4 left-1/2 transform -translate-x-1/2 z-[9999] bg-amber-100 text-amber-800 px-6 py-4 rounded-lg shadow-lg flex items-center space-x-3';
-        toast.innerHTML = `
-            <i class="fas fa-clock text-amber-600"></i>
-            <span class="font-medium">Your session has expired. Redirecting to login...</span>
-        `;
-        
+        toast.className = 'crm-toast crm-toast--warning is-in';
+        toast.textContent = 'Your session has expired. Redirecting to login...';
         document.body.appendChild(toast);
     }
 })();
 
 document.addEventListener('DOMContentLoaded', function() {
-    const flashMessages = document.querySelectorAll('.toast-message');
     const userIcon = document.getElementById('userIcon');
     const userDropdown = document.getElementById('userDropdown');
     const sidebar = document.getElementById('sidebar');
@@ -208,16 +204,6 @@ document.addEventListener('DOMContentLoaded', function() {
     if (sidebarToggle) {
         sidebarToggle.addEventListener('click', toggleSidebar);
     }
-
-    // Flash message auto-dismiss
-    flashMessages.forEach(function(message) {
-        setTimeout(function() {
-            message.classList.add('fade-out');
-            setTimeout(function() {
-                message.remove();
-            }, 500);
-        }, 4000);
-    });
 
     /** Position the user menu as fixed so it spans the sidebar + main area and is not clipped by sidebar overflow. */
     function positionUserDropdown() {

--- a/static/js/crm_toast.js
+++ b/static/js/crm_toast.js
@@ -1,0 +1,172 @@
+/**
+ * Site-wide toast notifications.
+ * window.showCrmToast(message, type, options)
+ * window.showToast(...) — same, for existing callers
+ */
+(function () {
+    'use strict';
+
+    var REGION_ID = 'crm-toast-region';
+    var MAX_TOASTS = 3;
+    var ENTER_MS = 20;
+    var EXIT_MS = 180;
+
+    var ICONS = {
+        success: 'fa-check',
+        error: 'fa-exclamation',
+        warning: 'fa-exclamation',
+        info: 'fa-info'
+    };
+
+    var DURATIONS = {
+        success: 4000,
+        error: 6000,
+        warning: 5000,
+        info: 4000
+    };
+
+    function normalizeType(type) {
+        var t = String(type || 'success').toLowerCase();
+        if (t === 'danger' || t === 'failed' || t === 'fail') return 'error';
+        if (t === 'warn') return 'warning';
+        if (t === 'message') return 'success';
+        if (t === 'error' || t === 'warning' || t === 'info' || t === 'success') return t;
+        return 'success';
+    }
+
+    function region() {
+        var el = document.getElementById(REGION_ID);
+        if (el) return el;
+        el = document.createElement('div');
+        el.id = REGION_ID;
+        el.className = 'crm-toast-region';
+        el.setAttribute('role', 'region');
+        el.setAttribute('aria-label', 'Notifications');
+        el.setAttribute('aria-live', 'polite');
+        document.body.appendChild(el);
+        bindRegion(el);
+        return el;
+    }
+
+    function capStack(host) {
+        var extras = host.querySelectorAll('.crm-toast');
+        while (extras.length > MAX_TOASTS) {
+            dismissToast(extras[0], true);
+            extras = host.querySelectorAll('.crm-toast');
+        }
+    }
+
+    function dismissToast(toast, immediate) {
+        if (!toast || toast.dataset.leaving === '1') return;
+        toast.dataset.leaving = '1';
+        if (toast._hideTimer) {
+            clearTimeout(toast._hideTimer);
+            toast._hideTimer = null;
+        }
+        if (immediate) {
+            toast.remove();
+            return;
+        }
+        toast.classList.remove('is-in');
+        toast.classList.add('is-out');
+        setTimeout(function () {
+            toast.remove();
+        }, EXIT_MS);
+    }
+
+    function armTimer(toast, duration) {
+        if (!duration || duration < 0) return;
+        toast._hideTimer = setTimeout(function () {
+            dismissToast(toast, false);
+        }, duration);
+    }
+
+    function bindRegion(host) {
+        if (!host || host._crmToastBound) return;
+        host._crmToastBound = true;
+        host.addEventListener('click', function (event) {
+            var btn = event.target.closest('.crm-toast__close');
+            if (!btn || !host.contains(btn)) return;
+            var toast = btn.closest('.crm-toast');
+            if (toast) dismissToast(toast, false);
+        });
+    }
+
+    function bindToast(toast, duration) {
+        toast.addEventListener('mouseenter', function () {
+            if (toast._hideTimer) {
+                clearTimeout(toast._hideTimer);
+                toast._hideTimer = null;
+            }
+        });
+        toast.addEventListener('mouseleave', function () {
+            armTimer(toast, duration);
+        });
+
+        requestAnimationFrame(function () {
+            toast.classList.add('is-in');
+        });
+        armTimer(toast, duration);
+    }
+
+    function showCrmToast(message, type, options) {
+        if (message == null || message === '') return null;
+        options = options || {};
+        var kind = normalizeType(type);
+        var duration = options.duration != null ? options.duration : DURATIONS[kind];
+        var host = region();
+
+        var toast = document.createElement('div');
+        toast.className = 'crm-toast crm-toast--' + kind;
+        toast.setAttribute('role', kind === 'error' ? 'alert' : 'status');
+
+        var icon = document.createElement('span');
+        icon.className = 'crm-toast__icon';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.innerHTML = '<i class="fas ' + ICONS[kind] + '"></i>';
+
+        var text = document.createElement('p');
+        text.className = 'crm-toast__message';
+        text.textContent = String(message);
+
+        var closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'crm-toast__close';
+        closeBtn.setAttribute('aria-label', 'Dismiss');
+        closeBtn.innerHTML = '<i class="fas fa-times" aria-hidden="true"></i>';
+
+        toast.appendChild(icon);
+        toast.appendChild(text);
+        toast.appendChild(closeBtn);
+        host.appendChild(toast);
+        bindRegion(host);
+        capStack(host);
+        bindToast(toast, duration);
+        return toast;
+    }
+
+    function hydrateServerToasts() {
+        var host = document.getElementById(REGION_ID);
+        if (!host) return;
+        bindRegion(host);
+        host.querySelectorAll('.crm-toast').forEach(function (toast) {
+            var kind = 'success';
+            toast.className.split(/\s+/).forEach(function (cls) {
+                if (cls.indexOf('crm-toast--') === 0) kind = cls.slice('crm-toast--'.length);
+            });
+            var duration = DURATIONS[kind] || DURATIONS.success;
+            setTimeout(function () {
+                bindToast(toast, duration);
+            }, ENTER_MS);
+        });
+    }
+
+    window.showCrmToast = showCrmToast;
+    window.showToast = showCrmToast;
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', hydrateServerToasts);
+    } else {
+        hydrateServerToasts();
+    }
+})();

--- a/static/js/document_mapper.js
+++ b/static/js/document_mapper.js
@@ -1650,55 +1650,10 @@
     }
 
     function showToast(message, type = 'info') {
-        const toast = document.createElement('div');
-        toast.className = `toast toast-${type}`;
-
-        const icon = type === 'success' ? 'check-circle' :
-                     type === 'error' ? 'exclamation-circle' :
-                     type === 'warning' ? 'exclamation-triangle' : 'info-circle';
-
-        const bg = type === 'success' ? '#10b981' :
-                   type === 'error' ? '#ef4444' :
-                   type === 'warning' ? '#f59e0b' : '#3b82f6';
-
-        toast.innerHTML = `<i class="fas fa-${icon}"></i><span>${message}</span>`;
-        toast.style.cssText = `
-            position: fixed;
-            bottom: 20px;
-            right: 20px;
-            padding: 12px 20px;
-            border-radius: 8px;
-            background: ${bg};
-            color: white;
-            font-weight: 500;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            z-index: 9999;
-            animation: slideIn 0.3s ease;
-        `;
-
-        document.body.appendChild(toast);
-
-        setTimeout(() => {
-            toast.style.animation = 'slideOut 0.3s ease';
-            setTimeout(() => toast.remove(), 300);
-        }, 3000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
-
-    // Add animation styles
-    const style = document.createElement('style');
-    style.textContent = `
-        @keyframes slideIn {
-            from { transform: translateX(100%); opacity: 0; }
-            to { transform: translateX(0); opacity: 1; }
-        }
-        @keyframes slideOut {
-            from { transform: translateX(0); opacity: 1; }
-            to { transform: translateX(100%); opacity: 0; }
-        }
-    `;
-    document.head.appendChild(style);
 
     // =============================================================================
     // INITIALIZATION

--- a/static/js/transaction_detail.js
+++ b/static/js/transaction_detail.js
@@ -582,23 +582,9 @@ document.addEventListener('click', function(event) {
 // =============================================================================
 
 function showToast(message, type = 'info') {
-    const toast = document.getElementById('toast');
-    const icon = document.getElementById('toastIcon');
-    document.getElementById('toastMessage').textContent = message;
-
-    icon.className = 'fas';
-    if (type === 'success') {
-        icon.classList.add('fa-check-circle', 'text-green-500');
-    } else if (type === 'error') {
-        icon.classList.add('fa-exclamation-circle', 'text-red-500');
-    } else if (type === 'warning') {
-        icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
-    } else {
-        icon.classList.add('fa-info-circle', 'text-blue-500');
+    if (typeof window.showCrmToast === 'function') {
+        return window.showCrmToast(message, type);
     }
-
-    toast.classList.remove('hidden');
-    setTimeout(() => toast.classList.add('hidden'), 4000);
 }
 
 // =============================================================================

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -13,461 +13,319 @@
 
 {% block content %}
 <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
-    
-    @keyframes fadeInUp {
-        from { opacity: 0; transform: translateY(20px); }
-        to { opacity: 1; transform: translateY(0); }
+  :root{
+    --brand-orange: #f97316;
+    --bg: #f4f4f4;
+    --panel: #ffffff;
+    --panel-soft: #f0f0f0;
+    --text: rgba(0, 0, 0, 0.88);
+    --muted: rgba(0, 0, 0, 0.56);
+    --border: rgba(0, 0, 0, 0.10);
+    --shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+    --focus: rgba(249, 115, 22, 0.18);
+    --accent-soft: rgba(249, 115, 22, 0.1);
+  }
+
+  .register-page{
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  .shell{ width: 100%; max-width: 920px; }
+
+  .card{
+    background: var(--panel);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    border-radius: 18px;
+    overflow: hidden;
+  }
+
+  .left{
+    background:
+      radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.07) 0%, transparent 55%),
+      var(--panel-soft);
+    color: var(--text);
+    position: relative;
+    border-right: 1px solid var(--border);
+  }
+  .left::before{
+    content:'';
+    position:absolute;
+    top:0; left:0; right:0;
+    height: 2px;
+    background: var(--brand-orange);
+  }
+  .left-muted{ color: var(--muted); }
+  .left-title{
+    color: var(--text);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
+  .left-chip{
+    display:inline-flex;
+    align-items:center;
+    gap:.5rem;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 6px 10px;
+    border-radius: 9999px;
+    background: var(--accent-soft);
+    color: var(--brand-orange);
+    border: 1px solid rgba(249, 115, 22, 0.16);
+  }
+  .left-bullet{
+    display:flex;
+    gap:.75rem;
+    align-items:flex-start;
+  }
+  .left-icon{
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    flex-shrink:0;
+    color: var(--brand-orange);
+  }
+
+  .kicker{ font-size: 12px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  .title{ font-size: 24px; font-weight: 800; color: var(--text); letter-spacing: -0.02em; }
+  .subtitle{ font-size: 14px; color: var(--muted); }
+
+  .label{
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 6px;
+    display: block;
+  }
+
+  .input{
+    height: 46px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    padding: 0 14px;
+    font-size: 15px;
+    width: 100%;
+    color: var(--text);
+    transition: border-color .15s ease, box-shadow .15s ease, background .15s ease;
+  }
+  .input::placeholder{ color: rgba(0,0,0,0.35); }
+  .input:focus{
+    outline: none;
+    border-color: var(--brand-orange);
+    box-shadow: 0 0 0 4px var(--focus);
+  }
+  .input:-webkit-autofill,
+  .input:-webkit-autofill:hover,
+  .input:-webkit-autofill:focus{
+    -webkit-text-fill-color: var(--text);
+    caret-color: var(--text);
+    box-shadow: 0 0 0 1000px var(--panel) inset;
+    transition: background-color 9999s ease-out;
+  }
+
+  .btn{
+    height: 46px;
+    border-radius: 12px;
+    width: 100%;
+    background: #ea580c;
+    color: #fff;
+    font-weight: 700;
+    font-size: 15px;
+    transition: background .15s ease, box-shadow .18s ease;
+  }
+  .btn:hover{
+    background: #c2410c;
+    box-shadow: 0 8px 20px rgba(234, 88, 12, 0.28);
+  }
+  .btn:active{ background: #980012; }
+
+  .divider{ height: 1px; background: var(--border); }
+
+  .footer-link{
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--brand-orange);
+    text-decoration: none;
+  }
+  .footer-link:hover{ text-decoration: underline; text-underline-offset: 3px; }
+
+  .legal{
+    font-size: 12px;
+    color: var(--muted);
+    text-align: center;
+  }
+  .legal a{
+    color: var(--text);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .home-link{
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+  }
+  .home-link:hover{ color: var(--brand-orange); }
+
+  @media (max-width: 1024px){
+    .left{
+      border-right: none;
+      border-bottom: 1px solid var(--border);
     }
-    @keyframes fadeInLeft {
-        from { opacity: 0; transform: translateX(-20px); }
-        to { opacity: 1; transform: translateX(0); }
-    }
-    @keyframes float {
-        0%, 100% { transform: translateY(0px); }
-        50% { transform: translateY(-8px); }
-    }
-    @keyframes shimmer {
-        0% { background-position: -1000px 0; }
-        100% { background-position: 1000px 0; }
-    }
-    @keyframes pulse-soft {
-        0%, 100% { opacity: 0.4; }
-        50% { opacity: 0.8; }
-    }
-    
-    .register-panel {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    }
-    
-    .animate-fade-in-up { animation: fadeInUp 0.6s ease-out forwards; }
-    .animate-fade-in-left { animation: fadeInLeft 0.6s ease-out forwards; }
-    .delay-1 { animation-delay: 0.1s; opacity: 0; }
-    .delay-2 { animation-delay: 0.2s; opacity: 0; }
-    .delay-3 { animation-delay: 0.3s; opacity: 0; }
-    .delay-4 { animation-delay: 0.4s; opacity: 0; }
-    
-    /* Geometric background patterns */
-    .hero-pattern {
-        background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-    }
-    
-    .feature-card {
-        transition: all 0.3s ease;
-    }
-    .feature-card:hover {
-        transform: translateY(-2px);
-    }
-    
-    /* Right panel background */
-    .right-bg {
-        background: 
-            radial-gradient(ellipse at 0% 0%, rgba(249, 115, 22, 0.03) 0%, transparent 50%),
-            radial-gradient(ellipse at 100% 100%, rgba(45, 62, 80, 0.04) 0%, transparent 50%),
-            linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
-    }
-    
-    /* Premium card */
-    .premium-card {
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(20px);
-        border: 1px solid rgba(255, 255, 255, 0.8);
-        box-shadow: 
-            0 0 0 1px rgba(0, 0, 0, 0.03),
-            0 2px 4px rgba(0, 0, 0, 0.02),
-            0 8px 16px rgba(0, 0, 0, 0.04),
-            0 24px 48px rgba(0, 0, 0, 0.06);
-        transition: all 0.3s ease;
-    }
-    .premium-card:hover {
-        box-shadow: 
-            0 0 0 1px rgba(0, 0, 0, 0.03),
-            0 2px 4px rgba(0, 0, 0, 0.02),
-            0 12px 24px rgba(0, 0, 0, 0.06),
-            0 32px 64px rgba(0, 0, 0, 0.08);
-    }
-    
-    /* Input styling */
-    .input-group {
-        position: relative;
-    }
-    .input-icon {
-        position: absolute;
-        left: 14px;
-        top: 50%;
-        transform: translateY(-50%);
-        color: #94a3b8;
-        transition: color 0.2s ease;
-        pointer-events: none;
-        font-size: 14px;
-    }
-    .premium-input {
-        padding-left: 42px;
-        height: 52px;
-        border: 2px solid #e2e8f0;
-        border-radius: 12px;
-        font-size: 15px;
-        transition: all 0.2s ease;
-        background: #f8fafc;
-    }
-    .premium-input:hover {
-        border-color: #cbd5e1;
-        background: #ffffff;
-    }
-    .premium-input:focus {
-        border-color: #2d3e50;
-        background: #ffffff;
-        box-shadow: 0 0 0 4px rgba(45, 62, 80, 0.08);
-        outline: none;
-    }
-    .premium-input:focus + .input-icon,
-    .input-group:focus-within .input-icon {
-        color: #2d3e50;
-    }
-    
-    /* Simple input (no icon) */
-    .simple-input {
-        height: 52px;
-        border: 2px solid #e2e8f0;
-        border-radius: 12px;
-        font-size: 15px;
-        transition: all 0.2s ease;
-        background: #f8fafc;
-        padding: 0 16px;
-    }
-    .simple-input:hover {
-        border-color: #cbd5e1;
-        background: #ffffff;
-    }
-    .simple-input:focus {
-        border-color: #2d3e50;
-        background: #ffffff;
-        box-shadow: 0 0 0 4px rgba(45, 62, 80, 0.08);
-        outline: none;
-    }
-    
-    /* Premium button */
-    .premium-btn {
-        position: relative;
-        overflow: hidden;
-        background: linear-gradient(135deg, #2d3e50 0%, #1a2634 100%);
-        transition: all 0.3s ease;
-    }
-    .premium-btn::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
-        transition: left 0.5s ease;
-    }
-    .premium-btn:hover::before {
-        left: 100%;
-    }
-    .premium-btn:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 12px 24px rgba(45, 62, 80, 0.25);
-    }
-    
-    /* Accent line */
-    .accent-line {
-        height: 4px;
-        background: linear-gradient(90deg, #f97316, #eab308, #f97316);
-        background-size: 200% 100%;
-        animation: shimmer 3s linear infinite;
-    }
-    
-    /* Floating orbs */
-    .orb {
-        position: absolute;
-        border-radius: 50%;
-        filter: blur(40px);
-        animation: pulse-soft 4s ease-in-out infinite;
-    }
-    .orb-1 {
-        width: 200px;
-        height: 200px;
-        background: rgba(234, 88, 12, 0.15);
-        top: -50px;
-        right: -50px;
-    }
-    .orb-2 {
-        width: 150px;
-        height: 150px;
-        background: rgba(45, 62, 80, 0.1);
-        bottom: -30px;
-        left: -30px;
-        animation-delay: 2s;
-    }
-    
-    /* Benefits badges */
-    .benefit-badge {
-        display: inline-flex;
-        align-items: center;
-        padding: 0;
-        background: transparent;
-        font-size: 13px;
-        font-weight: 500;
-        color: #64748b;
-    }
-    .benefit-badge i {
-        color: #f97316;
-        margin-right: 6px;
-    }
-    
-    /* Divider with text */
-    .divider-text {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-        color: #94a3b8;
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        font-weight: 600;
-    }
-    .divider-text::before,
-    .divider-text::after {
-        content: '';
-        flex: 1;
-        height: 1px;
-        background: linear-gradient(90deg, transparent, #e2e8f0, transparent);
-    }
+  }
 </style>
 
-<div class="min-h-screen flex register-panel">
-    <!-- Left Panel - Hero/Benefits Section -->
-    <div class="hidden lg:flex lg:w-[45%] xl:w-1/2 bg-gradient-to-br from-[#2d3e50] via-[#1a2634] to-[#0f1419] relative overflow-hidden">
-        <!-- Background pattern -->
-        <div class="absolute inset-0 hero-pattern"></div>
-        
-        <!-- Gradient overlays -->
-        <div class="absolute top-0 right-0 w-96 h-96 bg-gradient-to-bl from-orange-500/20 to-transparent rounded-full blur-3xl"></div>
-        <div class="absolute bottom-0 left-0 w-80 h-80 bg-gradient-to-tr from-amber-500/10 to-transparent rounded-full blur-3xl"></div>
-        
-        <!-- Content -->
-        <div class="relative z-10 flex flex-col justify-between p-12 xl:p-16 w-full">
-        <!-- Logo and Header -->
-            <div class="animate-fade-in-left">
-                <div class="flex items-center space-x-4 mb-16">
-                    <a href="{{ url_for('main.landing') }}" class="flex items-center" aria-label="Back to home">
-                        <div class="w-14 h-14 bg-gradient-to-br from-[#3d4d63] to-[#2d3e50] rounded-xl flex items-center justify-center shadow-xl border border-white/10">
-                            {{ brand_logo(size_class='crm-brand-logo-wrap--h12 crm-brand-logo-wrap--on-dark', width=219, height=48) }}
-                        </div>
-                    </a>
-                </div>
-                
-                <h1 class="text-4xl xl:text-5xl font-bold text-white leading-tight mb-6">
-                    Create your account.
-                </h1>
-                
-                <p class="text-xl text-slate-300 leading-relaxed max-w-lg">
-                    No credit card. The free tier stays free. You can be in within a couple of minutes. Up to 10,000 contacts, in an all-in-one CRM for agents.
-                </p>
-            </div>
-            
-            <!-- Feature Cards -->
-            <div class="space-y-4 my-12 animate-fade-in-left delay-2">
-                <div class="feature-card flex items-start space-x-4 bg-white/5 backdrop-blur-sm rounded-xl p-5 border border-white/10">
-                    <div class="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-lg flex items-center justify-center">
-                        <i class="fas fa-address-book text-white text-lg"></i>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-semibold text-lg">Smart Contact Management</h3>
-                        <p class="text-slate-400 text-sm mt-1">Up to 10,000 contacts with groups, notes, and activity tracking</p>
-                    </div>
-                </div>
-                
-                <div class="feature-card flex items-start space-x-4 bg-white/5 backdrop-blur-sm rounded-xl p-5 border border-white/10">
-                    <div class="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center">
-                        <i class="fas fa-tasks text-white text-lg"></i>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-semibold text-lg">Task & Follow-up System</h3>
-                        <p class="text-slate-400 text-sm mt-1">Due dates and email reminders for follow-up tasks</p>
-                    </div>
-                </div>
-                
-                <div class="feature-card flex items-start space-x-4 bg-white/5 backdrop-blur-sm rounded-xl p-5 border border-white/10">
-                    <div class="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-purple-500 to-purple-600 rounded-lg flex items-center justify-center">
-                        <i class="fas fa-chart-line text-white text-lg"></i>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-semibold text-lg">Performance Dashboard</h3>
-                        <p class="text-slate-400 text-sm mt-1">Track your pipeline, activities, and growth with real-time analytics</p>
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Trust indicators -->
-            <div class="animate-fade-in-left delay-4">
-                <div class="flex items-center space-x-6 text-slate-400 text-sm">
-                    <span class="flex items-center"><i class="fas fa-shield-alt text-emerald-400 mr-2"></i> Secure & Private</span>
-                    <span class="flex items-center"><i class="fas fa-clock text-blue-400 mr-2"></i> Quick Setup</span>
-                    <span class="flex items-center"><i class="fas fa-headset text-purple-400 mr-2"></i> Support Included</span>
-                </div>
-            </div>
-        </div>
+<div class="min-h-screen register-page flex items-center justify-center px-4 py-12">
+  <div class="shell">
+    <div class="mb-4">
+      <a href="{{ url_for('main.landing') }}" class="home-link">Back to home</a>
     </div>
-    
-    <!-- Right Panel - Registration Form -->
-    <div class="w-full lg:w-[55%] xl:w-1/2 right-bg flex items-center justify-center px-6 py-10 lg:px-10 xl:px-16 relative overflow-hidden">
-        <!-- Floating orbs -->
-        <div class="orb orb-1"></div>
-        <div class="orb orb-2"></div>
-        
-        <div class="w-full max-w-[520px] relative z-10 animate-fade-in-up">
-            <div class="hidden lg:block mb-4">
-                <a href="{{ url_for('main.landing') }}" class="text-sm font-medium text-slate-600 hover:text-orange-600">Back to home</a>
+
+    <div class="card">
+      <div class="grid grid-cols-1 lg:grid-cols-2">
+
+        <div class="left p-8 lg:p-10 flex flex-col justify-between">
+          <div>
+            <a href="{{ url_for('main.landing') }}" class="inline-flex" aria-label="Origen TechnolOG home">
+              {{ brand_logo(size_class='crm-brand-logo-wrap--h9', width=164, height=36) }}
+            </a>
+
+            <div class="mt-8">
+              <div class="left-chip">Free to start</div>
+              <p class="left-title mt-4 text-2xl lg:text-3xl leading-tight">
+                A couple of minutes, then you're in.
+              </p>
+              <p class="mt-3 text-sm lg:text-[15px] left-muted leading-relaxed">
+                No credit card. The free tier stays free. Up to 10,000 contacts, in a CRM built for agents.
+              </p>
             </div>
-            <!-- Mobile logo -->
-            <div class="lg:hidden text-center mb-8">
-                <div class="flex justify-center mb-4">
-                    <a href="{{ url_for('main.landing') }}" class="inline-flex" aria-label="Back to home">
-                        <div class="w-16 h-16 bg-gradient-to-br from-[#2d3e50] to-[#1a2634] rounded-xl flex items-center justify-center shadow-lg">
-                            {{ brand_logo(size_class='crm-brand-logo-wrap--h14 crm-brand-logo-wrap--on-dark', width=255, height=56) }}
-                        </div>
-                    </a>
+
+            <div class="mt-8 space-y-4">
+              <div class="left-bullet">
+                <div class="left-icon"><i class="fas fa-address-book"></i></div>
+                <div>
+                  <div class="font-semibold text-sm">Contacts and groups</div>
+                  <div class="text-xs left-muted">Notes and activity on each person, up to 10,000 contacts.</div>
                 </div>
-                <a href="{{ url_for('main.landing') }}" class="text-sm font-medium text-slate-600 hover:text-orange-600">Back to home</a>
+              </div>
+              <div class="left-bullet">
+                <div class="left-icon"><i class="fas fa-tasks"></i></div>
+                <div>
+                  <div class="font-semibold text-sm">Tasks and reminders</div>
+                  <div class="text-xs left-muted">Due dates and email reminders for follow-up.</div>
+                </div>
+              </div>
+              <div class="left-bullet">
+                <div class="left-icon"><i class="fas fa-chart-line"></i></div>
+                <div>
+                  <div class="font-semibold text-sm">Dashboard</div>
+                  <div class="text-xs left-muted">Pipeline and activity without a second tool.</div>
+                </div>
+              </div>
             </div>
-            
-            <!-- Form Card -->
-            <div class="premium-card rounded-2xl overflow-hidden">
-                <!-- Accent line at top -->
-                <div class="accent-line"></div>
-                
-                <div class="p-8 lg:p-10">
-                    <!-- Header -->
-                    <div class="text-center mb-8">
-                        <h2 class="text-3xl font-extrabold text-slate-900 mb-2 tracking-tight">Create your account.</h2>
-                        <p class="text-slate-500">No credit card. The free tier stays free. You can be in within a couple of minutes.</p>
-                    </div>
-                    
-                    <!-- Benefits -->
-                    <div class="flex items-center justify-center gap-6 mb-8 text-sm text-slate-500">
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Up to 10,000 contacts</span>
-                        <span class="text-slate-300">·</span>
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Instant Access</span>
-                        <span class="text-slate-300">·</span>
-                        <span class="flex items-center"><i class="fas fa-check text-orange-500 mr-2"></i>Secure</span>
-                    </div>
-                    
-                    <form method="POST" action="{{ url_for('auth.register') }}" class="space-y-4"
-                          data-analytics-form="registration"
-                          data-validation-categories="{{ form.errors.keys()|join(',') }}">
-                        {{ form.hidden_tag() }}
-                        
-                        <!-- Honeypot field - invisible to humans, bots will fill it -->
-                        <div style="position: absolute; left: -9999px; top: -9999px;" aria-hidden="true">
-                            <label for="referral_code">Leave this field empty</label>
-                            <input type="text" name="referral_code" id="referral_code" tabindex="-1" autocomplete="off" value="">
-                        </div>
-                        
-                        <!-- Organization Name -->
-                        <div class="input-group">
-                            <input type="text" name="company_name" required
-                                class="premium-input block w-full text-slate-900 placeholder-slate-400"
-                                placeholder="Your brokerage or team name" />
-                            <i class="input-icon fas fa-building"></i>
-                        </div>
-                        
-                        <div class="divider-text my-6">
-                            <span>Your Details</span>
-                        </div>
-                        
-                        <!-- Name Fields -->
-                        <div class="grid grid-cols-2 gap-3">
-                            <div>
-                                {{ form.first_name(class="simple-input block w-full text-slate-900 placeholder-slate-400", placeholder="First name") }}
-                                {% if form.first_name.errors %}
-                                    {% for error in form.first_name.errors %}
-                                        <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                            <div>
-                                {{ form.last_name(class="simple-input block w-full text-slate-900 placeholder-slate-400", placeholder="Last name") }}
-                                {% if form.last_name.errors %}
-                                    {% for error in form.last_name.errors %}
-                                        <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                        </div>
+          </div>
 
-                        <!-- Email -->
-                        <div class="input-group">
-                            {{ form.email(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Work email") }}
-                            <i class="input-icon fas fa-envelope"></i>
-                            {% if form.email.errors %}
-                                {% for error in form.email.errors %}
-                                    <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                {% endfor %}
-                            {% endif %}
-                        </div>
-
-                        <!-- Password Fields -->
-                        <div class="grid grid-cols-2 gap-3">
-                            <div class="input-group">
-                                {{ form.password(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Password") }}
-                                <i class="input-icon fas fa-lock"></i>
-                                {% if form.password.errors %}
-                                    {% for error in form.password.errors %}
-                                        <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                            <div class="input-group">
-                                {{ form.confirm_password(class="premium-input block w-full text-slate-900 placeholder-slate-400", placeholder="Confirm password") }}
-                                <i class="input-icon fas fa-lock"></i>
-                                {% if form.confirm_password.errors %}
-                                    {% for error in form.confirm_password.errors %}
-                                        <p class="text-red-500 text-xs mt-1">{{ error }}</p>
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                        </div>
-
-                        <!-- Submit Button -->
-                        <div class="pt-4">
-                            <button type="submit" class="premium-btn w-full h-14 rounded-xl text-base font-semibold text-white">
-                                <span class="relative z-10 flex items-center justify-center">
-                                    Create My Account
-                                    <i class="fas fa-arrow-right ml-2"></i>
-                                </span>
-                            </button>
-                        </div>
-                    </form>
-                    
-                    <!-- Footer text -->
-                    <p class="text-center text-xs text-slate-400 mt-6">
-                        By creating an account, you agree to our 
-                        <a href="{{ url_for('auth.terms_privacy') }}" target="_blank" class="text-slate-600 hover:text-slate-900 font-medium underline">Terms & Privacy Policy</a>
-                    </p>
-            </div>
+          <div class="mt-10 text-xs left-muted flex items-center gap-2">
+            <i class="fas fa-shield-alt" style="color: #248a3d"></i>
+            256-bit SSL encryption · Your data stays private
+          </div>
         </div>
 
-            <!-- Sign in link -->
-            <div class="text-center mt-8">
-            <p class="text-slate-600">
-                Already have an account?
-                    <a href="{{ url_for('auth.login') }}" class="font-semibold text-[#2d3e50] hover:text-orange-600 transition-colors ml-1">
-                        Sign in <i class="fas fa-arrow-right text-xs ml-1"></i>
-                </a>
+        <div class="p-8 lg:p-10">
+          <div class="mb-7">
+            <div class="kicker">Account</div>
+            <h1 class="title mt-1">Create your account.</h1>
+            <p class="subtitle mt-1">Brokerage, your name, email, and a password.</p>
+          </div>
+
+          <form method="POST" action="{{ url_for('auth.register') }}" class="space-y-4"
+                data-analytics-form="registration"
+                data-validation-categories="{{ form.errors.keys()|join(',') }}">
+            {{ form.hidden_tag() }}
+
+            <div style="position: absolute; left: -9999px; top: -9999px;" aria-hidden="true">
+              <label for="referral_code">Leave this field empty</label>
+              <input type="text" name="referral_code" id="referral_code" tabindex="-1" autocomplete="off" value="">
+            </div>
+
+            <div>
+              <label class="label" for="company_name">Brokerage or team</label>
+              <input type="text" name="company_name" id="company_name" required
+                     class="input" placeholder="Acme Realty" autocomplete="organization">
+            </div>
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label class="label" for="{{ form.first_name.id }}">First name</label>
+                {{ form.first_name(class="input", placeholder="First", autocomplete="given-name") }}
+                {% for error in form.first_name.errors %}
+                  <p class="text-red-600 text-xs mt-1">{{ error }}</p>
+                {% endfor %}
+              </div>
+              <div>
+                <label class="label" for="{{ form.last_name.id }}">Last name</label>
+                {{ form.last_name(class="input", placeholder="Last", autocomplete="family-name") }}
+                {% for error in form.last_name.errors %}
+                  <p class="text-red-600 text-xs mt-1">{{ error }}</p>
+                {% endfor %}
+              </div>
+            </div>
+
+            <div>
+              <label class="label" for="{{ form.email.id }}">Email</label>
+              {{ form.email(class="input", placeholder="you@brokerage.com", autocomplete="email") }}
+              {% for error in form.email.errors %}
+                <p class="text-red-600 text-xs mt-1">{{ error }}</p>
+              {% endfor %}
+            </div>
+
+            <div>
+              <label class="label" for="{{ form.password.id }}">Password</label>
+              {{ form.password(class="input", placeholder="••••••••", autocomplete="new-password") }}
+              {% for error in form.password.errors %}
+                <p class="text-red-600 text-xs mt-1">{{ error }}</p>
+              {% endfor %}
+            </div>
+
+            <div>
+              <label class="label" for="{{ form.confirm_password.id }}">Confirm password</label>
+              {{ form.confirm_password(class="input", placeholder="Repeat password", autocomplete="new-password") }}
+              {% for error in form.confirm_password.errors %}
+                <p class="text-red-600 text-xs mt-1">{{ error }}</p>
+              {% endfor %}
+            </div>
+
+            <div class="pt-2">
+              <button type="submit" class="btn">
+                Create account <i class="fas fa-arrow-right ml-2"></i>
+              </button>
+              <p class="legal mt-4">
+                By creating an account, you agree to our
+                <a href="{{ url_for('auth.terms_privacy') }}" target="_blank" rel="noopener">Terms &amp; Privacy Policy</a>
+              </p>
+            </div>
+
+            <div class="divider my-6"></div>
+
+            <p class="text-sm" style="color: var(--muted);">
+              Already have an account?
+              <a href="{{ url_for('auth.login') }}" class="footer-link ml-1">Sign in</a>
             </p>
-            </div>
-            
-            <!-- Trust badge -->
-            <div class="text-center mt-6">
-                <div class="inline-flex items-center text-xs text-slate-400">
-                    <i class="fas fa-shield-alt text-emerald-500 mr-2"></i>
-                    256-bit SSL encryption · Your data stays private
-                </div>
-            </div>
+          </form>
         </div>
+
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/auth/terms_privacy.html
+++ b/templates/auth/terms_privacy.html
@@ -12,80 +12,212 @@
 
 {% block content %}
 <style>
-    .legal-container {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  :root{
+    --brand-orange: #f97316;
+    --bg: #f4f4f4;
+    --panel: #ffffff;
+    --panel-soft: #f0f0f0;
+    --text: rgba(0, 0, 0, 0.88);
+    --muted: rgba(0, 0, 0, 0.56);
+    --border: rgba(0, 0, 0, 0.10);
+  }
+
+  .legal-page{
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+  .legal-shell{ width: 100%; max-width: 1080px; margin: 0 auto; }
+
+  .legal-kicker{
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .legal-title{
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    color: var(--text);
+  }
+  .legal-meta{ font-size: 14px; color: var(--muted); }
+
+  .legal-home{
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+  }
+  .legal-home:hover{ color: var(--brand-orange); }
+
+  .legal-layout{
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+  @media (min-width: 960px){
+    .legal-layout{
+      grid-template-columns: 220px minmax(0, 1fr);
+      gap: 3rem;
+      align-items: start;
     }
-    .legal-section {
-        scroll-margin-top: 100px;
-    }
-    .toc-link {
-        transition: all 0.2s ease;
-    }
-    .toc-link:hover {
-        color: #f97316;
-        padding-left: 8px;
-    }
+  }
+
+  .legal-toc{
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 1.1rem 1.15rem;
+  }
+  @media (min-width: 960px){
+    .legal-toc{ position: sticky; top: 1.25rem; }
+  }
+  .legal-toc h2{
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0 0 0.85rem;
+  }
+  .legal-toc h3{
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--brand-orange);
+    margin: 0.85rem 0 0.4rem;
+  }
+  .legal-toc h3:first-of-type{ margin-top: 0; }
+  .legal-toc ol{
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .legal-toc a{
+    display: block;
+    padding: 0.28rem 0;
+    font-size: 13px;
+    line-height: 1.35;
+    color: var(--text);
+    text-decoration: none;
+  }
+  .legal-toc a:hover{ color: var(--brand-orange); }
+
+  .legal-doc{
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 1.75rem 1.5rem 2rem;
+  }
+  @media (min-width: 768px){
+    .legal-doc{ padding: 2.25rem 2.5rem 2.5rem; }
+  }
+
+  .legal-h2{
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    margin: 0 0 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .legal-h3{
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0 0 0.75rem;
+  }
+  .legal-section{ scroll-margin-top: 1.25rem; margin-bottom: 2rem; }
+  .legal-copy{
+    font-size: 15px;
+    line-height: 1.65;
+    color: var(--text);
+  }
+  .legal-copy p{ margin: 0 0 0.75rem; }
+  .legal-copy ul{ margin: 0 0 0.75rem; padding-left: 1.25rem; }
+  .legal-copy li{ margin: 0.35rem 0; }
+  .legal-copy strong{ font-weight: 650; }
+
+  .legal-callout{
+    margin-top: 2.5rem;
+    padding: 1.25rem 1.35rem;
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .legal-callout h3{ margin-bottom: 0.5rem; }
+  .legal-callout a{ color: var(--brand-orange); font-weight: 600; text-decoration: none; }
+  .legal-callout a:hover{ text-decoration: underline; text-underline-offset: 2px; }
+
+  .legal-top{
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 1.5rem;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+  }
+  .legal-top:hover{ color: var(--brand-orange); }
 </style>
 
-<div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 py-16">
-    <div class="max-w-5xl mx-auto px-6 legal-container">
-        <!-- Header -->
-        <div class="text-center mb-12">
-            <a href="{{ url_for('main.landing') }}" class="inline-flex items-center text-slate-600 hover:text-slate-900 mb-6 transition-colors">
-                <i class="fas fa-arrow-left mr-2"></i>
-                Back to Home
-            </a>
-            <h1 class="text-4xl md:text-5xl font-bold text-slate-900 mb-4">Terms of Service & Privacy Policy</h1>
-            <p class="text-lg text-slate-600">Origen TechnolOG</p>
-            <p class="text-sm text-slate-500 mt-2">Last Updated: January 19, 2026</p>
-        </div>
+<div class="legal-page min-h-screen px-4 py-10 md:py-14">
+  <div class="legal-shell">
+    <header class="mb-8">
+      <a href="{{ url_for('main.landing') }}" class="legal-home">
+        <i class="fas fa-arrow-left mr-1"></i> Back to home
+      </a>
+      <p class="legal-kicker mt-5">Origen TechnolOG</p>
+      <h1 class="legal-title mt-1">Terms of Service &amp; Privacy Policy</h1>
+      <p class="legal-meta mt-2">Last updated January 19, 2026</p>
+    </header>
 
-        <!-- Main Content Card -->
-        <div class="bg-white rounded-2xl shadow-xl overflow-hidden">
-            <!-- Table of Contents -->
-            <div class="bg-slate-900 text-white p-8">
-                <h2 class="text-2xl font-bold mb-4">Quick Navigation</h2>
-                <div class="grid md:grid-cols-2 gap-4 text-sm">
-                    <div>
-                        <h3 class="font-semibold text-orange-400 mb-2">Terms of Service</h3>
-                        <ul class="space-y-2 text-slate-300">
-                            <li><a href="#tos-acceptance" class="toc-link block">1. Acceptance of Terms</a></li>
-                            <li><a href="#tos-service" class="toc-link block">2. Service Description</a></li>
-                            <li><a href="#tos-account" class="toc-link block">3. Account Registration</a></li>
-                            <li><a href="#tos-acceptable-use" class="toc-link block">4. Acceptable Use</a></li>
-                            <li><a href="#tos-subscription" class="toc-link block">5. Subscription & Payment</a></li>
-                            <li><a href="#tos-data" class="toc-link block">6. Your Data</a></li>
-                            <li><a href="#tos-termination" class="toc-link block">7. Termination</a></li>
-                            <li><a href="#tos-liability" class="toc-link block">8. Limitation of Liability</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="font-semibold text-orange-400 mb-2">Privacy Policy</h3>
-                        <ul class="space-y-2 text-slate-300">
-                            <li><a href="#privacy-intro" class="toc-link block">1. Introduction</a></li>
-                            <li><a href="#privacy-collection" class="toc-link block">2. Information We Collect</a></li>
-                            <li><a href="#privacy-usage" class="toc-link block">3. How We Use Information</a></li>
-                            <li><a href="#privacy-sharing" class="toc-link block">4. Information Sharing</a></li>
-                            <li><a href="#privacy-security" class="toc-link block">5. Data Security</a></li>
-                            <li><a href="#privacy-rights" class="toc-link block">6. Your Rights</a></li>
-                            <li><a href="#privacy-cookies" class="toc-link block">7. Cookies & Tracking</a></li>
-                            <li><a href="#privacy-changes" class="toc-link block">8. Policy Changes</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
+    <div class="legal-layout">
+      <nav class="legal-toc" aria-label="Page sections">
+        <h2>On this page</h2>
+        <h3>Terms of Service</h3>
+        <ol>
+          <li><a href="#tos-acceptance">1. Acceptance of Terms</a></li>
+          <li><a href="#tos-service">2. Service Description</a></li>
+          <li><a href="#tos-account">3. Account Registration</a></li>
+          <li><a href="#tos-acceptable-use">4. Acceptable Use</a></li>
+          <li><a href="#tos-subscription">5. Subscription &amp; Payment</a></li>
+          <li><a href="#tos-data">6. Your Data</a></li>
+          <li><a href="#tos-termination">7. Termination</a></li>
+          <li><a href="#tos-liability">8. Limitation of Liability</a></li>
+          <li><a href="#tos-governing">9. Governing Law</a></li>
+          <li><a href="#tos-general">10. General Provisions</a></li>
+        </ol>
+        <h3>Privacy Policy</h3>
+        <ol>
+          <li><a href="#privacy-intro">1. Introduction</a></li>
+          <li><a href="#privacy-collection">2. Information We Collect</a></li>
+          <li><a href="#privacy-usage">3. How We Use Information</a></li>
+          <li><a href="#privacy-sharing">4. Information Sharing</a></li>
+          <li><a href="#privacy-security">5. Data Security</a></li>
+          <li><a href="#privacy-rights">6. Your Rights</a></li>
+          <li><a href="#privacy-cookies">7. Cookies &amp; Tracking</a></li>
+          <li><a href="#privacy-children">8. Children's Privacy</a></li>
+          <li><a href="#privacy-transfers">9. International Transfers</a></li>
+          <li><a href="#privacy-retention">10. Data Retention</a></li>
+          <li><a href="#privacy-updates">11. Policy Changes</a></li>
+        </ol>
+      </nav>
 
-            <!-- Legal Content -->
-            <div class="p-8 md:p-12">
-                
+      <article class="legal-doc">
+ 
                 <!-- ========== TERMS OF SERVICE ========== -->
                 <section class="mb-16">
-                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-orange-500">Terms of Service</h2>
+                    <h2 class="legal-h2">Terms of Service</h2>
                     
                     <!-- Section 1 -->
                     <div id="tos-acceptance" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">1. Acceptance of Terms</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">1. Acceptance of Terms</h3>
+                        <div class="legal-copy">
                             <p>By accessing or using Origen TechnolOG ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you disagree with any part of these terms, you may not access the Service.</p>
                             <p>These Terms apply to all users of the Service, including without limitation users who are browsers, vendors, customers, merchants, and/or contributors of content.</p>
                         </div>
@@ -93,8 +225,8 @@
 
                     <!-- Section 2 -->
                     <div id="tos-service" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">2. Service Description</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">2. Service Description</h3>
+                        <div class="legal-copy">
                             <p>Origen TechnolOG is a cloud-based Customer Relationship Management (CRM) system designed for real estate professionals. The Service provides tools for contact management, task tracking, transaction management, document generation, and related business operations.</p>
                             <p>We reserve the right to modify, suspend, or discontinue the Service (or any part thereof) at any time with or without notice. We will not be liable to you or any third party for any modification, suspension, or discontinuance of the Service.</p>
                         </div>
@@ -102,8 +234,8 @@
 
                     <!-- Section 3 -->
                     <div id="tos-account" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">3. Account Registration and Security</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">3. Account Registration and Security</h3>
+                        <div class="legal-copy">
                             <p><strong>Registration Requirements:</strong></p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li>You must provide accurate, complete, and current information during registration</li>
@@ -119,8 +251,8 @@
 
                     <!-- Section 4 -->
                     <div id="tos-acceptable-use" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">4. Acceptable Use Policy</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">4. Acceptable Use Policy</h3>
+                        <div class="legal-copy">
                             <p>You agree not to use the Service to:</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li>Violate any laws, regulations, or third-party rights</li>
@@ -140,8 +272,8 @@
 
                     <!-- Section 5 -->
                     <div id="tos-subscription" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">5. Subscription and Payment Terms</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">5. Subscription and Payment Terms</h3>
+                        <div class="legal-copy">
                             <p><strong>Free Tier:</strong> We offer a free tier with limited features as described on our website. We reserve the right to modify free tier features at any time.</p>
                             <p><strong>Paid Subscriptions:</strong> When paid subscription tiers become available:</p>
                             <ul class="list-disc pl-6 space-y-2">
@@ -158,8 +290,8 @@
 
                     <!-- Section 6 -->
                     <div id="tos-data" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">6. Your Data and Intellectual Property</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">6. Your Data and Intellectual Property</h3>
+                        <div class="legal-copy">
                             <p><strong>Your Content:</strong> You retain all rights to the data, contacts, documents, and other content you upload to the Service ("Your Data"). You grant us a limited license to use, store, and process Your Data solely to provide the Service to you.</p>
                             <p><strong>Data Responsibility:</strong> You are solely responsible for:</p>
                             <ul class="list-disc pl-6 space-y-2">
@@ -175,8 +307,8 @@
 
                     <!-- Section 7 -->
                     <div id="tos-termination" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">7. Termination</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">7. Termination</h3>
+                        <div class="legal-copy">
                             <p><strong>By You:</strong> You may terminate your account at any time by contacting us or using the account cancellation feature. Termination takes effect at the end of your current billing period.</p>
                             <p><strong>By Us:</strong> We may suspend or terminate your account immediately if:</p>
                             <ul class="list-disc pl-6 space-y-2">
@@ -191,8 +323,8 @@
 
                     <!-- Section 8 -->
                     <div id="tos-liability" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">8. Disclaimers and Limitation of Liability</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">8. Disclaimers and Limitation of Liability</h3>
+                        <div class="legal-copy">
                             <p><strong>Disclaimer of Warranties:</strong> THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.</p>
                             <p>We do not warrant that:</p>
                             <ul class="list-disc pl-6 space-y-2">
@@ -208,17 +340,17 @@
                     </div>
 
                     <!-- Additional Sections -->
-                    <div class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">9. Governing Law and Dispute Resolution</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="tos-governing" class="legal-section mb-8">
+                        <h3 class="legal-h3">9. Governing Law and Dispute Resolution</h3>
+                        <div class="legal-copy">
                             <p>These Terms shall be governed by and construed in accordance with the laws of the United States, without regard to its conflict of law provisions.</p>
                             <p>Any disputes arising out of or relating to these Terms or the Service shall first be attempted to be resolved through good-faith negotiation. If negotiation fails, disputes shall be resolved through binding arbitration in accordance with the rules of the American Arbitration Association.</p>
                         </div>
                     </div>
 
-                    <div class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">10. General Provisions</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="tos-general" class="legal-section mb-8">
+                        <h3 class="legal-h3">10. General Provisions</h3>
+                        <div class="legal-copy">
                             <p><strong>Entire Agreement:</strong> These Terms constitute the entire agreement between you and Origen TechnolOG regarding the Service.</p>
                             <p><strong>Modifications:</strong> We may modify these Terms at any time by posting the revised Terms on our website. Your continued use of the Service after such changes constitutes acceptance of the new Terms.</p>
                             <p><strong>Severability:</strong> If any provision of these Terms is found to be unenforceable, the remaining provisions will remain in full force and effect.</p>
@@ -230,12 +362,12 @@
 
                 <!-- ========== PRIVACY POLICY ========== -->
                 <section>
-                    <h2 class="text-3xl font-bold text-slate-900 mb-8 pb-4 border-b-4 border-orange-500">Privacy Policy</h2>
+                    <h2 class="legal-h2">Privacy Policy</h2>
                     
                     <!-- Section 1 -->
                     <div id="privacy-intro" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">1. Introduction</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">1. Introduction</h3>
+                        <div class="legal-copy">
                             <p>Origen TechnolOG ("we," "us," or "our") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Service.</p>
                             <p>By using the Service, you consent to the data practices described in this Privacy Policy. If you do not agree with this Privacy Policy, please do not use the Service.</p>
                         </div>
@@ -243,8 +375,8 @@
 
                     <!-- Section 2 -->
                     <div id="privacy-collection" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">2. Information We Collect</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">2. Information We Collect</h3>
+                        <div class="legal-copy">
                             <p><strong>Information You Provide:</strong></p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li><strong>Account Information:</strong> Name, email address, phone number, company name, license number, username, and password</li>
@@ -267,8 +399,8 @@
 
                     <!-- Section 3 -->
                     <div id="privacy-usage" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">3. How We Use Your Information</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">3. How We Use Your Information</h3>
+                        <div class="legal-copy">
                             <p>We use the information we collect to:</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li><strong>Provide the Service:</strong> Create and manage your account, process transactions, and deliver requested features</li>
@@ -284,8 +416,8 @@
 
                     <!-- Section 4 -->
                     <div id="privacy-sharing" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">4. How We Share Your Information</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">4. How We Share Your Information</h3>
+                        <div class="legal-copy">
                             <p><strong>We do NOT sell your personal information.</strong> We may share information in the following circumstances:</p>
                             
                             <p><strong>Within Your Organization:</strong> Information is shared with other users in your organization as necessary to provide the Service (e.g., team members can see shared contacts).</p>
@@ -310,8 +442,8 @@
 
                     <!-- Section 5 -->
                     <div id="privacy-security" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">5. Data Security</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">5. Data Security</h3>
+                        <div class="legal-copy">
                             <p>We implement industry-standard security measures to protect your information:</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li><strong>Encryption:</strong> All data transmitted to and from the Service is encrypted using 256-bit SSL/TLS</li>
@@ -327,8 +459,8 @@
 
                     <!-- Section 6 -->
                     <div id="privacy-rights" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">6. Your Privacy Rights</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">6. Your Privacy Rights</h3>
+                        <div class="legal-copy">
                             <p>Depending on your location, you may have the following rights:</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li><strong>Access:</strong> Request a copy of the personal information we hold about you</li>
@@ -350,8 +482,8 @@
 
                     <!-- Section 7 -->
                     <div id="privacy-cookies" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">7. Cookies and Tracking Technologies</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                        <h3 class="legal-h3">7. Cookies and Tracking Technologies</h3>
+                        <div class="legal-copy">
                             <p>We use cookies and similar tracking technologies to enhance your experience:</p>
                             
                             <p><strong>Types of Cookies:</strong></p>
@@ -369,24 +501,24 @@
                     </div>
 
                     <!-- Section 8 -->
-                    <div id="privacy-changes" class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">8. Children's Privacy</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="privacy-children" class="legal-section mb-8">
+                        <h3 class="legal-h3">8. Children's Privacy</h3>
+                        <div class="legal-copy">
                             <p>The Service is not intended for individuals under the age of 18. We do not knowingly collect personal information from children. If you believe we have collected information from a child, please contact us immediately, and we will delete it.</p>
                         </div>
                     </div>
 
-                    <div class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">9. International Data Transfers</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="privacy-transfers" class="legal-section mb-8">
+                        <h3 class="legal-h3">9. International Data Transfers</h3>
+                        <div class="legal-copy">
                             <p>Your information may be transferred to and processed in countries other than your country of residence. These countries may have data protection laws different from your jurisdiction. By using the Service, you consent to such transfers.</p>
                             <p>When transferring data internationally, we implement appropriate safeguards such as Standard Contractual Clauses and ensure service providers comply with applicable data protection laws.</p>
                         </div>
                     </div>
 
-                    <div class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">10. Data Retention</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="privacy-retention" class="legal-section mb-8">
+                        <h3 class="legal-h3">10. Data Retention</h3>
+                        <div class="legal-copy">
                             <p>We retain your information for as long as necessary to provide the Service and fulfill the purposes described in this Privacy Policy, unless a longer retention period is required by law.</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li><strong>Active Accounts:</strong> Information retained while your account is active</li>
@@ -397,9 +529,9 @@
                         </div>
                     </div>
 
-                    <div class="legal-section mb-8">
-                        <h3 class="text-xl font-bold text-slate-800 mb-4">11. Changes to This Privacy Policy</h3>
-                        <div class="prose prose-slate max-w-none text-slate-700 space-y-3">
+                    <div id="privacy-updates" class="legal-section mb-8">
+                        <h3 class="legal-h3">11. Changes to This Privacy Policy</h3>
+                        <div class="legal-copy">
                             <p>We may update this Privacy Policy from time to time. We will notify you of material changes by:</p>
                             <ul class="list-disc pl-6 space-y-2">
                                 <li>Posting the updated policy on this page with a new "Last Updated" date</li>
@@ -411,26 +543,21 @@
                     </div>
                 </section>
 
-                <!-- Contact Information -->
-                <div class="mt-16 p-8 bg-slate-50 rounded-xl border-2 border-slate-200">
-                    <h3 class="text-2xl font-bold text-slate-900 mb-4">Contact Us</h3>
-                    <p class="text-slate-700 mb-4">If you have questions about these Terms of Service or Privacy Policy, or wish to exercise your privacy rights, please contact us:</p>
-                    <div class="space-y-2 text-slate-700">
-                        <p><strong>Email:</strong> <a href="mailto:info@origentechnolog.com" class="text-orange-600 hover:text-orange-700">info@origentechnolog.com</a></p>
-                        <p><strong>Website:</strong> <a href="{{ url_for('main.landing') }}" class="text-orange-600 hover:text-orange-700">{{ request.host }}</a></p>
-                        <p class="text-sm text-slate-500 mt-4">We will respond to your inquiry within 30 days.</p>
+                <div class="legal-callout">
+                    <h3 class="legal-h3">Contact us</h3>
+                    <div class="legal-copy">
+                        <p>If you have questions about these Terms of Service or Privacy Policy, or wish to exercise your privacy rights, please contact us:</p>
+                        <p><strong>Email:</strong> <a href="mailto:info@origentechnolog.com">info@origentechnolog.com</a></p>
+                        <p><strong>Website:</strong> <a href="{{ url_for('main.landing') }}">{{ request.host }}</a></p>
+                        <p class="legal-meta" style="margin-bottom:0">We will respond within 30 days.</p>
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <!-- Back to Top -->
-        <div class="text-center mt-8">
-            <a href="#" class="inline-flex items-center text-slate-600 hover:text-orange-600 transition-colors">
-                <i class="fas fa-arrow-up mr-2"></i>
-                Back to Top
-            </a>
-        </div>
+      </article>
     </div>
+
+    <a href="#" class="legal-top">
+      <i class="fas fa-arrow-up"></i> Back to top
+    </a>
+  </div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.7.2/dist/full.min.css" media="print" onload="this.media='all'">
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/fontawesome/css/all.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/nprogress/nprogress.min.css') }}" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/crm_toast.css') }}">
     <noscript>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@4.7.2/dist/full.min.css">
         <link rel="stylesheet" href="{{ url_for('static', filename='vendor/nprogress/nprogress.min.css') }}">
@@ -100,6 +101,29 @@
            one continuous dark panel with no dividing line. */
         body.crm-shell {
             background: linear-gradient(180deg, #0e1729 0%, #0a111f 60%, #070d18 100%);
+        }
+
+        /* Public auth pages: no app chrome. Login/register are their own layout. */
+        body.crm-auth-page {
+            background: #f4f4f4 !important;
+            overflow: auto;
+        }
+        body.crm-auth-page > header,
+        body.crm-auth-page aside#sidebar {
+            display: none !important;
+        }
+        body.crm-auth-page > .flex.flex-1 {
+            overflow: visible;
+        }
+        body.crm-auth-page main#mainContent {
+            margin-left: 0 !important;
+            border-radius: 0 !important;
+            background: #f4f4f4 !important;
+        }
+        body.crm-auth-page .content-wrapper {
+            padding: 0 !important;
+            min-height: 100%;
+            background: #f4f4f4 !important;
         }
 
         /* Top header: transparent (sits on the shared shell gradient) */
@@ -857,14 +881,6 @@
 
         .crm-sparkline--orange {
             color: var(--accent);
-        }
-
-        .toast-message {
-            transition: opacity 0.5s ease-out;
-        }
-
-        .toast-message.fade-out {
-            opacity: 0;
         }
 
         /* Add sidebar specific styles */
@@ -2249,7 +2265,7 @@
     {% block head_scripts %}{% endblock %}
 </head>
 
-<body class="crm-shell h-screen flex flex-col">
+<body class="crm-shell h-screen flex flex-col{% if request.endpoint in ('auth.login', 'auth.register', 'auth.reset_request', 'auth.reset_password', 'auth.accept_invite', 'auth.complete_invite', 'auth.terms_privacy', 'auth.registration_status') %} crm-auth-page{% endif %}">
 
     <!-- Top Header - Hidden on Mobile -->
     <header class="crm-topbar text-white h-14 items-center justify-between hidden md:flex">
@@ -2612,28 +2628,6 @@
     </div>
     {% endif %}
 
-    <!-- Flash Messages -->
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    <!-- Full-width container with flex + justify-center to center messages -->
-    <div class="fixed top-4 w-full flex justify-center z-50">
-        <div>
-            {% for category, message in messages %}
-            <div class="toast-message mb-4 p-4 rounded-md
-                        {% if category == 'error' %}
-                            bg-red-100 text-red-700
-                        {% else %}
-                            bg-green-100 text-green-700
-                        {% endif %}
-                    ">
-                {{ message }}
-            </div>
-            {% endfor %}
-        </div>
-    </div>
-    {% endif %}
-    {% endwith %}
-
     <div class="flex flex-1 overflow-hidden relative">
         <!-- Sidebar - Hidden on Mobile -->
         <aside id="sidebar"
@@ -2933,7 +2927,37 @@
     <!-- Contact Us Modal - Available on all pages -->
     {% include 'modals/contact_us_modal.html' %}
 
-    <!-- Base JS: sidebar, flash messages, user dropdown, tooltips, mobile menu -->
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% set toast_types = {
+        'error': 'error', 'danger': 'error',
+        'warning': 'warning', 'warn': 'warning',
+        'info': 'info',
+        'success': 'success', 'message': 'success'
+    } %}
+    {% set toast_icons = {
+        'success': 'fa-check',
+        'error': 'fa-exclamation',
+        'warning': 'fa-exclamation',
+        'info': 'fa-info'
+    } %}
+    <div id="crm-toast-region" class="crm-toast-region" role="region" aria-label="Notifications" aria-live="polite">
+        {% if messages %}
+            {% for category, message in messages %}
+                {% set toast_type = toast_types.get(category, 'success') %}
+        <div class="crm-toast crm-toast--{{ toast_type }} is-in" role="{{ 'alert' if toast_type == 'error' else 'status' }}">
+            <span class="crm-toast__icon" aria-hidden="true"><i class="fas {{ toast_icons.get(toast_type, 'fa-check') }}"></i></span>
+            <p class="crm-toast__message">{{ message }}</p>
+            <button type="button" class="crm-toast__close" aria-label="Dismiss">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+        </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+    {% endwith %}
+
+    <!-- Toasts, then base JS: sidebar, user dropdown, tooltips, mobile menu -->
+    <script src="{{ url_for('static', filename='js/crm_toast.js') }}"></script>
     <script src="{{ url_for('static', filename='js/base.js') }}"></script>
 
     <!-- Expandable sidebar: toggle + hover tooltips when collapsed -->

--- a/templates/contacts/form.html
+++ b/templates/contacts/form.html
@@ -5,13 +5,6 @@
 {% block content %}
 <div class="crm-page">
     <div class="crm-page__inner max-w-3xl">
-        <div id="toast-message" class="fixed top-4 left-1/2 z-50 hidden -translate-x-1/2 opacity-0 transition-opacity duration-300">
-            <div class="rounded-full border px-4 py-3 text-sm shadow-lg" style="background: var(--danger-soft); border-color: var(--hairline); color: var(--danger);">
-                <p class="font-semibold">Error</p>
-                <p>Please select at least one group.</p>
-            </div>
-        </div>
-
         <a href="{% if return_transaction_id %}{{ url_for('transactions.view_transaction', id=return_transaction_id) }}{% else %}{{ url_for('main.contacts') }}{% endif %}"
            class="crm-back mb-5">
             <i class="fas fa-chevron-left text-xs"></i>

--- a/templates/contacts/view.html
+++ b/templates/contacts/view.html
@@ -2325,23 +2325,9 @@
 
     // Simple toast notification
     function showToast(message, type = 'info') {
-        const toast = document.createElement('div');
-        toast.className = `fixed bottom-4 right-4 px-4 py-3 rounded-lg shadow-lg text-white z-50 transition-all duration-300 transform translate-y-2 opacity-0 ${type === 'success' ? 'bg-emerald-500' :
-            type === 'error' ? 'bg-red-500' : 'bg-slate-700'
-            }`;
-        toast.innerHTML = `<i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'} mr-2"></i>${message}`;
-        document.body.appendChild(toast);
-
-        // Animate in
-        requestAnimationFrame(() => {
-            toast.classList.remove('translate-y-2', 'opacity-0');
-        });
-
-        // Remove after 3 seconds
-        setTimeout(() => {
-            toast.classList.add('translate-y-2', 'opacity-0');
-            setTimeout(() => toast.remove(), 300);
-        }, 3000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
 
     // Drag and drop support

--- a/templates/modals/email_modal.html
+++ b/templates/modals/email_modal.html
@@ -837,27 +837,9 @@ window.emailModal = (function() {
     
     // Show toast notification
     function showToast(message, type = 'success') {
-        const toast = document.createElement('div');
-        toast.className = `fixed bottom-4 right-4 z-[400] px-6 py-3 rounded-xl shadow-lg text-white font-medium transform translate-y-full opacity-0 transition-all duration-300 ${
-            type === 'success' ? 'bg-green-500' : 'bg-red-500'
-        }`;
-        toast.innerHTML = `
-            <i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'} mr-2"></i>
-            ${message}
-        `;
-        
-        document.body.appendChild(toast);
-        
-        // Animate in
-        setTimeout(() => {
-            toast.classList.remove('translate-y-full', 'opacity-0');
-        }, 10);
-        
-        // Animate out and remove
-        setTimeout(() => {
-            toast.classList.add('translate-y-full', 'opacity-0');
-            setTimeout(() => toast.remove(), 300);
-        }, 3000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
     
     // Initialize event listeners

--- a/templates/transactions/document_field_editor.html
+++ b/templates/transactions/document_field_editor.html
@@ -1087,16 +1087,10 @@
         }
     }
     
-    // Toast notification
     function showToast(message, type = 'success') {
-        const toast = document.createElement('div');
-        toast.className = `fixed top-6 left-1/2 transform -translate-x-1/2 z-50 px-6 py-4 rounded-xl shadow-2xl text-white font-medium ${type === 'success' ? 'bg-teal-500' : 'bg-red-500'}`;
-        toast.innerHTML = `<i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'} mr-2"></i>${message}`;
-        document.body.appendChild(toast);
-        
-        setTimeout(() => {
-            toast.remove();
-        }, 3000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
 </script>
 {% endblock %}

--- a/templates/transactions/document_form.html
+++ b/templates/transactions/document_form.html
@@ -570,23 +570,9 @@
 
 <script>
     function showToast(message, type = 'info') {
-        const toast = document.getElementById('toast');
-        const icon = document.getElementById('toastIcon');
-        document.getElementById('toastMessage').textContent = message;
-
-        icon.className = 'fas';
-        if (type === 'success') {
-            icon.classList.add('fa-check-circle', 'text-green-500');
-        } else if (type === 'error') {
-            icon.classList.add('fa-exclamation-circle', 'text-red-500');
-        } else if (type === 'warning') {
-            icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
-        } else {
-            icon.classList.add('fa-info-circle', 'text-blue-500');
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
         }
-
-        toast.classList.remove('hidden');
-        setTimeout(() => toast.classList.add('hidden'), 4000);
     }
 
     function saveAndPreview() {

--- a/templates/transactions/document_preview.html
+++ b/templates/transactions/document_preview.html
@@ -356,25 +356,9 @@ function sendForSignature() {
 }
 
 function showToast(message, type) {
-    // Simple toast notification
-    const toast = document.createElement('div');
-    toast.className = `fixed bottom-24 sm:bottom-6 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
-        type === 'success' ? 'bg-green-600 text-white' : 
-        type === 'error' ? 'bg-red-600 text-white' : 
-        'bg-slate-800 text-white'
-    }`;
-    toast.innerHTML = `
-        <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
-        <span>${message}</span>
-    `;
-    document.body.appendChild(toast);
-    
-    setTimeout(() => {
-        toast.style.opacity = '0';
-        toast.style.transform = 'translateY(20px)';
-        toast.style.transition = 'all 0.3s ease-out';
-        setTimeout(() => toast.remove(), 300);
-    }, 3000);
+    if (typeof window.showCrmToast === 'function') {
+        return window.showCrmToast(message, type);
+    }
 }
 
 function printDocument() {

--- a/templates/transactions/fill_all_documents.html
+++ b/templates/transactions/fill_all_documents.html
@@ -1614,26 +1614,9 @@
     // =============================================================================
 
     function showToast(message, type = 'info') {
-        const toast = document.getElementById('toast');
-        const icon = document.getElementById('toastIcon');
-        document.getElementById('toastMessage').textContent = message;
-
-        toast.classList.remove('toast-warning');
-        icon.className = 'fas flex-shrink-0 text-lg';
-        if (type === 'success') {
-            icon.classList.add('fa-check-circle', 'text-green-500');
-        } else if (type === 'error') {
-            icon.classList.add('fa-exclamation-circle', 'text-red-500');
-        } else if (type === 'warning') {
-            icon.classList.add('fa-exclamation-triangle', 'text-amber-600');
-            toast.classList.add('toast-warning');
-        } else {
-            icon.classList.add('fa-info-circle', 'text-blue-500');
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
         }
-
-        toast.classList.remove('hidden');
-        const duration = type === 'warning' ? 6000 : 4000;
-        setTimeout(() => toast.classList.add('hidden'), duration);
     }
 
     function toggleCheckbox(element) {

--- a/templates/transactions/hoa_addendum_form.html
+++ b/templates/transactions/hoa_addendum_form.html
@@ -1035,23 +1035,9 @@
     // =============================================================================
 
     function showToast(message, type = 'info') {
-        const toast = document.getElementById('toast');
-        const icon = document.getElementById('toastIcon');
-        document.getElementById('toastMessage').textContent = message;
-
-        icon.className = 'fas';
-        if (type === 'success') {
-            icon.classList.add('fa-check-circle', 'text-green-500');
-        } else if (type === 'error') {
-            icon.classList.add('fa-exclamation-circle', 'text-red-500');
-        } else if (type === 'warning') {
-            icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
-        } else {
-            icon.classList.add('fa-info-circle', 'text-violet-500');
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
         }
-
-        toast.classList.remove('hidden');
-        setTimeout(() => toast.classList.add('hidden'), 4000);
     }
 
     function saveAndPreview() {

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -500,23 +500,9 @@ function confirmAndGenerate() {
 }
 
 function showToast(message, type = 'info') {
-    const toast = document.getElementById('toast');
-    const icon = document.getElementById('toastIcon');
-    document.getElementById('toastMessage').textContent = message;
-
-    icon.className = 'fas';
-    if (type === 'success') {
-        icon.classList.add('fa-check-circle', 'text-emerald-400');
-    } else if (type === 'error') {
-        icon.classList.add('fa-exclamation-circle', 'text-red-400');
-    } else if (type === 'warning') {
-        icon.classList.add('fa-exclamation-triangle', 'text-amber-400');
-    } else {
-        icon.classList.add('fa-info-circle', 'text-sky-400');
+    if (typeof window.showCrmToast === 'function') {
+        return window.showCrmToast(message, type);
     }
-
-    toast.classList.remove('hidden');
-    setTimeout(() => toast.classList.add('hidden'), 4000);
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/templates/transactions/listing_agreement_form.html
+++ b/templates/transactions/listing_agreement_form.html
@@ -1743,23 +1743,9 @@
     // =============================================================================
 
     function showToast(message, type = 'info') {
-        const toast = document.getElementById('toast');
-        const icon = document.getElementById('toastIcon');
-        document.getElementById('toastMessage').textContent = message;
-
-        icon.className = 'fas';
-        if (type === 'success') {
-            icon.classList.add('fa-check-circle', 'text-green-500');
-        } else if (type === 'error') {
-            icon.classList.add('fa-exclamation-circle', 'text-red-500');
-        } else if (type === 'warning') {
-            icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
-        } else {
-            icon.classList.add('fa-info-circle', 'text-blue-500');
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
         }
-
-        toast.classList.remove('hidden');
-        setTimeout(() => toast.classList.add('hidden'), 4000);
     }
 
     function saveAndPreview() {

--- a/templates/transactions/preview_all_documents.html
+++ b/templates/transactions/preview_all_documents.html
@@ -816,24 +816,9 @@
     const documentIds = [{% for doc in documents %}{{ doc.id }}{% if not loop.last %}, {% endif %}{% endfor %}];
     
     function showToast(message, type) {
-        const toast = document.createElement('div');
-        toast.className = `fixed bottom-24 sm:bottom-6 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
-            type === 'success' ? 'bg-green-600 text-white' : 
-            type === 'error' ? 'bg-red-600 text-white' : 
-            'bg-slate-800 text-white'
-        }`;
-        toast.innerHTML = `
-            <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
-            <span>${message}</span>
-        `;
-        document.body.appendChild(toast);
-        
-        setTimeout(() => {
-            toast.style.opacity = '0';
-            toast.style.transform = 'translateY(20px)';
-            toast.style.transition = 'all 0.3s ease-out';
-            setTimeout(() => toast.remove(), 300);
-        }, 5000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
     
     async function printAllDocuments() {

--- a/templates/transactions/seller_net_proceeds_form.html
+++ b/templates/transactions/seller_net_proceeds_form.html
@@ -1601,23 +1601,9 @@
     // =============================================================================
 
     function showToast(message, type = 'info') {
-        const toast = document.getElementById('toast');
-        const icon = document.getElementById('toastIcon');
-        document.getElementById('toastMessage').textContent = message;
-
-        icon.className = 'fas';
-        if (type === 'success') {
-            icon.classList.add('fa-check-circle', 'text-green-500');
-        } else if (type === 'error') {
-            icon.classList.add('fa-exclamation-circle', 'text-red-500');
-        } else if (type === 'warning') {
-            icon.classList.add('fa-exclamation-triangle', 'text-amber-500');
-        } else {
-            icon.classList.add('fa-info-circle', 'text-blue-500');
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
         }
-
-        toast.classList.remove('hidden');
-        setTimeout(() => toast.classList.add('hidden'), 4000);
     }
 
     function saveAndPreview() {

--- a/templates/transactions/simple_preview.html
+++ b/templates/transactions/simple_preview.html
@@ -379,24 +379,9 @@
     }
     
     function showToast(message, type) {
-        const toast = document.createElement('div');
-        toast.className = `fixed bottom-24 right-6 px-6 py-4 rounded-xl shadow-2xl z-50 flex items-center gap-3 ${
-            type === 'success' ? 'bg-green-600 text-white' : 
-            type === 'error' ? 'bg-red-600 text-white' : 
-            'bg-slate-800 text-white'
-        }`;
-        toast.innerHTML = `
-            <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
-            <span>${message}</span>
-        `;
-        document.body.appendChild(toast);
-        
-        setTimeout(() => {
-            toast.style.opacity = '0';
-            toast.style.transform = 'translateY(20px)';
-            toast.style.transition = 'all 0.3s ease-out';
-            setTimeout(() => toast.remove(), 300);
-        }, 3000);
+        if (typeof window.showCrmToast === 'function') {
+            return window.showCrmToast(message, type);
+        }
     }
     
     function printDocument() {

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -7,6 +7,7 @@ from tier_config.tier_limits import get_tier_defaults
 ROOT = Path(__file__).resolve().parents[1]
 LANDING = (ROOT / "templates" / "landing.html").read_text()
 REGISTER = (ROOT / "templates" / "auth" / "register.html").read_text()
+TERMS = (ROOT / "templates" / "auth" / "terms_privacy.html").read_text()
 FREE_LIMITS = get_tier_defaults("free")
 
 BANNED_LEFTOVERS = (
@@ -156,12 +157,25 @@ class TestRegisterLeftoverCopy:
         assert "250, 36, 60" not in REGISTER
         assert "@keyframes glow" not in REGISTER
 
-    def test_register_orbs_use_brand_orange(self):
-        assert "249, 115, 22" in REGISTER
-        assert "234, 88, 12" in REGISTER
+    def test_register_decorative_orbs_are_gone(self):
+        assert ".orb" not in REGISTER
+        assert "@keyframes pulse-soft" not in REGISTER
+        assert "@keyframes shimmer" not in REGISTER
+        assert "font-family: 'Inter'" not in REGISTER
+        assert "premium-card" not in REGISTER
 
     def test_register_does_not_claim_unlimited_contacts(self):
         assert "Unlimited contacts" not in REGISTER
         assert "unlimited contacts" not in REGISTER
         assert "Unlimited Contacts" not in REGISTER
         assert "Up to 10,000 contacts" in REGISTER
+
+
+class TestTermsPrivacyLayout:
+    def test_does_not_use_invertible_tailwind_surfaces(self):
+        assert "bg-slate-900" not in TERMS
+        assert "text-white" not in TERMS
+        assert "toc-link" not in TERMS
+        assert "Quick Navigation" not in TERMS
+        assert "legal-page" in TERMS
+        assert "On this page" in TERMS


### PR DESCRIPTION
## Summary
- Site-wide toasts sit above the glass topbar as compact paper cards instead of mint pills under the chrome.
- Register matches login (split card, no orbs/Inter), and public auth pages no longer show app chrome.
- Terms & privacy uses scoped legal surfaces so Atelier no longer inverts the TOC into white-on-gray.

## Test plan
- [ ] Trigger a Flask flash (save a contact, login error) and confirm the toast is readable, above the topbar, and auto-dismisses.
- [ ] Open `/register` and confirm it matches `/login`, with no sidebar/topbar and a working form.
- [ ] Open `/terms-privacy` in light and dark: TOC and body copy both readable, nav links jump to the right sections.
- [ ] Confirm local `showToast` calls (transaction detail, document mapper, email modal) still surface through the shared toaster.


Made with [Cursor](https://cursor.com)