### PR TITLE
feat: make agentflow.origentechnolog.com the canonical public URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from flask_migrate import Migrate
 from flask_compress import Compress
 from sqlalchemy import text
 from models import db, User
+from config import DEFAULT_APP_BASE_URL, LEGACY_PUBLIC_HOSTS
 from routes.main import main_bp
 from routes.auth import auth_bp
 from routes.tasks import tasks_bp
@@ -229,7 +230,7 @@ def create_app():
             can_access_reports=can_access_reports,
             can_access_transactions=can_access_transactions,
             show_customize_groups_new_badge=show_customize_groups_new_badge,
-            app_base_url=(app.config.get('APP_BASE_URL') or 'https://www.origentechnolog.com').rstrip('/'),
+            app_base_url=(app.config.get('APP_BASE_URL') or DEFAULT_APP_BASE_URL).rstrip('/'),
         )
 
     # Initialize Flask-Mail
@@ -279,6 +280,26 @@ def create_app():
     @app.route('/llms.txt')
     def llms_txt():
         return send_from_directory(app.static_folder, 'llms.txt', mimetype='text/plain')
+
+    @app.before_request
+    def redirect_legacy_public_hosts():
+        """Send www and apex GET traffic to the AgentFlow host.
+
+        Leave POST requests alone so inbound webhooks still registered on the
+        old hostname continue to land.
+        """
+        if request.method not in ('GET', 'HEAD'):
+            return None
+        if request.path.startswith('/webhooks/'):
+            return None
+        host = (request.host or '').split(':', 1)[0].lower()
+        if host not in LEGACY_PUBLIC_HOSTS:
+            return None
+        base = (app.config.get('APP_BASE_URL') or DEFAULT_APP_BASE_URL).rstrip('/')
+        target = f'{base}{request.path}'
+        if request.query_string:
+            target = f'{target}?{request.query_string.decode("latin-1")}'
+        return redirect(target, code=301)
 
     # =========================================================================
     # MULTI-TENANT RLS CONTEXT

--- a/config.py
+++ b/config.py
@@ -1,6 +1,12 @@
 import os
 from datetime import date, timedelta
 
+DEFAULT_APP_BASE_URL = 'https://agentflow.origentechnolog.com'
+LEGACY_PUBLIC_HOSTS = frozenset({
+    'www.origentechnolog.com',
+    'origentechnolog.com',
+})
+
 
 class Config:
     # Environment
@@ -80,7 +86,7 @@ class Config:
         'SENDGRID_EVENT_WEBHOOK_VERIFICATION_KEY'
     )
     APP_BASE_URL = os.getenv(
-        'APP_BASE_URL', 'https://www.origentechnolog.com'
+        'APP_BASE_URL', DEFAULT_APP_BASE_URL
     ).rstrip('/')
 
     # Redis / RQ task queue

--- a/email_templates/1_password_reset.html
+++ b/email_templates/1_password_reset.html
@@ -150,7 +150,7 @@ Subject Line: Reset Your AgentFlow Password
 Test Data JSON:
 {
   "first_name": "Sarah",
-  "reset_url": "https://app.origentechnolog.com/reset_password/abc123token",
+  "reset_url": "https://agentflow.origentechnolog.com/reset_password/abc123token",
   "current_year": "2026"
 }
 -->

--- a/email_templates/2_org_approved.html
+++ b/email_templates/2_org_approved.html
@@ -167,7 +167,7 @@ Subject Line: Welcome to AgentFlow! Your organization has been approved
 Test Data JSON:
 {
   "org_name": "Acme Realty Group",
-  "login_url": "https://app.origentechnolog.com/login",
+  "login_url": "https://agentflow.origentechnolog.com/login",
   "current_year": "2026"
 }
 -->

--- a/email_templates/4_team_invitation.html
+++ b/email_templates/4_team_invitation.html
@@ -150,7 +150,7 @@ Test Data JSON:
 {
   "inviter_name": "John Smith",
   "org_name": "Acme Realty Group",
-  "invite_url": "https://app.origentechnolog.com/invite/abc123token",
+  "invite_url": "https://agentflow.origentechnolog.com/invite/abc123token",
   "current_year": "2026"
 }
 -->

