### PR TITLE
fix: fold change an email into B.O.B. public copy

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,7 +10,7 @@ Origen TechnolOG is a free CRM for real estate agents. Use it to organize contac
 - Setup takes about 2 minutes.
 - One user, up to 10,000 contacts.
 - Contact management, task reminders, and Google email/calendar integration are on the free tier.
-- B.O.B. is the built-in assistant. Ask how many clients are in a ZIP. Tell it to add a contact, complete a task, or log a call. Changing an email waits for Confirm (15 minutes). 25 messages a day on the free plan.
+- B.O.B. is the built-in assistant. Ask how many clients are in a ZIP. Tell it to add a contact, change an email, complete a task, or log a call. 25 messages a day on the free plan.
 - Message B.O.B. on Telegram after you scan a QR from your profile.
 
 ## Public pages

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -70,7 +70,7 @@
               "name": "What is B.O.B.?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
+                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
               }
             }
           ]
@@ -282,7 +282,7 @@
                         The free tier is one user, up to 10,000 contacts, and 25 B.O.B. messages a day. Load your database, then put a due date on the next call so it isn't stuck in your notes app. Gmail send and Google Calendar task sync are included.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
-                        Ask B.O.B. to count clients in a ZIP, add a contact, or complete a task. Changing an email waits for Confirm (15 minutes). Message B.O.B. on Telegram after you scan a QR from your profile.
+                        Ask B.O.B. to count clients in a ZIP, add a contact, change an email, or complete a task. Message B.O.B. on Telegram after you scan a QR from your profile.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed">
                         Built for real estate agents, by real estate agents.
@@ -326,7 +326,7 @@
                 </details>
                 <details>
                     <summary>What is B.O.B.?</summary>
-                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
+                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
                 </details>
             </div>
         </div>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -86,7 +86,7 @@
               "name": "What is B.O.B.?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
+                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
               }
             }
           ]
@@ -589,7 +589,7 @@
                         </div>
                         <h3 class="text-2xl lg:text-3xl font-bold text-brand-900 mb-3">Talk to B.O.B.</h3>
                         <p class="text-brand-600 text-lg leading-relaxed">
-                            Ask how many clients are in a ZIP or city. Tell B.O.B. to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes).
+                            Ask how many clients are in a ZIP or city. Tell B.O.B. to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group.
                         </p>
                         <p class="text-brand-600 mt-3 leading-relaxed">
                             25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.
@@ -598,7 +598,7 @@
                     <ul class="space-y-3 text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Create a contact or complete a task
+                            Create a contact, change an email, or complete a task
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
@@ -1157,7 +1157,7 @@
                 </details>
                 <details>
                     <summary>What is B.O.B.?</summary>
-                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
+                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
                 </details>
             </div>
         </div>

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -64,7 +64,7 @@ FAQ_ITEMS = (
     ),
     (
         "What is B.O.B.?",
-        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
+        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
     ),
 )
 FAKE_SEO_QUESTIONS = (
@@ -132,6 +132,9 @@ class TestFreeRealEstateCrmRoute:
         assert "AI assistant" not in text
         assert "One user, up to 10,000 contacts." in text
         assert "25 messages a day on the free plan." in text
+        assert "change an email" in text
+        assert "Changing an email waits for Confirm (15 minutes)." not in text
+        assert "Confirm (15 minutes)" not in text
 
     def test_blocked_marketing_urls_are_not_built(self, client):
         for path in BLOCKED_SEO_PATHS:
@@ -242,7 +245,13 @@ class TestFreeRealEstateCrmCopy:
         assert question == "What is B.O.B.?"
         assert answer in PAGE
         assert answer in LANDING
-        assert "Confirm (15 minutes)" in answer
+        assert "add a contact, change an email, or complete a task" in PAGE
+        assert "change an email" in answer
+        assert "Confirm (15 minutes)" not in PAGE
+        assert "Confirm (15 minutes)" not in answer
+        assert "waits for Confirm" not in answer
+        assert "waits for a yes" not in answer
+        assert "until you say yes" not in answer
         assert "25 messages a day on the free plan" in answer
         assert "in the CRM or on Telegram" not in answer
         assert "same 25" not in PAGE.lower()

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -65,7 +65,7 @@ FAQ_ITEMS = (
     ),
     (
         "What is B.O.B.?",
-        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, complete a task, or log a call. It can add a note or put someone in a group. Changing an email waits for Confirm (15 minutes). You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
+        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
     ),
 )
 
@@ -179,6 +179,10 @@ class TestLandingLeftoverCopy:
             assert "10,000 contacts" in source
             assert "25 messages a day" in source or "25 B.O.B. messages a day" in source
             assert "Unlimited contacts" not in source
+            assert "Changing an email waits for Confirm (15 minutes)." not in source
+            assert "Confirm (15 minutes)" not in source
+            assert "waits for a yes" not in source
+            assert "until you say yes" not in source
         assert "One user" in LANDING or "1 user" in LANDING
         assert "one user" in FREE_CRM
         assert "One user" in LLMS
@@ -186,8 +190,12 @@ class TestLandingLeftoverCopy:
     def test_bob_is_a_headline_feature_with_real_tools(self):
         assert "Talk to B.O.B." in LANDING
         assert "Ask how many clients are in a ZIP or city." in LANDING
-        assert "add a contact, complete a task, or log a call" in LANDING
-        assert "Changing an email waits for Confirm (15 minutes)." in LANDING
+        assert "add a contact, change an email, complete a task, or log a call" in LANDING
+        assert "change an email" in LANDING
+        assert "Changing an email waits for Confirm (15 minutes)." not in LANDING
+        assert "Confirm (15 minutes)" not in LANDING
+        assert "waits for a yes" not in LANDING
+        assert "until you say yes" not in LANDING
         assert "25 messages a day" in LANDING
         assert "25/day free" in LANDING
         assert "AI-Powered B.O.B." not in LANDING
@@ -231,7 +239,11 @@ class TestLandingLeftoverCopy:
         assert "25 messages a day" in answer
         assert "Telegram" in answer
         assert "ZIP" in answer
-        assert "Confirm (15 minutes)" in answer
+        assert "change an email" in answer
+        assert "Confirm (15 minutes)" not in answer
+        assert "waits for Confirm" not in answer
+        assert "waits for a yes" not in answer
+        assert "until you say yes" not in answer
         assert "in the CRM or on Telegram" not in answer
         assert "AI" not in answer
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Removes the live Confirm sentence from public B.O.B. copy and folds “change an email” into the existing capability list.

## Why
Christopher rejected both the Confirm/15-minutes sentence and any replacement that still talked about waiting. The public copy should just say B.O.B. can change an email.

## Copy
Landing card body now matches:

> Ask how many clients are in a ZIP or city. Tell B.O.B. to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group.

The next paragraph is unchanged:

> 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.

FAQ “What is B.O.B.?” and FAQPage JSON-LD stay 1:1 with the visible FAQ. Same fold-in on `/free-real-estate-crm` and `llms.txt`. Register had no Confirm line, so it was left alone. Feature checklist first bullet now includes “change an email” (no fourth confirming bullet).

## Not in this PR
- No mention of Confirm, approval, waiting, or 15 minutes
- No title/H1 restuff
- No feature flag changes
- Do not merge

## Tests
Copy tests now lock the new sentence, require FAQ visible == JSON-LD, and reject leftover Confirm/wait phrasing. Still no “AI”, no unlimited contacts, no “same 25”.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b93df97-7cc7-45e4-b5cd-02a4d715d554?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b93df97-7cc7-45e4-b5cd-02a4d715d554&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

