### PR TITLE
Rewrite Follow Up Boss alternative page with honest comparison copy

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -458,9 +458,6 @@
                         Start Free
                         <i class="fas fa-arrow-right"></i>
                     </a>
-                    <p class="mt-8 text-lg text-brand-600 leading-relaxed">
-                        More on Origen is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>. Or start from the <a href="{{ url_for('main.landing') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">homepage</a>.
-                    </p>
                 </div>
             </div>
         </div>

--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -422,7 +422,7 @@
                 <div>
                     <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Follow Up Boss is probably the better fit</h2>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
-                        Be honest. Follow Up Boss may make more sense if you need:
+                        Follow Up Boss may make more sense if you need:
                     </p>
                     <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
                         <li>Advanced lead routing and distribution</li>

--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Follow Up Boss alternative | Origen TechnolOG</title>
+    <title>Follow Up Boss Alternative for Real Estate Agents | Origen</title>
     {{ public_seo(
-        title="Follow Up Boss alternative | Origen TechnolOG",
-        description="Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes.",
+        title="Follow Up Boss Alternative for Real Estate Agents | Origen",
+        description="Comparing Origen with Follow Up Boss? See pricing, features and where each CRM fits. Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
         canonical=app_base_url ~ "/follow-up-boss-alternative"
     ) }}
     <script type="application/ld+json">
@@ -33,7 +33,7 @@
             "price": "0",
             "priceCurrency": "USD"
           },
-          "description": "Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes.",
+          "description": "Comparing Origen with Follow Up Boss? See pricing, features and where each CRM fits. Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
           "url": "{{ app_base_url }}/follow-up-boss-alternative",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
@@ -43,34 +43,42 @@
           "mainEntity": [
             {
               "@type": "Question",
-              "name": "How much is Follow Up Boss?",
+              "name": "How much does Follow Up Boss cost?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user."
+                "text": "Follow Up Boss currently lists its Grow plan at $69 per user per month, or $58 per user per month when billed annually. It offers a 14-day free trial rather than a permanent free plan."
               }
             },
             {
               "@type": "Question",
-              "name": "Does Follow Up Boss have a free plan?",
+              "name": "Is Origen really free?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "No. They offer a 14-day trial. Full access, no credit card required for those 14 days."
+                "text": "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day."
               }
             },
             {
               "@type": "Question",
-              "name": "What does Origen include?",
+              "name": "Is Origen a full replacement for Follow Up Boss?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day."
+                "text": "That depends on what you use Follow Up Boss for. If you need its advanced lead routing, calling, texting, team management or large integration ecosystem, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit."
               }
             },
             {
               "@type": "Question",
-              "name": "Can I buy Pro today?",
+              "name": "Can I try Origen without moving everything over?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "No. Paid features come later. Nothing paid is for sale today."
+                "text": "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "What is B.O.B.?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you."
               }
             }
           ]
@@ -260,24 +268,42 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="max-w-3xl">
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
-                    A Follow Up Boss alternative you can start tonight.
+                    Looking for a Follow Up Boss alternative?
                 </h1>
-                <p class="text-lg sm:text-xl text-brand-600 mb-8">
-                    Follow Up Boss Grow is $69 per user per month on their pricing page. There is no free plan. You get a 14-day trial with full access and no credit card. After that they charge. Origen is $0 to start, no credit card, and the free plan stays free. One user, up to 10,000 contacts, 25 B.O.B. messages a day.
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    Follow Up Boss is a powerful CRM, especially for teams managing a large volume of leads. But not every agent needs everything it offers or wants another $69-per-user monthly subscription.
+                </p>
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    Origen gives individual real estate agents a simpler place to manage contacts, tasks, follow-ups and day-to-day CRM work, with a free plan you can keep using.
+                </p>
+                <p class="text-base text-brand-600 mb-8">
+                    No credit card required.
                 </p>
                 <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
                     Start Free
                     <i class="fas fa-arrow-right"></i>
                 </a>
+                <p class="mt-4 text-sm text-brand-500">
+                    Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day
+                </p>
             </div>
         </div>
     </section>
 
     <section class="bg-white py-16 md:py-20">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-3xl space-y-10">
