### PR TITLE
feat: rewrite AgentFlow homepage copy to explain the product

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -365,7 +365,7 @@
                         Log In
                     </a>
                     <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-5 py-2.5 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
-                        Get Started Free
+                        Start Free
                         <i class="fas fa-arrow-right text-sm"></i>
                     </a>
                 </div>
@@ -396,7 +396,7 @@
                     
                     <a href="{{ url_for('auth.login') }}" class="block text-lg font-semibold text-brand-800">Log In</a>
                     <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-semibold rounded-xl shadow-lg">
-                        Get Started Free
+                        Start Free
                     </a>
                 </div>
             </div>
@@ -412,11 +412,11 @@
                 <!-- Hero Content -->
                 <div class="text-center lg:text-left">
                     <h1 class="animate-fade-in-up text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
-                        Your clients and follow-ups, <span class="text-accent-500">in one place.</span>
+                        Keep up with every client <span class="text-accent-500">without living in your CRM.</span>
                     </h1>
                     
                     <p class="animate-fade-in-up delay-100 text-lg sm:text-xl text-brand-600 mb-8 max-w-xl mx-auto lg:mx-0">
-                        Built for real estate agents, by real estate agents. The free tier stays free. No credit card. Most people are in within a couple of minutes.
+                        AgentFlow keeps your contacts, follow-ups, tasks, notes, and client activity together. And when you don't want to click around, tell B.O.B. what you need done and let it handle the CRM work for you.
                     </p>
                     
                     <div class="animate-fade-in-up delay-200 flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
@@ -424,27 +424,15 @@
                             Start Free
                             <i class="fas fa-arrow-right"></i>
                         </a>
-                        <a href="#features" class="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white text-brand-700 font-semibold text-lg rounded-xl border-2 border-brand-200 hover:border-brand-300 hover:bg-brand-50 transition-all">
+                        <a href="#how-it-works" class="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white text-brand-700 font-semibold text-lg rounded-xl border-2 border-brand-200 hover:border-brand-300 hover:bg-brand-50 transition-all">
                             <i class="fas fa-play-circle"></i>
-                            See Features
+                            See How It Works
                         </a>
                     </div>
                     
-                    <!-- Trust indicators -->
-                    <div class="animate-fade-in-up delay-300 mt-10 flex flex-wrap items-center justify-center lg:justify-start gap-6 text-sm text-brand-500">
-                        <span class="flex items-center gap-2">
-                            <i class="fas fa-check-circle text-green-500"></i>
-                            The free tier stays free
-                        </span>
-                        <span class="flex items-center gap-2">
-                            <i class="fas fa-check-circle text-green-500"></i>
-                            No credit card
-                        </span>
-                        <span class="flex items-center gap-2">
-                            <i class="fas fa-check-circle text-green-500"></i>
-                            A couple of minutes to get in
-                        </span>
-                    </div>
+                    <p class="animate-fade-in-up delay-300 mt-10 text-sm text-brand-500">
+                        Free for one user · Up to 10,000 contacts · No credit card
+                    </p>
                 </div>
                 
                 <!-- Hero Image / Dashboard Mockup -->
@@ -464,7 +452,7 @@
                             </div>
                             <div class="flex-1 mx-4">
                                 <div class="bg-white rounded-lg px-4 py-1.5 text-xs text-brand-400 border border-brand-100">
-                                    agentflow.origentechnolog.com/dashboard
+                                    Example · agentflow.origentechnolog.com/dashboard
                                 </div>
                             </div>
                         </div>
@@ -478,12 +466,12 @@
                                     <div class="text-xl font-bold text-brand-800">847</div>
                                 </div>
                                 <div class="bg-white rounded-xl p-3 shadow-sm border border-brand-100">
-                                    <div class="text-xs text-brand-500 mb-1">Pipeline</div>
-                                    <div class="text-xl font-bold text-green-600">$124K</div>
+                                    <div class="text-xs text-brand-500 mb-1">Due soon</div>
+                                    <div class="text-xl font-bold text-accent-500">4</div>
                                 </div>
                                 <div class="bg-white rounded-xl p-3 shadow-sm border border-brand-100">
                                     <div class="text-xs text-brand-500 mb-1">Tasks</div>
-                                    <div class="text-xl font-bold text-accent-500">12</div>
+                                    <div class="text-xl font-bold text-brand-800">12</div>
                                 </div>
                             </div>
                             
@@ -511,24 +499,24 @@
                                 </div>
                             </div>
                             
-                            <!-- Pipeline preview -->
+                            <!-- Groups preview -->
                             <div class="bg-white rounded-xl p-4 shadow-sm border border-brand-100">
                                 <div class="text-sm font-semibold text-brand-700 mb-3 flex items-center gap-2">
-                                    <i class="fas fa-chart-line text-green-500"></i>
-                                    Transaction Pipeline
+                                    <i class="fas fa-layer-group text-brand-500"></i>
+                                    Contact groups
                                 </div>
                                 <div class="flex gap-2 overflow-hidden">
-                                    <div class="flex-1 bg-blue-50 rounded-lg p-2 text-center">
-                                        <div class="text-xs text-blue-600 font-medium">Preparing</div>
-                                        <div class="text-lg font-bold text-blue-700">3</div>
+                                    <div class="flex-1 bg-brand-50 rounded-lg p-2 text-center">
+                                        <div class="text-xs text-brand-600 font-medium">Sphere</div>
+                                        <div class="text-lg font-bold text-brand-800">312</div>
                                     </div>
                                     <div class="flex-1 bg-amber-50 rounded-lg p-2 text-center">
-                                        <div class="text-xs text-amber-600 font-medium">Active</div>
-                                        <div class="text-lg font-bold text-amber-700">5</div>
+                                        <div class="text-xs text-amber-700 font-medium">Past clients</div>
+                                        <div class="text-lg font-bold text-amber-800">88</div>
                                     </div>
-                                    <div class="flex-1 bg-green-50 rounded-lg p-2 text-center">
-                                        <div class="text-xs text-green-600 font-medium">Closed</div>
-                                        <div class="text-lg font-bold text-green-700">12</div>
+                                    <div class="flex-1 bg-accent-50 rounded-lg p-2 text-center">
+                                        <div class="text-xs text-accent-700 font-medium">New</div>
+                                        <div class="text-lg font-bold text-accent-700">41</div>
                                     </div>
                                 </div>
                             </div>
