### PR TITLE
fix: stop tests from sending live SendGrid mail

### DIFF
--- a/.github/workflows/scheduled_tests.yml
+++ b/.github/workflows/scheduled_tests.yml
@@ -17,6 +17,9 @@ jobs:
       DATABASE_URL: sqlite:////tmp/scheduled_browser_integration.db
       SECRET_KEY: ci-test-secret-key
       FLASK_ENV: development
+      SENDGRID_API_KEY: ''
+      MAIL_PASSWORD: ''
+      MAIL_USERNAME: ''
 
     steps:
       - name: Checkout code
@@ -51,7 +54,12 @@ jobs:
         run: python tests/bootstrap_browser_test_db.py
 
       - name: Start Flask app
+        env:
+          SENDGRID_API_KEY: ''
+          MAIL_PASSWORD: ''
+          MAIL_USERNAME: ''
         run: |
+          export SENDGRID_API_KEY= MAIL_PASSWORD= MAIL_USERNAME=
           python app.py &
           # Wait for server to start
           sleep 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
       DATABASE_URL: sqlite:////tmp/test_integration.db
       SECRET_KEY: ci-test-secret-key
       FLASK_ENV: development
+      # Blank, do not unset: empty values stop python-dotenv from loading a
+      # real key if a runner or checkout ever has a .env.
+      SENDGRID_API_KEY: ''
+      MAIL_PASSWORD: ''
+      MAIL_USERNAME: ''
 
     steps:
       - name: Checkout code
@@ -45,7 +50,12 @@ jobs:
         run: npm run build
 
       - name: Run unit tests
+        env:
+          SENDGRID_API_KEY: ''
+          MAIL_PASSWORD: ''
+          MAIL_USERNAME: ''
         run: |
+          export SENDGRID_API_KEY= MAIL_PASSWORD= MAIL_USERNAME=
           pytest tests/ -x -v --ignore=tests/run_tests.py --ignore=tests/run_scheduled_tests.py --ignore=tests/test_idor_protection.py --ignore=tests/test_sendgrid.py --tb=short
           pytest tests/test_idor_protection.py -x -v --tb=short
 
@@ -61,6 +71,9 @@ jobs:
       DATABASE_URL: sqlite:////tmp/browser_integration.db
       SECRET_KEY: ci-test-secret-key
       FLASK_ENV: development
+      SENDGRID_API_KEY: ''
+      MAIL_PASSWORD: ''
+      MAIL_USERNAME: ''
 
     steps:
       - name: Checkout code
@@ -95,7 +108,12 @@ jobs:
         run: python tests/bootstrap_browser_test_db.py
 
       - name: Start Flask app
+        env:
+          SENDGRID_API_KEY: ''
+          MAIL_PASSWORD: ''
+          MAIL_USERNAME: ''
         run: |
+          export SENDGRID_API_KEY= MAIL_PASSWORD= MAIL_USERNAME=
           python app.py &
           sleep 5
           curl --retry 5 --retry-delay 2 --retry-connrefused http://127.0.0.1:5011/login

