### PR TITLE
fix: relabel Wise Agent comparison Users row to Free-plan users

### DIFF
--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -359,7 +359,7 @@
                                     <td class="py-3">Up to 10,000 on free</td>
                                 </tr>
                                 <tr class="border-b border-brand-100">
-                                    <th class="py-3 pr-4 font-semibold text-brand-800">Users</th>
+                                    <th class="py-3 pr-4 font-semibold text-brand-800">Free-plan users</th>
                                     <td class="py-3 pr-4">N/A</td>
                                     <td class="py-3">1</td>
                                 </tr>

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -114,7 +114,7 @@ TABLE_ROWS = (
     ("Free plan", "No, 14-day free trial", "Yes"),
     ("Credit card", "Not published", "No"),
     ("Contacts", "Not published", "Up to 10,000 on free"),
-    ("Users", "N/A", "1"),
+    ("Free-plan users", "N/A", "1"),
     ("Calendar", "Team-friendly calendar", "Google Calendar task sync"),
     ("Calling & texting", "WiseText paid add-on", "Not included"),
     ("Shared team logins", "Up to 5 on one login", "1 user"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
One-line fact fix: relabel the comparison-table Users row to Free-plan users (Wise Agent N/A, Origen 1). Source: wiseagent.com/pricing as of 2026-08-18.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f71ca5d-a112-4c88-91eb-2138d9d7e10c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f71ca5d-a112-4c88-91eb-2138d9d7e10c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