@@ -544,18 +532,18 @@
     <section class="bg-brand-900 py-6">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex flex-col md:flex-row items-center justify-center gap-4 md:gap-12 text-center">
-                <div class="flex items-center gap-8 text-brand-400">
+                <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-brand-400">
                     <div class="flex items-center gap-2">
-                        <i class="fas fa-shield-alt text-accent-400"></i>
-                        <span class="text-sm">Secure & Private</span>
+                        <i class="fas fa-check text-accent-400"></i>
+                        <span class="text-sm">Contacts, notes, and tasks together</span>
                     </div>
                     <div class="flex items-center gap-2">
-                        <i class="fas fa-mobile-alt text-accent-400"></i>
-                        <span class="text-sm">Mobile Ready</span>
+                        <i class="fas fa-check text-accent-400"></i>
+                        <span class="text-sm">B.O.B. can take action in the CRM</span>
                     </div>
                     <div class="flex items-center gap-2">
-                        <i class="fas fa-headset text-accent-400"></i>
-                        <span class="text-sm">Real Support</span>
+                        <i class="fas fa-check text-accent-400"></i>
+                        <span class="text-sm">Gmail and Google Calendar included</span>
                     </div>
                 </div>
             </div>
@@ -570,97 +558,110 @@
             <!-- Section Header -->
             <div class="text-center mb-16">
                 <span class="inline-block px-4 py-1.5 bg-brand-800 text-white text-sm font-semibold rounded-full mb-4">
-                    EVERYTHING YOU NEED
+                    WHAT AGENTFLOW DOES
                 </span>
                 <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-900 mb-4">
-                    What's on the free tier
+                    Keep the client work together. Let B.O.B. handle the busywork.
                 </h2>
                 <p class="text-lg text-brand-600 max-w-2xl mx-auto">
-                    Contact management and task automation are on the free tier. Pro features are on the way.
+                    Your contacts are only part of the job. AgentFlow keeps the notes, follow-ups, tasks, and activity around each client in the same place. You can manage it yourself when you want to, or tell B.O.B. what needs to happen.
                 </p>
             </div>
             
-            <!-- Featured: Talk to B.O.B. -->
+            <!-- Featured: B.O.B. -->
             <div class="feature-card bg-white rounded-2xl p-6 lg:p-10 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden mb-6 lg:mb-8">
-                <span class="feature-badge badge-free">Free</span>
                 <div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-accent-500 to-accent-600"></div>
                 <div class="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
                     <div>
                         <div class="w-14 h-14 bg-gradient-to-br from-accent-500 to-accent-600 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-accent-500/20">
                             <span class="text-white text-2xl font-bold tracking-tight">B.</span>
                         </div>
-                        <h3 class="text-2xl lg:text-3xl font-bold text-brand-900 mb-3">Talk to B.O.B.</h3>
+                        <h3 class="text-2xl lg:text-3xl font-bold text-brand-900 mb-3">Tell B.O.B. what you need done</h3>
                         <p class="text-brand-600 text-lg leading-relaxed">
-                            Ask how many clients are in a ZIP or city. Tell B.O.B. to add a contact, change an email, complete a task, or log a call. It can add a note or put someone in a group.
+                            B.O.B. is the AI assistant built into AgentFlow. Ask it about what's in your CRM or tell it to take care of something for you.
                         </p>
                         <p class="text-brand-600 mt-3 leading-relaxed">
-                            25 messages a day on the free plan. Message B.O.B. on Telegram after you scan a QR from your profile.
+                            Find a client. Update their information. Add a note. Log a call. Finish a task. Organize contacts. Those are just examples.
+                        </p>
+                        <p class="text-brand-800 mt-3 leading-relaxed font-semibold">
+                            If you can do it in AgentFlow, you can ask B.O.B. to do it for you.
+                        </p>
+                        <p class="text-brand-600 mt-4 leading-relaxed flex items-start gap-2">
+                            <svg class="w-5 h-5 flex-shrink-0 mt-0.5" viewBox="0 0 240 240" aria-hidden="true">
+                                <circle cx="120" cy="120" r="120" fill="#229ED9"/>
+                                <path fill="#fff" d="M54.4 118.3c35.3-15.4 58.8-25.5 70.6-30.3 33.7-14 40.7-16.4 45.3-16.5 1 0 3.3.2 4.7 1.4 1.2 1 1.6 2.4 1.7 3.3.2.9.4 3 .2 4.6-1.8 19.2-9.7 65.7-13.7 87.2-1.7 9.1-5 12.1-8.2 12.4-7 .7-12.3-4.6-19-9-10.6-6.9-16.5-11.2-26.8-18-11.9-7.8-4.2-12.1 2.6-19.1 1.8-1.8 32.5-29.8 33.1-32.3.1-.3.1-1.5-.6-2.1-.7-.6-1.7-.4-2.5-.2-1.1.2-17.9 11.4-50.6 33.4-4.8 3.3-9.1 4.9-13 4.8-4.3-.1-12.5-2.4-18.7-4.4-7.5-2.4-13.5-3.7-13-7.9.3-2.2 3.3-4.4 9-6.7z"/>
+                            </svg>
+                            <span>You can also connect B.O.B. to Telegram and message it when you're away from AgentFlow. A voice note or a photo of a business card works too.</span>
                         </p>
                     </div>
                     <ul class="space-y-3 text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Create a contact, change an email, or complete a task
+                            Works with your AgentFlow data
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Count clients in a ZIP or city
+                            Takes actions inside the CRM
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            25/day free
+                            25 messages a day on the free plan
                         </li>
                     </ul>
                 </div>
             </div>
 
             <!-- Features Grid -->
-            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+            <div class="grid md:grid-cols-2 gap-6 lg:gap-8">
                 
-                <!-- Feature 1: Contact Management -->
+                <!-- Contacts -->
                 <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
-                    <span class="feature-badge badge-free">Free</span>
                     <div class="w-14 h-14 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-blue-500/20">
                         <i class="fas fa-address-book text-white text-xl"></i>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">Contact Management</h3>
+                    <h3 class="text-xl font-bold text-brand-900 mb-3">Know who you're talking to and what happened last</h3>
                     <p class="text-brand-600 mb-4">
