### PR TITLE
Fill transaction addresses from contacts and fix questionnaire Yes/No state

### DIFF
--- a/routes/transactions/api.py
+++ b/routes/transactions/api.py
@@ -36,6 +36,35 @@ def _require_tx(transaction_id, capability=CAP_VIEW):
     return tx
 
 
+def format_contact_address(contact):
+    """Build a single-line address from a contact's stored fields."""
+    street = (contact.street_address or '').strip()
+    city = (contact.city or '').strip()
+    state = (contact.state or '').strip()
+    zip_code = (contact.zip_code or '').strip()
+    city_state_zip = ', '.join(part for part in [city, ' '.join(part for part in [state, zip_code] if part)] if part)
+    if street and city_state_zip:
+        return f'{street}, {city_state_zip}'
+    return street or city_state_zip
+
+
+def contact_search_payload(contact):
+    """JSON payload for the transaction contact picker."""
+    return {
+        'id': contact.id,
+        'first_name': contact.first_name,
+        'last_name': contact.last_name,
+        'name': f'{contact.first_name} {contact.last_name}',
+        'email': contact.email,
+        'phone': contact.phone,
+        'street_address': contact.street_address or '',
+        'city': contact.city or '',
+        'state': contact.state or '',
+        'zip_code': contact.zip_code or '',
+        'full_address': format_contact_address(contact),
+    }
+
+
 # =============================================================================
 # API ENDPOINTS
 # =============================================================================
@@ -61,14 +90,7 @@ def search_contacts():
     
     contacts = contacts.order_by(Contact.last_name, Contact.first_name).limit(20).all()
     
-    return jsonify([{
-        'id': c.id,
-        'first_name': c.first_name,
-        'last_name': c.last_name,
-        'name': f'{c.first_name} {c.last_name}',
-        'email': c.email,
-        'phone': c.phone
-    } for c in contacts])
+    return jsonify([contact_search_payload(c) for c in contacts])
 
 
 @transactions_bp.route('/api/partners/search')

--- a/templates/transactions/create.html
+++ b/templates/transactions/create.html
@@ -132,25 +132,35 @@
                 </div>
                 <div class="crm-surface-body">
                     <div class="space-y-4">
+                        <div id="clientAddressPicker" class="hidden">
+                            <label for="clientAddressSelect" class="mb-2 block text-sm font-medium text-slate-700">
+                                Use a client address
+                            </label>
+                            <select id="clientAddressSelect" class="crm-input">
+                                <option value="">Choose a client address</option>
+                            </select>
+                            <p class="mt-1.5 text-xs text-slate-500">You can still type or edit the address below.</p>
+                        </div>
+
                         <div>
                             <label class="mb-2 block text-sm font-medium text-slate-700">
                                 Street address <span class="text-red-500">*</span>
                             </label>
-                            <input type="text" name="street_address" required class="crm-input" placeholder="123 Main St">
+                            <input type="text" name="street_address" id="streetAddressInput" required class="crm-input" placeholder="123 Main St">
                         </div>
 
                         <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
                             <div class="sm:col-span-2">
                                 <label class="mb-2 block text-sm font-medium text-slate-700">City</label>
-                                <input type="text" name="city" class="crm-input" placeholder="Austin">
+                                <input type="text" name="city" id="cityInput" class="crm-input" placeholder="Austin">
                             </div>
                             <div>
                                 <label class="mb-2 block text-sm font-medium text-slate-700">State</label>
-                                <input type="text" name="state" value="TX" class="crm-input">
+                                <input type="text" name="state" id="stateInput" value="TX" class="crm-input">
                             </div>
                             <div>
                                 <label class="mb-2 block text-sm font-medium text-slate-700">ZIP</label>
-                                <input type="text" name="zip_code" class="crm-input" placeholder="78701">
+                                <input type="text" name="zip_code" id="zipInput" class="crm-input" placeholder="78701">
                             </div>
                         </div>
 