+            <div class="max-w-3xl space-y-16">
                 <div>
-                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Price and limits</h2>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Origen vs. Follow Up Boss</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        These products aren't identical, and they shouldn't be presented as though they are.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Follow Up Boss has been built for agents and teams that need advanced lead management, routing, calling, texting, reporting and a large integration ecosystem.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        Origen is aimed at agents who want the core CRM work handled without starting with another monthly software bill.
+                    </p>
                     <div class="overflow-x-auto">
                         <table class="w-full text-left text-brand-700">
                             <thead>
@@ -289,54 +315,153 @@
                             </thead>
                             <tbody class="align-top">
                                 <tr class="border-b border-brand-100">
-                                    <th class="py-3 pr-4 font-semibold text-brand-800">Price</th>
-                                    <td class="py-3 pr-4">Grow is $69 per user per month ($58 billed annually)</td>
-                                    <td class="py-3">$0</td>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Starting price</th>
+                                    <td class="py-3 pr-4">$69/user/month on Grow</td>
+                                    <td class="py-3">Free</td>
                                 </tr>
                                 <tr class="border-b border-brand-100">
                                     <th class="py-3 pr-4 font-semibold text-brand-800">Free plan</th>
-                                    <td class="py-3 pr-4">No. They offer a 14-day trial.</td>
+                                    <td class="py-3 pr-4">No, 14-day free trial</td>
                                     <td class="py-3">Yes</td>
                                 </tr>
                                 <tr class="border-b border-brand-100">
-                                    <th class="py-3 pr-4 font-semibold text-brand-800">Card</th>
-                                    <td class="py-3 pr-4">The trial has no card. Then they charge.</td>
-                                    <td class="py-3">No card. The free plan stays free.</td>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Credit card to start</th>
+                                    <td class="py-3 pr-4">No</td>
+                                    <td class="py-3">No</td>
                                 </tr>
                                 <tr class="border-b border-brand-100">
                                     <th class="py-3 pr-4 font-semibold text-brand-800">Contacts</th>
-                                    <td class="py-3 pr-4">Unlimited (their pricing)</td>
-                                    <td class="py-3">Up to 10,000</td>
+                                    <td class="py-3 pr-4">Unlimited</td>
+                                    <td class="py-3">Up to 10,000 on free</td>
                                 </tr>
                                 <tr class="border-b border-brand-100">
-                                    <th class="py-3 pr-4 font-semibold text-brand-800">Users</th>
-                                    <td class="py-3 pr-4">Per seat</td>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Free-plan users</th>
+                                    <td class="py-3 pr-4">N/A</td>
                                     <td class="py-3">1</td>
                                 </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Gmail</th>
+                                    <td class="py-3 pr-4">Supported</td>
+                                    <td class="py-3">Send email through Gmail</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Calendar</th>
+                                    <td class="py-3 pr-4">Calendar and email sync</td>
+                                    <td class="py-3">Google Calendar task sync</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">AI</th>
+                                    <td class="py-3 pr-4">FUB AI features</td>
+                                    <td class="py-3">B.O.B. AI assistant</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Calling & texting</th>
+                                    <td class="py-3 pr-4">Available, with Calling included on higher plans or added to Grow</td>
+                                    <td class="py-3">Not included</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Advanced lead routing</th>
+                                    <td class="py-3 pr-4">Yes</td>
+                                    <td class="py-3">Not included</td>
+                                </tr>
                                 <tr>
-                                    <th class="py-3 pr-4 font-semibold text-brand-800">Fit</th>
-                                    <td class="py-3 pr-4">Their FAQ says they are not for anyone who "Generates less than 30 leads per month."</td>
-                                    <td class="py-3">We do not publish a lead count.</td>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Large integration ecosystem</th>
+                                    <td class="py-3 pr-4">Yes</td>
+                                    <td class="py-3">Not included</td>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
                 </div>
 