-                        Keep all your leads and clients organized in one place. Smart groups, search, and filters help you find anyone instantly.
+                        Keep the contact details and the history around them together. Notes, activity, groups, and the things you need to remember don't have to live in separate places.
+                    </p>
+                    <p class="text-brand-600 mb-4">
+                        Search when you know who you're looking for. Use groups and filters when you don't.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Up to 10,000 contacts
+                            Up to 10,000 contacts on the free plan
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Custom groups & tags
+                            Notes and activity history
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Contact activity history
+                            Groups, search, and filters
                         </li>
                     </ul>
                 </div>
                 
-                <!-- Feature 2: Task Management -->
+                <!-- Tasks and follow-ups -->
                 <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
-                    <span class="feature-badge badge-free">Free</span>
                     <div class="w-14 h-14 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-emerald-500/20">
                         <i class="fas fa-tasks text-white text-xl"></i>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">Task Automation</h3>
+                    <h3 class="text-xl font-bold text-brand-900 mb-3">Don't let the next step disappear</h3>
                     <p class="text-brand-600 mb-4">
-                        Set a due date and a reminder. The follow-up stays on your list.
+                        When something needs to happen later, put it where you'll actually see it. Add the task, set the due date, and keep it connected to the work you're already doing in AgentFlow.
+                    </p>
+                    <p class="text-brand-600 mb-4">
+                        AgentFlow can remind you by email, and B.O.B. can help you manage the tasks already in your CRM.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Due date reminders
+                            Due dates and reminders
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Priority management
+                            Priorities
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
@@ -669,10 +670,8 @@
                     </ul>
                 </div>
                 
-                <!-- Feature 2.5: Google Integration - NEW -->
+                <!-- Gmail and Google Calendar -->
                 <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden">
-                    <span class="feature-badge badge-free">Free</span>
-                    <!-- Subtle Google colors accent -->
                     <div class="absolute top-0 left-0 right-0 h-1 flex">
                         <div class="flex-1 bg-[#4285F4]"></div>
                         <div class="flex-1 bg-[#EA4335]"></div>
@@ -687,16 +686,16 @@
                             <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">Google Integration</h3>
+                    <h3 class="text-xl font-bold text-brand-900 mb-3">Gmail and Google Calendar, without the extra back-and-forth</h3>
                     <p class="text-brand-600 mb-4">
-                        Connect your Gmail to send emails directly from the CRM. Your tasks sync automatically to Google Calendar.
+                        Connect Gmail and send an email without leaving AgentFlow. Your AgentFlow tasks can also sync to Google Calendar, so the follow-ups you create in the CRM aren't stuck inside the CRM.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24">
                                 <path fill="#EA4335" d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"/>
                             </svg>
-                            Send emails from the CRM
+                            Send through your Gmail account
                         </li>
                         <li class="flex items-center gap-2">
                             <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24">
@@ -704,91 +703,82 @@
                                 <path fill="#fff" d="M19 20H5V9h14v11z"/>
                                 <path fill="#EA4335" d="M12 13h5v5h-5z"/>
                             </svg>
-                            Google Calendar task sync
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            One-click OAuth setup
+                            Sync AgentFlow tasks to Google Calendar
                         </li>
                     </ul>
                 </div>
 
-                <!-- B.O.B. on Telegram -->
-                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden">
-                    <span class="feature-badge badge-free">Free</span>
-                    <div class="absolute top-0 left-0 right-0 h-1 bg-[#229ED9]"></div>
-                    <div class="w-14 h-14 bg-white rounded-xl flex items-center justify-center mb-5 shadow-lg border-2 border-slate-100">
-                        <svg class="w-8 h-8" viewBox="0 0 240 240" aria-hidden="true">
-                            <circle cx="120" cy="120" r="120" fill="#229ED9"/>
-                            <path fill="#fff" d="M54.4 118.3c35.3-15.4 58.8-25.5 70.6-30.3 33.7-14 40.7-16.4 45.3-16.5 1 0 3.3.2 4.7 1.4 1.2 1 1.6 2.4 1.7 3.3.2.9.4 3 .2 4.6-1.8 19.2-9.7 65.7-13.7 87.2-1.7 9.1-5 12.1-8.2 12.4-7 .7-12.3-4.6-19-9-10.6-6.9-16.5-11.2-26.8-18-11.9-7.8-4.2-12.1 2.6-19.1 1.8-1.8 32.5-29.8 33.1-32.3.1-.3.1-1.5-.6-2.1-.7-.6-1.7-.4-2.5-.2-1.1.2-17.9 11.4-50.6 33.4-4.8 3.3-9.1 4.9-13 4.8-4.3-.1-12.5-2.4-18.7-4.4-7.5-2.4-13.5-3.7-13-7.9.3-2.2 3.3-4.4 9-6.7z"/>
-                        </svg>
+                <!-- Dashboard -->
+                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
+                    <div class="w-14 h-14 bg-gradient-to-br from-brand-700 to-brand-900 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-brand-900/20">
+                        <i class="fas fa-table-columns text-white text-xl"></i>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">B.O.B. on Telegram</h3>
+                    <h3 class="text-xl font-bold text-brand-900 mb-3">See what needs your attention</h3>
                     <p class="text-brand-600 mb-4">
-                        Message B.O.B. on Telegram after you scan a QR from your profile.
+                        Open AgentFlow and get a quick read on what's going on without digging through every contact. See the work that's coming up and jump into the things that need you.
                     </p>
                     <ul class="space-y-2 text-sm text-brand-600">
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Text, a voice note, or a photo of a card
+                            Contact counts and groups
                         </li>
                         <li class="flex items-center gap-2">
                             <i class="fas fa-check text-green-500"></i>
-                            Scan the QR, then tap Start
+                            Upcoming tasks
+                        </li>
+                        <li class="flex items-center gap-2">
+                            <i class="fas fa-check text-green-500"></i>
+                            Estimated commission on your contacts
                         </li>
                     </ul>
                 </div>
