### PR TITLE
feat: Wise Agent and kvCORE public comparison pages

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -443,6 +443,18 @@ def follow_up_boss_alternative():
     return render_template('follow_up_boss_alternative.html', current_year=datetime.now().year)
 
 
+@main_bp.route('/wise-agent-alternative')
+def wise_agent_alternative():
+    """Public Wise Agent alternative page. Always 200, even if logged in."""
+    return render_template('wise_agent_alternative.html', current_year=datetime.now().year)
+
+
+@main_bp.route('/kvcore-alternative')
+def kvcore_alternative():
+    """Public kvCORE alternative page. Always 200, even if logged in."""
+    return render_template('kvcore_alternative.html', current_year=datetime.now().year)
+
+
 # =============================================================================
 # CONTACTS LIST (Authenticated)
 # =============================================================================

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -21,3 +21,5 @@ Origen TechnolOG is a free CRM for real estate agents. Use it to organize contac
 - https://www.origentechnolog.com/terms-privacy
 - https://www.origentechnolog.com/free-real-estate-crm
 - https://www.origentechnolog.com/follow-up-boss-alternative
+- https://www.origentechnolog.com/wise-agent-alternative
+- https://www.origentechnolog.com/kvcore-alternative

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -18,4 +18,10 @@
   <url>
     <loc>https://www.origentechnolog.com/follow-up-boss-alternative</loc>
   </url>
+  <url>
+    <loc>https://www.origentechnolog.com/wise-agent-alternative</loc>
+  </url>
+  <url>
+    <loc>https://www.origentechnolog.com/kvcore-alternative</loc>
+  </url>
 </urlset>