--- a/email_templates/6_task_reminder.html
+++ b/email_templates/6_task_reminder.html
@@ -225,7 +225,7 @@ Test Data JSON:
       "contact_name": "John Smith",
       "due_date": "Jan 17, 2026",
       "priority": "High",
-      "task_url": "https://www.origentechnolog.com/tasks/123"
+      "task_url": "https://agentflow.origentechnolog.com/tasks/123"
     }
   ],
   "today_tasks": [
@@ -234,7 +234,7 @@ Test Data JSON:
       "contact_name": "Jane Doe",
       "due_date": "Jan 19, 2026",
       "priority": "High",
-      "task_url": "https://www.origentechnolog.com/tasks/127"
+      "task_url": "https://agentflow.origentechnolog.com/tasks/127"
     }
   ],
   "tomorrow_tasks": [
@@ -243,7 +243,7 @@ Test Data JSON:
       "contact_name": "Bob Wilson",
       "due_date": "Jan 20, 2026",
       "priority": "Medium",
-      "task_url": "https://www.origentechnolog.com/tasks/125"
+      "task_url": "https://agentflow.origentechnolog.com/tasks/125"
     }
   ],
   "upcoming_tasks": [
@@ -252,10 +252,10 @@ Test Data JSON:
       "contact_name": "Alice Johnson",
       "due_date": "Jan 21, 2026",
       "priority": "Low",
-      "task_url": "https://www.origentechnolog.com/tasks/126"
+      "task_url": "https://agentflow.origentechnolog.com/tasks/126"
     }
   ],
-  "view_all_url": "https://www.origentechnolog.com/tasks",
+  "view_all_url": "https://agentflow.origentechnolog.com/tasks",
   "current_year": "2026"
 }
 -->

--- a/email_templates/magic_link_account_welcome.html
+++ b/email_templates/magic_link_account_welcome.html
@@ -225,9 +225,9 @@
 {
   "first_name": "Chris",
   "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
-  "vcard_url": "https://app.origentechnolog.com/inbox/vcard",
-  "dashboard_url": "https://app.origentechnolog.com/dashboard",
-  "contacts_url": "https://app.origentechnolog.com/contacts",
-  "inbox_url": "https://app.origentechnolog.com/inbox",
+  "vcard_url": "https://agentflow.origentechnolog.com/inbox/vcard",
+  "dashboard_url": "https://agentflow.origentechnolog.com/dashboard",
+  "contacts_url": "https://agentflow.origentechnolog.com/contacts",
+  "inbox_url": "https://agentflow.origentechnolog.com/inbox",
   "year": "2026"
 }

--- a/email_templates/magic_link_contact_added.html
+++ b/email_templates/magic_link_contact_added.html
@@ -213,8 +213,8 @@
         "initials": "JH",
         "email": "janet.hill@example.com",
         "phone": "(281) 555-0133",
-        "view_url": "https://app.origentechnolog.com/contact/4",
-        "undo_url": "https://app.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_4",
+        "view_url": "https://agentflow.origentechnolog.com/contact/4",
+        "undo_url": "https://agentflow.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_4",
         "is_duplicate_merged": false,
         "group_name": "Open House Leads"
       },
@@ -223,13 +223,13 @@
         "initials": "DR",
         "email": "dreyes@example.com",
         "phone": "(713) 555-0109",
-        "view_url": "https://app.origentechnolog.com/contact/5",
-        "undo_url": "https://app.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_5",
+        "view_url": "https://agentflow.origentechnolog.com/contact/5",
+        "undo_url": "https://agentflow.origentechnolog.com/inbox/undo/SIGNED_TOKEN_FOR_CONTACT_5",
         "is_duplicate_merged": false
       }
     ],
-    "contacts_url": "https://app.origentechnolog.com/contacts",
-    "inbox_url": "https://app.origentechnolog.com/inbox",
+    "contacts_url": "https://agentflow.origentechnolog.com/contacts",
+    "inbox_url": "https://agentflow.origentechnolog.com/inbox",
     "source_kind": "CSV",
     "source_subject": "Leads from this weekend",
     "has_skipped": true,