-                
-                <!-- Feature 3: Transaction Pipeline -->
-                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
-                    <span class="feature-badge badge-pro">Pro · Coming Soon</span>
-                    <div class="w-14 h-14 bg-gradient-to-br from-purple-500 to-violet-600 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-purple-500/20">
-                        <i class="fas fa-file-contract text-white text-xl"></i>
-                    </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">Transaction Pipeline</h3>
-                    <p class="text-brand-600 mb-4">
-                        Track every deal from listing to close. Visualize your pipeline and know exactly where each transaction stands.
+            </div>
+
+            <!-- What's next -->
+            <div class="mt-20 md:mt-24">
+                <div class="text-center mb-12">
+                    <span class="inline-block px-4 py-1.5 bg-brand-800 text-white text-sm font-semibold rounded-full mb-4">
+                        WHAT'S NEXT
+                    </span>
+                    <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-900 mb-4">
+                        More of the transaction will live here, too.
+                    </h2>
+                    <p class="text-lg text-brand-600 max-w-2xl mx-auto">
+                        AgentFlow is starting with the CRM work agents deal with every day. We're also building the next pieces around the deal itself.
                     </p>
-                    <ul class="space-y-2 text-sm text-brand-600">
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Kanban deal view
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Commission tracking
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Document management
-                        </li>
-                    </ul>
                 </div>
-                
-                <!-- Feature 5: Document Generation -->
-                <div class="feature-card bg-white rounded-2xl p-6 lg:p-8 shadow-lg shadow-brand-900/5 border border-brand-100">
-                    <span class="feature-badge badge-pro">Pro · Coming Soon</span>
-                    <div class="w-14 h-14 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-cyan-500/20">
-                        <i class="fas fa-file-signature text-white text-xl"></i>
+
+                <div class="feature-card bg-white rounded-2xl p-6 lg:p-10 shadow-lg shadow-brand-900/5 border border-brand-100 relative overflow-hidden">
+                    <span class="feature-badge badge-pro">Coming later</span>
+                    <div class="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+                        <div>
+                            <div class="w-14 h-14 bg-gradient-to-br from-brand-700 to-brand-900 rounded-xl flex items-center justify-center mb-5 shadow-lg shadow-brand-900/20">
+                                <i class="fas fa-file-contract text-white text-xl"></i>
+                            </div>
+                            <h3 class="text-2xl lg:text-3xl font-bold text-brand-900 mb-3">Keep the deal with the client</h3>
+                            <p class="text-brand-600 text-lg leading-relaxed">
+                                Instead of moving to a completely separate system once a client becomes an active transaction, AgentFlow will let you keep the deal and the work around it connected.
+                            </p>
+                        </div>
+                        <ul class="space-y-3 text-brand-600">
+                            <li class="flex items-center gap-2">
+                                <i class="fas fa-check text-green-500"></i>
+                                Transaction stages
+                            </li>
+                            <li class="flex items-center gap-2">
+                                <i class="fas fa-check text-green-500"></i>
+                                Deal overview
+                            </li>
+                            <li class="flex items-center gap-2">
+                                <i class="fas fa-check text-green-500"></i>
+                                Commission tracking
+                            </li>
+                            <li class="flex items-center gap-2">
+                                <i class="fas fa-check text-green-500"></i>
+                                Documents attached to the transaction
+                            </li>
+                        </ul>
                     </div>
-                    <h3 class="text-xl font-bold text-brand-900 mb-3">Document Generation</h3>
-                    <p class="text-brand-600 mb-4">
-                        Generate listing agreements, disclosures, and more with auto-filled data. Then send them out for e-signature.
-                    </p>
-                    <ul class="space-y-2 text-sm text-brand-600">
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Auto-populated forms
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            E-signature collection
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <i class="fas fa-check text-green-500"></i>
-                            Standard real estate forms
-                        </li>
-                    </ul>
                 </div>
             </div>
         </div>
@@ -802,13 +792,13 @@
             <!-- Section Header -->
             <div class="text-center mb-16">
                 <span class="inline-block px-4 py-1.5 bg-accent-100 text-accent-700 text-sm font-semibold rounded-full mb-4">
-                    HOW IT WORKS
+                    GETTING STARTED
                 </span>
                 <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-900 mb-4">
-                    Get started in minutes
+                    Start with the people you're already working with
                 </h2>
                 <p class="text-lg text-brand-600 max-w-2xl mx-auto">
-                    Add your contacts, set the follow-ups, and keep notes as you go.
+                    You don't need to rebuild your business around a new CRM. Bring in your contacts, add the things you need to remember, and go from there.
                 </p>
             </div>
             
@@ -832,9 +822,9 @@
                             </div>
                         </div>
                         
-                        <h3 class="text-xl font-bold text-brand-900 mb-3">Import your contacts</h3>
+                        <h3 class="text-xl font-bold text-brand-900 mb-3">Bring in your contacts</h3>
                         <p class="text-brand-600 leading-relaxed">
-                            Add contacts manually or import from a spreadsheet. Organize them with smart groups and tags.
+                            Add contacts yourself or import them from a spreadsheet. Use groups if you already have a system for keeping people organized.
                         </p>
                     </div>
                 </div>
@@ -856,9 +846,9 @@
                             </div>
                         </div>
                         
-                        <h3 class="text-xl font-bold text-brand-900 mb-3">Stay organized</h3>
+                        <h3 class="text-xl font-bold text-brand-900 mb-3">Add what needs to happen next</h3>
                         <p class="text-brand-600 leading-relaxed">
-                            Add a task, pick a due date, and get an email reminder.
+                            Create follow-ups and tasks, set due dates, and keep notes with the client instead of relying on your memory or another random list.
                         </p>
                     </div>
                 </div>
@@ -869,17 +859,17 @@
                         <!-- Step number -->
                         <div class="relative inline-flex items-center justify-center w-32 h-32 mb-6">
                             <div class="absolute inset-0 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full"></div>
-                            <div class="relative w-20 h-20 bg-gradient-to-br from-green-500 to-emerald-600 rounded-2xl flex items-center justify-center shadow-xl">
-                                <i class="fas fa-user-friends text-white text-2xl"></i>
+                            <div class="relative w-20 h-20 bg-gradient-to-br from-accent-500 to-accent-600 rounded-2xl flex items-center justify-center shadow-xl">
+                                <span class="text-white text-2xl font-bold tracking-tight">B.</span>
                             </div>
                             <div class="absolute -top-1 -right-1 w-8 h-8 bg-accent-500 rounded-full flex items-center justify-center text-white font-bold text-sm shadow-lg">
                                 3
                             </div>
                         </div>
                         
-                        <h3 class="text-xl font-bold text-brand-900 mb-3">Build relationships</h3>
+                        <h3 class="text-xl font-bold text-brand-900 mb-3">Or just tell B.O.B.</h3>
                         <p class="text-brand-600 leading-relaxed">
