### PR TITLE
feat: Follow Up Boss alternative page + homepage free-CRM link

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -437,6 +437,12 @@ def free_real_estate_crm():
     return render_template('free_real_estate_crm.html', current_year=datetime.now().year)
 
 
+@main_bp.route('/follow-up-boss-alternative')
+def follow_up_boss_alternative():
+    """Public Follow Up Boss alternative page. Always 200, even if logged in."""
+    return render_template('follow_up_boss_alternative.html', current_year=datetime.now().year)
+
+
 # =============================================================================
 # CONTACTS LIST (Authenticated)
 # =============================================================================

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -20,3 +20,4 @@ Origen TechnolOG is a free CRM for real estate agents. Use it to organize contac
 - https://www.origentechnolog.com/login
 - https://www.origentechnolog.com/terms-privacy
 - https://www.origentechnolog.com/free-real-estate-crm
+- https://www.origentechnolog.com/follow-up-boss-alternative

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -15,4 +15,7 @@
   <url>
     <loc>https://www.origentechnolog.com/free-real-estate-crm</loc>
   </url>
+  <url>
+    <loc>https://www.origentechnolog.com/follow-up-boss-alternative</loc>
+  </url>
 </urlset>

--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -1,0 +1,420 @@
+{% from "components/seo_meta.html" import public_seo %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Follow Up Boss alternative | Origen TechnolOG</title>
+    {{ public_seo(
+        title="Follow Up Boss alternative | Origen TechnolOG",
+        description="Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes.",
+        canonical=app_base_url ~ "/follow-up-boss-alternative"
+    ) }}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": "{{ app_base_url }}/#organization",
+          "name": "Origen TechnolOG",
+          "url": "{{ app_base_url }}/",
+          "logo": "{{ app_base_url }}/static/images/logo_og_dark.png"
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "{{ app_base_url }}/follow-up-boss-alternative#software",
+          "name": "Origen TechnolOG",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web",
+          "isAccessibleForFree": true,
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+          },
+          "description": "Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes.",
+          "url": "{{ app_base_url }}/follow-up-boss-alternative",
+          "publisher": { "@id": "{{ app_base_url }}/#organization" }
+        },
+        {
+          "@type": "FAQPage",
+          "@id": "{{ app_base_url }}/follow-up-boss-alternative#faq",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "How much is Follow Up Boss?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Does Follow Up Boss have a free plan?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "No. They offer a 14-day trial. Full access, no credit card required for those 14 days."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "What does Origen include?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Can I buy Pro today?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "No. Paid features come later. Nothing paid is for sale today."
+              }
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['DM Sans', 'system-ui', 'sans-serif'],
+                    },
+                    colors: {
+                        brand: {
+                            50: '#f0f4f8',
+                            100: '#d9e2ec',
+                            200: '#bcccdc',
+                            300: '#9fb3c8',
+                            400: '#829ab1',
+                            500: '#627d98',
+                            600: '#486581',
+                            700: '#334e68',
+                            800: '#243b53',
+                            900: '#102a43',
+                        },
+                        accent: {
+                            50: '#fff7ed',
+                            100: '#ffedd5',
+                            200: '#fed7aa',
+                            300: '#fdba74',
+                            400: '#fb923c',
+                            500: '#f97316',
+                            600: '#ea580c',
+                            700: '#c2410c',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .hero-bg {
+            background-color: #f8fafc;
+            background-image:
+                radial-gradient(ellipse at 20% 0%, rgba(249, 115, 22, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 100%, rgba(36, 59, 83, 0.06) 0%, transparent 50%),
+                url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23334e68' fill-opacity='0.03'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+        .nav-blur {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        .btn-primary {
+            position: relative;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px -8px rgba(249, 115, 22, 0.4);
+        }
+        .mobile-menu {
+            transform: translateX(100%);
+            transition: transform 0.3s ease;
+        }
+        .mobile-menu.open {
+            transform: translateX(0);
+        }
+        .landing-faq {
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+        .landing-faq details {
+            border-bottom: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq details:first-of-type {
+            border-top: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq summary {
+            list-style: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1.15rem 0;
+            font-size: 1.05rem;
+            font-weight: 600;
+            color: #102a43;
+        }
+        .landing-faq summary::-webkit-details-marker {
+            display: none;
+        }
+        .landing-faq summary::after {
+            content: '';
+            width: 10px;
+            height: 10px;
+            flex-shrink: 0;
+            border-right: 1.5px solid #627d98;
+            border-bottom: 1.5px solid #627d98;
+            transform: rotate(45deg);
+            margin-top: -4px;
+        }
+        .landing-faq details[open] summary {
+            color: #ea580c;
+        }
+        .landing-faq details[open] summary::after {
+            border-color: #f97316;
+            transform: rotate(225deg);
+            margin-top: 4px;
+        }
+        .landing-faq .faq-answer {
+            padding: 0 0 1.15rem;
+            color: #486581;
+            font-size: 1rem;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+
+<body class="font-sans antialiased text-brand-800">
+
+    <nav class="fixed top-0 left-0 right-0 z-50 nav-blur bg-white/90 border-b border-brand-100/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 md:h-20">
+                <a href="{{ url_for('main.landing') }}" class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </a>
+
+                <div class="hidden md:flex items-center gap-8">
+                    <a href="{{ url_for('main.landing') }}#features" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Pricing</a>
+                </div>
+
+                <div class="hidden md:flex items-center gap-4">
+                    <a href="{{ url_for('auth.login') }}" class="text-brand-700 hover:text-brand-900 font-semibold transition-colors">
+                        Log In
+                    </a>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                        <i class="fas fa-arrow-right text-sm"></i>
+                    </a>
+                </div>
+
+                <button id="mobileMenuBtn" class="md:hidden p-2 text-brand-700 hover:text-brand-900">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </div>
+
+        <div id="mobileMenuOverlay" class="fixed inset-0 bg-black/50 z-40 md:hidden opacity-0 pointer-events-none transition-opacity duration-300"></div>
+
+        <div id="mobileMenu" class="mobile-menu fixed top-0 right-0 w-80 h-screen md:hidden z-50" style="background-color: #ffffff;">
+            <div class="p-6 h-full bg-white">
+                <button id="closeMobileMenu" class="absolute top-4 right-4 p-2 text-brand-600 hover:text-brand-900 z-10">
+                    <i class="fas fa-times text-xl"></i>
+                </button>
+
+                <div class="mt-12 space-y-6">
+                    <a href="{{ url_for('main.landing') }}#features" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="block text-lg font-medium text-brand-700 hover:text-accent-500">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Pricing</a>
+
+                    <hr class="border-brand-100">
+
+                    <a href="{{ url_for('auth.login') }}" class="block text-lg font-semibold text-brand-800">Log In</a>
+                    <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-bg pt-24 md:pt-32 pb-16 md:pb-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
+                    A Follow Up Boss alternative you can start tonight.
+                </h1>
+                <p class="text-lg sm:text-xl text-brand-600 mb-8">
+                    Follow Up Boss Grow is $69 per user per month on their pricing page. There is no free plan. You get a 14-day trial with full access and no credit card. After that they charge. Origen is $0 to start, no credit card, and the free plan stays free. One user, up to 10,000 contacts, 25 B.O.B. messages a day.
+                </p>
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section class="bg-white py-16 md:py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl space-y-10">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Price and limits</h2>
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-left text-brand-700">
+                            <thead>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-900"> </th>
+                                    <th class="py-3 pr-4 font-semibold text-brand-900">Follow Up Boss</th>
+                                    <th class="py-3 font-semibold text-brand-900">Origen</th>
+                                </tr>
+                            </thead>
+                            <tbody class="align-top">
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Price</th>
+                                    <td class="py-3 pr-4">Grow is $69 per user per month ($58 billed annually)</td>
+                                    <td class="py-3">$0</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Free plan</th>
+                                    <td class="py-3 pr-4">No. They offer a 14-day trial.</td>
+                                    <td class="py-3">Yes</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Card</th>
+                                    <td class="py-3 pr-4">The trial has no card. Then they charge.</td>
+                                    <td class="py-3">No card. The free plan stays free.</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Contacts</th>
+                                    <td class="py-3 pr-4">Unlimited (their pricing)</td>
+                                    <td class="py-3">Up to 10,000</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Users</th>
+                                    <td class="py-3 pr-4">Per seat</td>
+                                    <td class="py-3">1</td>
+                                </tr>
+                                <tr>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Fit</th>
+                                    <td class="py-3 pr-4">Their FAQ says they are not for anyone who "Generates less than 30 leads per month."</td>
+                                    <td class="py-3">We do not publish a lead count.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <p class="text-lg text-brand-600 leading-relaxed">
+                    Follow Up Boss publishes unlimited contacts, lead sources, and team plans. They also sell Calling and Action Plans. We do not have those, and we are not a replacement for them.
+                </p>
+                <p class="text-lg text-brand-600 leading-relaxed">
+                    Built for real estate agents, by real estate agents. Free is the product. Paid features come later. Nothing paid is for sale today.
+                </p>
+                <p class="text-lg text-brand-600 leading-relaxed">
+                    More on Origen is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>. Or start from the <a href="{{ url_for('main.landing') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">homepage</a>.
+                </p>
+
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section id="faq" class="bg-[#f4f4f4] py-16 md:py-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-10">Common questions</h2>
+            <div class="landing-faq">
+                <details>
+                    <summary>How much is Follow Up Boss?</summary>
+                    <p class="faq-answer">Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user.</p>
+                </details>
+                <details>
+                    <summary>Does Follow Up Boss have a free plan?</summary>
+                    <p class="faq-answer">No. They offer a 14-day trial. Full access, no credit card required for those 14 days.</p>
+                </details>
+                <details>
+                    <summary>What does Origen include?</summary>
+                    <p class="faq-answer">One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.</p>
+                </details>
+                <details>
+                    <summary>Can I buy Pro today?</summary>
+                    <p class="faq-answer">No. Paid features come later. Nothing paid is for sale today.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <footer class="bg-brand-900 py-12">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col md:flex-row items-center justify-between gap-6">
+                <div class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </div>
+
+                <div class="flex items-center gap-6 text-brand-400 text-sm">
+                    <a href="{{ url_for('auth.login') }}" class="hover:text-white transition-colors">Login</a>
+                    <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
+                    <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
+                    <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                </div>
+
+                <div class="text-brand-500 text-sm">
+                    &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+        const closeMobileMenu = document.getElementById('closeMobileMenu');
+        const mobileMenu = document.getElementById('mobileMenu');
+        const mobileMenuOverlay = document.getElementById('mobileMenuOverlay');
+
+        function openMobileMenu() {
+            mobileMenu.classList.add('open');
+            mobileMenuOverlay.classList.remove('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.add('opacity-100');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeMobileMenuFn() {
+            mobileMenu.classList.remove('open');
+            mobileMenuOverlay.classList.add('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.remove('opacity-100');
+            document.body.style.overflow = '';
+        }
+
+        mobileMenuBtn.addEventListener('click', openMobileMenu);
+        closeMobileMenu.addEventListener('click', closeMobileMenuFn);
+        mobileMenuOverlay.addEventListener('click', closeMobileMenuFn);
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', closeMobileMenuFn);
+        });
+    </script>
+
+    {% include 'modals/contact_us_modal.html' %}
+
+</body>
+</html>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1161,6 +1161,9 @@
                     <p class="faq-answer">The free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.</p>
                 </details>
             </div>
+            <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
+            </p>
         </div>
     </section>
     

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -1,4 +1,4 @@
-"""Public /free-real-estate-crm page: route, SEO, sitemap, and copy guards."""
+"""Public /follow-up-boss-alternative page: route, SEO, sitemap, and copy guards."""
 import re
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -7,23 +7,23 @@ from tier_config.tier_limits import get_tier_defaults
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PAGE = (ROOT / "templates" / "free_real_estate_crm.html").read_text()
+PAGE = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
 LANDING = (ROOT / "templates" / "landing.html").read_text()
 SITEMAP = ROOT / "static" / "sitemap.xml"
 FREE_LIMITS = get_tier_defaults("free")
 
-PAGE_PATH = "/free-real-estate-crm"
-TITLE = "Free real estate CRM | Origen TechnolOG"
-H1 = "A real estate CRM you can start tonight."
-LEAD = "Built for agents, by agents. The free tier stays free. No card. About two minutes."
+PAGE_PATH = "/follow-up-boss-alternative"
+TITLE = "Follow Up Boss alternative | Origen TechnolOG"
+H1 = "A Follow Up Boss alternative you can start tonight."
+META = "Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes."
 SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 ALLOWED_SITEMAP_PATHS = {
     "/",
     "/register",
     "/login",
     "/terms-privacy",
+    "/free-real-estate-crm",
     PAGE_PATH,
-    "/follow-up-boss-alternative",
 }
 BLOCKED_SEO_PATHS = (
     "/pricing",
@@ -52,21 +52,28 @@ BANNED_SLOP = (
 )
 FAQ_ITEMS = (
     (
-        "What does the free tier include?",
-        "One user, up to 10,000 contacts, and 25 B.O.B. messages a day. You can send email through Gmail and sync tasks to Google Calendar.",
+        "How much is Follow Up Boss?",
+        "Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user.",
     ),
     (
-        "Do I need a credit card?",
-        "No. Setup takes about two minutes.",
+        "Does Follow Up Boss have a free plan?",
+        "No. They offer a 14-day trial. Full access, no credit card required for those 14 days.",
+    ),
+    (
+        "What does Origen include?",
+        "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.",
     ),
     (
         "Can I buy Pro today?",
         "No. Paid features come later. Nothing paid is for sale today.",
     ),
-    (
-        "What can B.O.B. do?",
-        "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, just tell B.O.B. what you need done. It can find and update contacts, manage tasks, log activity, organize clients, and much more. If you can do it in Origen, you can ask B.O.B. to do it for you.\n\nThe free plan includes 25 messages a day, and you can also chat with B.O.B. through Telegram after connecting it from your profile.",
-    ),
+)
+FAKE_SEO_QUESTIONS = (
+    "origentech",
+    "Is this HubSpot",
+    "Is this Follow Up Boss or HubSpot",
+    "Is this origentech.com or Origin CRM",
+    "What can B.O.B. do?",
 )
 
 
@@ -76,22 +83,6 @@ def _faq_paragraphs(answer):
 
 def _json_ld_answer(answer):
     return "\\n\\n".join(_faq_paragraphs(answer))
-
-
-def _copy_without_bob_faq(html):
-    question, answer = FAQ_ITEMS[3]
-    stripped = html.replace(question, "")
-    for para in _faq_paragraphs(answer):
-        stripped = stripped.replace(para, "")
-    return stripped
-
-
-FAKE_SEO_QUESTIONS = (
-    "origentech",
-    "Is this HubSpot",
-    "Is this Follow Up Boss or HubSpot",
-    "Is this origentech.com or Origin CRM",
-)
 
 
 def _sitemap_paths():
@@ -115,7 +106,7 @@ def _visible_copy(html):
     return re.sub(r"\s+", " ", html)
 
 
-class TestFreeRealEstateCrmRoute:
+class TestFollowUpBossAlternativeRoute:
     def test_page_returns_200(self, client):
         resp = client.get(PAGE_PATH)
         assert resp.status_code == 200
@@ -127,7 +118,7 @@ class TestFreeRealEstateCrmRoute:
         resp = owner_a_client.get(PAGE_PATH)
         assert resp.status_code == 200
 
-    def test_sitemap_includes_page_as_only_extra_url(self, client):
+    def test_sitemap_includes_public_set_only(self, client):
         resp = client.get("/sitemap.xml")
         assert resp.status_code == 200
         paths = _sitemap_paths()
@@ -141,19 +132,11 @@ class TestFreeRealEstateCrmRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/free-real-estate-crm" in text
+        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in text
         for blocked in BLOCKED_SEO_PATHS:
             assert f"https://www.origentechnolog.com{blocked}" not in text
         assert "https://www.origentechnolog.com/dashboard" not in text
         assert "—" not in text
-        assert "Unlimited contacts" not in text
-        assert "AI" not in text
-        assert "AI assistant" not in text
-        assert "One user, up to 10,000 contacts." in text
-        assert "25 messages a day on the free plan." in text
-        assert "change an email" in text
-        assert "Changing an email waits for Confirm (15 minutes)." not in text
-        assert "Confirm (15 minutes)" not in text
 
     def test_blocked_marketing_urls_are_not_built(self, client):
         for path in BLOCKED_SEO_PATHS:
@@ -161,7 +144,7 @@ class TestFreeRealEstateCrmRoute:
             assert resp.status_code == 404, f"{path} should not be a public page"
 
 
-class TestFreeRealEstateCrmSeo:
+class TestFollowUpBossAlternativeSeo:
     def test_unique_title_canonical_and_og(self, app, client):
         page = client.get(PAGE_PATH).get_data(as_text=True)
         home = client.get("/").get_data(as_text=True)
@@ -171,9 +154,9 @@ class TestFreeRealEstateCrmSeo:
 
         assert f"<title>{TITLE}</title>" in page
         assert f'rel="canonical" href="{page_url}"' in page
-        assert 'property="og:title" content="Free real estate CRM | Origen TechnolOG"' in page
+        assert f'property="og:title" content="{TITLE}"' in page
         assert f'property="og:url" content="{page_url}"' in page
-        assert 'property="og:description" content="Built for agents, by agents. The free tier stays free. No card. About two minutes."' in page
+        assert f'property="og:description" content="{META}"' in page
 
         assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home
@@ -181,23 +164,33 @@ class TestFreeRealEstateCrmSeo:
         assert f'rel="canonical" href="{home_url}"' not in page
         assert TITLE not in home
 
-    def test_software_application_json_ld_price_is_zero(self, app, client):
+    def test_json_ld_types_and_price(self, app, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         base = _app_base_url(app)
+        assert '"@type": "Organization"' in html
         assert '"@type": "SoftwareApplication"' in html
+        assert '"@type": "FAQPage"' in html
+        assert "SearchAction" not in html
+        assert "aggregateRating" not in html
         assert '"price": "0"' in html
         assert '"priceCurrency": "USD"' in html
         assert '"isAccessibleForFree": true' in html
         assert f'"url": "{base}{PAGE_PATH}"' in html
 
+    def test_no_robots_noindex(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        assert "noindex" not in html.lower()
 
-class TestFreeRealEstateCrmCopy:
+
+class TestFollowUpBossAlternativeCopy:
     def test_required_human_copy(self):
         assert f"<title>{TITLE}</title>" in PAGE
         assert H1 in PAGE
-        assert LEAD in PAGE
+        assert META in PAGE
         assert "Start Free" in PAGE
         assert "url_for('auth.register')" in PAGE
+        assert "url_for('main.free_real_estate_crm')" in PAGE
+        assert "url_for('main.landing')" in PAGE
 
     def test_h1_is_the_human_line(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -207,6 +200,14 @@ class TestFreeRealEstateCrmCopy:
         h1 = re.sub(r"\s+", " ", h1).strip()
         assert h1 == H1
 
+    def test_lead_stays_sourced(self):
+        assert (
+            "Follow Up Boss Grow is $69 per user per month on their pricing page. "
+            "There is no free plan. You get a 14-day trial with full access and no credit card. "
+            "After that they charge. Origen is $0 to start, no credit card, and the free plan stays free. "
+            "One user, up to 10,000 contacts, 25 B.O.B. messages a day."
+        ) in PAGE
+
     def test_limits_match_repo(self):
         assert FREE_LIMITS["max_users"] == 1
         assert FREE_LIMITS["max_contacts"] == 10000
@@ -215,8 +216,17 @@ class TestFreeRealEstateCrmCopy:
         assert "one user" in visible.lower()
         assert "10,000 contacts" in visible
         assert "25 B.O.B. messages a day" in visible
-        assert "Unlimited contacts" not in PAGE
-        assert "unlimited contacts" not in PAGE.lower()
+        assert "25 messages a day" in visible
+        assert "$0" in visible
+        assert "unlimited contacts" in visible.lower()
+        assert "Unlimited (their pricing)" in PAGE
+        assert "up to 10,000" in visible.lower()
+
+    def test_does_not_claim_origen_has_unlimited_contacts(self):
+        visible = _visible_copy(PAGE)
+        assert re.search(r"Origen[^.]*unlimited contacts", visible, flags=re.I) is None
+        assert "Origen publishes unlimited contacts" not in PAGE
+        assert "unlimited contacts on Origen" not in PAGE.lower()
 
     def test_cta_goes_to_register(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -225,10 +235,27 @@ class TestFreeRealEstateCrmCopy:
     def test_no_em_dashes(self):
         assert "—" not in PAGE
 
-    def test_no_unlimited_contacts_or_never_paid_plan(self):
-        assert "Unlimited contacts" not in PAGE
+    def test_no_never_paid_plan(self):
         assert "never be a paid plan" not in PAGE.lower()
         assert "never be a paid" not in PAGE.lower()
+        assert "Paid features come later" in PAGE
+
+    def test_does_not_claim_fub_trial_needs_a_card(self):
+        lowered = PAGE.lower()
+        assert "trial requires a card" not in lowered
+        assert "trial requires a credit card" not in lowered
+        assert "need a credit card for the trial" not in lowered
+        assert "credit card required for those 14 days" in PAGE
+        assert "The trial has no card. Then they charge." in PAGE
+        assert "14-day trial with full access and no credit card" in PAGE
+
+    def test_does_not_claim_we_replace_fub_products(self):
+        lowered = PAGE.lower()
+        assert "replace action plans" not in lowered
+        assert "replace" in lowered
+        assert "we are not a replacement for them" in lowered
+        assert "200+ lead sources" not in PAGE
+        assert "we have calling" not in lowered
 
     def test_no_banned_slop(self):
         lowered = _visible_copy(PAGE).lower()
@@ -247,40 +274,34 @@ class TestFreeRealEstateCrmCopy:
             for para in _faq_paragraphs(answer):
                 assert PAGE.count(para) == 2
                 assert f'<p class="faq-answer">{para}</p>' in PAGE
-        include_answer = FAQ_ITEMS[0][1]
+        include_answer = FAQ_ITEMS[2][1]
         assert "One user" in include_answer
         assert "10,000 contacts" in include_answer
-        assert "25 B.O.B. messages a day" in include_answer
+        assert "25 messages a day" in include_answer
 
     def test_no_fake_seo_questions(self):
         for phrase in FAKE_SEO_QUESTIONS:
             assert phrase.lower() not in PAGE.lower()
 
-    def test_no_ai_word_outside_bob_faq(self):
-        visible = _visible_copy(_copy_without_bob_faq(PAGE))
+    def test_no_ai_word(self):
+        visible = _visible_copy(PAGE)
         assert re.search(r"\bAI\b", visible) is None
-        assert re.search(r"\bAI\b", _copy_without_bob_faq(PAGE)) is None
+        assert re.search(r"\bAI\b", PAGE) is None
 
-    def test_bob_faq_is_verbatim_and_card_stays(self):
-        question, answer = FAQ_ITEMS[3]
-        assert question == "What can B.O.B. do?"
-        assert "AI assistant" in answer
-        assert "If you can do it in Origen" in answer
-        assert "The free plan includes 25 messages a day" in answer
-        assert "Telegram" in answer
-        assert "from your profile" in answer
-        for para in _faq_paragraphs(answer):
-            assert f'<p class="faq-answer">{para}</p>' in PAGE
-            assert f'<p class="faq-answer">{para}</p>' in LANDING
-        assert "add a contact, change an email, or complete a task" in PAGE
-        assert "change an email" not in answer
-        assert "ZIP" not in answer
-        assert "What is B.O.B.?" not in PAGE
-        assert "B.O.B. is the built-in assistant." not in PAGE
+    def test_no_confirm_ttl_or_forbidden_claims(self):
         assert "Confirm (15 minutes)" not in PAGE
-        assert "Confirm (15 minutes)" not in answer
-        assert "waits for Confirm" not in answer
-        assert "waits for a yes" not in answer
-        assert "until you say yes" not in answer
-        assert "in the CRM or on Telegram" not in answer
-        assert "same 25" not in PAGE.lower()
+        assert "waits for Confirm" not in PAGE
+        assert "MLS" not in PAGE
+        assert "transaction" not in PAGE.lower()
+        assert "DocuSeal" not in PAGE
+        assert "calendar sync via B.O.B" not in PAGE.lower()
+
+    def test_sourced_fub_fit_line(self):
+        assert 'Generates less than 30 leads per month.' in PAGE
+        assert "We do not publish a lead count." in PAGE
+
+    def test_home_title_h1_and_bob_faq_unchanged(self):
+        assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in LANDING
+        assert "Your clients and follow-ups," in LANDING
+        assert "<summary>What can B.O.B. do?</summary>" in LANDING
+        assert LANDING.count("<summary>What can B.O.B. do?</summary>") == 1

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -121,6 +121,12 @@ class TestLandingLeftoverCopy:
         assert "Coming Soon" in LANDING
         assert "Pricing TBD" in LANDING
 
+    def test_one_human_link_to_free_real_estate_crm(self):
+        assert LANDING.count("url_for('main.free_real_estate_crm')") == 1
+        assert "the free real estate CRM page" in LANDING
+        assert "follow-up-boss-alternative" not in LANDING
+        assert "Follow Up Boss alternative" not in LANDING
+
     def test_keeps_visible_faq_and_matching_json_ld(self):
         assert '"@type": "FAQPage"' in LANDING
         assert LANDING.count("<summary>") == 5

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -41,6 +41,10 @@ class TestPublicRoutes:
         resp = client.get('/free-real-estate-crm')
         assert resp.status_code == 200
 
+    def test_follow_up_boss_alternative(self, client, seed):
+        resp = client.get('/follow-up-boss-alternative')
+        assert resp.status_code == 200
+
     def test_reset_password_page(self, client, seed):
         resp = client.get('/reset_password')
         assert resp.status_code in (200, 302)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two SEO tickets, one PR. Does not merge.

## Ticket 1: `/follow-up-boss-alternative`

New public, robots-allowed page matching `/free-real-estate-crm` for layout, routing, and schema.

- Title: `Follow Up Boss alternative | Origen TechnolOG`
- H1: `A Follow Up Boss alternative you can start tonight.`
- Meta: Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes.
- Canonical: `https://www.origentechnolog.com/follow-up-boss-alternative`
- URL added to `sitemap.xml` and `llms.txt` (public set only, no `/dashboard`)
- CTA Start Free → `/register`
- Text links to `/free-real-estate-crm` and `/`

Sourced FUB facts (followupboss.com/pricing and /faq, 2026-08-18):

- Grow $69/user/mo ($58 annual), Calling +$39/user, Pro $499/mo for 10 users
- No free plan. 14-day trial with full access and no credit card. After that they charge.
- FAQ: not for anyone who “Generates less than 30 leads per month.” Origen does not invent a lead count.
- They publish unlimited contacts, lead sources, and team plans. We do not claim those, and we do not claim to replace Action Plans, 200+ lead sources, or FUB Calling.

JSON-LD: Organization + SoftwareApplication (price 0) + FAQPage. No SearchAction. No ratings.

Visible FAQs match FAQPage (four only):

1. How much is Follow Up Boss?
2. Does Follow Up Boss have a free plan?
3. What does Origen include?
4. Can I buy Pro today?

## Ticket 2: homepage

One human link near the free-plan FAQ to `/free-real-estate-crm`, anchored “the free real estate CRM page.” Home title, H1, and gold B.O.B. FAQ are unchanged. No `/pricing` page. Pro / Coming Soon / Pricing TBD stay.

## Copy guards

- No em dashes
- No slop words
- Limits stated as 1 user / 10,000 contacts / 25 B.O.B. messages a day
- Does not claim unlimited contacts on our side
- Does not claim there will never be a paid plan
- Does not claim the FUB trial requires a card

## Tests

`81 passed` on `test_follow_up_boss_alternative.py`, `test_free_real_estate_crm.py`, `test_landing_copy.py`, and public navigation routes. Rendered page: 200, exact title/H1, 4 visible FAQs = 4 FAQPage questions, no `SearchAction`, no `noindex`, sitemap/llms include the URL, `/pricing` stays 404.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b00a457e-4c86-42c1-b918-2c1189555cdd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b00a457e-4c86-42c1-b918-2c1189555cdd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

