### PR TITLE
feat: use Christopher's B.O.B. FAQ copy on public pages

### DIFF
--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -67,10 +67,10 @@
             },
             {
               "@type": "Question",
-              "name": "What is B.O.B.?",
+              "name": "What can B.O.B. do?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
+                "text": "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.\n\nThe free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile."
               }
             }
           ]
@@ -325,8 +325,9 @@
                     <p class="faq-answer">No. Paid features come later. Nothing paid is for sale today.</p>
                 </details>
                 <details>
-                    <summary>What is B.O.B.?</summary>
-                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
+                    <summary>What can B.O.B. do?</summary>
+                    <p class="faq-answer">B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.</p>
+                    <p class="faq-answer">The free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.</p>
                 </details>
             </div>
         </div>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -83,10 +83,10 @@
             },
             {
               "@type": "Question",
-              "name": "What is B.O.B.?",
+              "name": "What can B.O.B. do?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile."
+                "text": "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.\n\nThe free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile."
               }
             }
           ]
@@ -1156,8 +1156,9 @@
                     <p class="faq-answer">Yes. Contacts, follow-ups, and tasks are set up the way agents actually work, not as a generic CRM.</p>
                 </details>
                 <details>
-                    <summary>What is B.O.B.?</summary>
-                    <p class="faq-answer">B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.</p>
+                    <summary>What can B.O.B. do?</summary>
+                    <p class="faq-answer">B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.</p>
+                    <p class="faq-answer">The free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.</p>
                 </details>
             </div>
         </div>

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -63,10 +63,28 @@ FAQ_ITEMS = (
         "No. Paid features come later. Nothing paid is for sale today.",
     ),
     (
-        "What is B.O.B.?",
-        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
+        "What can B.O.B. do?",
+        "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.\n\nThe free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.",
     ),
 )