-                            Keep detailed notes, track interactions, and nurture leads into loyal clients over time.
+                            Need to update someone, add a note, log activity, find a contact, or knock out a task? Tell B.O.B. what you want done.
                         </p>
                     </div>
                 </div>
@@ -888,7 +878,7 @@
             <!-- CTA -->
             <div class="text-center mt-16">
                 <a href="{{ url_for('auth.register') }}" class="btn-primary inline-flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-accent-500 to-accent-600 text-white font-bold text-lg rounded-xl shadow-xl">
-                    Start Your Free Account
+                    Start Free
                     <i class="fas fa-arrow-right"></i>
                 </a>
             </div>
@@ -899,22 +889,14 @@
     <!-- ========== STATS SECTION ========== -->
     <section class="bg-brand-900 py-16">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+            <div class="grid grid-cols-2 gap-8 text-center max-w-2xl mx-auto">
                 <div>
                     <div class="text-4xl md:text-5xl font-bold text-accent-400 mb-2">$0</div>
                     <div class="text-brand-300 text-sm md:text-base">To get started</div>
                 </div>
                 <div>
-                    <div class="text-4xl md:text-5xl font-bold text-white mb-2">2 min</div>
-                    <div class="text-brand-300 text-sm md:text-base">Average setup time</div>
-                </div>
-                <div>
-                    <div class="text-4xl md:text-5xl font-bold text-white mb-2">Mobile</div>
-                    <div class="text-brand-300 text-sm md:text-base">Ready & responsive</div>
-                </div>
-                <div>
-                    <div class="text-4xl md:text-5xl font-bold text-white mb-2">256-bit</div>
-                    <div class="text-brand-300 text-sm md:text-base">SSL encrypted</div>
+                    <div class="text-4xl md:text-5xl font-bold text-white mb-2">About 2 min</div>
+                    <div class="text-brand-300 text-sm md:text-base">To get in</div>
                 </div>
             </div>
         </div>
@@ -928,13 +910,13 @@
             <!-- Section Header -->
             <div class="text-center mb-16">
                 <span class="inline-block px-4 py-1.5 bg-brand-800 text-white text-sm font-semibold rounded-full mb-4">
-                    SIMPLE PRICING
+                    PRICING
                 </span>
                 <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-brand-900 mb-4">
-                    Start for free, upgrade when you're ready
+                    Start free. Stay there as long as it works for you.
                 </h2>
                 <p class="text-lg text-brand-600 max-w-2xl mx-auto">
-                    No hidden fees, no credit card required. Get started in minutes.
+                    No credit card required. The free plan includes the core AgentFlow CRM plus B.O.B., Gmail, and Google Calendar for one user.
                 </p>
             </div>
             
@@ -961,7 +943,7 @@
                     <ul class="space-y-3 flex-grow">
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
-                            1 user account
+                            1 user
                         </li>
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
@@ -969,137 +951,71 @@
                         </li>
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
-                            Task management
+                            Tasks and follow-ups
                         </li>
                         <li class="flex items-center gap-3 text-brand-700">
                             <i class="fas fa-check text-green-500"></i>
-                            Dashboard & analytics
+                            Notes and contact history
                         </li>
-                        
-                        <!-- Google Integration Highlight -->
-                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-gradient-to-r from-blue-50 via-white to-green-50 border border-slate-100">
-                            <div class="flex-shrink-0 mt-0.5">
-                                <svg class="w-5 h-5" viewBox="0 0 24 24">
-                                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                                </svg>
-                            </div>
-                            <div class="flex-1">
-                                <span class="font-semibold text-brand-800">Google Integration</span>
-                                <div class="text-xs text-brand-600 mt-1 space-y-0.5">
-                                    <div class="flex items-center gap-1.5">
-                                        <svg class="w-3 h-3" viewBox="0 0 24 24">
-                                            <path fill="#EA4335" d="M24 5.457v13.909c0 .904-.732 1.636-1.636 1.636h-3.819V11.73L12 16.64l-6.545-4.91v9.273H1.636A1.636 1.636 0 0 1 0 19.366V5.457c0-2.023 2.309-3.178 3.927-1.964L5.455 4.64 12 9.548l6.545-4.91 1.528-1.145C21.69 2.28 24 3.434 24 5.457z"/>
-                                        </svg>
-                                        Send emails via Gmail
-                                    </div>
-                                    <div class="flex items-center gap-1.5">
-                                        <svg class="w-3 h-3" viewBox="0 0 24 24">
-                                            <path fill="#4285F4" d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2z"/>
-                                            <path fill="#fff" d="M19 20H5V9h14v11z"/>
-                                            <path fill="#EA4335" d="M12 13h5v5h-5z"/>
-                                        </svg>
-                                        Calendar task sync
-                                    </div>
-                                </div>
-                            </div>
+                        <li class="flex items-center gap-3 text-brand-700">
+                            <i class="fas fa-check text-green-500"></i>
+                            Groups, search, and filters
                         </li>
-                        
-                        <!-- B.O.B. chat highlight -->
-                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-gradient-to-r from-amber-50 via-white to-orange-50 border border-amber-100">
-                            <div class="flex-shrink-0 mt-0.5">
-                                <span class="inline-flex w-5 h-5 items-center justify-center rounded-md bg-accent-500 text-white text-[11px] font-bold">B.</span>
-                            </div>
-                            <div class="flex-1">
-                                <span class="font-semibold text-brand-800">B.O.B.</span>
-                                <div class="text-xs text-brand-600 mt-1">
-                                    25 messages/day included free. Add a contact or count a ZIP from chat.
-                                </div>
-                            </div>
+                        <li class="flex items-center gap-3 text-brand-700">
+                            <i class="fas fa-check text-green-500"></i>
+                            Gmail sending
                         </li>