--- a/email_templates/magic_link_inbox.html
+++ b/email_templates/magic_link_inbox.html
@@ -218,8 +218,8 @@
 <!-- test data -->
 {
     "inbox_address": "chris.nichols-abc12345@inbox.origentechnolog.com",
-    "vcard_url": "https://app.origentechnolog.com/inbox/vcard",
-    "inbox_url": "https://app.origentechnolog.com/inbox",
+    "vcard_url": "https://agentflow.origentechnolog.com/inbox/vcard",
+    "inbox_url": "https://agentflow.origentechnolog.com/inbox",
     "inbound_domain": "inbox.origentechnolog.com",
     "year": "2026"
   }

--- a/jobs/activation_lifecycle.py
+++ b/jobs/activation_lifecycle.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 
 
 APP_BASE_URL = os.environ.get(
-    'APP_BASE_URL', 'https://www.origentechnolog.com'
+    'APP_BASE_URL', 'https://agentflow.origentechnolog.com'
 ).rstrip('/')
 
 

--- a/jobs/daily_briefing.py
+++ b/jobs/daily_briefing.py
@@ -119,7 +119,7 @@ def _maybe_telegram_briefing_nudge(user, content: dict) -> None:
         if get_active_channel(user.id) is None:
             return
         base = (os.environ.get('APP_BASE_URL')
-                or 'https://www.origentechnolog.com').rstrip('/')
+                or 'https://agentflow.origentechnolog.com').rstrip('/')
         notify_daily_briefing(
             user,
             content,

--- a/jobs/daily_health_check.py
+++ b/jobs/daily_health_check.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 CT = pytz.timezone('America/Chicago')
 APP_BASE_URL = os.environ.get(
-    'APP_BASE_URL', 'https://www.origentechnolog.com'
+    'APP_BASE_URL', 'https://agentflow.origentechnolog.com'
 ).rstrip('/')
 DEFAULT_TO = os.environ.get('HEALTH_CHECK_TO', 'chrisnichols17@gmail.com')
 DEFAULT_FROM = os.environ.get('HEALTH_CHECK_FROM', 'info@origentechnolog.com')

--- a/jobs/task_reminder.py
+++ b/jobs/task_reminder.py
@@ -37,7 +37,7 @@ CT = pytz.timezone('America/Chicago')
 
 # Base URL for task links in emails
 # Set via environment variable or default to production URL
-APP_BASE_URL = os.environ.get('APP_BASE_URL', 'https://www.origentechnolog.com')
+APP_BASE_URL = os.environ.get('APP_BASE_URL', 'https://agentflow.origentechnolog.com')
 
 
 def send_task_reminders():

--- a/scripts/backfill_inbox_addresses.py
+++ b/scripts/backfill_inbox_addresses.py
@@ -14,17 +14,17 @@ Usage:
 
     # Provision + send the announcement to every user that just got one.
     python3 scripts/backfill_inbox_addresses.py --commit --send-welcome \
-        --base-url https://www.origentechnolog.com
+        --base-url https://agentflow.origentechnolog.com
 
     # Re-send the announcement to users who already had an address
     # (useful for a one-off relaunch email — pair with --commit).
     python3 scripts/backfill_inbox_addresses.py --commit --send-welcome \
-        --include-existing --base-url https://www.origentechnolog.com
+        --include-existing --base-url https://agentflow.origentechnolog.com
 
     # Send a one-user test without touching anyone else.
     python3 scripts/backfill_inbox_addresses.py --commit --send-welcome \
         --include-existing --email chrisnichols17@gmail.com \
-        --base-url https://www.origentechnolog.com
+        --base-url https://agentflow.origentechnolog.com
 
 Safety:
 - The provisioning loop commits per user, so a single bad row does not
@@ -112,7 +112,7 @@ def main() -> int:
                              'Useful for production smoke tests.')
     parser.add_argument('--base-url', default=_default_base_url(),
                         help='Public app URL used for email links, e.g. '
-                             'https://www.origentechnolog.com. Required when '
+                             'https://agentflow.origentechnolog.com. Required when '
                              'sending welcome emails unless APP_BASE_URL, '
                              'PUBLIC_APP_URL, BASE_URL, or '
                              'RAILWAY_PUBLIC_DOMAIN is set.')