+
+
+def _faq_paragraphs(answer):
+    return tuple(part for part in answer.split("\n\n") if part)
+
+
+def _json_ld_answer(answer):
+    return "\\n\\n".join(_faq_paragraphs(answer))
+
+
+def _copy_without_bob_faq(html):
+    question, answer = FAQ_ITEMS[3]
+    stripped = html.replace(question, "")
+    for para in _faq_paragraphs(answer):
+        stripped = stripped.replace(para, "")
+    return stripped
+
+
 FAKE_SEO_QUESTIONS = (
     "origentech",
     "Is this HubSpot",
@@ -222,11 +240,12 @@ class TestFreeRealEstateCrmCopy:
         assert PAGE.count('"@type": "Question"') == 4
         for question, answer in FAQ_ITEMS:
             assert PAGE.count(question) == 2
-            assert PAGE.count(answer) == 2
             assert f"<summary>{question}</summary>" in PAGE
-            assert f'<p class="faq-answer">{answer}</p>' in PAGE
             assert f'"name": "{question}"' in PAGE
-            assert f'"text": "{answer}"' in PAGE
+            assert f'"text": "{_json_ld_answer(answer)}"' in PAGE
+            for para in _faq_paragraphs(answer):
+                assert PAGE.count(para) == 2
+                assert f'<p class="faq-answer">{para}</p>' in PAGE
         include_answer = FAQ_ITEMS[0][1]
         assert "One user" in include_answer
         assert "10,000 contacts" in include_answer
@@ -236,22 +255,31 @@ class TestFreeRealEstateCrmCopy:
         for phrase in FAKE_SEO_QUESTIONS:
             assert phrase.lower() not in PAGE.lower()
 
-    def test_no_ai_word_in_visible_copy(self):
-        assert re.search(r"\bAI\b", _visible_copy(PAGE)) is None
-        assert re.search(r"\bAI\b", PAGE) is None
+    def test_no_ai_word_outside_bob_faq(self):
+        visible = _visible_copy(_copy_without_bob_faq(PAGE))
+        assert re.search(r"\bAI\b", visible) is None
+        assert re.search(r"\bAI\b", _copy_without_bob_faq(PAGE)) is None
 
-    def test_bob_faq_matches_home_card(self):
+    def test_bob_faq_is_verbatim_and_card_stays(self):
         question, answer = FAQ_ITEMS[3]
-        assert question == "What is B.O.B.?"
-        assert answer in PAGE
-        assert answer in LANDING
+        assert question == "What can B.O.B. do?"
+        assert "AI assistant" in answer
+        assert "If you can do it in Origen" in answer
+        assert "The free plan includes 25 messages a day" in answer
+        assert "Telegram" in answer
+        assert "from your profile" in answer
+        for para in _faq_paragraphs(answer):
+            assert f'<p class="faq-answer">{para}</p>' in PAGE
+            assert f'<p class="faq-answer">{para}</p>' in LANDING
         assert "add a contact, change an email, or complete a task" in PAGE
-        assert "change an email" in answer
+        assert "change an email" not in answer
+        assert "ZIP" not in answer
+        assert "What is B.O.B.?" not in PAGE
+        assert "B.O.B. is the built-in assistant." not in PAGE
         assert "Confirm (15 minutes)" not in PAGE
         assert "Confirm (15 minutes)" not in answer
         assert "waits for Confirm" not in answer
         assert "waits for a yes" not in answer
         assert "until you say yes" not in answer
-        assert "25 messages a day on the free plan" in answer
         assert "in the CRM or on Telegram" not in answer
         assert "same 25" not in PAGE.lower()

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -44,6 +44,8 @@ DELETED_FAQ = (
     "Straight answers. No pitch.",
     "Questions people ask",
     "Origen TechnolOG (origentechnolog.com) is not Origen Tech, Origen-Tech, or Origin CRM.",
+    "What is B.O.B.?",
+    "B.O.B. is the built-in assistant.",
 )
 
 FAQ_ITEMS = (
@@ -64,10 +66,26 @@ FAQ_ITEMS = (
         "Yes. Contacts, follow-ups, and tasks are set up the way agents actually work, not as a generic CRM.",
     ),
     (
-        "What is B.O.B.?",
-        "B.O.B. is the built-in assistant. Ask how many clients are in a ZIP or city. Tell it to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group. You get 25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.",
+        "What can B.O.B. do?",
+        "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.\n\nThe free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.",
     ),
 )
+
+
+def _faq_paragraphs(answer):
+    return tuple(part for part in answer.split("\n\n") if part)
+
+
+def _json_ld_answer(answer):
+    return "\\n\\n".join(_faq_paragraphs(answer))
+
+
+def _copy_without_bob_faq(html):
+    question, answer = FAQ_ITEMS[4]
+    stripped = html.replace(question, "")
+    for para in _faq_paragraphs(answer):
+        stripped = stripped.replace(para, "")
+    return stripped
 
 
 class TestLandingLeftoverCopy:
@@ -109,11 +127,12 @@ class TestLandingLeftoverCopy:
         assert LANDING.count('"@type": "Question"') == 5
         for question, answer in FAQ_ITEMS:
             assert LANDING.count(question) == 2
-            assert LANDING.count(answer) == 2
             assert f"<summary>{question}</summary>" in LANDING
-            assert f'<p class="faq-answer">{answer}</p>' in LANDING
             assert f'"name": "{question}"' in LANDING
-            assert f'"text": "{answer}"' in LANDING
+            assert f'"text": "{_json_ld_answer(answer)}"' in LANDING
+            for para in _faq_paragraphs(answer):
+                assert LANDING.count(para) == 2
+                assert f'<p class="faq-answer">{para}</p>' in LANDING
 
     def test_old_faq_copy_is_gone(self):
         for phrase in DELETED_FAQ:
@@ -162,10 +181,11 @@ class TestLandingLeftoverCopy:
         assert "never be a paid" not in LANDING.lower()
         assert "Extra features later will be paid" in LANDING
 
-    def test_no_ai_word_in_visible_landing_or_register_copy(self):
-        for source in (LANDING, REGISTER, FREE_CRM):
-            visible = _visible_public_copy(source)
+    def test_no_ai_word_outside_bob_faq(self):
+        for source in (LANDING, FREE_CRM):
+            visible = _visible_public_copy(_copy_without_bob_faq(source))
             assert re.search(r"\bAI\b", visible) is None
+        assert re.search(r"\bAI\b", _visible_public_copy(REGISTER)) is None
         assert re.search(r"\bAI\b", LLMS) is None
         assert "AI assistant" not in LLMS
 
@@ -235,17 +255,19 @@ class TestLandingLeftoverCopy:
 
     def test_bob_faq_mentions_crm_work_and_telegram(self):
         question, answer = FAQ_ITEMS[4]
-        assert question == "What is B.O.B.?"
+        assert question == "What can B.O.B. do?"
+        assert "AI assistant" in answer
+        assert "If you can do it in Origen" in answer
         assert "25 messages a day" in answer
         assert "Telegram" in answer
-        assert "ZIP" in answer
-        assert "change an email" in answer
+        assert "from your profile" in answer
+        assert "ZIP" not in answer
+        assert "change an email" not in answer
         assert "Confirm (15 minutes)" not in answer
         assert "waits for Confirm" not in answer
         assert "waits for a yes" not in answer
         assert "until you say yes" not in answer
         assert "in the CRM or on Telegram" not in answer
-        assert "AI" not in answer
 
 
 class TestRegisterLeftoverCopy:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the public B.O.B. FAQ with Christopher's verbatim copy. Visible FAQ and FAQPage JSON-LD stay 1:1.

## What changed

- Homepage FAQ in `templates/landing.html`: "What is B.O.B.?" becomes **"What can B.O.B. do?"** with the two-paragraph answer (still 5 FAQ items).
- Matching homepage FAQPage JSON-LD (`name` + `acceptedAnswer.text`).
- Same question and answer on `/free-real-estate-crm` visible FAQ and JSON-LD.
- Tests no longer lock the old question, ZIP laundry list, or a shared FAQ/card string. The Talk to B.O.B. feature card is unchanged. "AI assistant" stays in the FAQ.

## What did not change

- Talk to B.O.B. feature card
- Title / H1
- Feature flags
- No em dashes
- Not merged

## Copy (verbatim)

**What can B.O.B. do?**

B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.

The free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5448f389-ee12-4bac-92c3-f250e50627eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5448f389-ee12-4bac-92c3-f250e50627eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

