### PR TITLE
feat: add muted FUB trademark disclaimer on alternative page

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -536,6 +536,9 @@
                     &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
                 </div>
             </div>
+            <p class="mt-8 max-w-3xl mx-auto text-center text-xs leading-relaxed text-brand-500">
+                Follow Up Boss is a trademark of its owner. Zillow Group acquired it in 2023. Origen is not affiliated with Follow Up Boss or Zillow Group, and they did not review or endorse this page. Prices and features here come from followupboss.com as of August 18, 2026.
+            </p>
         </div>
     </footer>
 

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -130,6 +130,12 @@ HERO_LINES = (
     "No credit card required.",
     "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",
 )
+DISCLAIMER = (
+    "Follow Up Boss is a trademark of its owner. Zillow Group acquired it in 2023. "
+    "Origen is not affiliated with Follow Up Boss or Zillow Group, and they did not "
+    "review or endorse this page. Prices and features here come from followupboss.com "
+    "as of August 18, 2026."
+)
 
 
 def _faq_paragraphs(answer):
@@ -256,6 +262,8 @@ class TestFollowUpBossAlternativeCopy:
         assert "url_for('main.landing')" in PAGE
         assert "More on Origen is on" not in PAGE
         assert "the free real estate CRM page" not in PAGE
+        assert DISCLAIMER in PAGE
+        assert PAGE.count(DISCLAIMER) == 1
 
     def test_h1_is_the_human_line(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -391,6 +399,21 @@ class TestFollowUpBossAlternativeCopy:
         assert "30 leads" not in lowered
         assert "less than 30" not in lowered
         assert "we do not publish a lead count" not in lowered
+
+    def test_footer_disclaimer_is_the_only_added_legal_line(self):
+        visible = _visible_copy(PAGE)
+        assert DISCLAIMER in visible
+        assert visible.count(DISCLAIMER) == 1
+        assert "More on Origen is on" not in visible
+        assert "30 leads" not in visible.lower()
+        assert "—" not in visible
+        assert "MFTB" not in PAGE
+        assert "Holdco" not in PAGE
+        assert "lawyer" not in visible.lower()
+        assert "/pricing" not in PAGE
+        lowered = visible.lower()
+        for phrase in BANNED_SLOP:
+            assert phrase not in lowered
 
     def test_no_banned_slop(self):
         lowered = _visible_copy(PAGE).lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Quiet footer-style trademark note on the live `/follow-up-boss-alternative` page. Christopher's copy, title, H1, FAQs, table, homepage, and gold B.O.B. FAQ are unchanged.

## What changed

- Added one muted `text-xs` line inside the existing dark footer, under the copyright row. Not a banner. Not a new heading.
- Verbatim text:

  Follow Up Boss is a trademark of its owner. Zillow Group acquired it in 2023. Origen is not affiliated with Follow Up Boss or Zillow Group, and they did not review or endorse this page. Prices and features here come from followupboss.com as of August 18, 2026.

- Tests now require that one disclaimer line and still forbid leftover "More on Origen…", the 30-leads gotcha, em dashes, and slop.

## Intentionally not changed

- Page title, H1, FAQs, comparison table, homepage, gold B.O.B. FAQ
- Sitemap and `llms.txt`
- No `/pricing`, no MFTB Holdco, no extra legal claims

## Tests

Local: `121 passed` across `tests/test_follow_up_boss_alternative.py`, `tests/test_navigation.py`, `tests/test_landing_copy.py`, and `tests/test_free_real_estate_crm.py`.

Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecbc96c8-ff40-4d2d-9247-e43ff84d7f9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecbc96c8-ff40-4d2d-9247-e43ff84d7f9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