-
-                        <li class="flex items-start gap-3 p-3 -mx-3 rounded-xl bg-[#229ED9]/5 border border-[#229ED9]/20">
-                            <div class="flex-shrink-0 mt-0.5">
-                                <svg class="w-5 h-5" viewBox="0 0 240 240" aria-hidden="true">
-                                    <circle cx="120" cy="120" r="120" fill="#229ED9"/>
-                                    <path fill="#fff" d="M54.4 118.3c35.3-15.4 58.8-25.5 70.6-30.3 33.7-14 40.7-16.4 45.3-16.5 1 0 3.3.2 4.7 1.4 1.2 1 1.6 2.4 1.7 3.3.2.9.4 3 .2 4.6-1.8 19.2-9.7 65.7-13.7 87.2-1.7 9.1-5 12.1-8.2 12.4-7 .7-12.3-4.6-19-9-10.6-6.9-16.5-11.2-26.8-18-11.9-7.8-4.2-12.1 2.6-19.1 1.8-1.8 32.5-29.8 33.1-32.3.1-.3.1-1.5-.6-2.1-.7-.6-1.7-.4-2.5-.2-1.1.2-17.9 11.4-50.6 33.4-4.8 3.3-9.1 4.9-13 4.8-4.3-.1-12.5-2.4-18.7-4.4-7.5-2.4-13.5-3.7-13-7.9.3-2.2 3.3-4.4 9-6.7z"/>
-                                </svg>
-                            </div>
-                            <div class="flex-1">
-                                <span class="font-semibold text-brand-800">B.O.B. on Telegram</span>
-                                <div class="text-xs text-brand-600 mt-1">
-                                    Scan a QR from your profile.
-                                </div>
-                            </div>
+                        <li class="flex items-center gap-3 text-brand-700">
+                            <i class="fas fa-check text-green-500"></i>
+                            Google Calendar task sync
                         </li>
-                        
-                        <li class="flex items-center gap-3 text-brand-400">
-                            <i class="fas fa-lock text-brand-300"></i>
-                            Unlimited B.O.B. chat and daily to-do (Pro)
+                        <li class="flex items-center gap-3 text-brand-700">
+                            <i class="fas fa-check text-green-500"></i>
+                            B.O.B. with 25 messages a day
                         </li>
-                        <li class="flex items-center gap-3 text-brand-400">
-                            <i class="fas fa-lock text-brand-300"></i>
-                            Transaction management (Pro)
-                        </li>
-                        <li class="flex items-center gap-3 text-brand-400">
-                            <i class="fas fa-lock text-brand-300"></i>
-                            Document generation (Pro)
-                        </li>
-                        <li class="flex items-center gap-3 text-brand-400">
-                            <i class="fas fa-lock text-brand-300"></i>
-                            Integrated E-sign (Pro)
-                        </li>
-                        <li class="flex items-center gap-3 text-brand-400">
-                            <i class="fas fa-lock text-brand-300"></i>
-                            Team invitations (Pro)
+                        <li class="flex items-center gap-3 text-brand-700">
+                            <i class="fas fa-check text-green-500"></i>
+                            B.O.B. through Telegram
                         </li>
                     </ul>
                     
                     <div class="mt-auto pt-8">
                         <a href="{{ url_for('auth.register') }}" class="block w-full text-center px-6 py-3 border-2 border-brand-300 text-brand-700 font-semibold rounded-xl hover:bg-brand-50 transition-colors">
-                        Get Started Free
+                        Start Free
                     </a>
                     </div>
                 </div>
                 
                 <!-- Pro Plan -->
                 <div class="bg-gradient-to-br from-brand-800 to-brand-900 rounded-2xl p-8 shadow-xl relative overflow-hidden flex flex-col h-full border-2 border-brand-700">
-                    <!-- Coming soon badge -->
                     <div class="absolute top-4 right-4">
                         <span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-accent-500 text-white text-xs font-bold rounded-full">
-                            <i class="fas fa-clock text-[10px]"></i>
-                            COMING SOON
+                            Coming later
                         </span>
                     </div>
                     
                     <div class="flex items-center gap-3 mb-4">
                         <div class="w-12 h-12 bg-accent-500 rounded-xl flex items-center justify-center">
-                            <i class="fas fa-rocket text-white text-xl"></i>
+                            <i class="fas fa-users text-white text-xl"></i>
                         </div>
                         <div>
                             <h3 class="text-2xl font-bold text-white">Pro</h3>
-                            <p class="text-brand-300 text-sm">For teams & power users</p>
+                            <p class="text-brand-300 text-sm">Coming later</p>
                         </div>
                     </div>
                     
-                    <div class="mb-6">
-                        <span class="text-4xl font-bold text-white">Pricing TBD</span>
-                    </div>
+                    <p class="mb-6 text-brand-200 leading-relaxed">
+                        We're building Pro for agents and teams who need more than the free plan. Pricing will be announced before it launches.
+                    </p>
                     
                     <ul class="space-y-3 flex-grow">
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>
-                            Everything in Free (incl. Google)
+                            More users
                         </li>
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>
-                            Up to 25 users
-                        </li>
-                        <li class="flex items-center gap-3 text-white">
-                            <i class="fas fa-check text-accent-400"></i>
-                            <strong>Unlimited</strong> B.O.B. chat
+                            Unlimited B.O.B.
                         </li>
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>
@@ -1111,15 +1027,7 @@
                         </li>
                         <li class="flex items-center gap-3 text-white">
                             <i class="fas fa-check text-accent-400"></i>
-                            Document generation
-                        </li>
-                        <li class="flex items-center gap-3 text-white">
-                            <i class="fas fa-check text-accent-400"></i>
-                            Integrated E-sign
-                        </li>
-                        <li class="flex items-center gap-3 text-white">
-                            <i class="fas fa-check text-accent-400"></i>
-                            Team invitations
+                            Team invites
                         </li>
                     </ul>
                     
@@ -1180,10 +1088,10 @@
         
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
             <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
-                Ready to try it?
+                See if AgentFlow fits the way you work.
             </h2>
             <p class="text-xl text-white/90 mb-10 max-w-2xl mx-auto">
-                Create an account when you're ready. No card.
+                You can start with the free plan, add a few contacts, and use the actual CRM before deciding anything.
             </p>
             
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
@@ -1196,6 +1104,7 @@
                     Contact Us
                 </button>
             </div>
+            <p class="mt-6 text-sm text-white/80">No credit card required.</p>
         </div>
     </section>
     

--- a/templates/modals/contact_us_modal.html
+++ b/templates/modals/contact_us_modal.html
@@ -14,8 +14,8 @@
                         <i class="fas fa-comment-dots text-white text-2xl"></i>
                     </div>
                 </div>