--- a/services/email_send_guard.py
+++ b/services/email_send_guard.py
@@ -1,0 +1,55 @@
+"""Internal outbound-email safety checks used by send helpers.
+
+This is not a product feature. It only blocks live sends from pytest/Playwright
+and known fixture recipient domains.
+"""
+from __future__ import annotations
+
+import logging
+
+from flask import current_app, has_app_context
+
+logger = logging.getLogger(__name__)
+
+# Addresses that exist only in tests / browser fixtures.
+_FIXTURE_DOMAINS = frozenset({
+    'test.com',
+    'example.com',
+    'localhost',
+})
+
+
+def is_fixture_recipient(to_email: str | None) -> bool:
+    """True for @test.com, @example.com, @localhost, and their subdomains."""
+    addr = (to_email or '').strip().lower()
+    if '@' not in addr:
+        return False
+    domain = addr.rsplit('@', 1)[-1]
+    if domain in _FIXTURE_DOMAINS:
+        return True
+    return any(domain.endswith('.' + suffix) for suffix in _FIXTURE_DOMAINS)
+
+
+def app_is_testing() -> bool:
+    """True when the current Flask app is in TESTING mode."""
+    if not has_app_context():
+        return False
+    return bool(current_app.config.get('TESTING'))
+
+
+def outbound_send_block_reason(to_email: str | None) -> str | None:
+    """Return a skip reason, or None if a live send is allowed."""
+    if app_is_testing():
+        return 'TESTING'
+    if is_fixture_recipient(to_email):
+        return 'fixture_recipient'
+    return None
+
+
+def skip_outbound_send(to_email: str | None) -> bool:
+    """Log and return True when helpers must not call a live mail API."""
+    reason = outbound_send_block_reason(to_email)
+    if not reason:
+        return False
+    logger.info('Outbound email skipped (%s) to=%s', reason, to_email)
+    return True

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from flask import current_app, url_for
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail, Email, To, Content
+from services.email_send_guard import skip_outbound_send
 
 # SendGrid Dynamic Template IDs
 TEMPLATES = {
@@ -62,6 +63,8 @@ class EmailService:
         Returns:
             True if sent successfully, False otherwise
         """
+        if skip_outbound_send(to_email):
+            return False
         if not self.gmail_enabled:
             current_app.logger.warning("Gmail fallback not configured - missing MAIL_USERNAME or MAIL_PASSWORD")
             return False
@@ -179,6 +182,9 @@ class EmailService:
         template_id = TEMPLATES.get(template_name)
         if not template_id:
             current_app.logger.error(f"Unknown email template: {template_name}")
+            return False
+
+        if skip_outbound_send(to_email):
             return False
         
         # Add current_year to all templates

--- a/services/sendgrid_outbound.py
+++ b/services/sendgrid_outbound.py
@@ -22,6 +22,7 @@ from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Email, Mail, To
 
+from services.email_send_guard import skip_outbound_send
 from services.inbox_provisioning import get_inbox_domain
 
 logger = logging.getLogger(__name__)
@@ -190,6 +191,8 @@ def _send_html(to_email: str, subject: str, html: str,
                *, reply_to: str | None = None,
                custom_args: dict | None = None) -> bool:
     """Wrap the SendGrid call and swallow errors (logged) so callers stay safe."""
+    if skip_outbound_send(to_email):
+        return False
     api_key = _sendgrid_api_key()
     if not api_key:
         logger.warning('SENDGRID_API_KEY missing — magic inbox email skipped.')
@@ -238,6 +241,8 @@ def _send_template(to_email: str, template_id: str, data: dict,
                    reply_to: str | None = None,
                    custom_args: dict | None = None) -> bool:
     """Send a SendGrid Dynamic Template with dynamic_template_data."""
+    if skip_outbound_send(to_email):
+        return False
     api_key = _sendgrid_api_key()
     if not api_key:
         logger.warning('SENDGRID_API_KEY missing — magic inbox email skipped.')

--- a/tests/browser_test_support.py
+++ b/tests/browser_test_support.py
@@ -39,6 +39,12 @@ def configure_browser_test_environment(project_root: Path) -> dict[str, str]:
     if env_test_path.exists():
         load_dotenv(env_test_path)
 
+    # Keep Playwright / CI Flask boots off live SendGrid even if a developer
+    # .env or .env.test still has a production key. Empty values also stop
+    # app.py load_dotenv(override=False) from re-injecting one.
+    for mail_key in ("SENDGRID_API_KEY", "MAIL_PASSWORD", "MAIL_USERNAME"):
+        os.environ[mail_key] = ""
+
     database_url = (
         os.getenv("TEST_DATABASE_URL")
         or os.getenv("DATABASE_URL")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ os.environ.setdefault('SECRET_KEY', 'test-secret-key')
 os.environ.setdefault('FLASK_ENV', 'testing')
 os.environ['APP_BASE_URL'] = 'https://agentflow.origentechnolog.com'
 
+# Blank mail secrets BEFORE importing app. app.py calls load_dotenv() with
+# override=False, so an existing empty value stops a local or cloud-agent
+# .env from injecting a real SENDGRID_API_KEY into Config and pytest.
+for _mail_key in ('SENDGRID_API_KEY', 'MAIL_PASSWORD', 'MAIL_USERNAME'):
+    os.environ[_mail_key] = ''
+
 from app import create_app
 from models import (
     db as _db, User, Organization, Contact, ContactGroup,
@@ -290,6 +296,38 @@ def _rollback_after_test(app):
     yield
     with app.app_context():
         _db.session.rollback()
+
+
+@pytest.fixture(autouse=True)
+def block_live_email(monkeypatch):
+    """Stub every live mail client so register/invite tests cannot hit SendGrid."""
+    from unittest.mock import MagicMock
+
+    from sendgrid import SendGridAPIClient
+
+    fake_response = MagicMock()
+    fake_response.status_code = 202
+    fake_response.body = b''
+    fake_response.headers = {}
+    sendgrid_send = MagicMock(return_value=fake_response)
+    monkeypatch.setattr(SendGridAPIClient, 'send', sendgrid_send)
+
+    gmail_send = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        'services.email_service.EmailService._send_via_gmail',
+        gmail_send,
+    )
+
+    try:
+        from flask_mail import Mail
+        monkeypatch.setattr(Mail, 'send', MagicMock())
+    except Exception:
+        pass
+
+    yield {
+        'sendgrid_send': sendgrid_send,
+        'gmail_send': gmail_send,
+    }
 
 
 @pytest.fixture()

--- a/tests/test_outbound_email_guard.py
+++ b/tests/test_outbound_email_guard.py
@@ -1,7 +1,7 @@
 """Regression: register and org invite must never reach live SendGrid."""
 from unittest.mock import MagicMock
 
-from models import OrganizationInvite, User
+from models import OrganizationInvite, User, db
 from services.email_send_guard import (
     is_fixture_recipient,
     outbound_send_block_reason,
@@ -116,7 +116,7 @@ class TestSendHelpersShortCircuit:
         from services.email_service import EmailService
 
         with app.app_context():
-            owner = User.query.get(seed['owner_a'])
+            owner = db.session.get(User, seed['owner_a'])
             org = owner.organization
             service = EmailService(api_key='SG.fake-pytest-key-not-real')
             assert service.send_team_invite(

--- a/tests/test_outbound_email_guard.py
+++ b/tests/test_outbound_email_guard.py
@@ -1,0 +1,126 @@
+"""Regression: register and org invite must never reach live SendGrid."""
+from unittest.mock import MagicMock
+
+from models import OrganizationInvite, User
+from services.email_send_guard import (
+    is_fixture_recipient,
+    outbound_send_block_reason,
+)
+
+
+class TestFixtureRecipientGuard:
+    def test_blocks_known_fixture_domains(self):
+        assert is_fixture_recipient('nina@test.com')
+        assert is_fixture_recipient('sam.seeded@test.com')
+        assert is_fixture_recipient('newinvite@test.com')
+        assert is_fixture_recipient('browser-test@example.com')
+        assert is_fixture_recipient('user@localhost')
+        assert is_fixture_recipient('agent@mail.test.com')
+
+    def test_allows_real_product_domains(self):
+        assert not is_fixture_recipient('agent@origentechnolog.com')
+        assert not is_fixture_recipient('hello@gmail.com')
+        assert not is_fixture_recipient('')
+        assert not is_fixture_recipient(None)
+
+
+class TestTestingFlagGuard:
+    def test_testing_blocks_even_real_looking_addresses(self, app):
+        with app.app_context():
+            assert app.config['TESTING'] is True
+            assert outbound_send_block_reason('agent@origentechnolog.com') == 'TESTING'
+
+    def test_production_mode_allows_real_recipient(self, app):
+        with app.app_context():
+            app.config['TESTING'] = False
+            try:
+                assert outbound_send_block_reason(
+                    'agent@origentechnolog.com'
+                ) is None
+                assert outbound_send_block_reason('nina@test.com') == 'fixture_recipient'
+            finally:
+                app.config['TESTING'] = True
+
+
+class TestRegisterAndInviteNeverCallSendGrid:
+    def test_nina_style_register_does_not_call_sendgrid(
+        self, client, app, seed, block_live_email,
+    ):
+        send_stub = block_live_email['sendgrid_send']
+        assert isinstance(send_stub, MagicMock)
+
+        resp = client.post('/register', data={
+            'company_name': 'No Send Realty',
+            'first_name': 'Nina',
+            'last_name': 'Guard',
+            'email': 'nina.nosend@test.com',
+            'password': 'supersecure123',
+            'confirm_password': 'supersecure123',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        send_stub.assert_not_called()
+        with app.app_context():
+            assert User.query.filter_by(email='nina.nosend@test.com').first()
+
+    def test_newinvite_style_invite_does_not_call_sendgrid(
+        self, owner_a_client, app, seed, block_live_email,
+    ):
+        send_stub = block_live_email['sendgrid_send']
+        assert isinstance(send_stub, MagicMock)
+
+        resp = owner_a_client.post('/org/members/invite', data={
+            'email': 'newinvite.nosend@test.com',
+            'role': 'agent',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        send_stub.assert_not_called()
+        with app.app_context():
+            invite = OrganizationInvite.query.filter_by(
+                email='newinvite.nosend@test.com',
+            ).first()
+            assert invite is not None
+
+    def test_send_helpers_stay_stubbed_even_with_fake_api_key(
+        self, client, app, seed, block_live_email, monkeypatch,
+    ):
+        monkeypatch.setenv('SENDGRID_API_KEY', 'SG.fake-pytest-key-not-real')
+        app.config['SENDGRID_API_KEY'] = 'SG.fake-pytest-key-not-real'
+        send_stub = block_live_email['sendgrid_send']
+
+        resp = client.post('/register', data={
+            'company_name': 'Leaked Key Realty',
+            'first_name': 'Sam',
+            'last_name': 'Seeded',
+            'email': 'sam.nosend@test.com',
+            'password': 'supersecure123',
+            'confirm_password': 'supersecure123',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        send_stub.assert_not_called()
+
+
+class TestSendHelpersShortCircuit:
+    def test_send_html_returns_false_in_testing(self, app, seed, block_live_email):
+        from services.sendgrid_outbound import _send_html
+
+        with app.app_context():
+            assert _send_html('nina@test.com', 'Hello', '<p>Hi</p>') is False
+        block_live_email['sendgrid_send'].assert_not_called()
+
+    def test_email_service_invite_returns_false_in_testing(
+        self, app, seed, block_live_email,
+    ):
+        from services.email_service import EmailService
+
+        with app.app_context():
+            owner = User.query.get(seed['owner_a'])
+            org = owner.organization
+            service = EmailService(api_key='SG.fake-pytest-key-not-real')
+            assert service.send_team_invite(
+                org, owner, 'newinvite@test.com', 'https://localhost/invite',
+            ) is False
+        block_live_email['sendgrid_send'].assert_not_called()
+        block_live_email['gmail_send'].assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Christopher saw a two-day SendGrid spike of Dropped/Invalid sends to pytest fixtures:

- `nina@test.com` / `sam.seeded@test.com` — subject "Your first follow-up in AgentFlow"
- `newinvite@test.com` — org invite, empty subject

Those addresses exist only in `tests/test_auth.py` and `tests/test_organization.py`. Welcome mail is hardcoded in `send_account_welcome()` and called from `routes/auth.py` on register / invite complete.

## Root cause (verified)

This was **not** a GitHub Actions secret injection.

- `.github/workflows/test.yml` never sets `SENDGRID_API_KEY`. Unused repo secrets are not auto-exported into the job env.
- No `Tests` unit-job run matches the 2026-08-19 6:21–6:23 PM CT burst. The closest unit run was ~3:04 PM CT. Scheduled Playwright uses `browser-test@example.com`, not these fixtures.
- `gh secret list` is 403 from this token, so I cannot prove a secret exists; I can prove CI does not reference one.

The live path is:

1. `app.py` calls `load_dotenv()` on import (`override=False`).
2. `Config.SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')` is captured at import.
3. `tests/conftest.py` imported `create_app` **without** blanking mail secrets first, so a local or Cursor/cloud-agent `.env` leaked the production key into pytest.
4. `tests/run_onboarding_e2e.py` already knew this (`load_dotenv` will not overwrite an existing empty key) and blanked `SENDGRID_API_KEY`. The rest of pytest did not.
5. Welcome email was wired into register (`02dae72` / `52931db`) without a SendGrid stub. CI already `--ignore=tests/test_sendgrid.py` and left every other test unprotected.

This environment currently has no `.env` and no `SENDGRID_API_KEY`, which matches a cleaned or fresh agent image. The leak happens whenever pytest runs with a production `.env` present.

## Fix

1. Autouse stub of `SendGridAPIClient.send`, Gmail fallback, and Flask-Mail in `tests/conftest.py`. Blank `SENDGRID_API_KEY` / `MAIL_PASSWORD` / `MAIL_USERNAME` **before** importing the app.
2. Send helpers (`_send_html`, `_send_template`, `EmailService.send` / `_send_via_gmail`) return `False` when `TESTING` is true or the recipient is `@test.com`, `@example.com`, or `@localhost`.
3. CI unit and Playwright jobs export those mail secrets as empty strings so a leaked key cannot ride along. Empty (not unset) so dotenv cannot refill them.
4. Regression tests for nina-style register and newinvite-style invite assert `SendGridAPIClient.send` is stubbed and never called.

Production welcome mail is unchanged. No API keys in the repo.

## Test plan

- `python3 -m pytest tests/test_auth.py tests/test_organization.py tests/test_magic_inbox.py tests/test_outbound_email_guard.py -v --tb=short`
- Result: **126 passed** in 7.11s
- Guard file re-run after polish: **9 passed**
- Head: `467e7b5be374454831afdd3eea0433906c7e906d`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-153bfd59-0db5-42a4-a292-497c078f1df8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-153bfd59-0db5-42a4-a292-497c078f1df8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