--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -1,0 +1,566 @@
+{% from "components/seo_meta.html" import public_seo %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>kvCORE Alternative for Real Estate Agents | Origen</title>
+    {{ public_seo(
+        title="kvCORE Alternative for Real Estate Agents | Origen",
+        description="kvCORE is now BoldTrail. See how Origen compares: a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
+        canonical=app_base_url ~ "/kvcore-alternative"
+    ) }}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": "{{ app_base_url }}/#organization",
+          "name": "Origen TechnolOG",
+          "url": "{{ app_base_url }}/",
+          "logo": "{{ app_base_url }}/static/images/logo_og_dark.png"
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "{{ app_base_url }}/kvcore-alternative#software",
+          "name": "Origen TechnolOG",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web",
+          "isAccessibleForFree": true,
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+          },
+          "description": "kvCORE is now BoldTrail. See how Origen compares: a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
+          "url": "{{ app_base_url }}/kvcore-alternative",
+          "publisher": { "@id": "{{ app_base_url }}/#organization" }
+        },
+        {
+          "@type": "FAQPage",
+          "@id": "{{ app_base_url }}/kvcore-alternative#faq",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "How much does kvCORE / BoldTrail cost?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "They do not publish a standard public price. Their pricing page is quote-only (Talk to Sales). Their blog says they don't publish standard public pricing."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Is kvCORE the same as BoldTrail?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "BoldTrail is the current product. kvCORE is the earlier name."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Is Origen really free?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "What is B.O.B.?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Can I try Origen without moving everything over?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Is Origen a full replacement for kvCORE / BoldTrail?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "That depends. If you need IDX websites, lead generation, recruiting, BackOffice, or the rest of the BoldTrail ecosystem, Origen doesn't currently try to duplicate all of that."
+              }
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['DM Sans', 'system-ui', 'sans-serif'],
+                    },
+                    colors: {
+                        brand: {
+                            50: '#f0f4f8',
+                            100: '#d9e2ec',
+                            200: '#bcccdc',
+                            300: '#9fb3c8',
+                            400: '#829ab1',
+                            500: '#627d98',
+                            600: '#486581',
+                            700: '#334e68',
+                            800: '#243b53',
+                            900: '#102a43',
+                        },
+                        accent: {
+                            50: '#fff7ed',
+                            100: '#ffedd5',
+                            200: '#fed7aa',
+                            300: '#fdba74',
+                            400: '#fb923c',
+                            500: '#f97316',
+                            600: '#ea580c',
+                            700: '#c2410c',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .hero-bg {
+            background-color: #f8fafc;
+            background-image:
+                radial-gradient(ellipse at 20% 0%, rgba(249, 115, 22, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 100%, rgba(36, 59, 83, 0.06) 0%, transparent 50%),
+                url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23334e68' fill-opacity='0.03'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+        .nav-blur {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        .btn-primary {
+            position: relative;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px -8px rgba(249, 115, 22, 0.4);
+        }
+        .mobile-menu {
+            transform: translateX(100%);
+            transition: transform 0.3s ease;
+        }
+        .mobile-menu.open {
+            transform: translateX(0);
+        }
+        .landing-faq {
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+        .landing-faq details {
+            border-bottom: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq details:first-of-type {
+            border-top: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq summary {
+            list-style: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1.15rem 0;
+            font-size: 1.05rem;
+            font-weight: 600;
+            color: #102a43;
+        }
+        .landing-faq summary::-webkit-details-marker {
+            display: none;
+        }
+        .landing-faq summary::after {
+            content: '';
+            width: 10px;
+            height: 10px;
+            flex-shrink: 0;
+            border-right: 1.5px solid #627d98;
+            border-bottom: 1.5px solid #627d98;
+            transform: rotate(45deg);
+            margin-top: -4px;
+        }
+        .landing-faq details[open] summary {
+            color: #ea580c;
+        }
+        .landing-faq details[open] summary::after {
+            border-color: #f97316;
+            transform: rotate(225deg);
+            margin-top: 4px;
+        }
+        .landing-faq .faq-answer {
+            padding: 0 0 1.15rem;
+            color: #486581;
+            font-size: 1rem;
+            line-height: 1.6;
+        }
+        .compare-table {
+            width: 100%;
+            min-width: 40rem;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+        .compare-table th,
+        .compare-table td {
+            padding: 1rem 1.5rem 1rem 0;
+            vertical-align: top;
+        }
+        .compare-table thead th {
+            padding-top: 0.75rem;
+            padding-bottom: 0.85rem;
+        }
+        .compare-table col.label { width: 26%; }
+        .compare-table col.fub { width: 42%; }
+        .compare-table col.origen { width: 32%; }
+    </style>
+</head>
+
+<body class="font-sans antialiased text-brand-800">
+
+    <nav class="fixed top-0 left-0 right-0 z-50 nav-blur bg-white/90 border-b border-brand-100/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 md:h-20">
+                <a href="{{ url_for('main.landing') }}" class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </a>
+
+                <div class="hidden md:flex items-center gap-8">
+                    <a href="{{ url_for('main.landing') }}#features" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Pricing</a>
+                </div>
+
+                <div class="hidden md:flex items-center gap-4">
+                    <a href="{{ url_for('auth.login') }}" class="text-brand-700 hover:text-brand-900 font-semibold transition-colors">
+                        Log In
+                    </a>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                        <i class="fas fa-arrow-right text-sm"></i>
+                    </a>
+                </div>
+
+                <button id="mobileMenuBtn" class="md:hidden p-2 text-brand-700 hover:text-brand-900">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </div>
+
+        <div id="mobileMenuOverlay" class="fixed inset-0 bg-black/50 z-40 md:hidden opacity-0 pointer-events-none transition-opacity duration-300"></div>
+
+        <div id="mobileMenu" class="mobile-menu fixed top-0 right-0 w-80 h-screen md:hidden z-50" style="background-color: #ffffff;">
+            <div class="p-6 h-full bg-white">
+                <button id="closeMobileMenu" class="absolute top-4 right-4 p-2 text-brand-600 hover:text-brand-900 z-10">
+                    <i class="fas fa-times text-xl"></i>
+                </button>
+
+                <div class="mt-12 space-y-6">
+                    <a href="{{ url_for('main.landing') }}#features" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="block text-lg font-medium text-brand-700 hover:text-accent-500">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Pricing</a>
+
+                    <hr class="border-brand-100">
+
+                    <a href="{{ url_for('auth.login') }}" class="block text-lg font-semibold text-brand-800">Log In</a>
+                    <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-bg pt-24 md:pt-32 pb-16 md:pb-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
+                    Looking for a kvCORE alternative?
+                </h1>
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. That is a real product, and it is built for a lot more than a solo agent's daily CRM work.
+                </p>
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    Origen gives individual agents a simpler place to manage contacts, tasks, follow-ups, with a free plan you can keep using.
+                </p>
+                <p class="text-base text-brand-600 mb-8">
+                    No credit card required.
+                </p>
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+                <p class="mt-4 text-sm text-brand-500">
+                    Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day
+                </p>
+        </div>
+    </section>
+
+    <section class="bg-white py-16 md:py-20">
+        <div class="px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto space-y-16">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Origen vs. kvCORE / BoldTrail</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        These products aren't identical, and they shouldn't be presented as though they are.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        BoldTrail is a large platform for agents, teams and brokerages. Official pages describe IDX, lead generation, recruiting and BackOffice as part of that ecosystem. Pricing is quote-only.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen is aimed at individual agents who want the core CRM work handled without starting with another monthly software bill.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Inside Real Estate acquired BoomTown in 2023 and official BoldTrail pages say BoomTown is being folded into BoldTrail.
+                    </p>
+                </div>
+            </div>
+
+            <div class="max-w-5xl mx-auto mt-10 mb-16 overflow-x-auto">
+                        <table class="compare-table text-left text-brand-700">
+                            <colgroup>
+                                <col class="label">
+                                <col class="fub">
+                                <col class="origen">
+                            </colgroup>
+                            <thead>
+                                <tr class="border-b border-brand-200">
+                                    <th class="font-semibold text-brand-900"> </th>
+                                    <th class="font-semibold text-brand-900">BoldTrail</th>
+                                    <th class="font-semibold text-brand-900">Origen</th>
+                                </tr>
+                            </thead>
+                            <tbody class="align-top">
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Starting price</th>
+                                    <td class="py-3 pr-4">Quote-only</td>
+                                    <td class="py-3">Free</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Free plan</th>
+                                    <td class="py-3 pr-4">No</td>
+                                    <td class="py-3">Yes</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">IDX / lead gen / recruiting / BackOffice</th>
+                                    <td class="py-3 pr-4">BoldTrail ecosystem</td>
+                                    <td class="py-3">Not included</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Credit card</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">No</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Contacts</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">Up to 10,000 on free</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Users</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">1</td>
+                                </tr>
+                                <tr>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Calendar</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">Google Calendar task sync</td>
+                                </tr>
+                            </tbody>
+                        </table>
+            </div>
+
+            <div class="max-w-3xl mx-auto space-y-16">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">The biggest difference is what you actually need</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        BoldTrail is built for a lot more than a solo agent's daily CRM work. That is useful if your business needs IDX websites, lead generation, recruiting or BackOffice.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Their own writing says a brand-new solo agent who hasn't closed a first deal yet can find the full BoldTrail ecosystem a lot, and that a lighter, lower-cost CRM may make more sense.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen starts with the work you do every day: contacts, tasks, follow-ups and keeping track of what's happening with your clients.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        And you can start using it without a sales call or another monthly subscription.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Then there's B.O.B.</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        B.O.B. is the AI assistant built into Origen.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Instead of clicking through the CRM every time you want to get something done, tell B.O.B. what you need.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Find a client. Update a contact. Add a note. Complete a task. Log activity. Organize contacts. Ask questions about what's already in your CRM.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        If you can do it in Origen, you can ask B.O.B. to do it for you.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        The free plan includes 25 B.O.B. messages per day.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        B.O.B. can also be connected to Telegram, so you don't always have to be sitting inside the CRM to use it.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Try Origen Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When BoldTrail is probably the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        BoldTrail may make more sense if you need:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>IDX websites</li>
+                        <li>Lead generation</li>
+                        <li>Recruiting</li>
+                        <li>BackOffice</li>
+                        <li>A platform for teams and brokerages</li>
+                        <li>The rest of the BoldTrail ecosystem</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        BoldTrail is an established product with a much larger feature set in several of these areas.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Origen may be the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen may make more sense if:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>You're an individual real estate agent</li>
+                        <li>You want a CRM without another monthly bill</li>
+                        <li>You mainly need contacts, tasks and follow-up organization</li>
+                        <li>You use Gmail and Google Calendar</li>
+                        <li>You want AI that can actually perform CRM work for you</li>
+                        <li>You'd rather start simple and add more later</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        You don't have to decide whether Origen can replace your current CRM before trying it. The free plan doesn't expire. Create an account, put a few contacts in it and see whether it fits the way you work.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Start Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="faq" class="bg-[#f4f4f4] py-16 md:py-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-10">Common questions</h2>
+            <div class="landing-faq">
+                <details>
+                    <summary>How much does kvCORE / BoldTrail cost?</summary>
+                    <p class="faq-answer">They do not publish a standard public price. Their pricing page is quote-only (Talk to Sales). Their blog says they don't publish standard public pricing.</p>
+                </details>
+                <details>
+                    <summary>Is kvCORE the same as BoldTrail?</summary>
+                    <p class="faq-answer">BoldTrail is the current product. kvCORE is the earlier name.</p>
+                </details>
+                <details>
+                    <summary>Is Origen really free?</summary>
+                    <p class="faq-answer">Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.</p>
+                    <p class="faq-answer">The current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.</p>
+                </details>
+                <details>
+                    <summary>What is B.O.B.?</summary>
+                    <p class="faq-answer">B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.</p>
+                    <p class="faq-answer">If you can do something in Origen, you can ask B.O.B. to do it for you.</p>
+                </details>
+                <details>
+                    <summary>Can I try Origen without moving everything over?</summary>
+                    <p class="faq-answer">Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.</p>
+                </details>
+                <details>
+                    <summary>Is Origen a full replacement for kvCORE / BoldTrail?</summary>
+                    <p class="faq-answer">That depends. If you need IDX websites, lead generation, recruiting, BackOffice, or the rest of the BoldTrail ecosystem, Origen doesn't currently try to duplicate all of that.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <footer class="bg-brand-900 py-12">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col md:flex-row items-center justify-between gap-6">
+                <div class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </div>
+
+                <div class="flex items-center gap-6 text-brand-400 text-sm">
+                    <a href="{{ url_for('auth.login') }}" class="hover:text-white transition-colors">Login</a>
+                    <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
+                    <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
+                    <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                </div>
+
+                <div class="text-brand-500 text-sm">
+                    &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
+                </div>
+            </div>
+            <p class="mt-8 max-w-3xl mx-auto text-center text-xs leading-relaxed text-brand-500">
+                kvCORE and BoldTrail are trademarks of their owners. Origen TechnolOG is not affiliated. Facts from boldtrail.com as of 2026-08-18.
+            </p>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+        const closeMobileMenu = document.getElementById('closeMobileMenu');
+        const mobileMenu = document.getElementById('mobileMenu');
+        const mobileMenuOverlay = document.getElementById('mobileMenuOverlay');
+
+        function openMobileMenu() {
+            mobileMenu.classList.add('open');
+            mobileMenuOverlay.classList.remove('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.add('opacity-100');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeMobileMenuFn() {
+            mobileMenu.classList.remove('open');
+            mobileMenuOverlay.classList.add('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.remove('opacity-100');
+            document.body.style.overflow = '';
+        }
+
+        mobileMenuBtn.addEventListener('click', openMobileMenu);
+        closeMobileMenu.addEventListener('click', closeMobileMenuFn);
+        mobileMenuOverlay.addEventListener('click', closeMobileMenuFn);
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', closeMobileMenuFn);
+        });
+    </script>
+
+    {% include 'modals/contact_us_modal.html' %}
+
+</body>
+</html>

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -1,0 +1,556 @@
+{% from "components/seo_meta.html" import public_seo %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wise Agent Alternative for Real Estate Agents | Origen</title>
+    {{ public_seo(
+        title="Wise Agent Alternative for Real Estate Agents | Origen",
+        description="Comparing Origen with Wise Agent? See pricing, features and where each CRM fits. Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
+        canonical=app_base_url ~ "/wise-agent-alternative"
+    ) }}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": "{{ app_base_url }}/#organization",
+          "name": "Origen TechnolOG",
+          "url": "{{ app_base_url }}/",
+          "logo": "{{ app_base_url }}/static/images/logo_og_dark.png"
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "{{ app_base_url }}/wise-agent-alternative#software",
+          "name": "Origen TechnolOG",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web",
+          "isAccessibleForFree": true,
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+          },
+          "description": "Comparing Origen with Wise Agent? See pricing, features and where each CRM fits. Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
+          "url": "{{ app_base_url }}/wise-agent-alternative",
+          "publisher": { "@id": "{{ app_base_url }}/#organization" }
+        },
+        {
+          "@type": "FAQPage",
+          "@id": "{{ app_base_url }}/wise-agent-alternative#faq",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "What is B.O.B.?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Is Origen really free?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Can I try Origen without moving everything over?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Is Origen a full replacement for Wise Agent?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "That depends. If you need paid team logins, WiseText, WiseSocial or the transaction and marketing tools on their pricing page, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "How much does Wise Agent cost?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Their pricing page lists CRM at $49 a month, or $499 a year ($42 a month billed annually). There is a 14-day free trial. There is no published free plan."
+              }
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+
+    <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['DM Sans', 'system-ui', 'sans-serif'],
+                    },
+                    colors: {
+                        brand: {
+                            50: '#f0f4f8',
+                            100: '#d9e2ec',
+                            200: '#bcccdc',
+                            300: '#9fb3c8',
+                            400: '#829ab1',
+                            500: '#627d98',
+                            600: '#486581',
+                            700: '#334e68',
+                            800: '#243b53',
+                            900: '#102a43',
+                        },
+                        accent: {
+                            50: '#fff7ed',
+                            100: '#ffedd5',
+                            200: '#fed7aa',
+                            300: '#fdba74',
+                            400: '#fb923c',
+                            500: '#f97316',
+                            600: '#ea580c',
+                            700: '#c2410c',
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .hero-bg {
+            background-color: #f8fafc;
+            background-image:
+                radial-gradient(ellipse at 20% 0%, rgba(249, 115, 22, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 100%, rgba(36, 59, 83, 0.06) 0%, transparent 50%),
+                url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23334e68' fill-opacity='0.03'%3E%3Cpath d='m36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+        .nav-blur {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        .btn-primary {
+            position: relative;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px -8px rgba(249, 115, 22, 0.4);
+        }
+        .mobile-menu {
+            transform: translateX(100%);
+            transition: transform 0.3s ease;
+        }
+        .mobile-menu.open {
+            transform: translateX(0);
+        }
+        .landing-faq {
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+        .landing-faq details {
+            border-bottom: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq details:first-of-type {
+            border-top: 1px solid rgba(16, 42, 67, 0.12);
+        }
+        .landing-faq summary {
+            list-style: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1.15rem 0;
+            font-size: 1.05rem;
+            font-weight: 600;
+            color: #102a43;
+        }
+        .landing-faq summary::-webkit-details-marker {
+            display: none;
+        }
+        .landing-faq summary::after {
+            content: '';
+            width: 10px;
+            height: 10px;
+            flex-shrink: 0;
+            border-right: 1.5px solid #627d98;
+            border-bottom: 1.5px solid #627d98;
+            transform: rotate(45deg);
+            margin-top: -4px;
+        }
+        .landing-faq details[open] summary {
+            color: #ea580c;
+        }
+        .landing-faq details[open] summary::after {
+            border-color: #f97316;
+            transform: rotate(225deg);
+            margin-top: 4px;
+        }
+        .landing-faq .faq-answer {
+            padding: 0 0 1.15rem;
+            color: #486581;
+            font-size: 1rem;
+            line-height: 1.6;
+        }
+        .compare-table {
+            width: 100%;
+            min-width: 40rem;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+        .compare-table th,
+        .compare-table td {
+            padding: 1rem 1.5rem 1rem 0;
+            vertical-align: top;
+        }
+        .compare-table thead th {
+            padding-top: 0.75rem;
+            padding-bottom: 0.85rem;
+        }
+        .compare-table col.label { width: 26%; }
+        .compare-table col.fub { width: 42%; }
+        .compare-table col.origen { width: 32%; }
+    </style>
+</head>
+
+<body class="font-sans antialiased text-brand-800">
+
+    <nav class="fixed top-0 left-0 right-0 z-50 nav-blur bg-white/90 border-b border-brand-100/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 md:h-20">
+                <a href="{{ url_for('main.landing') }}" class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_ogblueandblue.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </a>
+
+                <div class="hidden md:flex items-center gap-8">
+                    <a href="{{ url_for('main.landing') }}#features" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="text-brand-600 hover:text-brand-900 font-medium transition-colors">Pricing</a>
+                </div>
+
+                <div class="hidden md:flex items-center gap-4">
+                    <a href="{{ url_for('auth.login') }}" class="text-brand-700 hover:text-brand-900 font-semibold transition-colors">
+                        Log In
+                    </a>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                        <i class="fas fa-arrow-right text-sm"></i>
+                    </a>
+                </div>
+
+                <button id="mobileMenuBtn" class="md:hidden p-2 text-brand-700 hover:text-brand-900">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </div>
+
+        <div id="mobileMenuOverlay" class="fixed inset-0 bg-black/50 z-40 md:hidden opacity-0 pointer-events-none transition-opacity duration-300"></div>
+
+        <div id="mobileMenu" class="mobile-menu fixed top-0 right-0 w-80 h-screen md:hidden z-50" style="background-color: #ffffff;">
+            <div class="p-6 h-full bg-white">
+                <button id="closeMobileMenu" class="absolute top-4 right-4 p-2 text-brand-600 hover:text-brand-900 z-10">
+                    <i class="fas fa-times text-xl"></i>
+                </button>
+
+                <div class="mt-12 space-y-6">
+                    <a href="{{ url_for('main.landing') }}#features" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Features</a>
+                    <a href="{{ url_for('main.landing') }}#how-it-works" class="block text-lg font-medium text-brand-700 hover:text-accent-500">How It Works</a>
+                    <a href="{{ url_for('main.landing') }}#pricing" class="block text-lg font-medium text-brand-700 hover:text-accent-500">Pricing</a>
+
+                    <hr class="border-brand-100">
+
+                    <a href="{{ url_for('auth.login') }}" class="block text-lg font-semibold text-brand-800">Log In</a>
+                    <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
+                        Start Free
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-bg pt-24 md:pt-32 pb-16 md:pb-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
+                    Looking for a Wise Agent alternative?
+                </h1>
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. That is a real product, and a lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.
+                </p>
+                <p class="text-lg sm:text-xl text-brand-600 mb-6">
+                    Origen gives individual real estate agents a simpler place to do that work, with a free plan you can keep using.
+                </p>
+                <p class="text-base text-brand-600 mb-8">
+                    No credit card required.
+                </p>
+                <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                    Start Free
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+                <p class="mt-4 text-sm text-brand-500">
+                    Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day
+                </p>
+        </div>
+    </section>
+
+    <section class="bg-white py-16 md:py-20">
+        <div class="px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto space-y-16">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Origen vs. Wise Agent</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        These products aren't identical, and they shouldn't be presented as though they are.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Wise Agent has published pricing, team logins and add-ons such as WiseText and WiseSocial. That is a real product, and a lot of agents use it.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Origen is aimed at agents who want the core CRM work handled without starting with another monthly software bill.
+                    </p>
+                </div>
+            </div>
+
+            <div class="max-w-5xl mx-auto mt-10 mb-16 overflow-x-auto">
+                        <table class="compare-table text-left text-brand-700">
+                            <colgroup>
+                                <col class="label">
+                                <col class="fub">
+                                <col class="origen">
+                            </colgroup>
+                            <thead>
+                                <tr class="border-b border-brand-200">
+                                    <th class="font-semibold text-brand-900"> </th>
+                                    <th class="font-semibold text-brand-900">Wise Agent</th>
+                                    <th class="font-semibold text-brand-900">Origen</th>
+                                </tr>
+                            </thead>
+                            <tbody class="align-top">
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Starting price</th>
+                                    <td class="py-3 pr-4">$49/month on CRM</td>
+                                    <td class="py-3">Free</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Free plan</th>
+                                    <td class="py-3 pr-4">No, 14-day free trial</td>
+                                    <td class="py-3">Yes</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Credit card</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">No</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Contacts</th>
+                                    <td class="py-3 pr-4">Not published</td>
+                                    <td class="py-3">Up to 10,000 on free</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Users</th>
+                                    <td class="py-3 pr-4">N/A</td>
+                                    <td class="py-3">1</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Calendar</th>
+                                    <td class="py-3 pr-4">Team-friendly calendar</td>
+                                    <td class="py-3">Google Calendar task sync</td>
+                                </tr>
+                                <tr class="border-b border-brand-100">
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Calling & texting</th>
+                                    <td class="py-3 pr-4">WiseText paid add-on</td>
+                                    <td class="py-3">Not included</td>
+                                </tr>
+                                <tr>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Shared team logins</th>
+                                    <td class="py-3 pr-4">Up to 5 on one login</td>
+                                    <td class="py-3">1 user</td>
+                                </tr>
+                            </tbody>
+                        </table>
+            </div>
+
+            <div class="max-w-3xl mx-auto space-y-16">
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">The biggest difference is what you actually need</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Wise Agent makes sense if you want a published-price CRM with team logins and add-ons like WiseText. That is useful if your business needs it.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        But a solo agent looking for a clean CRM may not need all of that on day one.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen starts with the work you do every day: contacts, tasks, follow-ups and keeping track of what's happening with your clients.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        And you can start using it without turning on another monthly subscription.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">Then there's B.O.B.</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        B.O.B. is the AI assistant built into Origen.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Instead of clicking through the CRM every time you want to get something done, tell B.O.B. what you need.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Find a client. Update a contact. Add a note. Complete a task. Log activity. Organize contacts. Ask questions about what's already in your CRM.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        If you can do it in Origen, you can ask B.O.B. to do it for you.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        The free plan includes 25 B.O.B. messages per day.
+                    </p>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        B.O.B. can also be connected to Telegram, so you don't always have to be sitting inside the CRM to use it.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Try Origen Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Wise Agent is probably the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Wise Agent may make more sense if you need:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>Paid team logins, including up to 5 people on one login</li>
+                        <li>WiseText</li>
+                        <li>WiseSocial</li>
+                        <li>Transaction and marketing tools listed on their pricing page</li>
+                        <li>A CRM already set up for a small team sharing one login</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed">
+                        Wise Agent is an established product with a broader tool set in several of these areas.
+                    </p>
+                </div>
+
+                <div>
+                    <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">When Origen may be the better fit</h2>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-4">
+                        Origen may make more sense if:
+                    </p>
+                    <ul class="list-disc pl-5 space-y-2 text-lg text-brand-600 leading-relaxed mb-4">
+                        <li>You're an individual real estate agent</li>
+                        <li>You want a CRM without another monthly bill</li>
+                        <li>You mainly need contacts, tasks and follow-up organization</li>
+                        <li>You use Gmail and Google Calendar</li>
+                        <li>You want AI that can actually perform CRM work for you</li>
+                        <li>You'd rather start simple and add more later</li>
+                    </ul>
+                    <p class="text-lg text-brand-600 leading-relaxed mb-8">
+                        You don't have to decide whether Origen can replace your current CRM before trying it. The free plan doesn't expire. Create an account, put a few contacts in it and see whether it fits the way you work.
+                    </p>
+                    <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
+                        Start Free
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="faq" class="bg-[#f4f4f4] py-16 md:py-20">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl sm:text-4xl font-bold text-brand-900 mb-10">Common questions</h2>
+            <div class="landing-faq">
+                <details>
+                    <summary>What is B.O.B.?</summary>
+                    <p class="faq-answer">B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.</p>
+                    <p class="faq-answer">If you can do something in Origen, you can ask B.O.B. to do it for you.</p>
+                </details>
+                <details>
+                    <summary>Is Origen really free?</summary>
+                    <p class="faq-answer">Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.</p>
+                    <p class="faq-answer">The current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.</p>
+                </details>
+                <details>
+                    <summary>Can I try Origen without moving everything over?</summary>
+                    <p class="faq-answer">Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.</p>
+                </details>
+                <details>
+                    <summary>Is Origen a full replacement for Wise Agent?</summary>
+                    <p class="faq-answer">That depends. If you need paid team logins, WiseText, WiseSocial or the transaction and marketing tools on their pricing page, Origen doesn't currently try to duplicate all of that.</p>
+                    <p class="faq-answer">If what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.</p>
+                </details>
+                <details>
+                    <summary>How much does Wise Agent cost?</summary>
+                    <p class="faq-answer">Their pricing page lists CRM at $49 a month, or $499 a year ($42 a month billed annually). There is a 14-day free trial. There is no published free plan.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <footer class="bg-brand-900 py-12">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col md:flex-row items-center justify-between gap-6">
+                <div class="flex items-center">
+                    <img src="{{ url_for('static', filename='images/logo_og_dark.png') }}" alt="Origen TechnolOG" class="h-8 md:h-10 w-auto object-contain" width="183" height="40" />
+                </div>
+
+                <div class="flex items-center gap-6 text-brand-400 text-sm">
+                    <a href="{{ url_for('auth.login') }}" class="hover:text-white transition-colors">Login</a>
+                    <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
+                    <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
+                    <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                </div>
+
+                <div class="text-brand-500 text-sm">
+                    &copy; {{ current_year }} Origen TechnolOG. All rights reserved.
+                </div>
+            </div>
+            <p class="mt-8 max-w-3xl mx-auto text-center text-xs leading-relaxed text-brand-500">
+                Wise Agent is a trademark of its owner. Origen TechnolOG is not affiliated. Facts from wiseagent.com/pricing as of 2026-08-18.
+            </p>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+        const closeMobileMenu = document.getElementById('closeMobileMenu');
+        const mobileMenu = document.getElementById('mobileMenu');
+        const mobileMenuOverlay = document.getElementById('mobileMenuOverlay');
+
+        function openMobileMenu() {
+            mobileMenu.classList.add('open');
+            mobileMenuOverlay.classList.remove('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.add('opacity-100');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function closeMobileMenuFn() {
+            mobileMenu.classList.remove('open');
+            mobileMenuOverlay.classList.add('opacity-0', 'pointer-events-none');
+            mobileMenuOverlay.classList.remove('opacity-100');
+            document.body.style.overflow = '';
+        }
+
+        mobileMenuBtn.addEventListener('click', openMobileMenu);
+        closeMobileMenu.addEventListener('click', closeMobileMenuFn);
+        mobileMenuOverlay.addEventListener('click', closeMobileMenuFn);
+        mobileMenu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', closeMobileMenuFn);
+        });
+    </script>
+
+    {% include 'modals/contact_us_modal.html' %}
+
+</body>
+</html>

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -24,6 +24,8 @@ ALLOWED_SITEMAP_PATHS = {
     "/terms-privacy",
     PAGE_PATH,
     "/follow-up-boss-alternative",
+    "/wise-agent-alternative",
+    "/kvcore-alternative",
 }
 BLOCKED_SEO_PATHS = (
     "/pricing",

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -1,4 +1,4 @@
-"""Public /follow-up-boss-alternative page: route, SEO, sitemap, and copy guards."""
+"""Public /kvcore-alternative page: route, SEO, sitemap, and copy guards."""
 import re
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -7,18 +7,19 @@ from tier_config.tier_limits import get_tier_defaults
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PAGE = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
+PAGE = (ROOT / "templates" / "kvcore_alternative.html").read_text()
 LANDING = (ROOT / "templates" / "landing.html").read_text()
+FUB = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
 SITEMAP = ROOT / "static" / "sitemap.xml"
 LLMS = ROOT / "static" / "llms.txt"
 FREE_LIMITS = get_tier_defaults("free")
 
-PAGE_PATH = "/follow-up-boss-alternative"
-TITLE = "Follow Up Boss Alternative for Real Estate Agents | Origen"
-H1 = "Looking for a Follow Up Boss alternative?"
+PAGE_PATH = "/kvcore-alternative"
+TITLE = "kvCORE Alternative for Real Estate Agents | Origen"
+H1 = "Looking for a kvCORE alternative?"
 META = (
-    "Comparing Origen with Follow Up Boss? See pricing, features and where each CRM fits. "
-    "Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant."
+    "kvCORE is now BoldTrail. See how Origen compares: a free plan with up to 10,000 contacts "
+    "and B.O.B., its built-in AI assistant."
 )
 HOME_TITLE = "Free Real Estate CRM | Origen TechnolOG"
 HOME_H1_PART = "Your clients and follow-ups,"
@@ -40,9 +41,9 @@ ALLOWED_SITEMAP_PATHS = {
     "/login",
     "/terms-privacy",
     "/free-real-estate-crm",
-    PAGE_PATH,
+    "/follow-up-boss-alternative",
     "/wise-agent-alternative",
-    "/kvcore-alternative",
+    PAGE_PATH,
 }
 BLOCKED_SEO_PATHS = (
     "/pricing",
@@ -51,6 +52,9 @@ BLOCKED_SEO_PATHS = (
     "/help",
     "/features",
     "/contact",
+    "/boomtown-alternative",
+    "/boldtrail-alternative",
+    "/top-producer-alternative",
 )
 BANNED_SLOP = (
     "unlock",
@@ -74,24 +78,28 @@ BANNED_SLOP = (
 )
 FAQ_ITEMS = (
     (
-        "How much does Follow Up Boss cost?",
-        "Follow Up Boss currently lists its Grow plan at $69 per user per month, or $58 per user per month when billed annually. It offers a 14-day free trial rather than a permanent free plan.",
+        "How much does kvCORE / BoldTrail cost?",
+        "They do not publish a standard public price. Their pricing page is quote-only (Talk to Sales). Their blog says they don't publish standard public pricing.",
+    ),
+    (
+        "Is kvCORE the same as BoldTrail?",
+        "BoldTrail is the current product. kvCORE is the earlier name.",
     ),
     (
         "Is Origen really free?",
         "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.",
     ),
     (
-        "Is Origen a full replacement for Follow Up Boss?",
-        "That depends on what you use Follow Up Boss for. If you need its advanced lead routing, calling, texting, team management or large integration ecosystem, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.",
+        "What is B.O.B.?",
+        "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you.",
     ),
     (
         "Can I try Origen without moving everything over?",
         "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.",
     ),
     (
-        "What is B.O.B.?",
-        "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you.",
+        "Is Origen a full replacement for kvCORE / BoldTrail?",
+        "That depends. If you need IDX websites, lead generation, recruiting, BackOffice, or the rest of the BoldTrail ecosystem, Origen doesn't currently try to duplicate all of that.",
     ),
 )
 FAKE_SEO_QUESTIONS = (
@@ -100,43 +108,51 @@ FAKE_SEO_QUESTIONS = (
     "Is this Follow Up Boss or HubSpot",
     "Is this origentech.com or Origin CRM",
     "What can B.O.B. do?",
-    "How much is Follow Up Boss?",
-    "Does Follow Up Boss have a free plan?",
+    "How much is kvCORE?",
+    "How much is BoldTrail?",
+    "Does BoldTrail have a free plan?",
     "What does Origen include?",
     "Can I buy Pro today?",
 )
 TABLE_ROWS = (
-    ("Starting price", "$69/user/month on Grow", "Free"),
-    ("Free plan", "No, 14-day free trial", "Yes"),
-    ("Credit card to start", "No", "No"),
-    ("Contacts", "Unlimited", "Up to 10,000 on free"),
-    ("Free-plan users", "N/A", "1"),
-    ("Gmail", "Supported", "Send email through Gmail"),
-    ("Calendar", "Calendar and email sync", "Google Calendar task sync"),
-    ("AI", "FUB AI features", "B.O.B. AI assistant"),
-    ("Calling & texting", "Available, with Calling included on higher plans or added to Grow", "Not included"),
-    ("Advanced lead routing", "Yes", "Not included"),
-    ("Large integration ecosystem", "Yes", "Not included"),
+    ("Starting price", "Quote-only", "Free"),
+    ("Free plan", "No", "Yes"),
+    ("IDX / lead gen / recruiting / BackOffice", "BoldTrail ecosystem", "Not included"),
+    ("Credit card", "Not published", "No"),
+    ("Contacts", "Not published", "Up to 10,000 on free"),
+    ("Users", "Not published", "1"),
+    ("Calendar", "Not published", "Google Calendar task sync"),
 )
 SECTION_HEADINGS = (
-    "Origen vs. Follow Up Boss",
+    "Origen vs. kvCORE / BoldTrail",
     "The biggest difference is what you actually need",
     "Then there's B.O.B.",
-    "When Follow Up Boss is probably the better fit",
+    "When BoldTrail is probably the better fit",
     "When Origen may be the better fit",
     "Common questions",
 )
 HERO_LINES = (
-    "Follow Up Boss is a powerful CRM, especially for teams managing a large volume of leads. But not every agent needs everything it offers or wants another $69-per-user monthly subscription.",
-    "Origen gives individual real estate agents a simpler place to manage contacts, tasks, follow-ups and day-to-day CRM work, with a free plan you can keep using.",
+    "kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. That is a real product, and it is built for a lot more than a solo agent's daily CRM work.",
+    "Origen gives individual agents a simpler place to manage contacts, tasks, follow-ups, with a free plan you can keep using.",
     "No credit card required.",
     "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",
 )
 DISCLAIMER = (
-    "Follow Up Boss is a trademark of its owner. Zillow Group acquired it in 2023. "
-    "Origen is not affiliated with Follow Up Boss or Zillow Group, and they did not "
-    "review or endorse this page. Prices and features here come from followupboss.com "
-    "as of August 18, 2026."
+    "kvCORE and BoldTrail are trademarks of their owners. Origen TechnolOG is not affiliated. "
+    "Facts from boldtrail.com as of 2026-08-18."
+)
+BOOMTOWN_LINE = (
+    "Inside Real Estate acquired BoomTown in 2023 and official BoldTrail pages say "
+    "BoomTown is being folded into BoldTrail."
+)
+BOB_SECTION_LINES = (
+    "Then there's B.O.B.",
+    "B.O.B. is the AI assistant built into Origen.",
+    "Instead of clicking through the CRM every time you want to get something done, tell B.O.B. what you need.",
+    "Find a client. Update a contact. Add a note. Complete a task. Log activity. Organize contacts. Ask questions about what's already in your CRM.",
+    "If you can do it in Origen, you can ask B.O.B. to do it for you.",
+    "The free plan includes 25 B.O.B. messages per day.",
+    "B.O.B. can also be connected to Telegram, so you don't always have to be sitting inside the CRM to use it.",
 )
 
 
@@ -175,7 +191,7 @@ def _body_copy(html):
     return _visible_copy(body)
 
 
-class TestFollowUpBossAlternativeRoute:
+class TestKvcoreAlternativeRoute:
     def test_page_returns_200(self, client):
         resp = client.get(PAGE_PATH)
         assert resp.status_code == 200
@@ -201,8 +217,10 @@ class TestFollowUpBossAlternativeRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in text
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in LLMS.read_text()
+        assert "https://www.origentechnolog.com/kvcore-alternative" in text
+        assert "https://www.origentechnolog.com/kvcore-alternative" in LLMS.read_text()
+        assert "https://www.origentechnolog.com/boldtrail-alternative" not in text
+        assert "https://www.origentechnolog.com/boomtown-alternative" not in text
         for blocked in BLOCKED_SEO_PATHS:
             assert f"https://www.origentechnolog.com{blocked}" not in text
         assert "https://www.origentechnolog.com/dashboard" not in text
@@ -214,7 +232,7 @@ class TestFollowUpBossAlternativeRoute:
             assert resp.status_code == 404, f"{path} should not be a public page"
 
 
-class TestFollowUpBossAlternativeSeo:
+class TestKvcoreAlternativeSeo:
     def test_unique_title_canonical_and_og(self, app, client):
         page = client.get(PAGE_PATH).get_data(as_text=True)
         home = client.get("/").get_data(as_text=True)
@@ -252,7 +270,7 @@ class TestFollowUpBossAlternativeSeo:
         assert "noindex" not in html.lower()
 
 
-class TestFollowUpBossAlternativeCopy:
+class TestKvcoreAlternativeCopy:
     def test_required_human_copy(self):
         assert f"<title>{TITLE}</title>" in PAGE
         assert H1 in PAGE
@@ -262,10 +280,10 @@ class TestFollowUpBossAlternativeCopy:
         assert "url_for('auth.register')" in PAGE
         assert "url_for('main.free_real_estate_crm')" not in PAGE
         assert "url_for('main.landing')" in PAGE
-        assert "More on Origen is on" not in PAGE
-        assert "the free real estate CRM page" not in PAGE
         assert DISCLAIMER in PAGE
         assert PAGE.count(DISCLAIMER) == 1
+        assert BOOMTOWN_LINE in PAGE
+        assert PAGE.count("BoomTown") == 2
 
     def test_h1_is_the_human_line(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -275,7 +293,7 @@ class TestFollowUpBossAlternativeCopy:
         h1 = re.sub(r"\s+", " ", h1).strip()
         assert h1 == H1
 
-    def test_hero_uses_his_lines(self):
+    def test_hero_uses_specified_lines(self):
         for line in HERO_LINES:
             assert line in PAGE
 
@@ -283,16 +301,26 @@ class TestFollowUpBossAlternativeCopy:
         for heading in SECTION_HEADINGS:
             assert heading in PAGE
 
-    def test_comparison_table_matches_his_rows(self, client):
+    def test_comparison_table_matches_specified_rows(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         visible = _visible_copy(html)
-        for label, fub, origen in TABLE_ROWS:
+        for label, other, origen in TABLE_ROWS:
             assert label in visible
-            assert fub in visible
+            assert other in visible
             assert origen in visible
             assert label in PAGE
-            assert fub in PAGE
+            assert other in PAGE
             assert origen in PAGE
+
+    def test_no_invented_boldtrail_price_or_contact_cap(self):
+        visible = _visible_copy(PAGE)
+        assert "$" not in visible
+        assert "quote-only" in visible.lower()
+        assert re.search(r"Contacts\s+Not published\s+Up to 10,000 on free", visible) is not None
+        lowered = PAGE.lower()
+        assert "boldtrail costs" not in lowered
+        assert "starts at $" not in lowered
+        assert "unlimited contacts" not in lowered
 
     def test_limits_match_repo(self):
         assert FREE_LIMITS["max_users"] == 1
@@ -304,12 +332,6 @@ class TestFollowUpBossAlternativeCopy:
         assert "10,000 contacts" in visible
         assert "25 B.O.B. messages per day" in visible
         assert "Up to 10,000 on free" in visible
-
-    def test_does_not_claim_origen_has_unlimited_contacts(self):
-        visible = _visible_copy(PAGE)
-        assert re.search(r"Origen[^.]*unlimited contacts", visible, flags=re.I) is None
-        assert "Origen publishes unlimited contacts" not in PAGE
-        assert "unlimited contacts on Origen" not in PAGE.lower()
 
     def test_cta_goes_to_register(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -323,99 +345,63 @@ class TestFollowUpBossAlternativeCopy:
     def test_no_exclamation_in_visible_copy(self):
         assert "!" not in _visible_copy(PAGE)
 
-    def test_does_not_claim_never_paid_plan(self):
-        assert "never be a paid plan" not in PAGE.lower()
-        assert "never be a paid" not in PAGE.lower()
+    def test_bob_section_matches_fub_wording(self):
+        for line in BOB_SECTION_LINES:
+            assert line in PAGE
+            assert line in FUB
 
-    def test_does_not_claim_fub_trial_needs_a_card(self):
-        lowered = PAGE.lower()
-        assert "trial requires a card" not in lowered
-        assert "trial requires a credit card" not in lowered
-        assert "need a credit card for the trial" not in lowered
-        assert "credit card required for those 14 days" not in PAGE
-        assert "Then they charge." not in PAGE
-        assert "After that they charge" not in PAGE
-        visible = _visible_copy(PAGE)
-        assert "Credit card to start" in visible
-        assert re.search(r"Credit card to start\s+No\s+No", visible) is not None
-
-    def test_does_not_say_charges_you_after_14_days(self):
-        lowered = PAGE.lower()
-        assert "charges you after 14 days" not in lowered
-        assert "after that they charge" not in lowered
-        assert "14-day free trial rather than a permanent free plan" in PAGE
-
-    def test_does_not_say_we_are_not_a_replacement(self):
-        lowered = PAGE.lower()
-        assert "we are not a replacement for follow up boss" not in lowered
-        assert "we are not a replacement" not in lowered
-        assert "Is Origen a full replacement for Follow Up Boss?" in PAGE
-
-    def test_does_not_claim_built_by_agents(self):
-        lowered = PAGE.lower()
-        assert "built by real estate agents" not in lowered
-        assert "by real estate agents" not in lowered
-        assert "built for agents, by agents" not in lowered
-        assert "by agents" not in lowered
-
-    def test_does_not_claim_origen_calling_routing_or_integrations(self, client):
+    def test_does_not_claim_origen_calling_idx_routing_or_migration(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         visible = _visible_copy(html)
-        assert "Calling & texting" in visible
-        assert "Available, with Calling included on higher plans or added to Grow" in visible
-        assert "Advanced lead routing" in visible
-        assert "Large integration ecosystem" in visible
         assert re.search(
-            r"Calling & texting\s+Available, with Calling included on higher plans or added to Grow\s+Not included",
+            r"IDX / lead gen / recruiting / BackOffice\s+BoldTrail ecosystem\s+Not included",
             visible,
         ) is not None
-        assert re.search(r"Advanced lead routing\s+Yes\s+Not included", visible) is not None
-        assert re.search(r"Large integration ecosystem\s+Yes\s+Not included", visible) is not None
         lowered = visible.lower()
         assert "origen includes calling" not in lowered
         assert "origen includes texting" not in lowered
         assert "origen calling" not in lowered
+        assert "origen includes idx" not in lowered
+        assert "lead routing" not in lowered
         assert "twilio" not in lowered
         assert "automated crm migration" not in lowered
-        assert "automated fub migration" not in lowered
-        assert "import from follow up boss" not in lowered
-
-    def test_does_not_imply_fub_lacks_ai(self):
-        visible = _visible_copy(PAGE)
-        assert "FUB AI features" in visible
-        assert "B.O.B. AI assistant" in visible
-        lowered = visible.lower()
-        assert "follow up boss does not have ai" not in lowered
-        assert "fub has no ai" not in lowered
-        assert "fub lacks ai" not in lowered
-        assert "without ai" not in lowered
+        assert "import from kvcore" not in lowered
+        assert "import from boldtrail" not in lowered
+        assert "you will be moved" not in lowered
 
     def test_alternative_phrase_is_not_stuffed(self):
         body = _body_copy(PAGE)
-        matches = re.findall(r"follow up boss alternative", body, flags=re.I)
+        matches = re.findall(r"kvcore alternative", body, flags=re.I)
         assert len(matches) <= 1
-        assert PAGE.lower().count("follow up boss alternative") <= 3
+        assert PAGE.lower().count("kvcore alternative") <= 3
 
-    def test_no_thirty_leads_gotcha(self):
+    def test_boomtown_is_one_quiet_factual_sentence(self):
+        assert BOOMTOWN_LINE in PAGE
+        assert PAGE.count(BOOMTOWN_LINE) == 1
+        assert PAGE.count("BoomTown") == 2
+        assert "/boomtown-alternative" not in PAGE
+        assert "url_for('main.boomtown" not in PAGE
         lowered = PAGE.lower()
-        assert "30 leads" not in lowered
-        assert "less than 30" not in lowered
-        assert "we do not publish a lead count" not in lowered
+        assert "moved on" not in lowered
+        assert "migration deadline" not in lowered
 
     def test_footer_disclaimer_is_the_only_added_legal_line(self):
         visible = _visible_copy(PAGE)
         assert DISCLAIMER in visible
         assert visible.count(DISCLAIMER) == 1
-        assert "More on Origen is on" not in visible
-        assert "30 leads" not in visible.lower()
         assert "—" not in visible
-        assert "MFTB" not in PAGE
-        assert "Holdco" not in PAGE
-        assert "lawyer" not in visible.lower()
         assert "/pricing" not in PAGE
+        assert "Inside Real Estate" in PAGE
         lowered = visible.lower()
         for phrase in BANNED_SLOP:
             assert phrase not in lowered
+
+    def test_no_invented_legal_entity_name(self):
+        lowered = PAGE.lower()
+        assert "inside real estate llc" not in lowered
+        assert "inside real estate, inc" not in lowered
+        assert "holdco" not in lowered
+        assert "zillow" not in lowered
 
     def test_no_banned_slop(self):
         lowered = _visible_copy(PAGE).lower()
@@ -424,8 +410,8 @@ class TestFollowUpBossAlternativeCopy:
 
     def test_faq_matches_json_ld_and_repo_limits(self):
         assert '"@type": "FAQPage"' in PAGE
-        assert PAGE.count("<summary>") == 5
-        assert PAGE.count('"@type": "Question"') == 5
+        assert PAGE.count("<summary>") == 6
+        assert PAGE.count('"@type": "Question"') == 6
         for question, answer in FAQ_ITEMS:
             assert PAGE.count(question) == 2
             assert f"<summary>{question}</summary>" in PAGE
@@ -434,7 +420,7 @@ class TestFollowUpBossAlternativeCopy:
             for para in _faq_paragraphs(answer):
                 assert PAGE.count(para) == 2
                 assert f'<p class="faq-answer">{para}</p>' in PAGE
-        free_answer = FAQ_ITEMS[1][1]
+        free_answer = FAQ_ITEMS[2][1]
         assert "one user" in free_answer
         assert "10,000 contacts" in free_answer
         assert "25 B.O.B. messages per day" in free_answer
@@ -442,16 +428,6 @@ class TestFollowUpBossAlternativeCopy:
     def test_no_fake_seo_questions(self):
         for phrase in FAKE_SEO_QUESTIONS:
             assert phrase.lower() not in PAGE.lower()
-
-    def test_no_confirm_ttl_or_forbidden_claims(self):
-        assert "Confirm (15 minutes)" not in PAGE
-        assert "waits for Confirm" not in PAGE
-        assert "MLS" not in PAGE
-        assert "transaction" not in PAGE.lower()
-        assert "DocuSeal" not in PAGE
-        assert "calendar sync via B.O.B" not in PAGE.lower()
-        assert "document generation" not in PAGE.lower()
-        assert "doc gen" not in PAGE.lower()
 
     def test_home_title_h1_and_bob_faq_unchanged(self):
         assert f"<title>{HOME_TITLE}</title>" in LANDING
@@ -462,7 +438,12 @@ class TestFollowUpBossAlternativeCopy:
         assert HOME_BOB_P2 in LANDING
         assert LANDING.count(HOME_BOB_P1) == 2
         assert LANDING.count(HOME_BOB_P2) == 2
-        assert "follow-up-boss-alternative" not in LANDING
-        assert "wise-agent-alternative" not in LANDING
         assert "kvcore-alternative" not in LANDING
+        assert "wise-agent-alternative" not in LANDING
         assert "the free real estate CRM page" in LANDING
+
+    def test_fub_template_was_left_alone(self):
+        assert "Looking for a Follow Up Boss alternative?" in FUB
+        assert "kvcore-alternative" not in FUB
+        assert "wise-agent-alternative" not in FUB
+        assert "BoomTown" not in FUB

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -126,6 +126,10 @@ class TestLandingLeftoverCopy:
         assert "the free real estate CRM page" in LANDING
         assert "follow-up-boss-alternative" not in LANDING
         assert "Follow Up Boss alternative" not in LANDING
+        assert "wise-agent-alternative" not in LANDING
+        assert "Wise Agent alternative" not in LANDING
+        assert "kvcore-alternative" not in LANDING
+        assert "kvCORE alternative" not in LANDING
 
     def test_keeps_visible_faq_and_matching_json_ld(self):
         assert '"@type": "FAQPage"' in LANDING

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -45,6 +45,14 @@ class TestPublicRoutes:
         resp = client.get('/follow-up-boss-alternative')
         assert resp.status_code == 200
 
+    def test_wise_agent_alternative(self, client, seed):
+        resp = client.get('/wise-agent-alternative')
+        assert resp.status_code == 200
+
+    def test_kvcore_alternative(self, client, seed):
+        resp = client.get('/kvcore-alternative')
+        assert resp.status_code == 200
+
     def test_reset_password_page(self, client, seed):
         resp = client.get('/reset_password')
         assert resp.status_code in (200, 302)

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -1,4 +1,4 @@
-"""Public /follow-up-boss-alternative page: route, SEO, sitemap, and copy guards."""
+"""Public /wise-agent-alternative page: route, SEO, sitemap, and copy guards."""
 import re
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -7,17 +7,18 @@ from tier_config.tier_limits import get_tier_defaults
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PAGE = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
+PAGE = (ROOT / "templates" / "wise_agent_alternative.html").read_text()
 LANDING = (ROOT / "templates" / "landing.html").read_text()
+FUB = (ROOT / "templates" / "follow_up_boss_alternative.html").read_text()
 SITEMAP = ROOT / "static" / "sitemap.xml"
 LLMS = ROOT / "static" / "llms.txt"
 FREE_LIMITS = get_tier_defaults("free")
 
-PAGE_PATH = "/follow-up-boss-alternative"
-TITLE = "Follow Up Boss Alternative for Real Estate Agents | Origen"
-H1 = "Looking for a Follow Up Boss alternative?"
+PAGE_PATH = "/wise-agent-alternative"
+TITLE = "Wise Agent Alternative for Real Estate Agents | Origen"
+H1 = "Looking for a Wise Agent alternative?"
 META = (
-    "Comparing Origen with Follow Up Boss? See pricing, features and where each CRM fits. "
+    "Comparing Origen with Wise Agent? See pricing, features and where each CRM fits. "
     "Origen includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant."
 )
 HOME_TITLE = "Free Real Estate CRM | Origen TechnolOG"
@@ -40,8 +41,8 @@ ALLOWED_SITEMAP_PATHS = {
     "/login",
     "/terms-privacy",
     "/free-real-estate-crm",
+    "/follow-up-boss-alternative",
     PAGE_PATH,
-    "/wise-agent-alternative",
     "/kvcore-alternative",
 }
 BLOCKED_SEO_PATHS = (
@@ -51,6 +52,9 @@ BLOCKED_SEO_PATHS = (
     "/help",
     "/features",
     "/contact",
+    "/boomtown-alternative",
+    "/boldtrail-alternative",
+    "/top-producer-alternative",
 )
 BANNED_SLOP = (
     "unlock",
@@ -74,24 +78,24 @@ BANNED_SLOP = (
 )
 FAQ_ITEMS = (
     (
-        "How much does Follow Up Boss cost?",
-        "Follow Up Boss currently lists its Grow plan at $69 per user per month, or $58 per user per month when billed annually. It offers a 14-day free trial rather than a permanent free plan.",
+        "What is B.O.B.?",
+        "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you.",
     ),
     (
         "Is Origen really free?",
         "Yes. Origen has a free plan, not just a free trial. You don't need a credit card to start.\n\nThe current free plan includes one user, up to 10,000 contacts and 25 B.O.B. messages per day.",
     ),
     (
-        "Is Origen a full replacement for Follow Up Boss?",
-        "That depends on what you use Follow Up Boss for. If you need its advanced lead routing, calling, texting, team management or large integration ecosystem, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.",
-    ),
-    (
         "Can I try Origen without moving everything over?",
         "Yes. You can create a free account and try Origen with a few contacts first. There's no need to commit to a paid plan just to see whether it works for you.",
     ),
     (
-        "What is B.O.B.?",
-        "B.O.B. is the AI assistant inside Origen. You can ask it questions about your CRM or tell it to do CRM work for you.\n\nIf you can do something in Origen, you can ask B.O.B. to do it for you.",
+        "Is Origen a full replacement for Wise Agent?",
+        "That depends. If you need paid team logins, WiseText, WiseSocial or the transaction and marketing tools on their pricing page, Origen doesn't currently try to duplicate all of that.\n\nIf what you need is a straightforward CRM for contacts, tasks, follow-ups and day-to-day client work, Origen may be a much simpler fit.",
+    ),
+    (
+        "How much does Wise Agent cost?",
+        "Their pricing page lists CRM at $49 a month, or $499 a year ($42 a month billed annually). There is a 14-day free trial. There is no published free plan.",
     ),
 )
 FAKE_SEO_QUESTIONS = (
@@ -100,43 +104,47 @@ FAKE_SEO_QUESTIONS = (
     "Is this Follow Up Boss or HubSpot",
     "Is this origentech.com or Origin CRM",
     "What can B.O.B. do?",
-    "How much is Follow Up Boss?",
-    "Does Follow Up Boss have a free plan?",
+    "How much is Wise Agent?",
+    "Does Wise Agent have a free plan?",
     "What does Origen include?",
     "Can I buy Pro today?",
 )
 TABLE_ROWS = (
-    ("Starting price", "$69/user/month on Grow", "Free"),
+    ("Starting price", "$49/month on CRM", "Free"),
     ("Free plan", "No, 14-day free trial", "Yes"),
-    ("Credit card to start", "No", "No"),
-    ("Contacts", "Unlimited", "Up to 10,000 on free"),
-    ("Free-plan users", "N/A", "1"),
-    ("Gmail", "Supported", "Send email through Gmail"),
-    ("Calendar", "Calendar and email sync", "Google Calendar task sync"),
-    ("AI", "FUB AI features", "B.O.B. AI assistant"),
-    ("Calling & texting", "Available, with Calling included on higher plans or added to Grow", "Not included"),
-    ("Advanced lead routing", "Yes", "Not included"),
-    ("Large integration ecosystem", "Yes", "Not included"),
+    ("Credit card", "Not published", "No"),
+    ("Contacts", "Not published", "Up to 10,000 on free"),
+    ("Users", "N/A", "1"),
+    ("Calendar", "Team-friendly calendar", "Google Calendar task sync"),
+    ("Calling & texting", "WiseText paid add-on", "Not included"),
+    ("Shared team logins", "Up to 5 on one login", "1 user"),
 )
 SECTION_HEADINGS = (
-    "Origen vs. Follow Up Boss",
+    "Origen vs. Wise Agent",
     "The biggest difference is what you actually need",
     "Then there's B.O.B.",
-    "When Follow Up Boss is probably the better fit",
+    "When Wise Agent is probably the better fit",
     "When Origen may be the better fit",
     "Common questions",
 )
 HERO_LINES = (
-    "Follow Up Boss is a powerful CRM, especially for teams managing a large volume of leads. But not every agent needs everything it offers or wants another $69-per-user monthly subscription.",
-    "Origen gives individual real estate agents a simpler place to manage contacts, tasks, follow-ups and day-to-day CRM work, with a free plan you can keep using.",
+    "Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. That is a real product, and a lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.",
+    "Origen gives individual real estate agents a simpler place to do that work, with a free plan you can keep using.",
     "No credit card required.",
     "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",
 )
 DISCLAIMER = (
-    "Follow Up Boss is a trademark of its owner. Zillow Group acquired it in 2023. "
-    "Origen is not affiliated with Follow Up Boss or Zillow Group, and they did not "
-    "review or endorse this page. Prices and features here come from followupboss.com "
-    "as of August 18, 2026."
+    "Wise Agent is a trademark of its owner. Origen TechnolOG is not affiliated. "
+    "Facts from wiseagent.com/pricing as of 2026-08-18."
+)
+BOB_SECTION_LINES = (
+    "Then there's B.O.B.",
+    "B.O.B. is the AI assistant built into Origen.",
+    "Instead of clicking through the CRM every time you want to get something done, tell B.O.B. what you need.",
+    "Find a client. Update a contact. Add a note. Complete a task. Log activity. Organize contacts. Ask questions about what's already in your CRM.",
+    "If you can do it in Origen, you can ask B.O.B. to do it for you.",
+    "The free plan includes 25 B.O.B. messages per day.",
+    "B.O.B. can also be connected to Telegram, so you don't always have to be sitting inside the CRM to use it.",
 )
 
 
@@ -175,7 +183,7 @@ def _body_copy(html):
     return _visible_copy(body)
 
 
-class TestFollowUpBossAlternativeRoute:
+class TestWiseAgentAlternativeRoute:
     def test_page_returns_200(self, client):
         resp = client.get(PAGE_PATH)
         assert resp.status_code == 200
@@ -201,8 +209,8 @@ class TestFollowUpBossAlternativeRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in text
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in LLMS.read_text()
+        assert "https://www.origentechnolog.com/wise-agent-alternative" in text
+        assert "https://www.origentechnolog.com/wise-agent-alternative" in LLMS.read_text()
         for blocked in BLOCKED_SEO_PATHS:
             assert f"https://www.origentechnolog.com{blocked}" not in text
         assert "https://www.origentechnolog.com/dashboard" not in text
@@ -214,7 +222,7 @@ class TestFollowUpBossAlternativeRoute:
             assert resp.status_code == 404, f"{path} should not be a public page"
 
 
-class TestFollowUpBossAlternativeSeo:
+class TestWiseAgentAlternativeSeo:
     def test_unique_title_canonical_and_og(self, app, client):
         page = client.get(PAGE_PATH).get_data(as_text=True)
         home = client.get("/").get_data(as_text=True)
@@ -252,7 +260,7 @@ class TestFollowUpBossAlternativeSeo:
         assert "noindex" not in html.lower()
 
 
-class TestFollowUpBossAlternativeCopy:
+class TestWiseAgentAlternativeCopy:
     def test_required_human_copy(self):
         assert f"<title>{TITLE}</title>" in PAGE
         assert H1 in PAGE
@@ -262,8 +270,6 @@ class TestFollowUpBossAlternativeCopy:
         assert "url_for('auth.register')" in PAGE
         assert "url_for('main.free_real_estate_crm')" not in PAGE
         assert "url_for('main.landing')" in PAGE
-        assert "More on Origen is on" not in PAGE
-        assert "the free real estate CRM page" not in PAGE
         assert DISCLAIMER in PAGE
         assert PAGE.count(DISCLAIMER) == 1
 
@@ -275,7 +281,7 @@ class TestFollowUpBossAlternativeCopy:
         h1 = re.sub(r"\s+", " ", h1).strip()
         assert h1 == H1
 
-    def test_hero_uses_his_lines(self):
+    def test_hero_uses_specified_lines(self):
         for line in HERO_LINES:
             assert line in PAGE
 
@@ -283,16 +289,36 @@ class TestFollowUpBossAlternativeCopy:
         for heading in SECTION_HEADINGS:
             assert heading in PAGE
 
-    def test_comparison_table_matches_his_rows(self, client):
+    def test_comparison_table_matches_specified_rows(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         visible = _visible_copy(html)
-        for label, fub, origen in TABLE_ROWS:
+        for label, other, origen in TABLE_ROWS:
             assert label in visible
-            assert fub in visible
+            assert other in visible
             assert origen in visible
             assert label in PAGE
-            assert fub in PAGE
+            assert other in PAGE
             assert origen in PAGE
+
+    def test_no_invented_wise_agent_contact_cap_or_ai_row(self):
+        visible = _visible_copy(PAGE)
+        assert re.search(r"Wise Agent[^.]*unlimited contacts", visible, flags=re.I) is None
+        assert "unlimited contacts" not in PAGE.lower()
+        assert ">AI<" not in PAGE
+        assert "<th" in PAGE
+        assert re.search(r">\s*AI\s*<", PAGE) is None
+        assert "FUB AI" not in PAGE
+        assert "Wise Agent AI" not in PAGE
+        assert "Wise Agent contact cap" not in PAGE
+        assert re.search(r"Contacts\s+Not published\s+Up to 10,000 on free", visible) is not None
+
+    def test_does_not_guess_wise_agent_credit_card(self):
+        visible = _visible_copy(PAGE)
+        assert re.search(r"Credit card\s+Not published\s+No", visible) is not None
+        lowered = PAGE.lower()
+        assert "trial requires a card" not in lowered
+        assert "trial requires a credit card" not in lowered
+        assert "need a credit card for the trial" not in lowered
 
     def test_limits_match_repo(self):
         assert FREE_LIMITS["max_users"] == 1
@@ -304,12 +330,6 @@ class TestFollowUpBossAlternativeCopy:
         assert "10,000 contacts" in visible
         assert "25 B.O.B. messages per day" in visible
         assert "Up to 10,000 on free" in visible
-
-    def test_does_not_claim_origen_has_unlimited_contacts(self):
-        visible = _visible_copy(PAGE)
-        assert re.search(r"Origen[^.]*unlimited contacts", visible, flags=re.I) is None
-        assert "Origen publishes unlimited contacts" not in PAGE
-        assert "unlimited contacts on Origen" not in PAGE.lower()
 
     def test_cta_goes_to_register(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -323,99 +343,52 @@ class TestFollowUpBossAlternativeCopy:
     def test_no_exclamation_in_visible_copy(self):
         assert "!" not in _visible_copy(PAGE)
 
-    def test_does_not_claim_never_paid_plan(self):
-        assert "never be a paid plan" not in PAGE.lower()
-        assert "never be a paid" not in PAGE.lower()
+    def test_bob_section_matches_fub_wording(self):
+        for line in BOB_SECTION_LINES:
+            assert line in PAGE
+            assert line in FUB
 
-    def test_does_not_claim_fub_trial_needs_a_card(self):
-        lowered = PAGE.lower()
-        assert "trial requires a card" not in lowered
-        assert "trial requires a credit card" not in lowered
-        assert "need a credit card for the trial" not in lowered
-        assert "credit card required for those 14 days" not in PAGE
-        assert "Then they charge." not in PAGE
-        assert "After that they charge" not in PAGE
-        visible = _visible_copy(PAGE)
-        assert "Credit card to start" in visible
-        assert re.search(r"Credit card to start\s+No\s+No", visible) is not None
-
-    def test_does_not_say_charges_you_after_14_days(self):
-        lowered = PAGE.lower()
-        assert "charges you after 14 days" not in lowered
-        assert "after that they charge" not in lowered
-        assert "14-day free trial rather than a permanent free plan" in PAGE
-
-    def test_does_not_say_we_are_not_a_replacement(self):
-        lowered = PAGE.lower()
-        assert "we are not a replacement for follow up boss" not in lowered
-        assert "we are not a replacement" not in lowered
-        assert "Is Origen a full replacement for Follow Up Boss?" in PAGE
-
-    def test_does_not_claim_built_by_agents(self):
-        lowered = PAGE.lower()
-        assert "built by real estate agents" not in lowered
-        assert "by real estate agents" not in lowered
-        assert "built for agents, by agents" not in lowered
-        assert "by agents" not in lowered
-
-    def test_does_not_claim_origen_calling_routing_or_integrations(self, client):
+    def test_does_not_claim_origen_calling_idx_routing_or_migration(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         visible = _visible_copy(html)
-        assert "Calling & texting" in visible
-        assert "Available, with Calling included on higher plans or added to Grow" in visible
-        assert "Advanced lead routing" in visible
-        assert "Large integration ecosystem" in visible
         assert re.search(
-            r"Calling & texting\s+Available, with Calling included on higher plans or added to Grow\s+Not included",
+            r"Calling & texting\s+WiseText paid add-on\s+Not included",
             visible,
         ) is not None
-        assert re.search(r"Advanced lead routing\s+Yes\s+Not included", visible) is not None
-        assert re.search(r"Large integration ecosystem\s+Yes\s+Not included", visible) is not None
         lowered = visible.lower()
         assert "origen includes calling" not in lowered
         assert "origen includes texting" not in lowered
         assert "origen calling" not in lowered
+        assert "lead routing" not in lowered
+        assert "idx" not in lowered
         assert "twilio" not in lowered
         assert "automated crm migration" not in lowered
-        assert "automated fub migration" not in lowered
-        assert "import from follow up boss" not in lowered
-
-    def test_does_not_imply_fub_lacks_ai(self):
-        visible = _visible_copy(PAGE)
-        assert "FUB AI features" in visible
-        assert "B.O.B. AI assistant" in visible
-        lowered = visible.lower()
-        assert "follow up boss does not have ai" not in lowered
-        assert "fub has no ai" not in lowered
-        assert "fub lacks ai" not in lowered
-        assert "without ai" not in lowered
+        assert "import from wise agent" not in lowered
 
     def test_alternative_phrase_is_not_stuffed(self):
         body = _body_copy(PAGE)
-        matches = re.findall(r"follow up boss alternative", body, flags=re.I)
+        matches = re.findall(r"wise agent alternative", body, flags=re.I)
         assert len(matches) <= 1
-        assert PAGE.lower().count("follow up boss alternative") <= 3
-
-    def test_no_thirty_leads_gotcha(self):
-        lowered = PAGE.lower()
-        assert "30 leads" not in lowered
-        assert "less than 30" not in lowered
-        assert "we do not publish a lead count" not in lowered
+        assert PAGE.lower().count("wise agent alternative") <= 3
 
     def test_footer_disclaimer_is_the_only_added_legal_line(self):
         visible = _visible_copy(PAGE)
         assert DISCLAIMER in visible
         assert visible.count(DISCLAIMER) == 1
-        assert "More on Origen is on" not in visible
-        assert "30 leads" not in visible.lower()
+        assert "BoomTown" not in PAGE
         assert "—" not in visible
-        assert "MFTB" not in PAGE
-        assert "Holdco" not in PAGE
-        assert "lawyer" not in visible.lower()
-        assert "/pricing" not in PAGE
+        assert 'href="/pricing"' not in PAGE
+        assert "url_for('main.pricing')" not in PAGE
         lowered = visible.lower()
         for phrase in BANNED_SLOP:
             assert phrase not in lowered
+
+    def test_no_invented_legal_entity_name(self):
+        lowered = PAGE.lower()
+        assert "wise agent llc" not in lowered
+        assert "wise agent, inc" not in lowered
+        assert "wiseagent inc" not in lowered
+        assert "holdco" not in lowered
 
     def test_no_banned_slop(self):
         lowered = _visible_copy(PAGE).lower()
@@ -443,15 +416,12 @@ class TestFollowUpBossAlternativeCopy:
         for phrase in FAKE_SEO_QUESTIONS:
             assert phrase.lower() not in PAGE.lower()
 
-    def test_no_confirm_ttl_or_forbidden_claims(self):
-        assert "Confirm (15 minutes)" not in PAGE
-        assert "waits for Confirm" not in PAGE
-        assert "MLS" not in PAGE
-        assert "transaction" not in PAGE.lower()
-        assert "DocuSeal" not in PAGE
-        assert "calendar sync via B.O.B" not in PAGE.lower()
-        assert "document generation" not in PAGE.lower()
-        assert "doc gen" not in PAGE.lower()
+    def test_no_extra_wise_agent_prices_in_table(self):
+        assert "$11" not in PAGE
+        assert "$80" not in PAGE
+        assert "$69" not in PAGE
+        assert "$499" in PAGE
+        assert "$42" in PAGE
 
     def test_home_title_h1_and_bob_faq_unchanged(self):
         assert f"<title>{HOME_TITLE}</title>" in LANDING
@@ -462,7 +432,11 @@ class TestFollowUpBossAlternativeCopy:
         assert HOME_BOB_P2 in LANDING
         assert LANDING.count(HOME_BOB_P1) == 2
         assert LANDING.count(HOME_BOB_P2) == 2
-        assert "follow-up-boss-alternative" not in LANDING
         assert "wise-agent-alternative" not in LANDING
         assert "kvcore-alternative" not in LANDING
         assert "the free real estate CRM page" in LANDING
+
+    def test_fub_template_was_left_alone(self):
+        assert "Looking for a Follow Up Boss alternative?" in FUB
+        assert "wise-agent-alternative" not in FUB
+        assert "kvcore-alternative" not in FUB


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two isolated public comparison pages, cloned from the live Follow Up Boss page. Not linked from the homepage. Do not merge until reviewed.

## What shipped

- `/wise-agent-alternative` — `templates/wise_agent_alternative.html`, route always 200, tests in `tests/test_wise_agent_alternative.py`
- `/kvcore-alternative` — `templates/kvcore_alternative.html`, route always 200, tests in `tests/test_kvcore_alternative.py`
- Both URLs added to `static/sitemap.xml` and `static/llms.txt` (Public pages list only)
- `ALLOWED_SITEMAP_PATHS` updated in `tests/test_follow_up_boss_alternative.py` and `tests/test_free_real_estate_crm.py`
- Navigation smoke tests for the two new public routes

Layout, nav, hero, comparison table, B.O.B. section, when-better-fit lists, FAQ accordion, and JSON-LD (Organization + SoftwareApplication + FAQPage 1:1 with visible FAQs) match the FUB page. CTAs are Start Free and Try Origen Free, both to `/register`.

## What was left alone

- `templates/follow_up_boss_alternative.html` — not modified
- Homepage title, H1, and gold B.O.B. FAQ (“What can B.O.B. do?”) — not modified
- No homepage links to these pages
- No `/pricing`, `/boomtown-alternative`, `/boldtrail-alternative`, or `/top-producer-alternative`

## Copy and facts

Honest comparison copy. The other CRM is treated as good software. No invented stats, ranks, traffic, or legal entity names. No Origen claims for calling, texting, lead routing, IDX, large integrations, or automated CRM migration.

### Wise Agent (verified 2026-08-18)

Source: https://wiseagent.com/pricing

- CRM $49/mo or $499/yr ($42/mo billed annually)
- 14-day free trial; no published free plan
- Up to 5 team members on one login
- WiseText is a paid add-on (table says “paid add-on” only; extra add-on prices stayed off the table)
- Credit card requirement: not published
- Contact cap: not published
- No AI row (not on their pricing page)
- Footer: trademark of its owner; Origen TechnolOG not affiliated; facts from wiseagent.com/pricing as of 2026-08-18

### kvCORE / BoldTrail (verified 2026-08-18)

Sources:

- https://boldtrail.com/boldtrail-pricing — quote-only Talk to Sales (BASE / PLUS / PRO, no public dollar amounts)
- https://boldtrail.com/blog/blog-boldtrail-pricing/ — they don’t publish a standard public pricing page
- https://boldtrail.com/blog/kvcore-vs-boldtrail/ — a brand-new solo agent who hasn’t closed a first deal yet may find the full ecosystem a lot; a lighter, lower-cost CRM may make more sense
- https://boldtrail.com/blog/boldtrail-vs-boomtown/ and https://boldtrail.com/boomtown-is-now-boldtrail/ — Inside Real Estate acquired BoomTown in 2023; official pages say BoomTown is being folded into BoldTrail (one quiet sentence; no BoomTown URL; no invented migration timeline)

Footer: kvCORE and BoldTrail are trademarks of their owners. Origen TechnolOG is not affiliated. Facts from boldtrail.com as of 2026-08-18.

## Tests

New tests lock titles, H1s, metas, table cells, FAQ visible == JSON-LD, disclaimers, CTAs to `/register`, no slop, no em dashes, no `!` in visible copy, no invented Wise Agent contact cap or AI row, no invented BoldTrail price, homepage gold FAQ still intact, blocked marketing paths still 404.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a1a0b9c-00a9-4343-9f11-65b417182d5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a1a0b9c-00a9-4343-9f11-65b417182d5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

