### PR TITLE
Public copy: login sign-in line and register B.O.B. block

### DIFF
--- a/frontend/controllers/daily_briefing_controller.js
+++ b/frontend/controllers/daily_briefing_controller.js
@@ -187,7 +187,7 @@ export default class extends Controller {
     this._setCount(this.hasReconnectCountTarget && this.reconnectCountTarget, items.length);
     if (!items.length) {
       this.reconnectTarget.innerHTML = this._empty(
-        "Sphere looks warm. No one's going cold right now."
+        "No contacts need a reconnect right now."
       );
       return;
     }

--- a/frontend/controllers/daily_briefing_controller.js
+++ b/frontend/controllers/daily_briefing_controller.js
@@ -274,7 +274,7 @@ export default class extends Controller {
         }, 1400);
       }
     } catch (e) {
-      window.alert("Couldn't copy — select the text manually.");
+      window.alert("Couldn't copy. Select the text manually.");
     }
   }
 

--- a/services/marketing/system_templates.py
+++ b/services/marketing/system_templates.py
@@ -64,10 +64,7 @@ SYSTEM_TEMPLATES: tuple[dict[str, Any], ...] = (
         'key': 'open_house',
         'name': 'Open house invitation',
         'category': 'open_house',
-        'description': (
-            'An invitation with the address, the date, the time, and one '
-            'link. Fill in the address, date, and time before you send.'
-        ),
+        'description': 'An invitation with the address, the date, the time, and one link. Fill in the address, date, and time before you send.',
         'subject': 'Open house this weekend: 123 Main St',
         'preheader': 'Stop by Saturday between 2 and 4pm. No appointment needed.',
         'blocks': [

--- a/services/marketing/system_templates.py
+++ b/services/marketing/system_templates.py
@@ -65,8 +65,8 @@ SYSTEM_TEMPLATES: tuple[dict[str, Any], ...] = (
         'name': 'Open house invitation',
         'category': 'open_house',
         'description': (
-            'An invitation with the address, the date and time, and one clear '
-            'link. Fill in the bracketed details before you send.'
+            'An invitation with the address, the date, the time, and one '
+            'link. Fill in the address, date, and time before you send.'
         ),
         'subject': 'Open house this weekend: 123 Main St',
         'preheader': 'Stop by Saturday between 2 and 4pm. No appointment needed.',

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -340,7 +340,7 @@
               </h1>
 
               <p class="mt-3 text-sm lg:text-[15px] left-muted leading-relaxed">
-                Sign in to your contacts and tasks.
+                Keep your contacts, tasks, and follow-ups in one place.
               </p>
             </div>
 

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -340,7 +340,7 @@
               </h1>
 
               <p class="mt-3 text-sm lg:text-[15px] left-muted leading-relaxed">
-                Use your account credentials to access contacts, tasks, transactions, and team workspace.
+                Sign in to your contacts and tasks.
               </p>
             </div>
 

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -229,14 +229,14 @@
                 <div class="left-icon"><i class="fas fa-chart-line"></i></div>
                 <div>
                   <div class="font-semibold text-sm">Dashboard</div>
-                  <div class="text-xs left-muted">Pipeline and activity without a second tool.</div>
+                  <div class="text-xs left-muted">Contacts and tasks.</div>
                 </div>
               </div>
               <div class="left-bullet">
                 <div class="left-icon"><span class="text-sm font-bold">B.</span></div>
                 <div>
                   <div class="font-semibold text-sm">Talk to B.O.B.</div>
-                  <div class="text-xs left-muted">Ask it to add a contact or count clients in a ZIP. 25 messages a day in the CRM. Telegram after a QR from your profile.</div>
+                  <div class="text-xs left-muted">Tell B.O.B. what you need done. 25 messages a day in the CRM. Telegram after connecting it from your profile.</div>
                 </div>
               </div>
             </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -229,14 +229,14 @@
                 <div class="left-icon"><i class="fas fa-chart-line"></i></div>
                 <div>
                   <div class="font-semibold text-sm">Dashboard</div>
-                  <div class="text-xs left-muted">Contacts and tasks.</div>
+                  <div class="text-xs left-muted">Keep your contacts, tasks, and follow-ups in one place.</div>
                 </div>
               </div>
               <div class="left-bullet">
                 <div class="left-icon"><span class="text-sm font-bold">B.</span></div>
                 <div>
                   <div class="font-semibold text-sm">Talk to B.O.B.</div>
-                  <div class="text-xs left-muted">Tell B.O.B. what you need done. 25 messages a day in the CRM. Telegram after connecting it from your profile.</div>
+                  <div class="text-xs left-muted">Ask B.O.B. to add contacts, update records, or create tasks. 25 messages a day in the CRM. Telegram after connecting it from your profile.</div>
                 </div>
               </div>
             </div>

--- a/templates/contacts/list.html
+++ b/templates/contacts/list.html
@@ -382,7 +382,7 @@
             </aside>
         </div>
         {% else %}
-        {% call empty_state('No contacts yet', 'Add a contact, import a CSV, or forward an email to Magic Inbox.', 'fa-address-book') %}
+        {% call empty_state('No contacts yet', 'Add a contact, import a CSV, or forward an email to Magic Inbox. We save the contact for you.', 'fa-address-book') %}
             <a href="{{ url_for('inbound_email.inbox_home') }}" class="crm-btn crm-btn-secondary">
                 <i class="fas fa-paper-plane text-xs"></i>
                 Use Magic Inbox

--- a/templates/contacts/list.html
+++ b/templates/contacts/list.html
@@ -382,7 +382,7 @@
             </aside>
         </div>
         {% else %}
-        {% call empty_state('No contacts yet', 'Add your first contact, import a CSV, or forward an email to your Magic Inbox &mdash; we\'ll save the contact for you.', 'fa-address-book') %}
+        {% call empty_state('No contacts yet', 'Add a contact, import a CSV, or forward an email to Magic Inbox.', 'fa-address-book') %}
             <a href="{{ url_for('inbound_email.inbox_home') }}" class="crm-btn crm-btn-secondary">
                 <i class="fas fa-paper-plane text-xs"></i>
                 Use Magic Inbox

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -125,7 +125,7 @@
             </div>
             <div class="crm-magic-banner__copy" data-controller="copy">
                 <span class="crm-section-kicker">New · Magic Inbox</span>
-                <h3>Forward emails or photos — we save the contact for you.</h3>
+                <h3>Forward emails or photos. We save the contact.</h3>
                 <p>Send a business card, screenshot, vCard, or any email to your private address. The contact lands in your CRM automatically.</p>
                 <input type="hidden" data-copy-target="source" value="{{ current_user.inbox_address }}">
             </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -786,7 +786,7 @@
                         {% endfor %}
                     </div>
                     {% else %}
-                    {% call empty_state('No upcoming client tasks', 'Create a task to get started.', 'fa-tasks') %}
+                    {% call empty_state('No upcoming client tasks', 'Add a task for a contact.', 'fa-tasks') %}
                         <a href="{{ url_for('tasks.create_task') }}" class="crm-btn crm-btn-primary">Create task</a>
                     {% endcall %}
                     {% endif %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -125,7 +125,7 @@
             </div>
             <div class="crm-magic-banner__copy" data-controller="copy">
                 <span class="crm-section-kicker">New · Magic Inbox</span>
-                <h3>Forward emails or photos. We save the contact.</h3>
+                <h3>Forward emails or photos. We save the contact for you.</h3>
                 <p>Send a business card, screenshot, vCard, or any email to your private address. The contact lands in your CRM automatically.</p>
                 <input type="hidden" data-copy-target="source" value="{{ current_user.inbox_address }}">
             </div>
@@ -205,7 +205,7 @@
             <div class="crm-magic-banner__copy">
                 <span class="crm-section-kicker" data-daily-briefing-banner-target="label">Today · Daily Briefing</span>
                 <h3 data-daily-briefing-banner-target="teaser">Checking today's plan…</h3>
-                <p>Who to touch and what to move, from your contacts and tasks.</p>
+                <p>A focused list of who to touch and what to move, from your contacts and tasks.</p>
             </div>
             <div class="flex flex-wrap items-center gap-2 shrink-0 mt-3 lg:mt-0"
                  data-daily-briefing-banner-target="actions">
@@ -786,7 +786,7 @@
                         {% endfor %}
                     </div>
                     {% else %}
-                    {% call empty_state('No upcoming client tasks', 'Add a task for a contact.', 'fa-tasks') %}
+                    {% call empty_state('No upcoming client tasks', 'Add a follow-up task for a contact.', 'fa-tasks') %}
                         <a href="{{ url_for('tasks.create_task') }}" class="crm-btn crm-btn-primary">Create task</a>
                     {% endcall %}
                     {% endif %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -205,7 +205,7 @@
             <div class="crm-magic-banner__copy">
                 <span class="crm-section-kicker" data-daily-briefing-banner-target="label">Today · Daily Briefing</span>
                 <h3 data-daily-briefing-banner-target="teaser">Checking today's plan…</h3>
-                <p>A focused list of who to touch and what to move — grounded in your CRM.</p>
+                <p>Who to touch and what to move, from your contacts and tasks.</p>
             </div>
             <div class="flex flex-wrap items-center gap-2 shrink-0 mt-3 lg:mt-0"
                  data-daily-briefing-banner-target="actions">
@@ -374,7 +374,7 @@
                 <div class="mt-3 flex items-start gap-2 text-[11px] leading-snug text-slate-500">
                     <i class="fas fa-circle-info mt-0.5 text-slate-300"></i>
                     <p class="m-0">
-                        Stats reflect <strong>active residential listings</strong> (Single Family, Condo, Townhouse) per the RentCast <code class="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">/markets</code> endpoint &mdash; <em>asking</em> prices, not sold prices. &ldquo;Active listings&rdquo; counts every listing that touched the market in the month (cumulative). For closed-sale comps, check the MLS.
+                        Stats reflect <strong>active residential listings</strong> (Single Family, Condo, Townhouse) per the RentCast <code class="rounded bg-slate-100 px-1 py-0.5 text-[10px] text-slate-600">/markets</code> endpoint. <em>Asking</em> prices, not sold prices. &ldquo;Active listings&rdquo; counts every listing that touched the market in the month (cumulative). For closed-sale comps, check the MLS.
                     </p>
                 </div>
             </div>

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -173,7 +173,7 @@
 
       {% if not activity %}
         {% call empty_state(
-            'Nothing here yet',
+            'No inbound messages',
             'Send your first email or photo to your address above. New contacts will appear here as they are created.',
             'fa-paper-plane') %}
           <a href="mailto:{{ inbox_address }}" class="crm-btn crm-btn-primary">

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -26,7 +26,7 @@
           <div class="crm-section-kicker">Your private address</div>
           <h2 class="mt-1 crm-section-title">Send anything here</h2>
           <p class="mt-1 crm-section-description">
-            Forward emails, business card photos, or a vCard. We save the contact.
+            Forward emails, business card photos, or AirDrop a vCard. We extract the contact and save it to your CRM.
           </p>
 
           <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-stretch"

--- a/templates/inbox/home.html
+++ b/templates/inbox/home.html
@@ -26,9 +26,7 @@
           <div class="crm-section-kicker">Your private address</div>
           <h2 class="mt-1 crm-section-title">Send anything here</h2>
           <p class="mt-1 crm-section-description">
-            Treat this like a contact in your phone. Forward emails, share
-            business card photos, AirDrop a vCard — we extract the contact
-            and save it to your CRM.
+            Forward emails, business card photos, or a vCard. We save the contact.
           </p>
 
           <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-stretch"
@@ -138,8 +136,7 @@
           </h3>
           <p class="mt-1 text-sm text-slate-600">
             From your phone's photo app, share the picture to "AgentFlow Inbox".
-            Up to five cards per email — we read each one and create the
-            contact.
+            Up to five cards per email. We read each one and create the contact.
           </p>
         </div>
 

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -312,7 +312,7 @@
                 {% elif current_status == 'completed' %}
                     {% set _empty_msg = "No completed tasks yet." %}
                 {% else %}
-                    {% set _empty_msg = "Add a task." %}
+                    {% set _empty_msg = "Add your first task to start a follow-up." %}
                 {% endif %}
                 {% call empty_state('No tasks found', _empty_msg, 'fa-clipboard-check') %}
                     <a href="{{ url_for('tasks.create_task') }}" class="crm-btn crm-btn-accent">

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -308,7 +308,7 @@
             {% else %}
             <div class="crm-surface-body">
                 {% if current_status == 'pending' %}
-                    {% set _empty_msg = "You're all caught up." %}
+                    {% set _empty_msg = "No open tasks." %}
                 {% elif current_status == 'completed' %}
                     {% set _empty_msg = "No completed tasks yet." %}
                 {% else %}

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -312,7 +312,7 @@
                 {% elif current_status == 'completed' %}
                     {% set _empty_msg = "No completed tasks yet." %}
                 {% else %}
-                    {% set _empty_msg = "Get started by creating your first task." %}
+                    {% set _empty_msg = "Add a task." %}
                 {% endif %}
                 {% call empty_state('No tasks found', _empty_msg, 'fa-clipboard-check') %}
                     <a href="{{ url_for('tasks.create_task') }}" class="crm-btn crm-btn-accent">

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -196,7 +196,8 @@ class TestAuthPagesRender:
         resp = client.get('/login')
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
-        assert "Sign in to your contacts and tasks." in html
+        assert "Keep your contacts, tasks, and follow-ups in one place." in html
+        assert "Sign in to your contacts and tasks." not in html
         assert (
             "Use your account credentials to access contacts, tasks, "
             "transactions, and team workspace."
@@ -213,12 +214,15 @@ class TestAuthPagesRender:
         resp = client.get('/register')
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
-        assert "Contacts and tasks." in html
+        assert "Keep your contacts, tasks, and follow-ups in one place." in html
+        assert "Contacts and tasks." not in html
         assert "Talk to B.O.B." in html
         assert (
-            "Tell B.O.B. what you need done. 25 messages a day in the CRM. "
+            "Ask B.O.B. to add contacts, update records, or create tasks. "
+            "25 messages a day in the CRM. "
             "Telegram after connecting it from your profile."
         ) in html
+        assert "Tell B.O.B. what you need done." not in html
         assert "Pipeline and activity without a second tool." not in html
         assert "Ask it to add a contact or count clients in a ZIP." not in html
         assert "Telegram after a QR from your profile" not in html

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -192,12 +192,36 @@ class TestAuthPagesRender:
         assert b'crm-brand-logo-wrap--on-dark' in resp.data
         assert b'logo_agentflow_dark.png' in resp.data
 
+    def test_login_html_has_locked_sign_in_line(self, client, seed):
+        resp = client.get('/login')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Sign in to your contacts and tasks." in html
+        assert (
+            "Use your account credentials to access contacts, tasks, "
+            "transactions, and team workspace."
+        ) not in html
+
     def test_register_uses_dark_mark_on_dark_rail(self, client, seed):
         resp = client.get('/register')
         assert resp.status_code == 200
         assert b'Create your account' in resp.data
         assert b'crm-brand-logo-wrap--on-dark' in resp.data
         assert b'logo_agentflow_dark.png' in resp.data
+
+    def test_register_html_has_locked_public_copy(self, client, seed):
+        resp = client.get('/register')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "Contacts and tasks." in html
+        assert "Talk to B.O.B." in html
+        assert (
+            "Tell B.O.B. what you need done. 25 messages a day in the CRM. "
+            "Telegram after connecting it from your profile."
+        ) in html
+        assert "Pipeline and activity without a second tool." not in html
+        assert "Ask it to add a contact or count clients in a ZIP." not in html
+        assert "Telegram after a QR from your profile" not in html
 
     def test_reset_request_uses_dark_mark_on_card(self, client, seed):
         resp = client.get('/reset_password')

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -8,6 +8,7 @@ from tier_config.tier_limits import get_tier_defaults
 
 ROOT = Path(__file__).resolve().parents[1]
 LANDING = (ROOT / "templates" / "landing.html").read_text()
+LOGIN = (ROOT / "templates" / "auth" / "login.html").read_text()
 REGISTER = (ROOT / "templates" / "auth" / "register.html").read_text()
 TERMS = (ROOT / "templates" / "auth" / "terms_privacy.html").read_text()
 FREE_CRM = (ROOT / "templates" / "free_real_estate_crm.html").read_text()
@@ -116,6 +117,7 @@ class TestLandingLeftoverCopy:
 
     def test_no_em_dashes_in_public_copy(self):
         assert "—" not in LANDING
+        assert "—" not in LOGIN
         assert "—" not in REGISTER
 
     def test_keeps_homepage_h1(self):
@@ -345,11 +347,32 @@ class TestRegisterLeftoverCopy:
 
     def test_register_describes_bob_with_real_facts(self):
         assert "Talk to B.O.B." in REGISTER
+        assert "Tell B.O.B. what you need done." in REGISTER
         assert "25 messages a day in the CRM" in REGISTER
-        assert "Telegram after a QR from your profile" in REGISTER
-        assert "add a contact" in REGISTER
+        assert "Telegram after connecting it from your profile." in REGISTER
+        assert (
+            '<div class="font-semibold text-sm">Talk to B.O.B.</div>\n'
+            '                  <div class="text-xs left-muted">'
+            "Tell B.O.B. what you need done. 25 messages a day in the CRM. "
+            "Telegram after connecting it from your profile.</div>"
+        ) in REGISTER
+        assert "Ask it to add a contact or count clients in a ZIP." not in REGISTER
+        assert "Telegram after a QR from your profile" not in REGISTER
         assert "in the CRM or on Telegram" not in REGISTER
         assert "Unlimited contacts" not in REGISTER
+
+    def test_login_and_register_locked_replacements(self):
+        assert "Sign in to your contacts and tasks." in LOGIN
+        assert "Contacts and tasks." in REGISTER
+        assert "Tell B.O.B. what you need done." in REGISTER
+        assert "Telegram after connecting it from your profile." in REGISTER
+        assert (
+            "Use your account credentials to access contacts, tasks, "
+            "transactions, and team workspace."
+        ) not in LOGIN
+        assert "Pipeline and activity without a second tool." not in REGISTER
+        assert "Ask it to add a contact or count clients in a ZIP." not in REGISTER
+        assert "Telegram after a QR from your profile" not in REGISTER
 
 
 class TestTermsPrivacyLayout:

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -347,25 +347,32 @@ class TestRegisterLeftoverCopy:
 
     def test_register_describes_bob_with_real_facts(self):
         assert "Talk to B.O.B." in REGISTER
-        assert "Tell B.O.B. what you need done." in REGISTER
+        assert "Ask B.O.B. to add contacts, update records, or create tasks." in REGISTER
         assert "25 messages a day in the CRM" in REGISTER
         assert "Telegram after connecting it from your profile." in REGISTER
         assert (
             '<div class="font-semibold text-sm">Talk to B.O.B.</div>\n'
             '                  <div class="text-xs left-muted">'
-            "Tell B.O.B. what you need done. 25 messages a day in the CRM. "
+            "Ask B.O.B. to add contacts, update records, or create tasks. "
+            "25 messages a day in the CRM. "
             "Telegram after connecting it from your profile.</div>"
         ) in REGISTER
+        assert "Tell B.O.B. what you need done." not in REGISTER
         assert "Ask it to add a contact or count clients in a ZIP." not in REGISTER
         assert "Telegram after a QR from your profile" not in REGISTER
         assert "in the CRM or on Telegram" not in REGISTER
         assert "Unlimited contacts" not in REGISTER
 
     def test_login_and_register_locked_replacements(self):
-        assert "Sign in to your contacts and tasks." in LOGIN
-        assert "Contacts and tasks." in REGISTER
-        assert "Tell B.O.B. what you need done." in REGISTER
+        assert "Keep your contacts, tasks, and follow-ups in one place." in LOGIN
+        assert "Keep your contacts, tasks, and follow-ups in one place." in REGISTER
+        assert "Ask B.O.B. to add contacts, update records, or create tasks." in REGISTER
         assert "Telegram after connecting it from your profile." in REGISTER
+        assert "Sign in to your contacts and tasks." not in LOGIN
+        assert (
+            '<div class="text-xs left-muted">Contacts and tasks.</div>'
+        ) not in REGISTER
+        assert "Tell B.O.B. what you need done." not in REGISTER
         assert (
             "Use your account credentials to access contacts, tasks, "
             "transactions, and team workspace."

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -42,6 +42,37 @@ class TestLockedEmptyCopy:
         assert "Add a task for a contact." in text
         assert "Create a task to get started." not in text
 
+    def test_dashboard_inbox_banner(self):
+        text = _read("templates", "dashboard.html")
+        assert "Forward emails or photos. We save the contact." in text
+        assert "Forward emails or photos — we save the contact for you." not in text
+
+    def test_tasks_pending_empty_helper(self):
+        text = _read("templates", "tasks", "list.html")
+        assert '_empty_msg = "No open tasks."' in text
+        assert "You're all caught up." not in text
+        assert '_empty_msg = "Add a task."' in text
+
+    def test_inbox_address_helper(self):
+        text = _read("templates", "inbox", "home.html")
+        assert "Forward emails, business card photos, or a vCard. We save the contact." in text
+        assert "Treat this like a contact in your phone." not in text
+        assert "AirDrop a vCard" not in text
+        assert "we extract the contact" not in text
+        assert "No inbound messages" in text
+
+    def test_inbox_card_limit_helper(self):
+        text = _read("templates", "inbox", "home.html")
+        assert "Up to five cards per email. We read each one and create the contact." in text
+        assert "Up to five cards per email — we read each one and create the contact." not in text
+
+
+class TestLockedDailyBriefingCopy:
+    def test_reconnect_empty(self):
+        text = _read("frontend", "controllers", "daily_briefing_controller.js")
+        assert "No contacts need a reconnect right now." in text
+        assert "Sphere looks warm. No one's going cold right now." not in text
+
 
 class TestLockedOpenHouseDescription:
     LOCKED = (

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -23,7 +23,13 @@ class TestLockedEmptyCopy:
 
     def test_contacts_empty_helper(self):
         text = _read("templates", "contacts", "list.html")
-        assert "Add a contact, import a CSV, or forward an email to Magic Inbox." in text
+        assert (
+            "Add a contact, import a CSV, or forward an email to Magic Inbox. "
+            "We save the contact for you."
+        ) in text
+        assert (
+            "'Add a contact, import a CSV, or forward an email to Magic Inbox.'"
+        ) not in text
         assert (
             "Add your first contact, import a CSV, or forward an email to "
             "your Magic Inbox"
@@ -34,22 +40,31 @@ class TestLockedEmptyCopy:
 
     def test_tasks_empty_helper(self):
         text = _read("templates", "tasks", "list.html")
-        assert '_empty_msg = "Add a task."' in text
+        assert '_empty_msg = "Add your first task to start a follow-up."' in text
+        assert '_empty_msg = "Add a task."' not in text
         assert "Get started by creating your first task." not in text
 
     def test_dashboard_task_empty_helper(self):
         text = _read("templates", "dashboard.html")
-        assert "Add a task for a contact." in text
+        assert "Add a follow-up task for a contact." in text
+        assert "Add a task for a contact." not in text
         assert "Create a task to get started." not in text
 
     def test_dashboard_inbox_banner(self):
         text = _read("templates", "dashboard.html")
-        assert "Forward emails or photos. We save the contact." in text
+        assert "<h3>Forward emails or photos. We save the contact for you.</h3>" in text
+        assert "<h3>Forward emails or photos. We save the contact.</h3>" not in text
         assert "Forward emails or photos — we save the contact for you." not in text
 
     def test_dashboard_briefing_banner(self):
         text = _read("templates", "dashboard.html")
-        assert "Who to touch and what to move, from your contacts and tasks." in text
+        assert (
+            "<p>A focused list of who to touch and what to move, "
+            "from your contacts and tasks.</p>"
+        ) in text
+        assert (
+            "<p>Who to touch and what to move, from your contacts and tasks.</p>"
+        ) not in text
         assert "A focused list of who to touch and what to move — grounded in your CRM." not in text
         assert "A focused list of who to touch and what to move, grounded in your CRM." not in text
 
@@ -64,14 +79,16 @@ class TestLockedEmptyCopy:
         text = _read("templates", "tasks", "list.html")
         assert '_empty_msg = "No open tasks."' in text
         assert "You're all caught up." not in text
-        assert '_empty_msg = "Add a task."' in text
+        assert '_empty_msg = "Add your first task to start a follow-up."' in text
 
     def test_inbox_address_helper(self):
         text = _read("templates", "inbox", "home.html")
-        assert "Forward emails, business card photos, or a vCard. We save the contact." in text
+        assert (
+            "Forward emails, business card photos, or AirDrop a vCard. "
+            "We extract the contact and save it to your CRM."
+        ) in text
+        assert "Forward emails, business card photos, or a vCard. We save the contact." not in text
         assert "Treat this like a contact in your phone." not in text
-        assert "AirDrop a vCard" not in text
-        assert "we extract the contact" not in text
         assert "No inbound messages" in text
 
     def test_inbox_card_limit_helper(self):

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -1,0 +1,59 @@
+"""Locked empty-state and open-house copy."""
+from pathlib import Path
+
+from services.marketing import system_templates as st
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(*parts):
+    return ROOT.joinpath(*parts).read_text()
+
+
+class TestLockedEmptyCopy:
+    def test_inbox_empty_title(self):
+        text = _read("templates", "inbox", "home.html")
+        assert "No inbound messages" in text
+        assert "Nothing here yet" not in text
+        assert (
+            "Send your first email or photo to your address above. "
+            "New contacts will appear here as they are created."
+        ) in text
+
+    def test_contacts_empty_helper(self):
+        text = _read("templates", "contacts", "list.html")
+        assert "Add a contact, import a CSV, or forward an email to Magic Inbox." in text
+        assert (
+            "Add your first contact, import a CSV, or forward an email to "
+            "your Magic Inbox"
+        ) not in text
+        assert "we'll save the contact for you" not in text
+        assert "&mdash;" not in text
+        assert "—" not in text
+
+    def test_tasks_empty_helper(self):
+        text = _read("templates", "tasks", "list.html")
+        assert '_empty_msg = "Add a task."' in text
+        assert "Get started by creating your first task." not in text
+
+    def test_dashboard_task_empty_helper(self):
+        text = _read("templates", "dashboard.html")
+        assert "Add a task for a contact." in text
+        assert "Create a task to get started." not in text
+
+
+class TestLockedOpenHouseDescription:
+    LOCKED = (
+        "An invitation with the address, the date, the time, and one "
+        "link. Fill in the address, date, and time before you send."
+    )
+
+    def test_source_has_locked_description(self):
+        text = _read("services", "marketing", "system_templates.py")
+        assert self.LOCKED in text
+        assert "the date and time, and one clear" not in text
+        assert "Fill in the bracketed details before you send." not in text
+
+    def test_python_definition_has_locked_description(self):
+        assert st.definition("open_house")["description"] == self.LOCKED

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -47,6 +47,19 @@ class TestLockedEmptyCopy:
         assert "Forward emails or photos. We save the contact." in text
         assert "Forward emails or photos — we save the contact for you." not in text
 
+    def test_dashboard_briefing_banner(self):
+        text = _read("templates", "dashboard.html")
+        assert "Who to touch and what to move, from your contacts and tasks." in text
+        assert "A focused list of who to touch and what to move — grounded in your CRM." not in text
+        assert "A focused list of who to touch and what to move, grounded in your CRM." not in text
+
+    def test_dashboard_market_insights_footer(self):
+        text = _read("templates", "dashboard.html")
+        assert "endpoint. <em>Asking</em> prices" in text
+        assert "endpoint &mdash; <em>asking</em> prices" not in text
+        assert "endpoint, <em>asking</em> prices" not in text
+        assert "As of —" in text
+
     def test_tasks_pending_empty_helper(self):
         text = _read("templates", "tasks", "list.html")
         assert '_empty_msg = "No open tasks."' in text
@@ -72,6 +85,13 @@ class TestLockedDailyBriefingCopy:
         text = _read("frontend", "controllers", "daily_briefing_controller.js")
         assert "No contacts need a reconnect right now." in text
         assert "Sphere looks warm. No one's going cold right now." not in text
+
+    def test_copy_failed_alert_has_no_em_dash(self):
+        text = _read("frontend", "controllers", "daily_briefing_controller.js")
+        assert "Couldn't copy. Select the text manually." in text
+        assert "Couldn't copy — select the text manually." not in text
+        assert "—" not in text
+        assert "&mdash;" not in text
 
 
 class TestLockedOpenHouseDescription:

--- a/tests/test_marketing_copy.py
+++ b/tests/test_marketing_copy.py
@@ -188,6 +188,15 @@ class TestLockedMarketingCopy:
         assert 'Numbers, not headlines.' in starters
         assert 'What sold last month.' not in starters
 
+    def test_open_house_description(self):
+        starters = _read('services', 'marketing', 'system_templates.py')
+        assert (
+            'An invitation with the address, the date, the time, and one '
+            'link. Fill in the address, date, and time before you send.'
+        ) in starters
+        assert 'the date and time, and one clear' not in starters
+        assert 'Fill in the bracketed details before you send.' not in starters
+
     def test_addendum_54(self):
         wizard = _read('templates', 'marketing', 'wizard.html')
         assert '<option value="">Pick a template</option>' in wizard


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Locked public-copy replacements. Copy-originated. Christopher reviews. Do not merge.

All CURRENT strings for this specificity redo were present in the live files at HEAD `82918ed` and were replaced as written.

## Specificity redo. Nine locked REPLACE strings.

1. `templates/auth/login.html`
   - Was: Sign in to your contacts and tasks.
   - Now: Keep your contacts, tasks, and follow-ups in one place.

2. `templates/auth/register.html`
   - Was: Contacts and tasks.
   - Now: Keep your contacts, tasks, and follow-ups in one place.

3. `templates/auth/register.html`
   - Was: Tell B.O.B. what you need done. 25 messages a day in the CRM. Telegram after connecting it from your profile.
   - Now: Ask B.O.B. to add contacts, update records, or create tasks. 25 messages a day in the CRM. Telegram after connecting it from your profile.

4. `templates/inbox/home.html`
   - Was: Forward emails, business card photos, or a vCard. We save the contact.
   - Now: Forward emails, business card photos, or AirDrop a vCard. We extract the contact and save it to your CRM.

5. `templates/contacts/list.html`
   - Was: Add a contact, import a CSV, or forward an email to Magic Inbox.
   - Now: Add a contact, import a CSV, or forward an email to Magic Inbox. We save the contact for you.

6. `templates/tasks/list.html`
   - Was: Add a task.
   - Now: Add your first task to start a follow-up.

7. `templates/dashboard.html`
   - Was: Forward emails or photos. We save the contact.
   - Now: Forward emails or photos. We save the contact for you.

8. `templates/dashboard.html`
   - Was: Who to touch and what to move, from your contacts and tasks.
   - Now: A focused list of who to touch and what to move, from your contacts and tasks.

9. `templates/dashboard.html`
   - Was: Add a task for a contact.
   - Now: Add a follow-up task for a contact.

## Left alone. Copy did not list these.

- Register B.O.B. heading: Talk to B.O.B.
- Inbox empty title: No inbound messages
- Inbox empty helper: Send your first email or photo to your address above. New contacts will appear here as they are created.
- Inbox card helper: Up to five cards per email. We read each one and create the contact.
- Tasks pending empty: No open tasks.
- Briefing reconnect empty: No contacts need a reconnect right now.
- Copy-failed alert: Couldn't copy. Select the text manually.
- Open-house description: An invitation with the address, the date, the time, and one link. Fill in the address, date, and time before you send.
- Market insights footer: endpoint. Asking prices
- KPI / As of — placeholder dashes
- Homepage H1s, Gold FAQ, What's Next
- No transactions on login or register

## Tests

- `tests/test_landing_copy.py` and `tests/test_auth.py` pin the new login and register lines and reject the old ones.
- `tests/test_locked_app_copy.py` pins the inbox, contacts, tasks, and dashboard REPLACE lines and rejects the CURRENT versions.
- Untouched locked-string checks stay green.

## Playbook notes

- Feature playbook. Architect skipped. This is locked before/after copy, not a design fork.
- Interrogate skipped. Copy is locked.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d32488b2-dc44-4127-9ae7-3692c119a64c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d32488b2-dc44-4127-9ae7-3692c119a64c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

