### PR TITLE
fix: lock free CRM H1 and B.O.B. public copy

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,7 +10,7 @@ AgentFlow is a free CRM for real estate agents. Use it to organize contacts, man
 - Setup takes about 2 minutes.
 - One user, up to 10,000 contacts.
 - Contact management, task reminders, and Google email/calendar integration are on the free tier.
-- B.O.B. is the built-in assistant. Ask how many clients are in a ZIP. Tell it to add a contact, change an email, complete a task, or log a call. 25 messages a day on the free plan.
+- B.O.B. is the built-in assistant. Tell it what you need done in the CRM. It can find and update contacts, manage tasks, log activity, organize clients, and much more. 25 messages a day on the free plan.
 - Message B.O.B. on Telegram after you scan a QR from your profile.
 
 ## Public pages

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -262,7 +262,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="max-w-3xl">
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-brand-900 leading-tight mb-6">
-                    A real estate CRM you can start tonight.
+                    A free real estate CRM you can start tonight.
                 </h1>
                 <p class="text-lg sm:text-xl text-brand-600 mb-8">
                     Built for agents, by agents. The free tier stays free. No card. About two minutes.
@@ -284,7 +284,7 @@
                         The free tier is one user, up to 10,000 contacts, and 25 B.O.B. messages a day. Load your database, then put a due date on the next call so it isn't stuck in your notes app. Gmail send and Google Calendar task sync are included.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
-                        Ask B.O.B. to count clients in a ZIP, add a contact, change an email, or complete a task. Message B.O.B. on Telegram after you scan a QR from your profile.
+                        Ask B.O.B. to find a client, add a contact, log a call, or complete a task. Message B.O.B. on Telegram after you connect it from your profile.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed">
                         Built for real estate agents, by real estate agents.

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -14,7 +14,7 @@ FREE_LIMITS = get_tier_defaults("free")
 
 PAGE_PATH = "/free-real-estate-crm"
 TITLE = "Free real estate CRM | AgentFlow"
-H1 = "A real estate CRM you can start tonight."
+H1 = "A free real estate CRM you can start tonight."
 LEAD = "Built for agents, by agents. The free tier stays free. No card. About two minutes."
 SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 ALLOWED_SITEMAP_PATHS = {
@@ -153,7 +153,8 @@ class TestFreeRealEstateCrmRoute:
         assert "AI assistant" not in text
         assert "One user, up to 10,000 contacts." in text
         assert "25 messages a day on the free plan." in text
-        assert "change an email" in text
+        assert "Tell it what you need done in the CRM." in text
+        assert "It can find and update contacts, manage tasks, log activity, organize clients, and much more." in text
         assert "Changing an email waits for Confirm (15 minutes)." not in text
         assert "Confirm (15 minutes)" not in text
 
@@ -274,7 +275,8 @@ class TestFreeRealEstateCrmCopy:
         for para in _faq_paragraphs(answer):
             assert f'<p class="faq-answer">{para}</p>' in PAGE
             assert f'<p class="faq-answer">{para}</p>' in LANDING
-        assert "add a contact, change an email, or complete a task" in PAGE
+        assert "Ask B.O.B. to find a client, add a contact, log a call, or complete a task." in PAGE
+        assert "Message B.O.B. on Telegram after you connect it from your profile." in PAGE
         assert "change an email" not in answer
         assert "ZIP" not in answer
         assert "What is B.O.B.?" not in PAGE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two locked public-copy replacements on `/free-real-estate-crm` and `static/llms.txt`. One PR against `main`.

## Ticket 1 — `/free-real-estate-crm`

- H1 is now `A free real estate CRM you can start tonight.`
- Lead stays: `Built for agents, by agents. The free tier stays free. No card. About two minutes.`
- B.O.B. body is now: `Ask B.O.B. to find a client, add a contact, log a call, or complete a task. Message B.O.B. on Telegram after you connect it from your profile.`
- Title, meta, canonical, and the gold B.O.B. FAQ stay verbatim.

## Ticket 2 — `static/llms.txt`

- B.O.B. facts are now: `B.O.B. is the built-in assistant. Tell it what you need done in the CRM. It can find and update contacts, manage tasks, log activity, organize clients, and much more. 25 messages a day on the free plan.`
- Telegram line stays.
- No `AI` / `AI assistant` added.
- Limits stay one user / 10,000 contacts.

## Tests

Updated `tests/test_free_real_estate_crm.py` assertions to the new locked strings only.

`pytest tests/test_free_real_estate_crm.py tests/test_landing_copy.py tests/test_follow_up_boss_alternative.py tests/test_wise_agent_alternative.py tests/test_kvcore_alternative.py`: 143 passed.

Homepage H1 is untouched. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63c89416-f705-454c-8070-e323551a0e92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63c89416-f705-454c-8070-e323551a0e92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