-                <h2 class="text-3xl font-bold text-brand-900 text-center mb-2">How can we help you?</h2>
-                <p class="text-brand-600 text-center">Have a question, suggestion, or need assistance? We'd love to hear from you.</p>
+                <h2 class="text-3xl font-bold text-brand-900 text-center mb-2">Get in touch</h2>
+                <p class="text-brand-600 text-center">Have a question about AgentFlow? Send us a message and we'll get back to you by email.</p>
             </div>
             
             <!-- Form -->
@@ -36,7 +36,7 @@
                         id="contactSubject" 
                         name="subject"
                         class="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent transition-all text-brand-900 placeholder-gray-400"
-                        placeholder="Brief summary of your inquiry"
+                        placeholder="A quick summary"
                         required
                     >
                 </div>
@@ -44,23 +44,22 @@
                 <!-- Message Field -->
                 <div class="mb-5">
                     <label for="contactMessage" class="block text-sm font-semibold text-brand-700 mb-2">
-                        Tell us more
+                        Message
                     </label>
                     <textarea 
                         id="contactMessage" 
                         name="message"
                         rows="6"
                         class="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-transparent transition-all text-brand-900 placeholder-gray-400 resize-none"
-                        placeholder="Provide details about your question or feedback..."
+                        placeholder="Your message"
                         required
                     ></textarea>
-                    <p class="mt-2 text-xs text-gray-500">The more details you provide, the better we can help you.</p>
                 </div>
                 
                 <!-- Email Field (pre-filled if logged in) -->
                 <div class="mb-6">
                     <label for="contactEmail" class="block text-sm font-semibold text-brand-700 mb-2">
-                        We'll reply to
+                        Your email
                     </label>
                     <div class="relative">
                         <input 
@@ -105,12 +104,12 @@
 // Different placeholder configurations
 const CONTACT_PLACEHOLDERS = {
     landing: {
-        subject: "Questions about pricing, features, or getting started?",
-        message: "Tell us what you'd like to know about AgentFlow CRM. Ask about features, pricing plans, signing up, or schedule a demo..."
+        subject: "A quick summary",
+        message: "Your message"
     },
     app: {
-        subject: "Brief summary of your inquiry",
-        message: "Describe your issue, feedback, or question in detail. Include any relevant information that will help us assist you better..."
+        subject: "A quick summary",
+        message: "Your message"
     }
 };
 

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -21,7 +21,7 @@ META = (
     "AgentFlow includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant."
 )
 HOME_TITLE = "Free Real Estate CRM | AgentFlow"