-                <p class="text-lg text-brand-600 leading-relaxed">
-                    Follow Up Boss publishes unlimited contacts, lead sources, and team plans. They also sell Calling and Action Plans. We do not have those, and we are not a replacement for them.
-                </p>
-                <p class="text-lg text-brand-600 leading-relaxed">
-                    Built for real estate agents, by real estate agents. Free is the product. Paid features come later. Nothing paid is for sale today.
-                </p>
-                <p class="text-lg text-brand-600 leading-relaxed">
-                    More on Origen is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>. Or start from the <a href="{{ url_for('main.landing') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">homepage</a>.
-                </p>
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">The biggest difference is what you actually need</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Follow Up Boss makes a lot of sense for teams handling serious lead volume. It includes tools for lead distribution, automated follow-up, calling and texting, reporting, team management and a large integration ecosystem.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        That's useful if your business needs it.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        But a solo agent looking for a clean CRM may not need all of that on day one.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen starts with the work you do every day: contacts, tasks, follow-ups and keeping track of what's happening with your clients.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        And you can start using it without turning on another monthly subscription.
+                    </p>
+                </div>
 
-                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
-                    Start Free
-                    <i class="fas fa-arrow-right"></i>
-                </a>
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Then there's B.O.B.</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        B.O.B. is the AI assistant built into Origen.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Instead of clicking through the CRM every time you want to get something done, tell B.O.B. what you need.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Find a client. Update a contact. Add a note. Complete a task. Log activity. Organize contacts. Ask questions about what's already in your CRM.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        If you can do it in Origen, you can ask B.O.B. to do it for you.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        The free plan includes 25 B.O.B. messages per day.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        B.O.B. can also be connected to Telegram, so you don't always have to be sitting inside the CRM to use it.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Try Origen Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Follow Up Boss is probably the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Be honest. Follow Up Boss may make more sense if you need:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>Advanced lead routing and distribution</li>
+                        <li>Built-in calling and texting</li>
+                        <li>Large-team management</li>
+                        <li>Deep reporting</li>
+                        <li>Hundreds of third-party integrations</li>
+                        <li>Mature lead automation</li>
+                        <li>A CRM built around high lead volume</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Follow Up Boss is an established product with a much larger feature set in several of these areas.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Origen may be the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen may make more sense if:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>You're an individual real estate agent</li>
+                        <li>You want a CRM without another monthly bill</li>
+                        <li>You mainly need contacts, tasks and follow-up organization</li>
+                        <li>You use Gmail and Google Calendar</li>
+                        <li>You want AI that can actually perform CRM work for you</li>
+                        <li>You'd rather start simple and add more later</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        You don't have to decide whether Origen can replace your current CRM before trying it. The free plan doesn't expire. Create an account, put a few contacts in it and see whether it fits the way you work.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Start Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                    <p class="mt-8 text-lg text-brand-600 leading-relaxed">
+                        More on Origen is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>. Or start from the <a href="{{ url_for('main.landing') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">homepage</a>.
+                    </p>
+                </div>
             </div>
         </div>
     </section>
@@ -346,20 +471,27 @@
             <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-10">Common questions</h2>
             <div class="landing-faq">
                 <details>
-                    <summary>How much is Follow Up Boss?</summary>
-                    <p class="faq-answer">Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user.</p>
+                    <summary>How much does Follow Up Boss cost?</summary>
+                    <p class="faq-answer">Follow Up Boss currently lists its Grow plan at $69 per user per month, or $58 per user per month when billed annually. It offers a 14-day free trial rather than a permanent free plan.</p>
                 </details>
                 <details>
-                    <summary>Does Follow Up Boss have a free plan?</summary>
-                    <p class="faq-answer">No. They offer a 14-day trial. Full access, no credit card required for those 14 days.</p>
+                    <summary>Is Origen really free?</summary>
+                    <p class="faq-answer">Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.</p>
+                    <p class="faq-answer">The current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.</p>
                 </details>
                 <details>
-                    <summary>What does Origen include?</summary>
-                    <p class="faq-answer">One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.</p>
+                    <summary>Is Origen a full replacement for Follow Up Boss?</summary>
+                    <p class="faq-answer">That depends on what you use Follow Up Boss for. If you need its advanced lead routing, calling, texting, team management or large integration ecosystem, Origen doesn't currently try to duplicate all of that.</p>
+                    <p class="faq-answer">If what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.</p>
                 </details>
                 <details>
