### PR TITLE
style: center FUB alternative copy and widen the comparison table

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -206,6 +206,24 @@
             font-size: 1rem;
             line-height: 1.6;
         }
+        .compare-table {
+            width: 100%;
+            min-width: 40rem;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+        .compare-table th,
+        .compare-table td {
+            padding: 1rem 1.5rem 1rem 0;
+            vertical-align: top;
+        }
+        .compare-table thead th {
+            padding-top: 0.75rem;
+            padding-bottom: 0.85rem;
+        }
+        .compare-table col.label { width: 26%; }
+        .compare-table col.fub { width: 42%; }
+        .compare-table col.origen { width: 32%; }
     </style>
 </head>
 
@@ -265,8 +283,7 @@
     </nav>
 
     <section class="hero-bg pt-24 md:pt-32 pb-16 md:pb-20">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-3xl">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
                     Looking for a Follow Up Boss alternative?
                 </h1>
@@ -286,13 +303,12 @@
                 <p class="mt-4 text-sm text-brand-500">
                     Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day
                 </p>
-            </div>
         </div>
     </section>
 
     <section class="bg-white py-16 md:py-20">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-3xl space-y-16">
+        <div class="px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto space-y-16">
                 <div>
                     <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Origen vs. Follow Up Boss</h2>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
@@ -301,16 +317,24 @@
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
                         Follow Up Boss has been built for agents and teams that need advanced lead management, routing, calling, texting, reporting and a large integration ecosystem.
                     </p>
-                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                    <p class="text-lg text-brand-600 leading-relaxed">
                         Origen is aimed at agents who want the core CRM work handled without starting with another monthly software bill.
                     </p>
-                    <div class="overflow-x-auto">
-                        <table class="w-full text-left text-brand-700">
+                </div>
+            </div>
+
+            <div class="max-w-5xl mx-auto mt-10 mb-16 overflow-x-auto">
+                        <table class="compare-table text-left text-brand-700">
+                            <colgroup>
+                                <col class="label">
+                                <col class="fub">
+                                <col class="origen">
+                            </colgroup>
                             <thead>
-                                <tr class="border-b border-brand-100">
-                                    <th class="py-3 pr-4 font-semibold text-brand-900"> </th>
-                                    <th class="py-3 pr-4 font-semibold text-brand-900">Follow Up Boss</th>
-                                    <th class="py-3 font-semibold text-brand-900">Origen</th>
+                                <tr class="border-b border-brand-200">
+                                    <th class="font-semibold text-brand-900"> </th>
+                                    <th class="font-semibold text-brand-900">Follow Up Boss</th>
+                                    <th class="font-semibold text-brand-900">Origen</th>
                                 </tr>
                             </thead>
                             <tbody class="align-top">
@@ -371,9 +395,9 @@
                                 </tr>
                             </tbody>
                         </table>
-                    </div>
-                </div>
+            </div>
 
+            <div class="max-w-3xl mx-auto space-y-16">
                 <div>
                     <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">The biggest difference is what you actually need</h2>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replays Christopher’s already-written layout tweak from `e21bb48` (dead branch `cursor/fub-alternative-rewrite-dd98`) onto current `main` after #314.

## What changed

Layout only on `/follow-up-boss-alternative`:

- Added `.compare-table` CSS: full width, `min-width: 40rem`, collapsed borders, fixed layout. `th`/`td` padding `1rem 1.5rem 1rem 0`, top-aligned. Column widths 26% / 42% / 32%.
- Hero is now a single centered `max-w-3xl mx-auto` wrapper (dropped the extra inner `max-w-3xl`).
- Body intro stays `max-w-3xl`. The comparison table is lifted into `max-w-5xl` so it has room. Remaining sections go back to `max-w-3xl`.

## What did not change

- No public copy, titles, H1, FAQs, or table cell text
- No homepage / gold B.O.B. FAQ
- No leftover “More on Origen…” sentence
- No em dashes
- Tests untouched (copy assertions stay)

## Checks

- Template diff matches `e21bb48` exactly (38 additions, 14 deletions)
- Visible copy matches `main` (`6173061`)
- `python3 -m pytest tests/test_follow_up_boss_alternative.py` — 32 passed
- Related copy/nav tests — 120 passed, no markup test updates needed
- Rendered at 1440px: hero H1 width 704 (`max-w-3xl`), table width 1024 (`max-w-5xl`)

[Centered FUB alternative hero](https://cursor.com/agents/bc-5a113024-6a6f-4fc5-9307-e7086877088d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_hero_centered.png)
[Wider comparison table](https://cursor.com/agents/bc-5a113024-6a6f-4fc5-9307-e7086877088d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffub_alt_compare_table.png)

Do not merge until reviewed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a113024-6a6f-4fc5-9307-e7086877088d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a113024-6a6f-4fc5-9307-e7086877088d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