-HOME_H1_PART = "Your clients and follow-ups,"
+HOME_H1_PART = "Keep up with every client"
 HOME_BOB_QUESTION = "What can B.O.B. do?"
 HOME_BOB_P1 = (
     "B.O.B. is the AI assistant built into AgentFlow. Instead of clicking through the CRM, "

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -22,7 +22,7 @@ META = (
     "and B.O.B., its built-in AI assistant."
 )
 HOME_TITLE = "Free Real Estate CRM | AgentFlow"
-HOME_H1_PART = "Your clients and follow-ups,"
+HOME_H1_PART = "Keep up with every client"
 HOME_BOB_QUESTION = "What can B.O.B. do?"
 HOME_BOB_P1 = (
     "B.O.B. is the AI assistant built into AgentFlow. Instead of clicking through the CRM, "

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -81,11 +81,15 @@ def _json_ld_answer(answer):
     return "\\n\\n".join(_faq_paragraphs(answer))
 
 
-def _copy_without_bob_faq(html):
+def _copy_without_bob_ai(html):
     question, answer = FAQ_ITEMS[4]
     stripped = html.replace(question, "")
     for para in _faq_paragraphs(answer):
         stripped = stripped.replace(para, "")
+    stripped = stripped.replace(
+        "B.O.B. is the AI assistant built into AgentFlow.",
+        "",
+    )
     return stripped
 
 
@@ -100,27 +104,32 @@ class TestLandingLeftoverCopy:
         assert "seamlessly" not in REGISTER.lower()
 
     def test_exact_replacements_are_present(self):
-        assert "What's on the free tier" in LANDING
-        assert "Ready to try it?" in LANDING
-        assert "Create an account when you're ready. No card." in LANDING
-        assert "Set a due date and a reminder. The follow-up stays on your list." in LANDING
+        assert "WHAT AGENTFLOW DOES" in LANDING
+        assert "Keep the client work together. Let B.O.B. handle the busywork." in LANDING
+        assert "See if AgentFlow fits the way you work." in LANDING
+        assert "You can start with the free plan, add a few contacts, and use the actual CRM before deciding anything." in LANDING
+        assert "Don't let the next step disappear" in LANDING
         assert "Contacts and follow-up tasks in one CRM" not in LANDING
+        assert "What's on the free tier" not in LANDING
+        assert "Ready to try it?" not in LANDING
+        assert "Create an account when you're ready. No card." not in LANDING
 
     def test_no_em_dashes_in_public_copy(self):
         assert "—" not in LANDING
         assert "—" not in REGISTER
 
     def test_keeps_homepage_h1(self):
-        assert "Your clients and follow-ups," in LANDING
-        assert "in one place." in LANDING
+        assert "Keep up with every client" in LANDING
+        assert "without living in your CRM." in LANDING
 
     def test_keeps_start_free_cta(self):
         assert "Start Free" in LANDING
 
-    def test_keeps_pro_coming_soon_and_pricing_tbd(self):
+    def test_keeps_pro_coming_later_without_a_buy_cta(self):
         assert "Pro" in LANDING
-        assert "Coming Soon" in LANDING
-        assert "Pricing TBD" in LANDING
+        assert "Coming later" in LANDING
+        assert "Pricing TBD" not in LANDING
+        assert "COMING SOON" not in LANDING
 
     def test_one_human_link_to_free_real_estate_crm(self):
         assert LANDING.count("url_for('main.free_real_estate_crm')") == 1
@@ -171,16 +180,16 @@ class TestLandingLeftoverCopy:
         assert "10/day free" not in LANDING
         assert "Up to 10,000 contacts" in LANDING
         assert "25 messages a day" in LANDING
-        assert "25/day free" in LANDING
-        assert "25 messages/day included free" in LANDING
+        assert "25/day free" not in LANDING
+        assert "25 messages/day included free" not in LANDING
 
     def test_free_pricing_card_matches_product_limits(self):
         start = LANDING.index("<!-- Free Plan -->")
         end = LANDING.index("<!-- Pro Plan -->")
         card = LANDING[start:end]
-        assert "1 user account" in card
+        assert "1 user" in card
         assert "Up to 10,000 contacts" in card
-        assert "25 messages/day included free" in card
+        assert "B.O.B. with 25 messages a day" in card
         assert "Unlimited contacts" not in card
         assert "10 messages" not in card
         assert "10/day" not in card
@@ -192,9 +201,9 @@ class TestLandingLeftoverCopy:
         assert "never be a paid" not in LANDING.lower()
         assert "Extra features later will be paid" in LANDING
 
-    def test_no_ai_word_outside_bob_faq(self):
+    def test_no_ai_word_outside_bob_copy(self):
         for source in (LANDING, FREE_CRM):
-            visible = _visible_public_copy(_copy_without_bob_faq(source))
+            visible = _visible_public_copy(_copy_without_bob_ai(source))
             assert re.search(r"\bAI\b", visible) is None
         assert re.search(r"\bAI\b", _visible_public_copy(REGISTER)) is None
         assert re.search(r"\bAI\b", LLMS) is None
@@ -219,16 +228,18 @@ class TestLandingLeftoverCopy:
         assert "One user" in LLMS
 
     def test_bob_is_a_headline_feature_with_real_tools(self):
-        assert "Talk to B.O.B." in LANDING
-        assert "Ask how many clients are in a ZIP or city." in LANDING
-        assert "add a contact, change an email, complete a task, or log a call" in LANDING
-        assert "change an email" in LANDING
+        assert "Tell B.O.B. what you need done" in LANDING
+        assert "B.O.B. is the AI assistant built into AgentFlow." in LANDING
+        assert "Takes actions inside the CRM" in LANDING
+        assert "If you can do it in AgentFlow, you can ask B.O.B. to do it for you." in LANDING
+        assert "Those are just examples." in LANDING
+        assert "Ask how many clients are in a ZIP or city." not in LANDING
         assert "Changing an email waits for Confirm (15 minutes)." not in LANDING
         assert "Confirm (15 minutes)" not in LANDING
         assert "waits for a yes" not in LANDING
         assert "until you say yes" not in LANDING
         assert "25 messages a day" in LANDING
-        assert "25/day free" in LANDING
+        assert "25/day free" not in LANDING
         assert "AI-Powered B.O.B." not in LANDING
         assert "B.O.B. AI Assistant" not in LANDING
         assert "Unlimited AI + daily todo" not in LANDING
@@ -238,9 +249,12 @@ class TestLandingLeftoverCopy:
         assert "drafts and questions about your work" not in LANDING
         assert "Business Optimization Buddy" not in LANDING
 
-    def test_telegram_is_mentioned_with_official_logo(self):
-        assert "B.O.B. on Telegram" in LANDING
-        assert "Message B.O.B. on Telegram after you scan a QR from your profile." in LANDING
+    def test_telegram_is_part_of_bob_not_a_separate_product(self):
+        assert "B.O.B. on Telegram" not in LANDING
+        assert "connect B.O.B. to Telegram" in LANDING
+        assert "B.O.B. through Telegram" in LANDING
+        assert "voice note" in LANDING
+        assert "business card" in LANDING
         assert 'fill="#229ED9"' in LANDING
         assert 'viewBox="0 0 240 240"' in LANDING
         assert "<circle cx=\"120\" cy=\"120\" r=\"120\" fill=\"#229ED9\"/>" in LANDING
@@ -279,6 +293,32 @@ class TestLandingLeftoverCopy:
         assert "waits for a yes" not in answer
         assert "until you say yes" not in answer
         assert "in the CRM or on Telegram" not in answer
+
+
+class TestLandingProductClaims:
+    def test_does_not_promise_document_generation_or_esign(self):
+        assert "Document Generation" not in LANDING
+        assert "listing agreements" not in LANDING.lower()
+        assert "auto-populated forms" not in LANDING.lower()
+        assert "E-signature collection" not in LANDING
+        assert "Integrated E-sign" not in LANDING
+        assert "Standard real estate forms" not in LANDING
+
+    def test_does_not_claim_contact_tags(self):
+        assert "groups, tags" not in LANDING.lower()
+        assert "Custom groups & tags" not in LANDING
+
+    def test_signup_cta_is_start_free(self):
+        assert LANDING.count("Start Free") >= 4
+        assert "Get Started Free" not in LANDING
+        assert "Start Your Free Account" not in LANDING
+
+    def test_does_not_call_tasks_automation(self):
+        assert "Task Automation" not in LANDING
+        assert "Google Integration" not in LANDING
+        assert "Contact Management" not in LANDING
+        assert "One-click OAuth" not in LANDING
+        assert "power users" not in LANDING.lower()
 
 
 class TestRegisterLeftoverCopy:

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -22,7 +22,7 @@ META = (
     "AgentFlow includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant."
 )
 HOME_TITLE = "Free Real Estate CRM | AgentFlow"
-HOME_H1_PART = "Your clients and follow-ups,"
+HOME_H1_PART = "Keep up with every client"
 HOME_BOB_QUESTION = "What can B.O.B. do?"
 HOME_BOB_P1 = (
     "B.O.B. is the AI assistant built into AgentFlow. Instead of clicking through the CRM, "


### PR DESCRIPTION
## Summary
- Rewrites the public homepage so it explains what using AgentFlow actually feels like: clients and the work around them stay together, and B.O.B. can do CRM work when asked.
- Replaces feature-category copy (Contact Management, Task Automation, Google Integration) with outcome-led sections, folds Telegram into B.O.B., and moves transactions into a clear coming-later preview.
- Drops document generation / e-sign claims (those are frozen in the product) and contact-tag claims that the app does not actually support. FAQ copy is unchanged.

## Test plan
- [ ] Load `/` logged out and read the page top to bottom: hero, features, how it works, pricing, FAQ, final CTA
- [ ] Confirm signup buttons all say **Start Free**, secondary hero CTA goes to How It Works, and Pro is clearly not for sale
- [ ] Confirm FAQ questions/answers match the previous reviewed copy
- [ ] Open Contact Us and check the simpler form labels
- [ ] Spot-check that the page does not promise tags, document generation, or e-sign
- [ ] `pytest tests/test_landing_copy.py tests/test_follow_up_boss_alternative.py tests/test_wise_agent_alternative.py tests/test_kvcore_alternative.py tests/test_free_real_estate_crm.py`


Made with [Cursor](https://cursor.com)