-                    <summary>Can I buy Pro today?</summary>
-                    <p class="faq-answer">No. Paid features come later. Nothing paid is for sale today.</p>
+                    <summary>Can I try Origen without moving everything over?</summary>
+                    <p class="faq-answer">Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.</p>
+                </details>
+                <details>
+                    <summary>What is B.O.B.?</summary>
+                    <p class="faq-answer">B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.</p>
+                    <p class="faq-answer">If you can do something in Origen, you can ask B.O.B. to do it for you.</p>
                 </details>
             </div>
         </div>

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -10,12 +10,29 @@ ROOT = Path(__file__).resolve().parents[1]
 PAGE = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
 LANDING = (ROOT / "templates" / "landing.html").read_text()
 SITEMAP = ROOT / "static" / "sitemap.xml"
+LLMS = ROOT / "static" / "llms.txt"
 FREE_LIMITS = get_tier_defaults("free")
 
 PAGE_PATH = "/follow-up-boss-alternative"
-TITLE = "Follow Up Boss alternative | Origen TechnolOG"
-H1 = "A Follow Up Boss alternative you can start tonight."
-META = "Follow Up Boss Grow is $69 per user per month. Origen is a free real estate CRM. No card. About two minutes."
+TITLE = "Follow Up Boss Alternative for Real Estate Agents | Origen"
+H1 = "Looking for a Follow Up Boss alternative?"
+META = (
+    "Comparing Origen with Follow Up Boss? See pricing, features and where each CRM fits. "
+    "Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant."
+)
+HOME_TITLE = "Free Real Estate CRM | Origen TechnolOG"
+HOME_H1_PART = "Your clients and follow-ups,"
+HOME_BOB_QUESTION = "What can B.O.B. do?"
+HOME_BOB_P1 = (
+    "B.O.B. is the AI assistant built into Origen. Instead of clicking through the CRM, "
+    "just tell B.O.B. what you need done. It can find and update contacts, manage tasks, "
+    "log activity, organize clients, and much more. If you can do it in Origen, you can "
+    "ask B.O.B. to do it for you."
+)
+HOME_BOB_P2 = (
+    "The free plan includes 25 messages a day, and you can also chat with B.O.B. "
+    "through Telegram after connecting it from your profile."
+)
 SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 ALLOWED_SITEMAP_PATHS = {
     "/",
@@ -39,11 +56,14 @@ BANNED_SLOP = (
     "elevate",
     "seamless",
     "seamlessly",
+    "streamline",
+    "streamlined",
     "revolutionize",
     "transform",
     "supercharge",
     "robust",
     "comprehensive",
+    "game-changing",
     "all-in-one solution",
     "take your business to the next level",
     "designed for your success",
@@ -52,20 +72,24 @@ BANNED_SLOP = (
 )
 FAQ_ITEMS = (
     (
-        "How much is Follow Up Boss?",
-        "Grow is $69 per user per month on followupboss.com/pricing. Pro is $499 a month for 10 users. Calling on Grow is $39 per user.",
+        "How much does Follow Up Boss cost?",
+        "Follow Up Boss currently lists its Grow plan at $69 per user per month, or $58 per user per month when billed annually. It offers a 14-day free trial rather than a permanent free plan.",
     ),
     (
-        "Does Follow Up Boss have a free plan?",
-        "No. They offer a 14-day trial. Full access, no credit card required for those 14 days.",
+        "Is Origen really free?",
+        "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.",
     ),
     (
-        "What does Origen include?",
-        "One user, up to 10,000 contacts, tasks, and a dashboard. You can send email through Gmail and sync tasks to Google Calendar. B.O.B. is included, with 25 messages a day.",
+        "Is Origen a full replacement for Follow Up Boss?",
+        "That depends on what you use Follow Up Boss for. If you need its advanced lead routing, calling, texting, team management or large integration ecosystem, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.",
     ),
     (
-        "Can I buy Pro today?",
-        "No. Paid features come later. Nothing paid is for sale today.",
+        "Can I try Origen without moving everything over?",
+        "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.",
+    ),
+    (
+        "What is B.O.B.?",
+        "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you.",
     ),
 )
 FAKE_SEO_QUESTIONS = (
@@ -74,6 +98,37 @@ FAKE_SEO_QUESTIONS = (
     "Is this Follow Up Boss or HubSpot",
     "Is this origentech.com or Origin CRM",
     "What can B.O.B. do?",
+    "How much is Follow Up Boss?",
+    "Does Follow Up Boss have a free plan?",
+    "What does Origen include?",
+    "Can I buy Pro today?",
+)
+TABLE_ROWS = (
+    ("Starting price", "$69/user/month on Grow", "Free"),
+    ("Free plan", "No, 14-day free trial", "Yes"),
+    ("Credit card to start", "No", "No"),
+    ("Contacts", "Unlimited", "Up to 10,000 on free"),
+    ("Free-plan users", "N/A", "1"),
+    ("Gmail", "Supported", "Send email through Gmail"),
+    ("Calendar", "Calendar and email sync", "Google Calendar task sync"),
+    ("AI", "FUB AI features", "B.O.B. AI assistant"),
+    ("Calling & texting", "Available, with Calling included on higher plans or added to Grow", "Not included"),
+    ("Advanced lead routing", "Yes", "Not included"),
+    ("Large integration ecosystem", "Yes", "Not included"),
+)
+SECTION_HEADINGS = (
+    "Origen vs. Follow Up Boss",
+    "The biggest difference is what you actually need",
+    "Then there's B.O.B.",
+    "When Follow Up Boss is probably the better fit",
+    "When Origen may be the better fit",
+    "Common questions",
+)
+HERO_LINES = (
+    "Follow Up Boss is a powerful CRM, especially for teams managing a large volume of leads. But not every agent needs everything it offers or wants another $69-per-user monthly subscription.",
+    "Origen gives individual real estate agents a simpler place to manage contacts, tasks, follow-ups and day-to-day CRM work, with a free plan you can keep using.",
+    "No credit card required.",
+    "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",
 )
 
 
@@ -106,6 +161,12 @@ def _visible_copy(html):
     return re.sub(r"\s+", " ", html)
 
 
+def _body_copy(html):
+    match = re.search(r"<body\b[^>]*>(.*)</body>", html, flags=re.I | re.S)
+    body = match.group(1) if match else html
+    return _visible_copy(body)
+
+
 class TestFollowUpBossAlternativeRoute:
     def test_page_returns_200(self, client):
         resp = client.get(PAGE_PATH)
@@ -133,6 +194,7 @@ class TestFollowUpBossAlternativeRoute:
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
         assert "https://www.origentechnolog.com/follow-up-boss-alternative" in text
+        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in LLMS.read_text()
         for blocked in BLOCKED_SEO_PATHS:
             assert f"https://www.origentechnolog.com{blocked}" not in text
         assert "https://www.origentechnolog.com/dashboard" not in text
@@ -158,7 +220,7 @@ class TestFollowUpBossAlternativeSeo:
         assert f'property="og:url" content="{page_url}"' in page
         assert f'property="og:description" content="{META}"' in page
 
-        assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in home
+        assert f"<title>{HOME_TITLE}</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home
         assert page.count("<title>") == 1
         assert f'rel="canonical" href="{home_url}"' not in page
@@ -188,6 +250,7 @@ class TestFollowUpBossAlternativeCopy:
         assert H1 in PAGE
         assert META in PAGE
         assert "Start Free" in PAGE
+        assert "Try Origen Free" in PAGE
         assert "url_for('auth.register')" in PAGE
         assert "url_for('main.free_real_estate_crm')" in PAGE
         assert "url_for('main.landing')" in PAGE
@@ -200,27 +263,35 @@ class TestFollowUpBossAlternativeCopy:
         h1 = re.sub(r"\s+", " ", h1).strip()
         assert h1 == H1
 
-    def test_lead_stays_sourced(self):
-        assert (
-            "Follow Up Boss Grow is $69 per user per month on their pricing page. "
-            "There is no free plan. You get a 14-day trial with full access and no credit card. "
-            "After that they charge. Origen is $0 to start, no credit card, and the free plan stays free. "
-            "One user, up to 10,000 contacts, 25 B.O.B. messages a day."
-        ) in PAGE
+    def test_hero_uses_his_lines(self):
+        for line in HERO_LINES:
+            assert line in PAGE
+
+    def test_section_headings_are_present(self):
+        for heading in SECTION_HEADINGS:
+            assert heading in PAGE
+
+    def test_comparison_table_matches_his_rows(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        visible = _visible_copy(html)
+        for label, fub, origen in TABLE_ROWS:
+            assert label in visible
+            assert fub in visible
+            assert origen in visible
+            assert label in PAGE
+            assert fub in PAGE
+            assert origen in PAGE
 
     def test_limits_match_repo(self):
         assert FREE_LIMITS["max_users"] == 1
         assert FREE_LIMITS["max_contacts"] == 10000
         assert FREE_LIMITS["daily_ai_chat_messages"] == 25
         visible = _visible_copy(PAGE)
+        assert "1 user" in visible
         assert "one user" in visible.lower()
         assert "10,000 contacts" in visible
-        assert "25 B.O.B. messages a day" in visible
-        assert "25 messages a day" in visible
-        assert "$0" in visible
-        assert "unlimited contacts" in visible.lower()
-        assert "Unlimited (their pricing)" in PAGE
-        assert "up to 10,000" in visible.lower()
+        assert "25 B.O.B. messages per day" in visible
+        assert "Up to 10,000 on free" in visible
 
     def test_does_not_claim_origen_has_unlimited_contacts(self):
         visible = _visible_copy(PAGE)
@@ -231,31 +302,93 @@ class TestFollowUpBossAlternativeCopy:
     def test_cta_goes_to_register(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         assert re.search(r'href="/register"[^>]*>\s*Start Free', html) is not None
+        assert re.search(r'href="/register"[^>]*>\s*Try Origen Free', html) is not None
 
     def test_no_em_dashes(self):
         assert "—" not in PAGE
+        assert "—" not in LANDING
 
-    def test_no_never_paid_plan(self):
+    def test_no_exclamation_in_visible_copy(self):
+        assert "!" not in _visible_copy(PAGE)
+
+    def test_does_not_claim_never_paid_plan(self):
         assert "never be a paid plan" not in PAGE.lower()
         assert "never be a paid" not in PAGE.lower()
-        assert "Paid features come later" in PAGE
 
     def test_does_not_claim_fub_trial_needs_a_card(self):
         lowered = PAGE.lower()
         assert "trial requires a card" not in lowered
         assert "trial requires a credit card" not in lowered
         assert "need a credit card for the trial" not in lowered
-        assert "credit card required for those 14 days" in PAGE
-        assert "The trial has no card. Then they charge." in PAGE
-        assert "14-day trial with full access and no credit card" in PAGE
+        assert "credit card required for those 14 days" not in PAGE
+        assert "Then they charge." not in PAGE
+        assert "After that they charge" not in PAGE
+        visible = _visible_copy(PAGE)
+        assert "Credit card to start" in visible
+        assert re.search(r"Credit card to start\s+No\s+No", visible) is not None
 
-    def test_does_not_claim_we_replace_fub_products(self):
+    def test_does_not_say_charges_you_after_14_days(self):
         lowered = PAGE.lower()
-        assert "replace action plans" not in lowered
-        assert "replace" in lowered
-        assert "we are not a replacement for them" in lowered
-        assert "200+ lead sources" not in PAGE
-        assert "we have calling" not in lowered
+        assert "charges you after 14 days" not in lowered
+        assert "after that they charge" not in lowered
+        assert "14-day free trial rather than a permanent free plan" in PAGE
+
+    def test_does_not_say_we_are_not_a_replacement(self):
+        lowered = PAGE.lower()
+        assert "we are not a replacement for follow up boss" not in lowered
+        assert "we are not a replacement" not in lowered
+        assert "Is Origen a full replacement for Follow Up Boss?" in PAGE
+
+    def test_does_not_claim_built_by_agents(self):
+        lowered = PAGE.lower()
+        assert "built by real estate agents" not in lowered
+        assert "by real estate agents" not in lowered
+        assert "built for agents, by agents" not in lowered
+        assert "by agents" not in lowered
+
+    def test_does_not_claim_origen_calling_routing_or_integrations(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        visible = _visible_copy(html)
+        assert "Calling & texting" in visible
+        assert "Available, with Calling included on higher plans or added to Grow" in visible
+        assert "Advanced lead routing" in visible
+        assert "Large integration ecosystem" in visible
+        assert re.search(
+            r"Calling & texting\s+Available, with Calling included on higher plans or added to Grow\s+Not included",
+            visible,
+        ) is not None
+        assert re.search(r"Advanced lead routing\s+Yes\s+Not included", visible) is not None
+        assert re.search(r"Large integration ecosystem\s+Yes\s+Not included", visible) is not None
+        lowered = visible.lower()
+        assert "origen includes calling" not in lowered
+        assert "origen includes texting" not in lowered
+        assert "origen calling" not in lowered
+        assert "twilio" not in lowered
+        assert "automated crm migration" not in lowered
+        assert "automated fub migration" not in lowered
+        assert "import from follow up boss" not in lowered
+
+    def test_does_not_imply_fub_lacks_ai(self):
+        visible = _visible_copy(PAGE)
+        assert "FUB AI features" in visible
+        assert "B.O.B. AI assistant" in visible
+        lowered = visible.lower()
+        assert "follow up boss does not have ai" not in lowered
+        assert "fub has no ai" not in lowered
+        assert "fub lacks ai" not in lowered
+        assert "without ai" not in lowered
+
+    def test_alternative_phrase_is_not_stuffed(self):
+        body = _body_copy(PAGE)
+        matches = re.findall(r"follow up boss alternative", body, flags=re.I)
+        assert len(matches) <= 1
+        assert PAGE.lower().count("follow up boss alternative") <= 3
+
+    def test_no_thirty_leads_gotcha(self):
+        lowered = PAGE.lower()
+        assert "30 leads" not in lowered
+        assert "less than 30" not in lowered
+        assert "we do not publish a lead count" not in lowered
 
     def test_no_banned_slop(self):
         lowered = _visible_copy(PAGE).lower()
@@ -264,8 +397,8 @@ class TestFollowUpBossAlternativeCopy:
 
     def test_faq_matches_json_ld_and_repo_limits(self):
         assert '"@type": "FAQPage"' in PAGE
-        assert PAGE.count("<summary>") == 4
-        assert PAGE.count('"@type": "Question"') == 4
+        assert PAGE.count("<summary>") == 5
+        assert PAGE.count('"@type": "Question"') == 5
         for question, answer in FAQ_ITEMS:
             assert PAGE.count(question) == 2
             assert f"<summary>{question}</summary>" in PAGE
@@ -274,19 +407,14 @@ class TestFollowUpBossAlternativeCopy:
             for para in _faq_paragraphs(answer):
                 assert PAGE.count(para) == 2
                 assert f'<p class="faq-answer">{para}</p>' in PAGE
-        include_answer = FAQ_ITEMS[2][1]
-        assert "One user" in include_answer
-        assert "10,000 contacts" in include_answer
-        assert "25 messages a day" in include_answer
+        free_answer = FAQ_ITEMS[1][1]
+        assert "one user" in free_answer
+        assert "10,000 contacts" in free_answer
+        assert "25 B.O.B. messages per day" in free_answer
 
     def test_no_fake_seo_questions(self):
         for phrase in FAKE_SEO_QUESTIONS:
             assert phrase.lower() not in PAGE.lower()
-
-    def test_no_ai_word(self):
-        visible = _visible_copy(PAGE)
-        assert re.search(r"\bAI\b", visible) is None
-        assert re.search(r"\bAI\b", PAGE) is None
 
     def test_no_confirm_ttl_or_forbidden_claims(self):
         assert "Confirm (15 minutes)" not in PAGE
@@ -295,13 +423,17 @@ class TestFollowUpBossAlternativeCopy:
         assert "transaction" not in PAGE.lower()
         assert "DocuSeal" not in PAGE
         assert "calendar sync via B.O.B" not in PAGE.lower()
-
-    def test_sourced_fub_fit_line(self):
-        assert 'Generates less than 30 leads per month.' in PAGE
-        assert "We do not publish a lead count." in PAGE
+        assert "document generation" not in PAGE.lower()
+        assert "doc gen" not in PAGE.lower()
 
     def test_home_title_h1_and_bob_faq_unchanged(self):
-        assert "<title>Free Real Estate CRM | Origen TechnolOG</title>" in LANDING
-        assert "Your clients and follow-ups," in LANDING
-        assert "<summary>What can B.O.B. do?</summary>" in LANDING
-        assert LANDING.count("<summary>What can B.O.B. do?</summary>") == 1
+        assert f"<title>{HOME_TITLE}</title>" in LANDING
+        assert HOME_H1_PART in LANDING
+        assert f"<summary>{HOME_BOB_QUESTION}</summary>" in LANDING
+        assert LANDING.count(f"<summary>{HOME_BOB_QUESTION}</summary>") == 1
+        assert HOME_BOB_P1 in LANDING
+        assert HOME_BOB_P2 in LANDING
+        assert LANDING.count(HOME_BOB_P1) == 2
+        assert LANDING.count(HOME_BOB_P2) == 2
+        assert "follow-up-boss-alternative" not in LANDING
+        assert "the free real estate CRM page" in LANDING

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -252,8 +252,10 @@ class TestFollowUpBossAlternativeCopy:
         assert "Start Free" in PAGE
         assert "Try Origen Free" in PAGE
         assert "url_for('auth.register')" in PAGE
-        assert "url_for('main.free_real_estate_crm')" in PAGE
+        assert "url_for('main.free_real_estate_crm')" not in PAGE
         assert "url_for('main.landing')" in PAGE
+        assert "More on Origen is on" not in PAGE
+        assert "the free real estate CRM page" not in PAGE
 
     def test_h1_is_the_human_line(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrite the live public page `/follow-up-boss-alternative` using Christopher Nichols’ comparison copy.

## What changed

- Exact SEO: title `Follow Up Boss Alternative for Real Estate Agents | Origen`, H1 `Looking for a Follow Up Boss alternative?`, and the specified meta description
- Canonical stays `https://www.origentechnolog.com/follow-up-boss-alternative`
- Honest comparison table (price, free plan, Gmail, calendar, AI on both sides, calling/texting/routing/integrations marked Not included for Origen)
- His sections: what you actually need, B.O.B., when Follow Up Boss is the better fit, when Origen may be
- Five visible FAQs match FAQPage JSON-LD 1:1
- CTAs: Start Free / Try Origen Free → `/register`
- Homepage gold B.O.B. FAQ, title, and H1 are untouched
- `sitemap.xml` and `llms.txt` still list the URL

## Copy fixes

- Removed the leaked writer note “Be honest.” from the Follow Up Boss fit section. That paragraph now starts: `Follow Up Boss may make more sense if you need:`
- Removed the leftover “More on Origen is on the free real estate CRM page. Or start from the homepage.” paragraph after the last Start Free CTA. Footer and nav links stay.

## What this does not do

- No attack on Follow Up Boss, no 30-leads gotcha, no “charges you after 14 days”
- No “we are not a replacement,” no feature-parity claim, no “built by real estate agents”
- Does not imply FUB lacks AI or that their trial needs a card
- Does not claim Origen calling, texting, advanced routing, a large integration ecosystem, or automated CRM migration
- Does not add `/pricing` or change homepage gold B.O.B. FAQ

## Tests

`tests/test_follow_up_boss_alternative.py` rewritten to the new copy. Old title/H1/four-FAQ/30-leads assertions are gone. This page no longer asserts a `free_real_estate_crm` body link.

## Walkthrough

[Hero with exact H1 and free-plan limits](https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_hero.webp)
[Origen vs Follow Up Boss comparison table](https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_comparison_table.webp)
[Calling and routing marked Not included, plus B.O.B. section](https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_bob_section.webp)
[When Follow Up Boss is the better fit](https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_when_fub_fits.webp)
[When Origen may fit and five Common questions](https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_faq.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5479a8ef-b798-4264-93d2-82257a52dd98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5479a8ef-b798-4264-93d2-82257a52dd98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

