### PR TITLE
fix: listen for inbox identification jobs on the worker

### DIFF
--- a/tests/test_worker_queues.py
+++ b/tests/test_worker_queues.py
@@ -1,0 +1,11 @@
+"""Lock the RQ worker listen list to the queues producers actually use."""
+
+
+def test_worker_listens_to_inbox_bootstrap_queue():
+    from worker import QUEUE_NAMES
+
+    assert QUEUE_NAMES == (
+        "doc_extraction",
+        "bob_telegram",
+        "contract_bootstrap",
+    )

--- a/worker.py
+++ b/worker.py
@@ -25,6 +25,14 @@ from config import Config
 log = logging.getLogger("worker")
 logging.basicConfig(level=logging.INFO)
 
+# Queues this process must consume. Inbox identification enqueues onto
+# contract_bootstrap; omitting a name here leaves those jobs Queued forever.
+QUEUE_NAMES = (
+    "doc_extraction",
+    "bob_telegram",
+    "contract_bootstrap",
+)
+
 
 def _connect_redis(url: str, attempts: int = 12, delay: float = 2.5) -> Redis:
     """
@@ -59,10 +67,7 @@ def _connect_redis(url: str, attempts: int = 12, delay: float = 2.5) -> Redis:
 def main():
     with app.app_context():
         conn = _connect_redis(Config.REDIS_URL)
-        queues = [
-            Queue("doc_extraction", connection=conn),
-            Queue("bob_telegram", connection=conn),
-        ]
+        queues = [Queue(name, connection=conn) for name in QUEUE_NAMES]
         worker = Worker(queues, connection=conn)
         worker.work(with_scheduler=True)
 


### PR DESCRIPTION
## Summary
- Inbox uploads enqueue `process_contract_bootstrap_job` onto Redis queue `contract_bootstrap`, but `document-worker` only subscribed to `doc_extraction` and `bob_telegram`.
- Production multi-PDF inbox batches therefore stayed on **Queued** forever (0 of N identified) even though the worker was healthy.
- Subscribe the worker to `contract_bootstrap` and lock the listen list with a unit test so this cannot silently regress.

## Test plan
- [ ] Confirm `tests/test_worker_queues.py` passes
- [ ] After deploy, confirm `document-worker` logs `Listening on doc_extraction, bob_telegram, contract_bootstrap`
- [ ] Re-open or re-upload the stuck inbox batch and confirm rows move Queued → Reading → Identified
- [ ] Confirm existing-transaction document extraction still completes (`doc_extraction`)


Made with [Cursor](https://cursor.com)