--- a/scripts/send_gmail_html.py
+++ b/scripts/send_gmail_html.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # Template variables
     template_vars = {
         "org_name": ORG_NAME,
-        "login_url": "https://app.origentechnolog.com/login",
+        "login_url": "https://agentflow.origentechnolog.com/login",
         "current_year": str(datetime.now().year)
     }
     

--- a/scripts/simulate_inbound.py
+++ b/scripts/simulate_inbound.py
@@ -41,7 +41,7 @@ Usage:
 
     # Point at a deployed instance instead of localhost:
     python3 scripts/simulate_inbound.py text \\
-        --base-url https://app.origentechnolog.com
+        --base-url https://agentflow.origentechnolog.com
 
 The script reads ``SENDGRID_INBOUND_WEBHOOK_SECRET`` from the environment
 (or .env) and appends it as ``?secret=...`` so the webhook accepts the hit

--- a/services/gmail_service.py
+++ b/services/gmail_service.py
@@ -39,7 +39,6 @@ GMAIL_SCOPES = [
 
 # OAuth redirect URIs
 REDIRECT_URI_LOCAL = 'http://127.0.0.1:5011/integrations/gmail/callback'
-REDIRECT_URI_PROD = 'https://www.origentechnolog.com/integrations/gmail/callback'
 
 # HTML sanitization for email body display and signature
 ALLOWED_TAGS = ['p', 'br', 'b', 'i', 'strong', 'em', 'a', 'ul', 'ol', 'li', 'blockquote', 'div', 'span', 'img']
@@ -52,7 +51,7 @@ ALLOWED_ATTRS = {
 def _get_redirect_uri() -> str:
     """Get the appropriate redirect URI based on environment."""
     if Config.FLASK_ENV == 'production':
-        return REDIRECT_URI_PROD
+        return f"{Config.APP_BASE_URL.rstrip('/')}/integrations/gmail/callback"
     return REDIRECT_URI_LOCAL
 
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -15,11 +15,11 @@ AgentFlow is a free CRM for real estate agents. Use it to organize contacts, man
 
 ## Public pages
 
-- https://www.origentechnolog.com/
-- https://www.origentechnolog.com/register
-- https://www.origentechnolog.com/login
-- https://www.origentechnolog.com/terms-privacy
-- https://www.origentechnolog.com/free-real-estate-crm
-- https://www.origentechnolog.com/follow-up-boss-alternative
-- https://www.origentechnolog.com/wise-agent-alternative
-- https://www.origentechnolog.com/kvcore-alternative
+- https://agentflow.origentechnolog.com/
+- https://agentflow.origentechnolog.com/register
+- https://agentflow.origentechnolog.com/login
+- https://agentflow.origentechnolog.com/terms-privacy
+- https://agentflow.origentechnolog.com/free-real-estate-crm
+- https://agentflow.origentechnolog.com/follow-up-boss-alternative
+- https://agentflow.origentechnolog.com/wise-agent-alternative
+- https://agentflow.origentechnolog.com/kvcore-alternative

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -17,4 +17,4 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
-Sitemap: https://www.origentechnolog.com/sitemap.xml
+Sitemap: https://agentflow.origentechnolog.com/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.origentechnolog.com/</loc>
+    <loc>https://agentflow.origentechnolog.com/</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/register</loc>
+    <loc>https://agentflow.origentechnolog.com/register</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/login</loc>
+    <loc>https://agentflow.origentechnolog.com/login</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/terms-privacy</loc>
+    <loc>https://agentflow.origentechnolog.com/terms-privacy</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/free-real-estate-crm</loc>
+    <loc>https://agentflow.origentechnolog.com/free-real-estate-crm</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/follow-up-boss-alternative</loc>
+    <loc>https://agentflow.origentechnolog.com/follow-up-boss-alternative</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/wise-agent-alternative</loc>
+    <loc>https://agentflow.origentechnolog.com/wise-agent-alternative</loc>
   </url>
   <url>
-    <loc>https://www.origentechnolog.com/kvcore-alternative</loc>
+    <loc>https://agentflow.origentechnolog.com/kvcore-alternative</loc>
   </url>
 </urlset>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -464,7 +464,7 @@
                             </div>
                             <div class="flex-1 mx-4">
                                 <div class="bg-white rounded-lg px-4 py-1.5 text-xs text-brand-400 border border-brand-100">
-                                    origentechnolog.com/dashboard
+                                    agentflow.origentechnolog.com/dashboard
                                 </div>
                             </div>
                         </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ _TEST_DB = 'sqlite:////tmp/test_integration.db'
 os.environ['DATABASE_URL'] = _TEST_DB
 os.environ.setdefault('SECRET_KEY', 'test-secret-key')
 os.environ.setdefault('FLASK_ENV', 'testing')
+os.environ['APP_BASE_URL'] = 'https://agentflow.origentechnolog.com'
 
 from app import create_app
 from models import (

--- a/tests/test_bob_telegram.py
+++ b/tests/test_bob_telegram.py
@@ -56,12 +56,27 @@ WEBHOOK_SECRET = 'test-webhook-secret'
 
 @pytest.fixture(autouse=True)
 def _telegram_config(app):
+    previous = {
+        key: app.config.get(key)
+        for key in (
+            'TELEGRAM_BOT_TOKEN',
+            'TELEGRAM_BOT_USERNAME',
+            'TELEGRAM_WEBHOOK_SECRET',
+            'TELEGRAM_WEBHOOK_PATH',
+            'APP_BASE_URL',
+        )
+    }
     app.config['TELEGRAM_BOT_TOKEN'] = '123456:TESTTOKEN'
     app.config['TELEGRAM_BOT_USERNAME'] = 'BobTestBot'
     app.config['TELEGRAM_WEBHOOK_SECRET'] = WEBHOOK_SECRET
     app.config['TELEGRAM_WEBHOOK_PATH'] = WEBHOOK_PATH
     app.config['APP_BASE_URL'] = 'https://example.test'
     yield
+    for key, value in previous.items():
+        if value is None:
+            app.config.pop(key, None)
+        else:
+            app.config[key] = value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_canonical_host.py
+++ b/tests/test_canonical_host.py
@@ -1,0 +1,83 @@
+"""Canonical host, sitemap/robots/llms URLs, and www redirects."""
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from config import DEFAULT_APP_BASE_URL
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SITEMAP = ROOT / "static" / "sitemap.xml"
+ROBOTS = ROOT / "static" / "robots.txt"
+LLMS = ROOT / "static" / "llms.txt"
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+PUBLIC_PATHS = (
+    "/",
+    "/register",
+    "/login",
+    "/terms-privacy",
+    "/free-real-estate-crm",
+    "/follow-up-boss-alternative",
+    "/wise-agent-alternative",
+    "/kvcore-alternative",
+)
+
+
+def test_default_app_base_url_is_agentflow():
+    assert DEFAULT_APP_BASE_URL == "https://agentflow.origentechnolog.com"
+
+
+def test_sitemap_locs_use_agentflow_host():
+    locs = [
+        el.text or ""
+        for el in ET.parse(SITEMAP).getroot().findall("sm:url/sm:loc", SITEMAP_NS)
+    ]
+    assert locs
+    for loc in locs:
+        assert loc.startswith("https://agentflow.origentechnolog.com"), loc
+        assert "www.origentechnolog.com" not in loc
+
+
+def test_robots_sitemap_points_at_agentflow():
+    text = ROBOTS.read_text()
+    assert "Sitemap: https://agentflow.origentechnolog.com/sitemap.xml" in text
+    assert "www.origentechnolog.com" not in text
+
+
+def test_llms_txt_lists_agentflow_public_pages():
+    text = LLMS.read_text()
+    for path in PUBLIC_PATHS:
+        url = f"https://agentflow.origentechnolog.com{path if path != '/' else '/'}"
+        assert url in text
+    assert "www.origentechnolog.com" not in text
+    assert "https://agentflow.origentechnolog.com/dashboard" not in text
+
+
+def test_www_get_redirects_to_agentflow(client):
+    resp = client.get(
+        "/free-real-estate-crm?utm=1",
+        headers={"Host": "www.origentechnolog.com"},
+    )
+    assert resp.status_code == 301
+    assert (
+        resp.headers["Location"]
+        == "https://agentflow.origentechnolog.com/free-real-estate-crm?utm=1"
+    )
+
+
+def test_apex_get_redirects_to_agentflow(client):
+    resp = client.get("/", headers={"Host": "origentechnolog.com"})
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == "https://agentflow.origentechnolog.com/"
+
+
+def test_agentflow_host_is_not_redirected(client):
+    resp = client.get("/", headers={"Host": "agentflow.origentechnolog.com"})
+    assert resp.status_code == 200
+
+
+def test_www_webhook_post_is_not_redirected(client):
+    resp = client.post(
+        "/webhooks/sendgrid/inbound-parse",
+        headers={"Host": "www.origentechnolog.com"},
+    )
+    assert resp.status_code != 301

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -153,13 +153,13 @@ def _sitemap_paths():
     locs = [el.text or "" for el in tree.getroot().findall("sm:url/sm:loc", SITEMAP_NS)]
     paths = []
     for loc in locs:
-        path = loc.replace("https://www.origentechnolog.com", "", 1) or "/"
+        path = loc.replace("https://agentflow.origentechnolog.com", "", 1) or "/"
         paths.append(path)
     return paths
 
 
 def _app_base_url(app):
-    return (app.config.get("APP_BASE_URL") or "https://www.origentechnolog.com").rstrip("/")
+    return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
 
 
 def _visible_copy(html):
@@ -201,11 +201,11 @@ class TestFollowUpBossAlternativeRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in text
-        assert "https://www.origentechnolog.com/follow-up-boss-alternative" in LLMS.read_text()
+        assert "https://agentflow.origentechnolog.com/follow-up-boss-alternative" in text
+        assert "https://agentflow.origentechnolog.com/follow-up-boss-alternative" in LLMS.read_text()
         for blocked in BLOCKED_SEO_PATHS:
-            assert f"https://www.origentechnolog.com{blocked}" not in text
-        assert "https://www.origentechnolog.com/dashboard" not in text
+            assert f"https://agentflow.origentechnolog.com{blocked}" not in text
+        assert "https://agentflow.origentechnolog.com/dashboard" not in text
         assert "—" not in text
 
     def test_blocked_marketing_urls_are_not_built(self, client):

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -101,13 +101,13 @@ def _sitemap_paths():
     locs = [el.text or "" for el in tree.getroot().findall("sm:url/sm:loc", SITEMAP_NS)]
     paths = []
     for loc in locs:
-        path = loc.replace("https://www.origentechnolog.com", "", 1) or "/"
+        path = loc.replace("https://agentflow.origentechnolog.com", "", 1) or "/"
         paths.append(path)
     return paths
 
 
 def _app_base_url(app):
-    return (app.config.get("APP_BASE_URL") or "https://www.origentechnolog.com").rstrip("/")
+    return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
 
 
 def _visible_copy(html):
@@ -143,10 +143,10 @@ class TestFreeRealEstateCrmRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/free-real-estate-crm" in text
+        assert "https://agentflow.origentechnolog.com/free-real-estate-crm" in text
         for blocked in BLOCKED_SEO_PATHS:
-            assert f"https://www.origentechnolog.com{blocked}" not in text
-        assert "https://www.origentechnolog.com/dashboard" not in text
+            assert f"https://agentflow.origentechnolog.com{blocked}" not in text
+        assert "https://agentflow.origentechnolog.com/dashboard" not in text
         assert "—" not in text
         assert "Unlimited contacts" not in text
         assert "AI" not in text

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -169,13 +169,13 @@ def _sitemap_paths():
     locs = [el.text or "" for el in tree.getroot().findall("sm:url/sm:loc", SITEMAP_NS)]
     paths = []
     for loc in locs:
-        path = loc.replace("https://www.origentechnolog.com", "", 1) or "/"
+        path = loc.replace("https://agentflow.origentechnolog.com", "", 1) or "/"
         paths.append(path)
     return paths
 
 
 def _app_base_url(app):
-    return (app.config.get("APP_BASE_URL") or "https://www.origentechnolog.com").rstrip("/")
+    return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
 
 
 def _visible_copy(html):
@@ -217,13 +217,13 @@ class TestKvcoreAlternativeRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/kvcore-alternative" in text
-        assert "https://www.origentechnolog.com/kvcore-alternative" in LLMS.read_text()
-        assert "https://www.origentechnolog.com/boldtrail-alternative" not in text
-        assert "https://www.origentechnolog.com/boomtown-alternative" not in text
+        assert "https://agentflow.origentechnolog.com/kvcore-alternative" in text
+        assert "https://agentflow.origentechnolog.com/kvcore-alternative" in LLMS.read_text()
+        assert "https://agentflow.origentechnolog.com/boldtrail-alternative" not in text
+        assert "https://agentflow.origentechnolog.com/boomtown-alternative" not in text
         for blocked in BLOCKED_SEO_PATHS:
-            assert f"https://www.origentechnolog.com{blocked}" not in text
-        assert "https://www.origentechnolog.com/dashboard" not in text
+            assert f"https://agentflow.origentechnolog.com{blocked}" not in text
+        assert "https://agentflow.origentechnolog.com/dashboard" not in text
         assert "—" not in text
 
     def test_blocked_marketing_urls_are_not_built(self, client):

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -161,13 +161,13 @@ def _sitemap_paths():
     locs = [el.text or "" for el in tree.getroot().findall("sm:url/sm:loc", SITEMAP_NS)]
     paths = []
     for loc in locs:
-        path = loc.replace("https://www.origentechnolog.com", "", 1) or "/"
+        path = loc.replace("https://agentflow.origentechnolog.com", "", 1) or "/"
         paths.append(path)
     return paths
 
 
 def _app_base_url(app):
-    return (app.config.get("APP_BASE_URL") or "https://www.origentechnolog.com").rstrip("/")
+    return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
 
 
 def _visible_copy(html):
@@ -209,11 +209,11 @@ class TestWiseAgentAlternativeRoute:
         resp = client.get("/llms.txt")
         assert resp.status_code == 200
         text = resp.get_data(as_text=True)
-        assert "https://www.origentechnolog.com/wise-agent-alternative" in text
-        assert "https://www.origentechnolog.com/wise-agent-alternative" in LLMS.read_text()
+        assert "https://agentflow.origentechnolog.com/wise-agent-alternative" in text
+        assert "https://agentflow.origentechnolog.com/wise-agent-alternative" in LLMS.read_text()
         for blocked in BLOCKED_SEO_PATHS:
-            assert f"https://www.origentechnolog.com{blocked}" not in text
-        assert "https://www.origentechnolog.com/dashboard" not in text
+            assert f"https://agentflow.origentechnolog.com{blocked}" not in text
+        assert "https://agentflow.origentechnolog.com/dashboard" not in text
         assert "—" not in text
 
     def test_blocked_marketing_urls_are_not_built(self, client):


### PR DESCRIPTION
## Summary
- Makes `https://agentflow.origentechnolog.com` the official public host for sitemap, `robots.txt`, `llms.txt`, canonical/OG/JSON-LD, and generated email/app links.
- 301s GET/HEAD traffic from `www.origentechnolog.com` and the apex host so Google consolidates ranking. POSTs to `/webhooks/` stay on the old host so inbound email is not broken.
- Railway `APP_BASE_URL` is already staged for the next deploy (no restart yet).

## Before merge
Add this authorized redirect URI in Google Cloud (Gmail/Calendar OAuth client), and keep the old `www` URI until after deploy:

`https://agentflow.origentechnolog.com/integrations/gmail/callback`

Optional in Squarespace Domain Forwarding: change the apex rule from `origentechnolog.com` → `www` to `origentechnolog.com` → `https://agentflow.origentechnolog.com` so the naked domain is one hop, not two.

## Test plan
- [ ] `https://agentflow.origentechnolog.com/` serves the landing page
- [ ] `https://www.origentechnolog.com/free-real-estate-crm` 301s to the AgentFlow URL (same path)
- [ ] View source: canonical, `og:url`, `og:image`, and JSON-LD `@id`/`url` use `agentflow.origentechnolog.com`
- [ ] `/sitemap.xml`, `/robots.txt`, `/llms.txt` list AgentFlow URLs only
- [ ] Gmail connect still completes after the new Google redirect URI is added
- [ ] Magic Inbox inbound email still arrives (`inbox.origentechnolog.com` unchanged)


Made with [Cursor](https://cursor.com)