@@ -210,7 +220,16 @@ document.addEventListener('DOMContentLoaded', function() {
     const ownershipSection = document.getElementById('ownershipSection');
 
     let selectedContactIds = new Set();
+    const selectedContactData = new Map();
     let searchTimeout;
+    let applyingClientAddress = false;
+
+    const clientAddressPicker = document.getElementById('clientAddressPicker');
+    const clientAddressSelect = document.getElementById('clientAddressSelect');
+    const streetAddressInput = document.getElementById('streetAddressInput');
+    const cityInput = document.getElementById('cityInput');
+    const stateInput = document.getElementById('stateInput');
+    const zipInput = document.getElementById('zipInput');
 
     function getInitials(name) {
         const trimmed = (name || '').trim();
@@ -276,11 +295,63 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    function formatContactAddress(contact) {
+        const street = (contact.street_address || '').trim();
+        const city = (contact.city || '').trim();
+        const state = (contact.state || '').trim();
+        const zip = (contact.zip_code || '').trim();
+        const cityStateZip = [city, [state, zip].filter(Boolean).join(' ')].filter(Boolean).join(', ');
+        if (street && cityStateZip) return street + ', ' + cityStateZip;
+        return street || cityStateZip || (contact.full_address || '').trim();
+    }
+
+    function contactHasAddress(contact) {
+        return Boolean((contact.street_address || '').trim());
+    }
+
+    function refreshClientAddressPicker() {
+        const previous = clientAddressSelect.value;
+        const contactsWithAddresses = Array.from(selectedContactData.values()).filter(contactHasAddress);
+
+        clientAddressSelect.innerHTML = '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Choose a client address';
+        clientAddressSelect.appendChild(placeholder);
+
+        contactsWithAddresses.forEach(contact => {
+            const option = document.createElement('option');
+            option.value = String(contact.id);
+            option.textContent = (contact.name || 'Client') + ' \u2014 ' + formatContactAddress(contact);
+            clientAddressSelect.appendChild(option);
+        });
+
+        if (previous && contactsWithAddresses.some(contact => String(contact.id) === previous)) {
+            clientAddressSelect.value = previous;
+        }
+
+        clientAddressPicker.classList.toggle('hidden', contactsWithAddresses.length === 0);
+    }
+
+    function applyClientAddress(contactId) {
+        const contact = selectedContactData.get(Number(contactId));
+        if (!contact) return;
+
+        applyingClientAddress = true;
+        streetAddressInput.value = (contact.street_address || '').trim();
+        cityInput.value = (contact.city || '').trim();
+        stateInput.value = (contact.state || '').trim() || 'TX';
+        zipInput.value = (contact.zip_code || '').trim();
+        applyingClientAddress = false;
+    }
+
     function addContact(contact) {
         if (selectedContactIds.has(contact.id)) return;
 
         selectedContactIds.add(contact.id);
+        selectedContactData.set(contact.id, contact);
         noContactsMessage.classList.add('hidden');
+        refreshClientAddressPicker();
 
         const contactMeta = [contact.email, contact.phone].filter(Boolean).join(' \u00b7 ');
         const contactEl = document.createElement('div');
@@ -307,9 +378,27 @@ document.addEventListener('DOMContentLoaded', function() {
         id: {{ preselected_contact.id }},
         name: {{ (preselected_contact.first_name ~ ' ' ~ preselected_contact.last_name)|tojson }},
         email: {{ (preselected_contact.email or '')|tojson }},
-        phone: {{ (preselected_contact.phone or '')|tojson }}
+        phone: {{ (preselected_contact.phone or '')|tojson }},
+        street_address: {{ (preselected_contact.street_address or '')|tojson }},
+        city: {{ (preselected_contact.city or '')|tojson }},
+        state: {{ (preselected_contact.state or '')|tojson }},
+        zip_code: {{ (preselected_contact.zip_code or '')|tojson }}
     });
     {% endif %}
+
+    clientAddressSelect.addEventListener('change', function() {
+        if (this.value) {
+            applyClientAddress(this.value);
+        }
+    });
+
+    [streetAddressInput, cityInput, stateInput, zipInput].forEach(input => {
+        input.addEventListener('input', function() {
+            if (!applyingClientAddress) {
+                clientAddressSelect.value = '';
+            }
+        });
+    });
 
     selectedContacts.addEventListener('click', function(e) {
         const removeBtn = e.target.closest('.remove-contact');
@@ -317,7 +406,9 @@ document.addEventListener('DOMContentLoaded', function() {
             const contactEl = removeBtn.closest('[data-contact-id]');
             const contactId = parseInt(contactEl.dataset.contactId, 10);
             selectedContactIds.delete(contactId);
+            selectedContactData.delete(contactId);
             contactEl.remove();
+            refreshClientAddressPicker();
 
             if (selectedContactIds.size === 0) {
                 noContactsMessage.classList.remove('hidden');

--- a/templates/transactions/intake.html
+++ b/templates/transactions/intake.html
@@ -5,71 +5,91 @@
 
 {% block content %}
 <style>
-    .toggle-card {
+    /* Selection is driven by :checked so it survives theme overrides.
+       Tokens keep Yes/No readable in both light and dark. */
+    .question-item label:has(> .toggle-input),
+    .question-item label:has(> .option-input) {
+        position: relative;
+        color: inherit !important;
+    }
+
+    .question-item .toggle-input,
+    .question-item .option-input {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        opacity: 0;
+        cursor: pointer;
+    }
+
+    .toggle-card,
+    .option-pill {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: 0.5rem;
         padding: 0.5rem 1.25rem;
         border-radius: 0.375rem;
-        border: 1px solid #e2e8f0;
-        background: #ffffff;
+        border: 1px solid var(--hairline);
+        background: var(--paper);
         font-size: 0.875rem;
-        color: #475569;
+        color: var(--ink-3);
         cursor: pointer;
         transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
     }
 
-    .toggle-card:hover {
-        border-color: #cbd5e1;
-        background: #f8fafc;
+    .option-pill {
+        padding: 0.5rem 0.875rem;
+    }
+
+    .toggle-card:hover,
+    .option-pill:hover {
+        border-color: var(--ink-5);
+        background: var(--paper-2);
+        color: var(--ink-2);
     }
 
     .toggle-input:focus-visible + .toggle-card,
     .option-input:focus-visible + .option-pill {
-        outline: 2px solid #f97316;
+        outline: 2px solid var(--accent);
         outline-offset: 2px;
     }
 
+    .toggle-input:checked + .toggle-card[data-answer="yes"],
     .toggle-card.selected-yes {
-        border-color: #10b981;
-        background: #ecfdf5;
-        color: #065f46;
+        border-color: var(--positive) !important;
+        background: var(--positive-soft) !important;
+        color: var(--positive) !important;
+        box-shadow: 0 0 0 3px var(--positive-soft);
     }
 
-    .toggle-card.selected-yes .toggle-icon { color: #059669; }
+    .toggle-input:checked + .toggle-card[data-answer="yes"] .toggle-icon,
+    .toggle-card.selected-yes .toggle-icon {
+        color: var(--positive) !important;
+    }
 
+    .toggle-input:checked + .toggle-card[data-answer="no"],
     .toggle-card.selected-no {
-        border-color: #ef4444;
-        background: #fef2f2;
-        color: #991b1b;
+        border-color: var(--danger) !important;
+        background: var(--danger-soft) !important;
+        color: var(--danger) !important;
+        box-shadow: 0 0 0 3px var(--danger-soft);
     }
 
-    .toggle-card.selected-no .toggle-icon { color: #dc2626; }
-
-    .option-pill {
-        display: inline-flex;
-        align-items: center;
-        padding: 0.5rem 0.875rem;
-        border-radius: 0.375rem;
-        border: 1px solid #e2e8f0;
-        background: #ffffff;
-        font-size: 0.875rem;
-        color: #475569;
-        cursor: pointer;
-        transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+    .toggle-input:checked + .toggle-card[data-answer="no"] .toggle-icon,
+    .toggle-card.selected-no .toggle-icon {
+        color: var(--danger) !important;
     }
 
-    .option-pill:hover {
-        border-color: #cbd5e1;
-        background: #f8fafc;
-    }
-
+    .option-input:checked + .option-pill,
     .option-pill.selected {
-        border-color: #f97316;
-        background: #fff7ed;
-        color: #c2410c;
+        border-color: var(--accent) !important;
+        background: var(--accent-soft) !important;
+        color: var(--accent-ink) !important;
         font-weight: 500;
+        box-shadow: 0 0 0 3px var(--accent-soft);
     }
 </style>
 
@@ -159,8 +179,8 @@
                                     <input type="radio" name="{{ question.id }}" value="true"
                                            class="sr-only toggle-input"
                                            {% if intake_data.get(question.id) == true %}checked{% endif %}>
-                                    <div class="toggle-card {% if intake_data.get(question.id) == true %}selected-yes{% endif %}">
-                                        <i class="fas fa-check toggle-icon text-xs text-slate-400"></i>
+                                    <div class="toggle-card {% if intake_data.get(question.id) == true %}selected-yes{% endif %}" data-answer="yes">
+                                        <i class="fas fa-check toggle-icon text-xs" aria-hidden="true"></i>
                                         <span class="toggle-text">Yes</span>
                                     </div>
                                 </label>
@@ -168,8 +188,8 @@
                                     <input type="radio" name="{{ question.id }}" value="false"
                                            class="sr-only toggle-input"
                                            {% if intake_data.get(question.id) == false %}checked{% endif %}>
-                                    <div class="toggle-card {% if intake_data.get(question.id) == false %}selected-no{% endif %}">
-                                        <i class="fas fa-times toggle-icon text-xs text-slate-400"></i>
+                                    <div class="toggle-card {% if intake_data.get(question.id) == false %}selected-no{% endif %}" data-answer="no">
+                                        <i class="fas fa-times toggle-icon text-xs" aria-hidden="true"></i>
                                         <span class="toggle-text">No</span>
                                     </div>
                                 </label>

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -6,6 +6,9 @@ history, intake, download, signing, and cross-org isolation.
 """
 import pytest
 from conftest import login
+from models import Contact, db
+from routes.transactions.api import format_contact_address
+from types import SimpleNamespace
 
 
 class TestTransactionList:
@@ -47,6 +50,9 @@ class TestTransactionCreate:
     def test_new_form_loads(self, owner_a_client, seed):
         resp = owner_a_client.get('/transactions/new')
         assert resp.status_code == 200
+        assert b'clientAddressSelect' in resp.data
+        assert b'Use a client address' in resp.data
+        assert b'streetAddressInput' in resp.data
 
     def test_create_transaction(self, owner_a_client, seed):
         resp = owner_a_client.post('/transactions/', data={
@@ -258,6 +264,41 @@ class TestTransactionContactSearch:
         resp = owner_a_client.get('/transactions/api/contacts/search?q=Jane')
         assert resp.status_code == 200
 
+    def test_search_contacts_includes_address(self, app, owner_a_client, seed):
+        with app.app_context():
+            contact = Contact.query.get(seed['contact_a'])
+            contact.street_address = '123 Main St'
+            contact.city = 'Austin'
+            contact.state = 'TX'
+            contact.zip_code = '78701'
+            db.session.commit()
+
+        resp = owner_a_client.get('/transactions/api/contacts/search?q=Jane')
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload
+        match = next(item for item in payload if item['id'] == seed['contact_a'])
+        assert match['street_address'] == '123 Main St'
+        assert match['city'] == 'Austin'
+        assert match['state'] == 'TX'
+        assert match['zip_code'] == '78701'
+        assert match['full_address'] == '123 Main St, Austin, TX 78701'
+
+    def test_format_contact_address(self):
+        contact = SimpleNamespace(
+            street_address='6004 Lakeside Dr',
+            city='Austin',
+            state='TX',
+            zip_code='78746',
+        )
+        assert format_contact_address(contact) == '6004 Lakeside Dr, Austin, TX 78746'
+        assert format_contact_address(SimpleNamespace(
+            street_address='  10 Main  ', city='', state='', zip_code='',
+        )) == '10 Main'
+        assert format_contact_address(SimpleNamespace(
+            street_address='', city='', state='', zip_code='',
+        )) == ''
+
 
 class TestTransactionDocuments:
     """Document management within transactions."""
@@ -316,6 +357,12 @@ class TestTransactionIntake:
     def test_intake_loads(self, owner_a_client, seed):
         resp = owner_a_client.get(f'/transactions/{seed["tx_a"]}/intake')
         assert resp.status_code in (200, 302)
+        if resp.status_code == 200:
+            assert b'data-answer="yes"' in resp.data
+            assert b'data-answer="no"' in resp.data
+            assert b'.toggle-input:checked + .toggle-card[data-answer="yes"]' in resp.data
+            assert b'var(--positive-soft)' in resp.data
+            assert b'var(--danger-soft)' in resp.data
 
     def test_intake_cross_org_blocked(self, owner_a_client, seed):
         resp = owner_a_client.get(f'/transactions/{seed["tx_b"]}/intake')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Selected contacts with a stored address now show up as a quick-fill dropdown on the create-transaction property address step. Agents can still type or edit the address after picking one.

The property questionnaire Yes/No buttons now use checked-state CSS and Atelier tokens, so the selected answer stays visible in both light and dark mode.

## Changes
- Contact search returns street/city/state/ZIP plus a formatted `full_address`
- Create transaction address section offers “Use a client address” when a selected contact has an address
- Questionnaire Yes/No (and select pills) selection is driven by `:checked` with `--positive` / `--danger` / `--accent` tokens

## Testing
- `pytest tests/test_transactions.py` — 39 passed
- Manual: add clients with addresses, pick from the dropdown, then edit the street
- Manual: Yes/No selection in dark and light mode

[create_transaction_client_address_quickfill.mp4](https://cursor.com/agents/bc-01a01701-e7f1-7452-be77-1df40651d71b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_transaction_client_address_quickfill.mp4)
[create_transaction_manual_address_edit.mp4](https://cursor.com/agents/bc-01a01701-e7f1-7452-be77-1df40651d71b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_transaction_manual_address_edit.mp4)
[questionnaire_yes_no_light_and_dark.mp4](https://cursor.com/agents/bc-01a01701-e7f1-7452-be77-1df40651d71b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquestionnaire_yes_no_light_and_dark.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01701-e7f1-7452-be77-1df40651d71b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01701-e7f1-7452-be77-1df40651d71b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

