### PR TITLE
Client portal API v1 for the iPhone app

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ from routes.notifications import notifications_bp
 from routes.inbound_email import inbound_bp
 from routes.partner_directory import partner_directory_bp
 from routes.portal import portal_bp
+from routes.client_api import client_api_bp
 from routes.groups import groups_bp
 from routes.analytics_webhooks import analytics_webhooks_bp
 from routes.bob_telegram import bob_telegram_bp
@@ -268,6 +269,7 @@ def create_app():
     app.register_blueprint(inbound_bp)
     app.register_blueprint(partner_directory_bp)
     app.register_blueprint(portal_bp)
+    app.register_blueprint(client_api_bp)
     app.register_blueprint(groups_bp)
     app.register_blueprint(analytics_webhooks_bp)
     app.register_blueprint(bob_telegram_bp)

--- a/migrations/versions/add_client_app_invite_and_branding.py
+++ b/migrations/versions/add_client_app_invite_and_branding.py
@@ -1,0 +1,96 @@
+"""Client app invite codes and org brand accent.
+
+Revision ID: add_client_app_invite_brand
+Revises: add_marketing_tables
+Create Date: 2026-08-20
+
+Adds:
+- organizations.brand_accent (optional hex color for the client iPhone app)
+- client_portal_access.invite_code (human grant for the app)
+- client_portal_access.invite_expires_at
+- client_portal_access.session_version (invalidates issued JWTs)
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_client_app_invite_brand'
+down_revision = 'add_marketing_tables'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table_name, column_name):
+    tables = inspect(conn).get_table_names()
+    if table_name not in tables:
+        return False
+    return column_name in {
+        col['name'] for col in inspect(conn).get_columns(table_name)
+    }
+
+
+def _index_exists(conn, table_name, index_name):
+    tables = inspect(conn).get_table_names()
+    if table_name not in tables:
+        return False
+    return index_name in {
+        idx['name'] for idx in inspect(conn).get_indexes(table_name)
+    }
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'organizations', 'brand_accent'):
+        op.add_column(
+            'organizations',
+            sa.Column('brand_accent', sa.String(length=7), nullable=True),
+        )
+
+    if not _column_exists(conn, 'client_portal_access', 'invite_code'):
+        op.add_column(
+            'client_portal_access',
+            sa.Column('invite_code', sa.String(length=16), nullable=True),
+        )
+    if not _column_exists(conn, 'client_portal_access', 'invite_expires_at'):
+        op.add_column(
+            'client_portal_access',
+            sa.Column('invite_expires_at', sa.DateTime(), nullable=True),
+        )
+    if not _column_exists(conn, 'client_portal_access', 'session_version'):
+        op.add_column(
+            'client_portal_access',
+            sa.Column(
+                'session_version',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('1'),
+            ),
+        )
+
+    if not _index_exists(conn, 'client_portal_access', 'uq_client_portal_access_invite_code'):
+        op.create_index(
+            'uq_client_portal_access_invite_code',
+            'client_portal_access',
+            ['invite_code'],
+            unique=True,
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'client_portal_access', 'uq_client_portal_access_invite_code'):
+        op.drop_index(
+            'uq_client_portal_access_invite_code',
+            table_name='client_portal_access',
+        )
+    if _column_exists(conn, 'client_portal_access', 'session_version'):
+        op.drop_column('client_portal_access', 'session_version')
+    if _column_exists(conn, 'client_portal_access', 'invite_expires_at'):
+        op.drop_column('client_portal_access', 'invite_expires_at')
+    if _column_exists(conn, 'client_portal_access', 'invite_code'):
+        op.drop_column('client_portal_access', 'invite_code')
+    if _column_exists(conn, 'organizations', 'brand_accent'):
+        op.drop_column('organizations', 'brand_accent')

--- a/migrations/versions/add_transaction_mls_listing_url.py
+++ b/migrations/versions/add_transaction_mls_listing_url.py
@@ -1,0 +1,42 @@
+"""Add public MLS listing URL on transactions.
+
+Revision ID: add_tx_mls_listing_url
+Revises: add_client_app_invite_brand
+Create Date: 2026-08-20
+
+Agents store the live listing link here. The client iPhone Home screen
+shows it in place of Message when the URL is set.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_tx_mls_listing_url'
+down_revision = 'add_client_app_invite_brand'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table_name, column_name):
+    tables = inspect(conn).get_table_names()
+    if table_name not in tables:
+        return False
+    return column_name in {
+        col['name'] for col in inspect(conn).get_columns(table_name)
+    }
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not _column_exists(conn, 'transactions', 'mls_listing_url'):
+        op.add_column(
+            'transactions',
+            sa.Column('mls_listing_url', sa.String(length=500), nullable=True),
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    if _column_exists(conn, 'transactions', 'mls_listing_url'):
+        op.drop_column('transactions', 'mls_listing_url')

--- a/models.py
+++ b/models.py
@@ -32,6 +32,8 @@ class Organization(db.Model):
     name = db.Column(db.String(200), nullable=False)
     slug = db.Column(db.String(100), unique=True, nullable=False)
     logo_url = db.Column(db.String(500))
+    # Client iPhone app accent. Unset uses the product orange.
+    brand_accent = db.Column(db.String(7))
     
     # Subscription tier
     subscription_tier = db.Column(db.String(50), default='free')  # free, pro, enterprise
@@ -4068,14 +4070,18 @@ class ActivationEvent(db.Model):
 # =============================================================================
 
 class ClientPortalAccess(db.Model):
-    """A private, revocable magic link that lets one transaction participant
-    (a seller) view their own transaction in the client portal.
+    """A private, revocable grant that lets one transaction participant
+    view their own transaction in the client portal.
 
-    Auth is the token itself: a long, url-safe random string. There is no
-    password and no User account. The link can be rotated or revoked by the
-    agent at any time. One row per participant per transaction.
+    The HTML portal still authenticates with ``token`` in the URL. The
+    iPhone app uses ``invite_code`` exchanged for a short-lived JWT.
+    Both bind this one participant on this one transaction. The agent
+    can rotate or revoke the grant at any time.
     """
     __tablename__ = 'client_portal_access'
+
+    INVITE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+    INVITE_CODE_LENGTH = 8
 
     id = db.Column(db.Integer, primary_key=True)
     organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
@@ -4085,8 +4091,14 @@ class ClientPortalAccess(db.Model):
     participant_id = db.Column(db.Integer, db.ForeignKey('transaction_participants.id',
                                ondelete='CASCADE'), nullable=False, index=True)
 
-    # The secret in the URL. ~43 chars from token_urlsafe(32).
+    # The secret in the HTML portal URL. ~43 chars from token_urlsafe(32).
     token = db.Column(db.String(64), unique=True, nullable=False, index=True)
+
+    # Human invite code for the iPhone app. Stored without a hyphen.
+    invite_code = db.Column(db.String(16), unique=True, nullable=True, index=True)
+    invite_expires_at = db.Column(db.DateTime, nullable=True)
+    # Bumped on rotate and on session leave so existing JWTs stop working.
+    session_version = db.Column(db.Integer, nullable=False, default=1)
 
     is_active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
@@ -4103,6 +4115,78 @@ class ClientPortalAccess(db.Model):
     def generate_token():
         """Cryptographically secure, url-safe token (~43 chars)."""
         return secrets.token_urlsafe(32)
+
+    @classmethod
+    def generate_invite_code(cls):
+        """Short unambiguous code. Letters and digits that do not look alike."""
+        for _ in range(12):
+            raw = ''.join(
+                secrets.choice(cls.INVITE_ALPHABET)
+                for _ in range(cls.INVITE_CODE_LENGTH)
+            )
+            taken = cls.query.filter_by(invite_code=raw).first()
+            if not taken:
+                return raw
+        return ''.join(
+            secrets.choice(cls.INVITE_ALPHABET)
+            for _ in range(cls.INVITE_CODE_LENGTH + 2)
+        )
+
+    @staticmethod
+    def normalize_invite_code(value):
+        if not value:
+            return ''
+        return ''.join(ch for ch in str(value).upper() if ch.isalnum())
+
+    @classmethod
+    def format_invite_code(cls, value):
+        raw = cls.normalize_invite_code(value)
+        if len(raw) == cls.INVITE_CODE_LENGTH:
+            return f'{raw[:4]}-{raw[4:]}'
+        return raw or None
+
+    @classmethod
+    def find_by_invite_code(cls, value):
+        raw = cls.normalize_invite_code(value)
+        if not raw:
+            return None
+        return cls.query.filter_by(invite_code=raw).first()
+
+    def ensure_invite_code(self):
+        if not self.invite_code:
+            self.invite_code = self.generate_invite_code()
+        if not self.session_version:
+            self.session_version = 1
+        return self.invite_code
+
+    def rotate_invite(self):
+        """Issue a fresh invite code and web token. Existing JWTs die."""
+        self.token = self.generate_token()
+        self.invite_code = self.generate_invite_code()
+        self.session_version = (self.session_version or 1) + 1
+        self.is_active = True
+        self.revoked_at = None
+        self.invite_expires_at = None
+        self.view_count = 0
+        self.last_viewed_at = None
+
+    def revoke(self):
+        self.is_active = False
+        self.revoked_at = datetime.utcnow()
+        self.session_version = (self.session_version or 1) + 1
+
+    def bump_session(self):
+        """Invalidate issued JWTs. The invite code still works."""
+        self.session_version = (self.session_version or 1) + 1
+
+    def invite_is_expired(self, now=None):
+        if not self.invite_expires_at:
+            return False
+        return (now or datetime.utcnow()) > self.invite_expires_at
+
+    @property
+    def invite_code_display(self):
+        return self.format_invite_code(self.invite_code)
 
     def record_view(self):
         self.view_count = (self.view_count or 0) + 1

--- a/models.py
+++ b/models.py
@@ -994,6 +994,9 @@ class Transaction(db.Model):
     
     # Flexible extra data for additional fields
     extra_data = db.Column(db.JSON, default={})
+
+    # Public MLS / listing page shown to the client in the iPhone app
+    mls_listing_url = db.Column(db.String(500))
     
     # RentCast property intelligence data (buyer transactions)
     rentcast_data = db.Column(db.JSON, default=None)  # Full API response

--- a/routes/client_api.py
+++ b/routes/client_api.py
@@ -23,6 +23,7 @@ from services.client_portal_auth import (
 from services.portal_service import (
     CLIENT_PORTAL_ROLES,
     SELLER_ROLES,
+    _participant_first_name,
     client_document_file_url,
     documents_for_client_api,
     list_client_messages,
@@ -145,6 +146,8 @@ def create_session():
         'token': token,
         'token_type': 'Bearer',
         'expires_in': JWT_TTL_SECONDS,
+        'participant_first_name': _participant_first_name(participant),
+        'role': (participant.role or 'seller').lower(),
         'branding': branding_for_access(access),
     })
 

--- a/routes/client_api.py
+++ b/routes/client_api.py
@@ -1,0 +1,242 @@
+"""JSON API for the client iPhone app.
+
+Wraps the existing client portal. Auth is a ClientPortalAccess grant:
+invite code in, short-lived JWT out. Flask-Login cookies are ignored.
+Do not put the grant token in a URL.
+"""
+from __future__ import annotations
+
+import logging
+from functools import wraps
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy import text
+
+from models import db, PortalMessage, SellerShowing
+from services.client_portal_auth import (
+    JWT_TTL_SECONDS,
+    branding_for_access,
+    exchange_invite_code,
+    issue_client_jwt,
+    load_access_from_jwt,
+)
+from services.portal_service import (
+    CLIENT_PORTAL_ROLES,
+    SELLER_ROLES,
+    documents_for_client_api,
+    list_client_messages,
+    serialize_client_deal,
+)
+
+logger = logging.getLogger(__name__)
+
+client_api_bp = Blueprint('client_api', __name__, url_prefix='/api/client/v1')
+
+
+def _json_error(message, status=401):
+    return jsonify({'error': message}), status
+
+
+def _set_org_context(org_id: int) -> None:
+    try:
+        db.session.execute(
+            text("SELECT set_config('app.current_org_id', :org_id, false)"),
+            {'org_id': str(org_id)},
+        )
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+@client_api_bp.teardown_request
+def _reset_org_context(exc=None):
+    try:
+        db.session.execute(text('RESET app.current_org_id'))
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+def _bearer_token():
+    header = request.headers.get('Authorization') or ''
+    if header.lower().startswith('bearer '):
+        return header[7:].strip()
+    return ''
+
+
+def client_jwt_required(view):
+    """Authorize from the client JWT only. A CRM cookie is not enough."""
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        token = _bearer_token()
+        if not token:
+            return _json_error('Sign in with your invite code first.', 401)
+        access, error = load_access_from_jwt(token)
+        if error:
+            return _json_error(error, 401)
+
+        _set_org_context(access.organization_id)
+
+        tx = access.transaction
+        participant = access.participant
+        if (
+            tx is None
+            or participant is None
+            or participant.transaction_id != tx.id
+            or (participant.role or '') not in CLIENT_PORTAL_ROLES
+        ):
+            return _json_error('This invite is no longer active.', 401)
+
+        g.client_access = access
+        return view(access, *args, **kwargs)
+
+    return wrapper
+
+
+@client_api_bp.route('/session', methods=['POST'])
+def create_session():
+    data = request.get_json(silent=True) or {}
+    code = data.get('code') or request.form.get('code')
+    access, error = exchange_invite_code(code)
+    if error:
+        return _json_error(error, 401)
+
+    _set_org_context(access.organization_id)
+    tx = access.transaction
+    participant = access.participant
+    if (
+        tx is None
+        or participant is None
+        or participant.transaction_id != tx.id
+        or (participant.role or '') not in CLIENT_PORTAL_ROLES
+    ):
+        return _json_error('This invite is no longer active.', 401)
+
+    try:
+        access.record_view()
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+
+    token = issue_client_jwt(access)
+    return jsonify({
+        'token': token,
+        'token_type': 'Bearer',
+        'expires_in': JWT_TTL_SECONDS,
+        'branding': branding_for_access(access),
+    })
+
+
+@client_api_bp.route('/session/leave', methods=['POST'])
+@client_jwt_required
+def leave_session(access):
+    access.bump_session()
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@client_api_bp.route('/deal', methods=['GET'])
+@client_jwt_required
+def get_deal(access):
+    deal = serialize_client_deal(access)
+    deal['branding'] = branding_for_access(access)
+    return jsonify(deal)
+
+
+@client_api_bp.route('/messages', methods=['GET'])
+@client_jwt_required
+def get_messages(access):
+    return jsonify({'messages': list_client_messages(access)})
+
+
+@client_api_bp.route('/messages', methods=['POST'])
+@client_jwt_required
+def post_message(access):
+    data = request.get_json(silent=True) or {}
+    body = (data.get('body') or request.form.get('body') or '').strip()
+    if not body:
+        return _json_error('Write a message before sending.', 400)
+    if len(body) > 4000:
+        body = body[:4000]
+
+    msg = PortalMessage(
+        organization_id=access.organization_id,
+        transaction_id=access.transaction_id,
+        participant_id=access.participant_id,
+        sender='client',
+        kind='message',
+        body=body,
+    )
+    db.session.add(msg)
+    db.session.commit()
+
+    try:
+        from routes.portal import _notify_agent_of_message
+        _notify_agent_of_message(access, body)
+    except Exception:
+        logger.exception('Client API: failed to notify agent of client message.')
+
+    return jsonify({
+        'message': list_client_messages(access)[-1],
+    }), 201
+
+
+@client_api_bp.route('/documents', methods=['GET'])
+@client_jwt_required
+def get_documents(access):
+    return jsonify(documents_for_client_api(access))
+
+
+def _showing_for_access(access, showing_id):
+    role = (getattr(access.participant, 'role', None) or '').lower()
+    if role not in SELLER_ROLES:
+        return None, _json_error('Showing approvals are for sellers on this listing.', 403)
+    showing = SellerShowing.query.filter_by(
+        id=showing_id,
+        transaction_id=access.transaction_id,
+        organization_id=access.organization_id,
+    ).first()
+    if not showing:
+        return None, _json_error('Showing not found.', 404)
+    if showing.status != SellerShowing.STATUS_PENDING_APPROVAL:
+        return None, _json_error('This showing is not waiting for your approval.', 409)
+    return showing, None
+
+
+@client_api_bp.route('/showings/<int:showing_id>/approve', methods=['POST'])
+@client_jwt_required
+def approve_showing(access, showing_id):
+    from datetime import datetime
+
+    showing, error_response = _showing_for_access(access, showing_id)
+    if error_response:
+        return error_response
+    showing.status = SellerShowing.STATUS_APPROVED
+    showing.approved_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({
+        'ok': True,
+        'showing_id': showing.id,
+        'status': showing.status,
+    })
+
+
+@client_api_bp.route('/showings/<int:showing_id>/decline', methods=['POST'])
+@client_jwt_required
+def decline_showing(access, showing_id):
+    showing, error_response = _showing_for_access(access, showing_id)
+    if error_response:
+        return error_response
+    showing.status = SellerShowing.STATUS_DECLINED
+    db.session.commit()
+    return jsonify({
+        'ok': True,
+        'showing_id': showing.id,
+        'status': showing.status,
+    })

--- a/routes/client_api.py
+++ b/routes/client_api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from functools import wraps
 
-from flask import Blueprint, g, jsonify, request
+from flask import Blueprint, g, jsonify, redirect, request
 from sqlalchemy import text
 
 from models import db, PortalMessage, SellerShowing
@@ -23,9 +23,12 @@ from services.client_portal_auth import (
 from services.portal_service import (
     CLIENT_PORTAL_ROLES,
     SELLER_ROLES,
+    client_document_file_url,
     documents_for_client_api,
     list_client_messages,
+    milestones_for_client_api,
     serialize_client_deal,
+    showings_for_client_api,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,9 +136,9 @@ def create_session():
     })
 
 
-@client_api_bp.route('/session/leave', methods=['POST'])
+@client_api_bp.route('/session', methods=['DELETE'])
 @client_jwt_required
-def leave_session(access):
+def delete_session(access):
     access.bump_session()
     db.session.commit()
     return jsonify({'ok': True})
@@ -187,10 +190,33 @@ def post_message(access):
     }), 201
 
 
+@client_api_bp.route('/milestones', methods=['GET'])
+@client_jwt_required
+def get_milestones(access):
+    return jsonify(milestones_for_client_api(access))
+
+
 @client_api_bp.route('/documents', methods=['GET'])
 @client_jwt_required
 def get_documents(access):
     return jsonify(documents_for_client_api(access))
+
+
+@client_api_bp.route('/documents/<int:doc_id>/file', methods=['GET'])
+@client_jwt_required
+def get_document_file(access, doc_id):
+    url, error_status = client_document_file_url(access, doc_id)
+    if error_status:
+        if error_status == 403:
+            return _json_error('That document is not yours.', 403)
+        return _json_error('Document not found.', 404)
+    return redirect(url)
+
+
+@client_api_bp.route('/showings', methods=['GET'])
+@client_jwt_required
+def get_showings(access):
+    return jsonify(showings_for_client_api(access))
 
 
 def _showing_for_access(access, showing_id):

--- a/routes/client_api.py
+++ b/routes/client_api.py
@@ -73,6 +73,21 @@ def _bearer_token():
     return ''
 
 
+def _role_allowed(role):
+    return (role or '').strip().lower() in CLIENT_PORTAL_ROLES
+
+
+def _invite_from_request():
+    """Native posts invite_code. Older clients may still send code."""
+    data = request.get_json(silent=True)
+    if isinstance(data, dict):
+        if 'invite_code' in data:
+            return data.get('invite_code')
+        if 'code' in data:
+            return data.get('code')
+    return request.form.get('invite_code') or request.form.get('code')
+
+
 def client_jwt_required(view):
     """Authorize from the client JWT only. A CRM cookie is not enough."""
     @wraps(view)
@@ -92,7 +107,7 @@ def client_jwt_required(view):
             tx is None
             or participant is None
             or participant.transaction_id != tx.id
-            or (participant.role or '') not in CLIENT_PORTAL_ROLES
+            or not _role_allowed(participant.role)
         ):
             return _json_error('This invite is no longer active.', 401)
 
@@ -104,11 +119,9 @@ def client_jwt_required(view):
 
 @client_api_bp.route('/session', methods=['POST'])
 def create_session():
-    data = request.get_json(silent=True) or {}
-    code = data.get('code') or request.form.get('code')
-    access, error = exchange_invite_code(code)
+    access, error = exchange_invite_code(_invite_from_request())
     if error:
-        return _json_error(error, 401)
+        return _json_error(error, 422)
 
     _set_org_context(access.organization_id)
     tx = access.transaction
@@ -117,9 +130,9 @@ def create_session():
         tx is None
         or participant is None
         or participant.transaction_id != tx.id
-        or (participant.role or '') not in CLIENT_PORTAL_ROLES
+        or not _role_allowed(participant.role)
     ):
-        return _json_error('This invite is no longer active.', 401)
+        return _json_error('This invite is no longer active.', 422)
 
     try:
         access.record_view()

--- a/routes/organization.py
+++ b/routes/organization.py
@@ -31,6 +31,7 @@ def settings():
         'organization/settings.html',
         org=org,
         mcp_enabled=org_has_feature('MCP_CONNECTOR', org),
+        client_app_branding=org_has_feature('TRANSACTIONS', org),
     )
 
 
@@ -51,6 +52,15 @@ def update_settings():
         org.logo_url = logo_url
     elif request.form.get('remove_logo'):
         org.logo_url = None
+
+    from feature_flags import org_has_feature
+    from services.client_portal_auth import normalize_brand_accent
+    if org_has_feature('TRANSACTIONS', org):
+        accent = normalize_brand_accent(request.form.get('brand_accent'))
+        if accent is False:
+            flash('Accent color must be a 6-digit hex like #f97316.', 'error')
+            return redirect(url_for('org.settings'))
+        org.brand_accent = accent
     
     db.session.commit()
     flash('Organization settings updated.', 'success')

--- a/routes/portal.py
+++ b/routes/portal.py
@@ -79,7 +79,7 @@ def portal_access(view):
         participant = access.participant
         if (tx is None or participant is None
                 or participant.transaction_id != tx.id
-                or (participant.role or '') not in CLIENT_PORTAL_ROLES):
+                or (participant.role or '').strip().lower() not in CLIENT_PORTAL_ROLES):
             return render_template('portal/invalid.html'), 404
 
         g.portal = access

--- a/routes/transactions/crud.py
+++ b/routes/transactions/crud.py
@@ -14,7 +14,8 @@ from models import (
     TransactionDocument, DocumentSignature, AuditEvent, Contact, ContactFile, Task,
     SellerListingProfile, SellerOffer, SellerOfferActivity, SellerAcceptedContract,
     SellerContractMilestone, SellerCommissionTerms, SellerListingPriceChange,
-    SellerOfferDocument, SellerOfferVersion, SellerContractDocument
+    SellerOfferDocument, SellerOfferVersion, SellerContractDocument,
+    ClientPortalAccess,
 )
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy import func, case, and_
@@ -482,6 +483,19 @@ def view_transaction(id):
     participants = TransactionParticipant.query.options(
         joinedload(TransactionParticipant.contact)
     ).filter_by(transaction_id=id).all()
+    from services.portal_service import CLIENT_PORTAL_ROLES
+    client_invite_participants = [
+        p for p in participants
+        if (p.role or '').lower() in CLIENT_PORTAL_ROLES
+    ]
+    client_invite_by_id = {}
+    if client_invite_participants:
+        for access in ClientPortalAccess.query.filter_by(
+            transaction_id=transaction.id,
+            organization_id=current_user.organization_id,
+            is_active=True,
+        ).all():
+            client_invite_by_id[access.participant_id] = access
     
     # Load documents sorted by created_at
     documents = TransactionDocument.query.filter_by(
@@ -1077,6 +1091,8 @@ def view_transaction(id):
         'transactions/detail.html',
         transaction=transaction,
         participants=participants,
+        client_invite_participants=client_invite_participants,
+        client_invite_by_id=client_invite_by_id,
         documents=documents,
         listing_documents=listing_documents,
         document_packages=document_packages,

--- a/routes/transactions/portal_admin.py
+++ b/routes/transactions/portal_admin.py
@@ -4,7 +4,7 @@ Lets the agent generate, copy, rotate, and revoke the private seller portal
 link from the transaction detail page. All endpoints are agent-authenticated
 and org-scoped; the portal itself (token-authenticated) lives in routes/portal.py.
 """
-from flask import abort, jsonify, request, url_for
+from flask import abort, jsonify, request
 from flask_login import current_user, login_required
 
 from models import (
@@ -28,10 +28,6 @@ def _get_transaction(id, capability=CAP_EDIT):
     return transaction
 
 
-def _link_url(access):
-    return url_for('portal.home', token=access.token, _external=True)
-
-
 def _serialize(participant, access):
     return {
         'participant_id': participant.id,
@@ -42,7 +38,6 @@ def _serialize(participant, access):
         'email': participant.display_email,
         'has_link': access is not None,
         'access_id': access.id if access else None,
-        'url': _link_url(access) if access else None,
         'invite_code': (
             access.invite_code_display if access and access.invite_code else None),
         'view_count': access.view_count if access else 0,
@@ -108,7 +103,7 @@ def portal_create_link(id):
         transaction_id=transaction.id,
         organization_id=current_user.organization_id,
     ).first()
-    if not participant or participant.role not in CLIENT_ROLES:
+    if not participant or (participant.role or '').strip().lower() not in CLIENT_ROLES:
         return jsonify({
             'success': False,
             'error': 'Not a seller or buyer on this transaction.',

--- a/routes/transactions/portal_admin.py
+++ b/routes/transactions/portal_admin.py
@@ -12,6 +12,7 @@ from models import (
     TransactionParticipant,
     db,
 )
+from services.portal_service import normalize_mls_listing_url
 from services.transaction_auth import CAP_EDIT, CAP_VIEW, get_transaction_for_user
 from . import transactions_bp
 from .decorators import transactions_required
@@ -159,3 +160,21 @@ def portal_revoke_link(id, access_id):
     access.revoke()
     db.session.commit()
     return jsonify({'success': True, 'participant_id': access.participant_id})
+
+
+@transactions_bp.route('/<int:id>/mls-listing-url', methods=['POST'])
+@login_required
+@transactions_required
+def update_mls_listing_url(id):
+    """Save the public MLS listing link shown on the client Home screen."""
+    transaction = _get_transaction(id)
+    data = request.get_json(silent=True) or request.form
+    raw = data.get('mls_listing_url', data.get('url', ''))
+    try:
+        url = normalize_mls_listing_url(raw)
+    except ValueError as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+
+    transaction.mls_listing_url = url
+    db.session.commit()
+    return jsonify({'success': True, 'mls_listing_url': url})

--- a/routes/transactions/portal_admin.py
+++ b/routes/transactions/portal_admin.py
@@ -43,6 +43,8 @@ def _serialize(participant, access):
         'has_link': access is not None,
         'access_id': access.id if access else None,
         'url': _link_url(access) if access else None,
+        'invite_code': (
+            access.invite_code_display if access and access.invite_code else None),
         'view_count': access.view_count if access else 0,
         'last_viewed': (
             access.last_viewed_at.strftime('%b %d, %Y')
@@ -119,9 +121,14 @@ def portal_create_link(id):
             transaction_id=transaction.id,
             participant_id=participant.id,
             token=ClientPortalAccess.generate_token(),
+            invite_code=ClientPortalAccess.generate_invite_code(),
+            session_version=1,
             is_active=True,
         )
         db.session.add(access)
+        db.session.commit()
+    else:
+        access.ensure_invite_code()
         db.session.commit()
 
     return jsonify({'success': True, 'link': _serialize(participant, access)})
@@ -138,11 +145,7 @@ def portal_rotate_link(id, access_id):
         transaction_id=transaction.id,
         organization_id=current_user.organization_id,
     ).first_or_404()
-    access.token = ClientPortalAccess.generate_token()
-    access.is_active = True
-    access.revoked_at = None
-    access.view_count = 0
-    access.last_viewed_at = None
+    access.rotate_invite()
     db.session.commit()
     return jsonify({'success': True, 'link': _serialize(access.participant, access)})
 
@@ -152,14 +155,12 @@ def portal_rotate_link(id, access_id):
 @transactions_required
 def portal_revoke_link(id, access_id):
     """Turn off a portal link. The seller's URL stops working immediately."""
-    from datetime import datetime
     transaction = _get_transaction(id)
     access = ClientPortalAccess.query.filter_by(
         id=access_id,
         transaction_id=transaction.id,
         organization_id=current_user.organization_id,
     ).first_or_404()
-    access.is_active = False
-    access.revoked_at = datetime.utcnow()
+    access.revoke()
     db.session.commit()
     return jsonify({'success': True, 'participant_id': access.participant_id})

--- a/services/bob_tools/listings.py
+++ b/services/bob_tools/listings.py
@@ -69,6 +69,7 @@ def get_listing(ctx: BobContext, *, transaction_id: int | None = None) -> ToolRe
             'status': tx.status,
             'list_price': str(profile.current_list_price) if profile and profile.current_list_price else None,
             'mls_number': profile.mls_number if profile else None,
+            'mls_listing_url': tx.mls_listing_url,
             'go_live_date': profile.go_live_date.isoformat() if profile and profile.go_live_date else None,
             'occupancy_status': profile.occupancy_status if profile else None,
             'listing_description': extra.get('listing_description') or '',
@@ -83,6 +84,7 @@ def update_listing_fields(
     transaction_id: int,
     list_price=None,
     mls_number: str = '',
+    mls_listing_url: str = '',
     go_live_date: str = '',
     occupancy_status: str = '',
     public_showing_instructions: str = '',
@@ -108,6 +110,7 @@ def update_listing_fields(
     before = {
         'list_price': str(profile.current_list_price) if profile.current_list_price else None,
         'mls_number': profile.mls_number,
+        'mls_listing_url': tx.mls_listing_url,
     }
     if list_price not in (None, ''):
         try:
@@ -118,6 +121,12 @@ def update_listing_fields(
             return ToolResult.failure('list_price must be a number.')
     if mls_number:
         profile.mls_number = mls_number.strip()[:100]
+    if mls_listing_url != '':
+        from services.portal_service import normalize_mls_listing_url
+        try:
+            tx.mls_listing_url = normalize_mls_listing_url(mls_listing_url)
+        except ValueError as exc:
+            return ToolResult.failure(str(exc))
     if go_live_date:
         try:
             profile.go_live_date = datetime.strptime(go_live_date, '%Y-%m-%d').date()
@@ -136,6 +145,7 @@ def update_listing_fields(
             'after': {
                 'list_price': str(profile.current_list_price) if profile.current_list_price else None,
                 'mls_number': profile.mls_number,
+                'mls_listing_url': tx.mls_listing_url,
                 'go_live_date': profile.go_live_date.isoformat() if profile.go_live_date else None,
             },
         },
@@ -155,10 +165,12 @@ def preview_update_listing_fields(args: dict, ctx: BobContext) -> dict:
         'before': {
             'list_price': str(profile.current_list_price) if profile and profile.current_list_price else None,
             'mls_number': profile.mls_number if profile else None,
+            'mls_listing_url': tx.mls_listing_url if tx else None,
         },
         'after': {
             'list_price': args.get('list_price'),
             'mls_number': args.get('mls_number'),
+            'mls_listing_url': args.get('mls_listing_url'),
         },
     }
 

--- a/services/bob_tools/registry.py
+++ b/services/bob_tools/registry.py
@@ -1283,7 +1283,7 @@ TRANSACTION_TOOLS = (
     Tool(
         name='update_listing_fields',
         description=(
-            'Update list price, MLS number, go-live date, occupancy, or public '
+            'Update list price, MLS number, MLS listing link, go-live date, occupancy, or public '
             'showing notes on a seller listing the user can edit. Only send '
             'fields that should change.'
         ),
@@ -1291,6 +1291,10 @@ TRANSACTION_TOOLS = (
             'transaction_id': _TX_ID,
             'list_price': {'type': 'number', 'description': 'New list price in dollars.'},
             'mls_number': {'type': 'string', 'description': 'MLS number if assigned.'},
+            'mls_listing_url': {
+                'type': 'string',
+                'description': 'Public http(s) listing page. Shown on the client Home screen.',
+            },
             'go_live_date': {'type': 'string', 'description': 'Go-live date, YYYY-MM-DD.'},
             'occupancy_status': {'type': 'string', 'description': 'vacant, owner_occupied, or tenant_occupied.'},
             'public_showing_instructions': {'type': 'string', 'description': 'Public showing instructions.'},
@@ -1301,6 +1305,7 @@ TRANSACTION_TOOLS = (
             transaction_id=args['transaction_id'],
             list_price=args.get('list_price'),
             mls_number=args.get('mls_number', ''),
+            mls_listing_url=args.get('mls_listing_url', ''),
             go_live_date=args.get('go_live_date', ''),
             occupancy_status=args.get('occupancy_status', ''),
             public_showing_instructions=args.get('public_showing_instructions', ''),

--- a/services/client_portal_auth.py
+++ b/services/client_portal_auth.py
@@ -1,0 +1,180 @@
+"""Invite-code grant and short-lived JWT for the client iPhone app.
+
+The grant is still ClientPortalAccess. The HTML portal keeps using the
+URL token. The app never puts that token in a path. A human invite code
+is exchanged for a JWT sent as Authorization: Bearer.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+import time
+
+from flask import current_app
+
+from models import ClientPortalAccess, Organization
+
+
+DEFAULT_ACCENT = '#f97316'
+DEFAULT_ACCENT_INK = '#ea580c'
+JWT_TTL_SECONDS = 12 * 60 * 60
+JWT_TYP = 'client_portal'
+_HEX_COLOR = re.compile(r'^#[0-9A-Fa-f]{6}$')
+
+
+def normalize_brand_accent(value):
+    raw = (value or '').strip()
+    if not raw:
+        return None
+    if not _HEX_COLOR.match(raw):
+        return False
+    return raw.lower()
+
+
+def org_branding(org):
+    """Name, logo, and accent for THIS app. Defaults to product orange."""
+    if org is None:
+        return {
+            'name': 'Your brokerage',
+            'logo_url': None,
+            'accent': DEFAULT_ACCENT,
+            'accent_ink': DEFAULT_ACCENT_INK,
+        }
+    accent = (getattr(org, 'brand_accent', None) or '').strip().lower()
+    if not _HEX_COLOR.match(accent or ''):
+        accent = DEFAULT_ACCENT
+        accent_ink = DEFAULT_ACCENT_INK
+    elif accent == DEFAULT_ACCENT:
+        accent_ink = DEFAULT_ACCENT_INK
+    else:
+        accent_ink = _darken_hex(accent)
+    return {
+        'name': org.name,
+        'logo_url': org.logo_url or None,
+        'accent': accent,
+        'accent_ink': accent_ink,
+    }
+
+
+def branding_for_access(access):
+    org = Organization.query.get(access.organization_id)
+    return org_branding(org)
+
+
+def _darken_hex(hex_color, factor=0.88):
+    h = hex_color.lstrip('#')
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+    return '#{:02x}{:02x}{:02x}'.format(
+        max(0, int(r * factor)),
+        max(0, int(g * factor)),
+        max(0, int(b * factor)),
+    )
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')
+
+
+def _b64url_decode(value: str) -> bytes:
+    pad = '=' * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + pad)
+
+
+def _secret() -> bytes:
+    key = current_app.config.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
+    if isinstance(key, bytes):
+        return key
+    return str(key).encode('utf-8')
+
+
+def issue_client_jwt(access, now=None, ttl_seconds=JWT_TTL_SECONDS):
+    """Return a compact HS256 JWT bound to this grant and session_version."""
+    now = int(now if now is not None else time.time())
+    payload = {
+        'typ': JWT_TYP,
+        'aid': access.id,
+        'oid': access.organization_id,
+        'tid': access.transaction_id,
+        'pid': access.participant_id,
+        'sv': access.session_version or 1,
+        'iat': now,
+        'exp': now + int(ttl_seconds),
+        'iss': 'agentflow-client',
+    }
+    header = {'alg': 'HS256', 'typ': 'JWT'}
+    header_b64 = _b64url_encode(json.dumps(header, separators=(',', ':')).encode())
+    body_b64 = _b64url_encode(json.dumps(payload, separators=(',', ':')).encode())
+    signing = f'{header_b64}.{body_b64}'.encode('ascii')
+    sig = hmac.new(_secret(), signing, hashlib.sha256).digest()
+    return f'{header_b64}.{body_b64}.{_b64url_encode(sig)}'
+
+
+def decode_client_jwt(token):
+    """Return claims dict or None if the signature or shape is wrong."""
+    if not token or token.count('.') != 2:
+        return None
+    header_b64, body_b64, sig_b64 = token.split('.')
+    signing = f'{header_b64}.{body_b64}'.encode('ascii')
+    try:
+        expected = hmac.new(_secret(), signing, hashlib.sha256).digest()
+        given = _b64url_decode(sig_b64)
+    except (ValueError, TypeError):
+        return None
+    if not hmac.compare_digest(expected, given):
+        return None
+    try:
+        claims = json.loads(_b64url_decode(body_b64))
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(claims, dict) or claims.get('typ') != JWT_TYP:
+        return None
+    return claims
+
+
+def jwt_is_expired(claims, now=None):
+    now = int(now if now is not None else time.time())
+    try:
+        return int(claims.get('exp') or 0) <= now
+    except (TypeError, ValueError):
+        return True
+
+
+def exchange_invite_code(code, now=None):
+    """Resolve a human invite code to an active grant.
+
+    Returns (access, error_message). error_message is set on 401 cases.
+    """
+    access = ClientPortalAccess.find_by_invite_code(code)
+    if not access:
+        return None, 'That invite code is not valid.'
+    if not access.is_active:
+        return None, 'This invite is no longer active.'
+    if access.invite_is_expired(now=now):
+        return None, 'This invite has expired.'
+    return access, None
+
+
+def load_access_from_jwt(token, now=None):
+    """Return (access, error_message) for a Bearer JWT."""
+    claims = decode_client_jwt(token)
+    if not claims:
+        return None, 'Sign in with your invite code first.'
+    if jwt_is_expired(claims, now=now):
+        return None, 'Your session expired. Enter your invite code again.'
+    access = ClientPortalAccess.query.get(claims.get('aid'))
+    if not access or not access.is_active:
+        return None, 'This invite is no longer active.'
+    if int(access.session_version or 1) != int(claims.get('sv') or 0):
+        return None, 'Your session is no longer valid. Enter your invite code again.'
+    if (
+        access.organization_id != claims.get('oid')
+        or access.transaction_id != claims.get('tid')
+        or access.participant_id != claims.get('pid')
+    ):
+        return None, 'Sign in with your invite code first.'
+    return access, None

--- a/services/client_portal_auth.py
+++ b/services/client_portal_auth.py
@@ -147,7 +147,7 @@ def jwt_is_expired(claims, now=None):
 def exchange_invite_code(code, now=None):
     """Resolve a human invite code to an active grant.
 
-    Returns (access, error_message). error_message is set on 401 cases.
+    Returns (access, error_message). Invite failures map to HTTP 422.
     """
     access = ClientPortalAccess.find_by_invite_code(code)
     if not access:

--- a/services/portal_service.py
+++ b/services/portal_service.py
@@ -497,10 +497,14 @@ def _showings_block(tx):
         lvl = getattr(s, 'feedback_interest_level', None)
         if lvl in interest_counts:
             interest_counts[lvl] += 1
+        status_key = (s.status or 'scheduled')
         items.append({
+            'id': s.id,
             'date': start.strftime('%a, %b %-d') if start else 'Scheduled',
             'time': start.strftime('%-I:%M %p') if start else None,
-            'status': (s.status or 'scheduled').replace('_', ' ').title(),
+            'status': status_key.replace('_', ' ').title(),
+            'status_key': status_key,
+            'can_decide': status_key == 'pending_approval',
             'agent_brokerage': getattr(s, 'showing_agent_brokerage', None),
             'has_feedback': has_fb,
             'interest': INTEREST_LABELS.get(lvl) if lvl else None,
@@ -735,3 +739,165 @@ def _updates_block(tx, participant):
             'author': (f'{author.first_name}' if author else 'Your agent'),
         })
     return out
+
+
+# --------------------------------------------------------------------------
+# JSON projection for the client iPhone app
+# --------------------------------------------------------------------------
+
+_DEAL_KEYS = (
+    'portal_role',
+    'client_first_name',
+    'property',
+    'agent',
+    'headline',
+    'headline_statement',
+    'stages',
+    'current_stage_index',
+    'current_stage',
+    'progress_pct',
+    'showings',
+    'offers',
+    'milestones',
+    'requirements',
+    'documents',
+    'price_changes',
+    'net_proceeds',
+    'updates',
+)
+
+# Keys that must never leave the client-safe DTO, even if a future helper
+# adds them. Commission, lockbox, RentCast, and other-party contact fields.
+_FORBIDDEN_KEY_MARKERS = (
+    'commission',
+    'lockbox',
+    'gate_code',
+    'alarm',
+    'rentcast',
+    'access_instructions',
+    'access_type',
+    'private_notes',
+    'showing_agent_email',
+    'showing_agent_phone',
+    'showing_agent_name',
+    'buyer_name',
+    'buyer_names',
+    'buyer_agent_email',
+    'buyer_agent_phone',
+    'potential_commission',
+)
+
+
+def serialize_client_deal(access):
+    """JSON-ready, client-safe deal from ``build_portal_context``."""
+    ctx = build_portal_context(access)
+    deal = {key: _json_safe(ctx.get(key)) for key in _DEAL_KEYS}
+    _assert_client_safe(deal)
+    return deal
+
+
+def list_client_messages(access, limit=50):
+    """Deal-scoped notes for this participant only."""
+    from models import PortalMessage
+
+    msgs = (
+        PortalMessage.query.filter_by(
+            transaction_id=access.transaction_id,
+            participant_id=access.participant_id,
+        )
+        .order_by(PortalMessage.created_at.asc())
+        .limit(limit)
+        .all()
+    )
+    out = []
+    for m in msgs:
+        author = getattr(m, 'author', None)
+        if m.sender == 'client':
+            author_name = _participant_first_name(access.participant)
+        elif author and author.first_name:
+            author_name = author.first_name
+        else:
+            author_name = 'Your agent'
+        created = getattr(m, 'created_at', None)
+        out.append({
+            'id': m.id,
+            'sender': m.sender,
+            'kind': m.kind,
+            'body': m.body,
+            'author': author_name,
+            'created_at': created.isoformat() if created else None,
+            'date': _day(created),
+        })
+    return out
+
+
+def documents_for_client_api(access):
+    """Participant-only docs, with short-lived signed URLs on completed files."""
+    ctx = build_portal_context(access)
+    documents = ctx.get('documents') or {}
+    completed = []
+    for item in documents.get('completed') or []:
+        row = dict(item)
+        row['view_url'] = None
+        if row.get('can_view') and row.get('doc_id'):
+            row['view_url'] = _signed_doc_url(access, row['doc_id'])
+        completed.append(row)
+    return {
+        'needs_signature': list(documents.get('needs_signature') or []),
+        'completed': completed,
+        'needs_count': documents.get('needs_count', 0),
+        'completed_count': documents.get('completed_count', 0),
+    }
+
+
+def _signed_doc_url(access, doc_id):
+    from models import TransactionDocument
+    from services.supabase_storage import get_transaction_document_url
+
+    doc = TransactionDocument.query.filter_by(
+        id=doc_id, transaction_id=access.transaction_id).first()
+    email = (access.participant.display_email or '').strip().lower()
+    if not doc or doc.status != 'signed' or not doc.signed_file_path:
+        return None
+    sigs = doc.signatures.all()
+    if sigs and not any((s.signer_email or '').strip().lower() == email for s in sigs):
+        return None
+    try:
+        return get_transaction_document_url(doc.signed_file_path, expires_in=3600)
+    except Exception:
+        logger.exception('Client API: failed to sign document URL for doc %s', doc_id)
+        return None
+
+
+def _json_safe(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    try:
+        from decimal import Decimal
+        if isinstance(value, Decimal):
+            return float(value)
+    except Exception:
+        pass
+    return str(value)
+
+
+def _assert_client_safe(payload):
+    """Drop any forbidden keys that slipped into the projection."""
+    if isinstance(payload, dict):
+        for key in list(payload.keys()):
+            hay = str(key).lower()
+            if any(marker in hay for marker in _FORBIDDEN_KEY_MARKERS):
+                payload.pop(key, None)
+                continue
+            _assert_client_safe(payload[key])
+    elif isinstance(payload, list):
+        for item in payload:
+            _assert_client_safe(item)

--- a/services/portal_service.py
+++ b/services/portal_service.py
@@ -840,7 +840,8 @@ def documents_for_client_api(access):
         row = dict(item)
         row['view_url'] = None
         if row.get('can_view') and row.get('doc_id'):
-            row['view_url'] = _signed_doc_url(access, row['doc_id'])
+            url, _status = client_document_file_url(access, row['doc_id'])
+            row['view_url'] = url
         completed.append(row)
     return {
         'needs_signature': list(documents.get('needs_signature') or []),
@@ -850,7 +851,30 @@ def documents_for_client_api(access):
     }
 
 
-def _signed_doc_url(access, doc_id):
+def milestones_for_client_api(access):
+    """Same client-safe milestone block as ``build_portal_context``."""
+    ctx = build_portal_context(access)
+    payload = _json_safe(ctx.get('milestones') or {'items': [], 'next': None})
+    _assert_client_safe(payload)
+    return payload
+
+
+def showings_for_client_api(access):
+    """Same client-safe showings block as ``build_portal_context``."""
+    ctx = build_portal_context(access)
+    payload = _json_safe(ctx.get('showings') or {
+        'items': [], 'total': 0, 'this_week': 0,
+        'with_feedback': 0, 'interest_counts': {},
+    })
+    _assert_client_safe(payload)
+    return payload
+
+
+def client_document_file_url(access, doc_id):
+    """Signed URL for a completed doc this participant can view.
+
+    Returns ``(url, error_status)``. ``error_status`` is None on success.
+    """
     from models import TransactionDocument
     from services.supabase_storage import get_transaction_document_url
 
@@ -858,15 +882,18 @@ def _signed_doc_url(access, doc_id):
         id=doc_id, transaction_id=access.transaction_id).first()
     email = (access.participant.display_email or '').strip().lower()
     if not doc or doc.status != 'signed' or not doc.signed_file_path:
-        return None
+        return None, 404
     sigs = doc.signatures.all()
     if sigs and not any((s.signer_email or '').strip().lower() == email for s in sigs):
-        return None
+        return None, 403
     try:
-        return get_transaction_document_url(doc.signed_file_path, expires_in=3600)
+        url = get_transaction_document_url(doc.signed_file_path, expires_in=3600)
     except Exception:
         logger.exception('Client API: failed to sign document URL for doc %s', doc_id)
-        return None
+        url = None
+    if not url:
+        return None, 404
+    return url, None
 
 
 def _json_safe(value):

--- a/services/portal_service.py
+++ b/services/portal_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, date
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,30 @@ STAGE_DEFS = [
     ('closing', 'Closing', 'fa-key'),
     ('closed', 'Sold', 'fa-champagne-glasses'),
 ]
+
+def normalize_mls_listing_url(value):
+    """Return a cleaned http(s) listing URL, or None if blank.
+
+    Raises ValueError when the value is present but not a public web link.
+    """
+    raw = (value or '').strip()
+    if not raw:
+        return None
+    parsed = urlparse(raw)
+    if parsed.scheme not in ('http', 'https') or not parsed.netloc:
+        raise ValueError('Use a full http or https link.')
+    if len(raw) > 500:
+        raise ValueError('That link is too long.')
+    return raw
+
+
+def public_mls_listing_url(value):
+    """Same as normalize, but bad stored values become None instead of raising."""
+    try:
+        return normalize_mls_listing_url(value)
+    except ValueError:
+        return None
+
 
 BUYER_STAGE_DEFS = [
     ('showing', 'Searching & touring', 'fa-magnifying-glass'),
@@ -128,6 +153,7 @@ def build_portal_context(access):
         'property': _property_block(tx),
         'agent': _agent_block(tx),
         'headline': _headline_block(tx, profile, is_buyer=is_buyer),
+        'mls_listing_url': public_mls_listing_url(getattr(tx, 'mls_listing_url', None)),
         'updated_label': _updated_label(tx),
     }
 
@@ -308,6 +334,7 @@ def _headline_block(tx, profile, *, is_buyer=False):
         'price_reduced': bool(original_price and list_price and float(original_price) > float(list_price)),
         'days_on_market': days_on_market,
         'mls_number': None if is_buyer else (profile.mls_number if profile else None),
+        'mls_listing_url': public_mls_listing_url(getattr(tx, 'mls_listing_url', None)),
         'status': tx.status,
         'status_label': _status_label(tx.status, is_buyer=is_buyer),
         'expected_close': _full_day(getattr(tx, 'expected_close_date', None)),
@@ -498,10 +525,21 @@ def _showings_block(tx):
         if lvl in interest_counts:
             interest_counts[lvl] += 1
         status_key = (s.status or 'scheduled')
+        duration = 30
+        end = getattr(s, 'scheduled_end_at', None)
+        if start and end:
+            duration = max(int((end - start).total_seconds() / 60), 15)
+        starts_at = None
+        if start:
+            starts_at = start.isoformat()
+            if start.tzinfo is None and not starts_at.endswith('Z'):
+                starts_at = f'{starts_at}Z'
         items.append({
             'id': s.id,
             'date': start.strftime('%a, %b %-d') if start else 'Scheduled',
             'time': start.strftime('%-I:%M %p') if start else None,
+            'starts_at': starts_at,
+            'duration_minutes': duration,
             'status': status_key.replace('_', ' ').title(),
             'status_key': status_key,
             'can_decide': status_key == 'pending_approval',
@@ -751,6 +789,7 @@ _DEAL_KEYS = (
     'property',
     'agent',
     'headline',
+    'mls_listing_url',
     'headline_statement',
     'stages',
     'current_stage_index',

--- a/templates/organization/settings.html
+++ b/templates/organization/settings.html
@@ -64,8 +64,27 @@
                             <input id="org-logo" type="url" name="logo_url" value="{{ org.logo_url or '' }}"
                                    class="crm-input" placeholder="https://example.com/logo.png"
                                    {% if current_user.org_role != 'owner' %}disabled{% endif %}>
-                            <p class="crm-form-help">Used in document headers and outbound emails.</p>
+                            <p class="crm-form-help">
+                                {% if client_app_branding|default(false) %}
+                                Used in document headers, outbound emails, and the client iPhone app.
+                                {% else %}
+                                Used in document headers and outbound emails.
+                                {% endif %}
+                            </p>
                         </div>
+
+                        {% if client_app_branding|default(false) %}
+                        <div>
+                            <label for="org-brand-accent" class="crm-form-label">Client app accent</label>
+                            <input id="org-brand-accent" type="text" name="brand_accent"
+                                   value="{{ org.brand_accent or '' }}"
+                                   class="crm-input" placeholder="#f97316" maxlength="7"
+                                   {% if current_user.org_role != 'owner' %}disabled{% endif %}>
+                            <p class="crm-form-help">
+                                Color for buttons in the client iPhone app. Leave blank for the default orange.
+                            </p>
+                        </div>
+                        {% endif %}
 
                         {% if current_user.org_role == 'owner' %}
                         <div class="flex items-center justify-end pt-2">

--- a/templates/portal/show.html
+++ b/templates/portal/show.html
@@ -40,6 +40,12 @@
       {{ headline.status_label }}
     </div>
 
+    {% if headline.mls_listing_url %}
+    <p class="mt-3">
+      <a class="pp-link" href="{{ headline.mls_listing_url }}" target="_blank" rel="noopener noreferrer">View listing</a>
+    </p>
+    {% endif %}
+
     {% if headline.list_price or headline.days_on_market is not none %}
     <div class="pp-specs">
       {% if headline.list_price %}

--- a/templates/transactions/_client_app_invite.html
+++ b/templates/transactions/_client_app_invite.html
@@ -1,0 +1,108 @@
+{# Invite codes for the client iPhone app. Sellers and buyers only. #}
+{% if can_access_transactions(current_user) %}
+<section class="crm-surface" id="client-app-invite">
+    <div class="crm-surface-header">
+        {{ section_header('Client app invite') }}
+    </div>
+    <div class="crm-surface-body space-y-3">
+        <p class="text-sm" style="color: var(--ink-3);">
+            Give this person a short code to open their transaction in the iPhone app.
+            The code works only for that person on this transaction.
+        </p>
+        {% if client_invite_participants|default([]) %}
+        <ul class="divide-y divide-slate-100">
+            {% for participant in client_invite_participants %}
+            {% set access = (client_invite_by_id|default({})).get(participant.id) %}
+            <li class="flex flex-col gap-2 py-2.5 first:pt-0 last:pb-0"
+                data-participant-id="{{ participant.id }}"
+                data-access-id="{{ access.id if access else '' }}">
+                <div class="min-w-0">
+                    <div class="truncate text-sm font-medium text-slate-900">{{ participant.display_name }}</div>
+                    <div class="text-xs text-slate-500">{{ participant.role|replace('_', ' ')|title }}</div>
+                </div>
+                {% if access and access.invite_code %}
+                <div class="flex flex-wrap items-center gap-2">
+                    <code class="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-sm font-semibold tracking-wider text-slate-900">{{ access.invite_code_display }}</code>
+                    <button type="button"
+                            class="crm-btn crm-btn-secondary"
+                            data-client-invite-action="rotate">
+                        Rotate code
+                    </button>
+                    <button type="button"
+                            class="crm-btn crm-btn-secondary"
+                            data-client-invite-action="revoke">
+                        Revoke
+                    </button>
+                </div>
+                {% else %}
+                <div>
+                    <button type="button"
+                            class="crm-btn crm-btn-secondary"
+                            data-client-invite-action="create">
+                        Create invite
+                    </button>
+                </div>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-sm text-slate-500">Add a seller or buyer, then you can create an invite.</p>
+        {% endif %}
+    </div>
+</section>
+<script>
+(function () {
+    var card = document.getElementById('client-app-invite');
+    if (!card) return;
+    var txId = {{ transaction.id }};
+
+    function post(url, body) {
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify(body || {})
+        }).then(function (res) {
+            return res.json().then(function (data) {
+                if (!res.ok || data.success === false) {
+                    throw new Error(data.error || 'Could not update the invite.');
+                }
+                return data;
+            });
+        });
+    }
+
+    card.addEventListener('click', function (event) {
+        var button = event.target.closest('[data-client-invite-action]');
+        if (!button) return;
+        var row = button.closest('[data-participant-id]');
+        if (!row) return;
+        var action = button.getAttribute('data-client-invite-action');
+        var participantId = row.getAttribute('data-participant-id');
+        var accessId = row.getAttribute('data-access-id');
+        var req;
+        if (action === 'create') {
+            req = post('/transactions/' + txId + '/portal/create', { participant_id: Number(participantId) });
+        } else if (action === 'rotate' && accessId) {
+            req = post('/transactions/' + txId + '/portal/' + accessId + '/rotate', {});
+        } else if (action === 'revoke' && accessId) {
+            req = post('/transactions/' + txId + '/portal/' + accessId + '/revoke', {});
+        } else {
+            return;
+        }
+        button.disabled = true;
+        req.then(function () {
+            window.location.reload();
+        }).catch(function (err) {
+            alert(err.message || 'Could not update the invite.');
+            button.disabled = false;
+        });
+    });
+})();
+</script>
+{% endif %}

--- a/templates/transactions/_client_app_invite.html
+++ b/templates/transactions/_client_app_invite.html
@@ -9,6 +9,7 @@
             Give this person a short code to open their transaction in the iPhone app.
             The code works only for that person on this transaction.
         </p>
+        <p class="hidden text-sm text-red-700" data-invite-error></p>
         {% if client_invite_participants|default([]) %}
         <ul class="divide-y divide-slate-100">
             {% for participant in client_invite_participants %}
@@ -57,6 +58,27 @@
     if (!card) return;
     var txId = {{ transaction.id }};
 
+    function showInviteError(message) {
+        var text = message || 'Could not update the invite.';
+        if (typeof window.showCrmToast === 'function') {
+            window.showCrmToast(text, 'error');
+        } else if (typeof window.showToast === 'function') {
+            window.showToast(text, 'error');
+        }
+        var box = card.querySelector('[data-invite-error]');
+        if (box) {
+            box.textContent = text;
+            box.classList.remove('hidden');
+        }
+    }
+
+    function clearInviteError() {
+        var box = card.querySelector('[data-invite-error]');
+        if (!box) return;
+        box.textContent = '';
+        box.classList.add('hidden');
+    }
+
     function post(url, body) {
         return fetch(url, {
             method: 'POST',
@@ -96,10 +118,11 @@
             return;
         }
         button.disabled = true;
+        clearInviteError();
         req.then(function () {
             window.location.reload();
         }).catch(function (err) {
-            alert(err.message || 'Could not update the invite.');
+            showInviteError(err.message || 'Could not update the invite.');
             button.disabled = false;
         });
     });

--- a/templates/transactions/_client_app_invite.html
+++ b/templates/transactions/_client_app_invite.html
@@ -10,6 +10,8 @@
             The code works only for that person on this transaction.
         </p>
         <p class="hidden text-sm text-red-700" data-invite-error></p>
+        {% set mls_field_id = 'client-app-mls-listing-url' %}
+        {% include 'transactions/_mls_listing_url.html' %}
         {% if client_invite_participants|default([]) %}
         <ul class="divide-y divide-slate-100">
             {% for participant in client_invite_participants %}

--- a/templates/transactions/_mls_listing_url.html
+++ b/templates/transactions/_mls_listing_url.html
@@ -19,6 +19,7 @@
             Save
         </button>
     </div>
+    <p class="hidden text-xs text-red-700" data-mls-listing-error></p>
     {% if transaction.mls_listing_url %}
     <a href="{{ transaction.mls_listing_url }}"
        target="_blank"
@@ -80,10 +81,14 @@
             }
             window.location.reload();
         }).catch(function (err) {
+            var message = err.message || 'Could not save that listing link.';
             if (typeof showToast === 'function') {
-                showToast(err.message || 'Could not save that listing link.', 'error');
-            } else {
-                alert(err.message || 'Could not save that listing link.');
+                showToast(message, 'error');
+            }
+            var line = field.querySelector('[data-mls-listing-error]');
+            if (line) {
+                line.textContent = message;
+                line.classList.remove('hidden');
             }
             saveBtn.disabled = false;
             saveBtn.textContent = original;

--- a/templates/transactions/_mls_listing_url.html
+++ b/templates/transactions/_mls_listing_url.html
@@ -1,0 +1,94 @@
+{# Public MLS listing link shown on the client iPhone Home screen. #}
+{% set mls_field_id = mls_field_id|default('mls-listing-url') %}
+<div class="space-y-1.5" data-mls-listing-field>
+    <label class="crm-field-label" for="{{ mls_field_id }}">MLS listing link</label>
+    <p class="text-xs text-slate-500">Shows on the client's Home screen in place of Message.</p>
+    <div class="flex flex-wrap items-center gap-2">
+        <input type="url"
+               id="{{ mls_field_id }}"
+               inputmode="url"
+               autocomplete="off"
+               spellcheck="false"
+               placeholder="https://"
+               value="{{ transaction.mls_listing_url or '' }}"
+               data-saved-value="{{ transaction.mls_listing_url or '' }}"
+               class="crm-input min-w-[16rem] flex-1">
+        <button type="button"
+                class="crm-btn crm-btn-secondary hidden px-3 py-1.5 text-xs"
+                data-mls-listing-save>
+            Save
+        </button>
+    </div>
+    {% if transaction.mls_listing_url %}
+    <a href="{{ transaction.mls_listing_url }}"
+       target="_blank"
+       rel="noopener noreferrer"
+       class="inline-block text-xs font-medium text-slate-600 underline decoration-slate-300 underline-offset-2 hover:text-slate-900">
+        Open listing
+    </a>
+    {% endif %}
+</div>
+<script>
+(function () {
+    var field = document.getElementById({{ mls_field_id|tojson }}).closest('[data-mls-listing-field]');
+    if (!field) return;
+    var input = field.querySelector('input[type="url"]');
+    var saveBtn = field.querySelector('[data-mls-listing-save]');
+    var txId = {{ transaction.id }};
+    if (!input || !saveBtn) return;
+
+    function currentValue() {
+        return (input.value || '').trim();
+    }
+
+    function savedValue() {
+        return (input.getAttribute('data-saved-value') || '').trim();
+    }
+
+    function syncSave() {
+        if (currentValue() !== savedValue()) {
+            saveBtn.classList.remove('hidden');
+        } else {
+            saveBtn.classList.add('hidden');
+        }
+    }
+
+    input.addEventListener('input', syncSave);
+    saveBtn.addEventListener('click', function () {
+        var original = saveBtn.textContent;
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving...';
+        fetch('/transactions/' + txId + '/mls-listing-url', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify({ mls_listing_url: currentValue() })
+        }).then(function (res) {
+            return res.json().then(function (data) {
+                if (!res.ok || data.success === false) {
+                    throw new Error(data.error || 'Could not save that listing link.');
+                }
+                return data;
+            });
+        }).then(function () {
+            if (typeof showToast === 'function') {
+                showToast('MLS listing link saved.', 'success');
+            }
+            window.location.reload();
+        }).catch(function (err) {
+            if (typeof showToast === 'function') {
+                showToast(err.message || 'Could not save that listing link.', 'error');
+            } else {
+                alert(err.message || 'Could not save that listing link.');
+            }
+            saveBtn.disabled = false;
+            saveBtn.textContent = original;
+        });
+    });
+    syncSave();
+})();
+</script>

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1332,8 +1332,10 @@
                         </form>
                         {% endif %}
 
-                        {# Lockbox combo (always editable) #}
-                        <div class="{% if listing_info %}mt-4 border-t border-slate-100 pt-4{% endif %}">
+                        {# MLS listing link + lockbox (always editable) #}
+                        <div class="{% if listing_info %}mt-4 border-t border-slate-100 pt-4{% endif %} space-y-4">
+                            {% set mls_field_id = 'listing-info-mls-listing-url' %}
+                            {% include 'transactions/_mls_listing_url.html' %}
                             <div class="flex items-center justify-between gap-3">
                                 <span class="text-sm text-[color:var(--ink-3)]">Lockbox combo</span>
                                 <div class="flex items-center gap-2">

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1194,6 +1194,7 @@
                     </div>
                 </section>
 
+                {% include 'transactions/_client_app_invite.html' %}
 
                 {% if transaction.transaction_type.name == 'seller' %}
                 {# ----- Listing info card (seller only) ----- #}

--- a/tests/test_client_portal_api.py
+++ b/tests/test_client_portal_api.py
@@ -200,6 +200,13 @@ def test_session_exchange_valid_invalid_revoked_expired(app, seed, client):
         assert branding['logo_url'] == 'https://example.com/origen-logo.png'
         assert branding['accent'] == '#123456'
 
+        iphone = _open_session(client, valid_code, key='invite_code')
+        assert iphone.status_code == 200
+        assert iphone.get_json()['participant_first_name']
+        assert iphone.get_json()['role'] in (
+            'seller', 'co_seller', 'buyer', 'co_buyer',
+        )
+
         assert _open_session(client, 'NOTA-CODE').status_code == 422
         assert _open_session(client, revoked_code).status_code == 422
         assert _open_session(client, expired_code).status_code == 422
@@ -761,3 +768,53 @@ def test_default_branding_uses_product_orange(app, seed, client):
     assert branding['accent'] == '#f97316'
     assert branding['accent_ink'] == '#ea580c'
     assert branding['name'] == 'Test Realty A'
+
+
+def test_mls_listing_url_round_trip_on_deal(app, seed, owner_a_client, client):
+    from services.portal_service import normalize_mls_listing_url, public_mls_listing_url
+
+    assert normalize_mls_listing_url('') is None
+    assert normalize_mls_listing_url('https://har.com/listing/123') == (
+        'https://har.com/listing/123'
+    )
+    assert public_mls_listing_url('javascript:alert(1)') is None
+
+    with app.app_context():
+        tx = _seller_tx(seed, '913 Mls Link Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        tx_id, code = tx.id, access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+    empty = client.get('/api/client/v1/deal', headers=_auth_headers(token)).get_json()
+    assert empty['mls_listing_url'] is None
+    assert empty['headline']['mls_listing_url'] is None
+
+    rejected = owner_a_client.post(
+        f'/transactions/{tx_id}/mls-listing-url',
+        json={'mls_listing_url': 'javascript:alert(1)'},
+    )
+    assert rejected.status_code == 400
+
+    saved = owner_a_client.post(
+        f'/transactions/{tx_id}/mls-listing-url',
+        json={'mls_listing_url': 'https://har.com/listing/913'},
+    )
+    assert saved.status_code == 200
+    assert saved.get_json()['mls_listing_url'] == 'https://har.com/listing/913'
+
+    deal = client.get('/api/client/v1/deal', headers=_auth_headers(token)).get_json()
+    assert deal['mls_listing_url'] == 'https://har.com/listing/913'
+    assert deal['headline']['mls_listing_url'] == 'https://har.com/listing/913'
+
+    cleared = owner_a_client.post(
+        f'/transactions/{tx_id}/mls-listing-url',
+        json={'mls_listing_url': ''},
+    )
+    assert cleared.status_code == 200
+    assert cleared.get_json()['mls_listing_url'] is None
+    cleared_deal = client.get(
+        '/api/client/v1/deal', headers=_auth_headers(token),
+    ).get_json()
+    assert cleared_deal['mls_listing_url'] is None

--- a/tests/test_client_portal_api.py
+++ b/tests/test_client_portal_api.py
@@ -216,12 +216,30 @@ def test_jwt_required_cookie_login_is_not_enough(app, seed, owner_a_client, clie
 
     for path in (
         '/api/client/v1/deal',
+        '/api/client/v1/milestones',
         '/api/client/v1/messages',
         '/api/client/v1/documents',
+        '/api/client/v1/documents/1/file',
+        '/api/client/v1/showings',
     ):
         assert owner_a_client.get(path).status_code == 401
         assert client.get(path).status_code == 401
-        assert client.get(path, headers=_auth_headers(token)).status_code == 200
+
+    assert client.get(
+        '/api/client/v1/deal', headers=_auth_headers(token),
+    ).status_code == 200
+    assert client.get(
+        '/api/client/v1/milestones', headers=_auth_headers(token),
+    ).status_code == 200
+    assert client.get(
+        '/api/client/v1/messages', headers=_auth_headers(token),
+    ).status_code == 200
+    assert client.get(
+        '/api/client/v1/documents', headers=_auth_headers(token),
+    ).status_code == 200
+    assert client.get(
+        '/api/client/v1/showings', headers=_auth_headers(token),
+    ).status_code == 200
 
     assert owner_a_client.post(
         '/api/client/v1/showings/1/approve',
@@ -229,7 +247,9 @@ def test_jwt_required_cookie_login_is_not_enough(app, seed, owner_a_client, clie
     assert owner_a_client.post(
         '/api/client/v1/showings/1/decline',
     ).status_code == 401
-    assert owner_a_client.post('/api/client/v1/session/leave').status_code == 401
+    assert owner_a_client.delete('/api/client/v1/session').status_code == 401
+    leftover = owner_a_client.post('/api/client/v1/session/leave')
+    assert leftover.status_code == 404
 
 
 def test_deal_payload_is_client_safe(app, seed, client):
@@ -368,6 +388,7 @@ def test_documents_only_that_participant(app, seed, client, monkeypatch):
         ))
         db.session.commit()
         code = access.invite_code
+        mine_id, other_id = mine.id, theirs.id
 
     token = _open_session(client, code).get_json()['token']
     docs = client.get(
@@ -378,6 +399,20 @@ def test_documents_only_that_participant(app, seed, client, monkeypatch):
     assert 'Buyer Rep' not in names
     listing = next(row for row in docs['completed'] if row['name'] == 'Listing Agreement')
     assert listing['view_url'].startswith('https://signed.example/')
+    assert listing['doc_id'] == mine_id
+
+    file_resp = client.get(
+        f'/api/client/v1/documents/{mine_id}/file',
+        headers=_auth_headers(token),
+    )
+    assert file_resp.status_code in (302, 301)
+    assert file_resp.headers['Location'].startswith('https://signed.example/')
+
+    denied = client.get(
+        f'/api/client/v1/documents/{other_id}/file',
+        headers=_auth_headers(token),
+    )
+    assert denied.status_code == 403
 
 
 def test_showing_approve_decline_only_when_pending(app, seed, client):
@@ -420,6 +455,13 @@ def test_showing_approve_decline_only_when_pending(app, seed, client):
     token = _open_session(client, code).get_json()['token']
     headers = _auth_headers(token)
 
+    listed = client.get('/api/client/v1/showings', headers=headers)
+    assert listed.status_code == 200
+    showing_ids = [item['id'] for item in listed.get_json()['items']]
+    assert pending_id in showing_ids
+    assert scheduled_id in showing_ids
+    assert all('showing_agent_name' not in item for item in listed.get_json()['items'])
+
     denied = client.post(
         f'/api/client/v1/showings/{scheduled_id}/approve', headers=headers,
     )
@@ -455,8 +497,13 @@ def test_session_leave_invalidates_jwt_not_invite(app, seed, client):
         '/api/client/v1/deal', headers=_auth_headers(token),
     ).status_code == 200
 
-    left = client.post(
+    leftover = client.post(
         '/api/client/v1/session/leave', headers=_auth_headers(token),
+    )
+    assert leftover.status_code == 404
+
+    left = client.delete(
+        '/api/client/v1/session', headers=_auth_headers(token),
     )
     assert left.status_code == 200
     assert client.get(
@@ -469,6 +516,48 @@ def test_session_leave_invalidates_jwt_not_invite(app, seed, client):
         '/api/client/v1/deal',
         headers=_auth_headers(again.get_json()['token']),
     ).status_code == 200
+
+
+def test_milestones_wrap_portal_dto(app, seed, client):
+    from models import SellerAcceptedContract, SellerContractMilestone
+
+    with app.app_context():
+        tx = _seller_tx(seed, '913 Milestone Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        contract = SellerAcceptedContract(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            position='primary',
+            status='active',
+            accepted_price=400000,
+        )
+        db.session.add(contract)
+        db.session.flush()
+        db.session.add(SellerContractMilestone(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            accepted_contract_id=contract.id,
+            milestone_key='option_period',
+            title='Option period ends',
+            due_at=datetime.utcnow() + timedelta(days=6),
+            status='not_started',
+        ))
+        db.session.commit()
+        code = access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+    resp = client.get(
+        '/api/client/v1/milestones', headers=_auth_headers(token),
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    titles = [item['title'] for item in body['items']]
+    assert 'Option period ends' in titles
+    blob = json.dumps(body)
+    assert 'commission' not in blob.lower()
+    assert 'lockbox' not in blob.lower()
 
 
 def test_messages_round_trip(app, seed, client):

--- a/tests/test_client_portal_api.py
+++ b/tests/test_client_portal_api.py
@@ -1,0 +1,610 @@
+"""Client iPhone app API: invite codes, JWT sessions, client-safe deal."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+from models import (
+    ClientPortalAccess,
+    DocumentSignature,
+    Organization,
+    PortalMessage,
+    SellerCommissionTerms,
+    SellerListingProfile,
+    SellerShowing,
+    Transaction,
+    TransactionDocument,
+    TransactionParticipant,
+    TransactionRequirement,
+    TransactionType,
+    db,
+)
+
+
+LOCKBOX_SECRET = 'LOCK-SECRET-99'
+RENTCAST_SECRET = 'RENTCAST-HIDE-ME'
+OTHER_PARTY_EMAIL = 'other-party-secret@example.com'
+COMMISSION_TITLE = 'Listing commission CDA'
+
+
+def _seller_tx(seed, address='900 Client App Ln'):
+    tx_type = TransactionType.query.filter_by(
+        organization_id=seed['org_a'], name='seller',
+    ).first()
+    tx = Transaction(
+        organization_id=seed['org_a'],
+        created_by_id=seed['owner_a'],
+        transaction_type_id=tx_type.id,
+        street_address=address,
+        city='Austin',
+        state='TX',
+        zip_code='78701',
+        status='active',
+        rentcast_data={'secret': RENTCAST_SECRET},
+    )
+    db.session.add(tx)
+    db.session.flush()
+    return tx
+
+
+def _participant(seed, tx, *, role='seller', contact_id=None, name=None, email=None):
+    p = TransactionParticipant(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        contact_id=contact_id,
+        role=role,
+        name=name,
+        email=email,
+        is_primary=True,
+    )
+    db.session.add(p)
+    db.session.flush()
+    return p
+
+
+def _grant(seed, tx, participant, *, invite_expires_at=None):
+    access = ClientPortalAccess(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        participant_id=participant.id,
+        token=ClientPortalAccess.generate_token(),
+        invite_code=ClientPortalAccess.generate_invite_code(),
+        session_version=1,
+        is_active=True,
+        invite_expires_at=invite_expires_at,
+    )
+    db.session.add(access)
+    db.session.flush()
+    return access
+
+
+def _auth_headers(token):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _open_session(client, code):
+    return client.post(
+        '/api/client/v1/session',
+        json={'code': code},
+        content_type='application/json',
+    )
+
+
+def test_invite_code_create_rotate_revoke_binds_one_participant(
+    app, seed, owner_a_client,
+):
+    with app.app_context():
+        tx = _seller_tx(seed, '901 Invite Bind Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        other = _participant(
+            seed, tx, role='co_seller', name='Pat Seller',
+            email='pat-seller@example.com',
+        )
+        db.session.commit()
+        tx_id, seller_id, other_id = tx.id, seller.id, other.id
+
+    created = owner_a_client.post(
+        f'/transactions/{tx_id}/portal/create',
+        json={'participant_id': seller_id},
+    )
+    assert created.status_code == 200
+    seller_link = created.get_json()['link']
+    assert seller_link['participant_id'] == seller_id
+    assert seller_link['invite_code']
+    seller_code = seller_link['invite_code']
+
+    other_created = owner_a_client.post(
+        f'/transactions/{tx_id}/portal/create',
+        json={'participant_id': other_id},
+    )
+    other_code = other_created.get_json()['link']['invite_code']
+    assert other_code != seller_code
+
+    seller_session = _open_session(owner_a_client, seller_code)
+    other_session = _open_session(owner_a_client, other_code)
+    assert seller_session.status_code == 200
+    assert other_session.status_code == 200
+
+    seller_deal = owner_a_client.get(
+        '/api/client/v1/deal',
+        headers=_auth_headers(seller_session.get_json()['token']),
+    ).get_json()
+    other_deal = owner_a_client.get(
+        '/api/client/v1/deal',
+        headers=_auth_headers(other_session.get_json()['token']),
+    ).get_json()
+    assert seller_deal['client_first_name'] == 'Jane'
+    assert other_deal['client_first_name'] == 'Pat'
+
+    rotated = owner_a_client.post(
+        f"/transactions/{tx_id}/portal/{seller_link['access_id']}/rotate",
+    )
+    assert rotated.status_code == 200
+    new_code = rotated.get_json()['link']['invite_code']
+    assert new_code != seller_code
+    assert _open_session(owner_a_client, seller_code).status_code == 401
+    assert _open_session(owner_a_client, new_code).status_code == 200
+    assert owner_a_client.get(
+        '/api/client/v1/deal',
+        headers=_auth_headers(seller_session.get_json()['token']),
+    ).status_code == 401
+
+    revoked = owner_a_client.post(
+        f"/transactions/{tx_id}/portal/{seller_link['access_id']}/revoke",
+    )
+    assert revoked.status_code == 200
+    assert _open_session(owner_a_client, new_code).status_code == 401
+
+
+def test_session_exchange_valid_invalid_revoked_expired(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '902 Session Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        expired = _grant(
+            seed, tx,
+            _participant(seed, tx, role='co_seller', name='Expired Person',
+                         email='expired-person@example.com'),
+            invite_expires_at=datetime.utcnow() - timedelta(days=1),
+        )
+        revoked = _grant(
+            seed, tx,
+            _participant(seed, tx, role='co_seller', name='Revoked Person',
+                         email='revoked-person@example.com'),
+        )
+        revoked.revoke()
+        org = db.session.get(Organization, seed['org_a'])
+        org.logo_url = 'https://example.com/origen-logo.png'
+        org.brand_accent = '#123456'
+        db.session.commit()
+        valid_code = access.invite_code_display
+        expired_code = expired.invite_code
+        revoked_code = revoked.invite_code
+
+    try:
+        ok = _open_session(client, valid_code)
+        assert ok.status_code == 200
+        body = ok.get_json()
+        assert body['token']
+        assert body['token_type'] == 'Bearer'
+        assert body['expires_in'] > 0
+        branding = body['branding']
+        assert branding['name'] == 'Test Realty A'
+        assert branding['logo_url'] == 'https://example.com/origen-logo.png'
+        assert branding['accent'] == '#123456'
+
+        assert _open_session(client, 'NOTA-CODE').status_code == 401
+        assert _open_session(client, revoked_code).status_code == 401
+        assert _open_session(client, expired_code).status_code == 401
+    finally:
+        with app.app_context():
+            org = db.session.get(Organization, seed['org_a'])
+            org.logo_url = None
+            org.brand_accent = None
+            db.session.commit()
+
+
+def test_jwt_required_cookie_login_is_not_enough(app, seed, owner_a_client, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '903 Jwt Gate Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+
+    for path in (
+        '/api/client/v1/deal',
+        '/api/client/v1/messages',
+        '/api/client/v1/documents',
+    ):
+        assert owner_a_client.get(path).status_code == 401
+        assert client.get(path).status_code == 401
+        assert client.get(path, headers=_auth_headers(token)).status_code == 200
+
+    assert owner_a_client.post(
+        '/api/client/v1/showings/1/approve',
+    ).status_code == 401
+    assert owner_a_client.post(
+        '/api/client/v1/showings/1/decline',
+    ).status_code == 401
+    assert owner_a_client.post('/api/client/v1/session/leave').status_code == 401
+
+
+def test_deal_payload_is_client_safe(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '904 Safe Deal Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        _participant(
+            seed, tx, role='buyer', name='Hidden Buyer',
+            email=OTHER_PARTY_EMAIL,
+        )
+        access = _grant(seed, tx, seller)
+        db.session.add(SellerListingProfile(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            current_list_price=450000,
+            access_type='lockbox',
+            lockbox_type='supra',
+            gate_code=LOCKBOX_SECRET,
+            private_showing_notes='Do not tell the client the combo.',
+        ))
+        db.session.add(SellerCommissionTerms(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            listing_commission_percent=3,
+            listing_commission_flat=15000,
+        ))
+        db.session.add(SellerShowing(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            showing_agent_name='Rival Agent',
+            showing_agent_email='rival@other-broker.com',
+            showing_agent_phone='5559990000',
+            showing_agent_brokerage='Other Brokerage',
+            buyer_name='Secret Buyer',
+            scheduled_start_at=datetime.utcnow() + timedelta(days=1),
+            status=SellerShowing.STATUS_PENDING_APPROVAL,
+            access_instructions_snapshot=LOCKBOX_SECRET,
+            private_notes='Lockbox code inside',
+        ))
+        db.session.add(TransactionRequirement(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            package_key='test',
+            phase_key='option',
+            requirement_key='earnest_money',
+            title='Deliver earnest money',
+            work_status='pending',
+            responsible_party_label='Seller',
+        ))
+        db.session.add(TransactionRequirement(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            package_key='test',
+            phase_key='internal',
+            requirement_key='listing_commission_cda',
+            title=COMMISSION_TITLE,
+            work_status='pending',
+        ))
+        db.session.commit()
+        code = access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+    resp = client.get('/api/client/v1/deal', headers=_auth_headers(token))
+    assert resp.status_code == 200
+    deal = resp.get_json()
+    blob = json.dumps(deal)
+
+    assert deal['property']['street'] == '904 Safe Deal Ln'
+    titles = [row['title'] for row in deal['requirements']]
+    assert 'Deliver earnest money' in titles
+    assert COMMISSION_TITLE not in titles
+    assert 'assignee_user_id' not in blob
+    assert 'risk_level' not in blob
+
+    assert 'commission' not in blob.lower()
+    assert LOCKBOX_SECRET not in blob
+    assert RENTCAST_SECRET not in blob
+    assert OTHER_PARTY_EMAIL not in blob
+    assert 'rival@other-broker.com' not in blob
+    assert '5559990000' not in blob
+    assert 'Secret Buyer' not in blob
+    assert 'lockbox' not in blob.lower()
+    assert 'rentcast' not in blob.lower()
+    assert deal['showings']['items'][0]['id']
+    assert deal['showings']['items'][0]['can_decide'] is True
+    assert 'showing_agent_name' not in blob
+
+
+def test_documents_only_that_participant(app, seed, client, monkeypatch):
+    monkeypatch.setattr(
+        'services.supabase_storage.get_transaction_document_url',
+        lambda path, expires_in=3600: f'https://signed.example/{path}',
+    )
+
+    with app.app_context():
+        tx = _seller_tx(seed, '905 Docs Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        mine = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            template_slug='listing-agreement',
+            template_name='Listing Agreement',
+            status='signed',
+            signed_file_path='org/tx/listing-signed.pdf',
+        )
+        theirs = TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            template_slug='buyer-rep',
+            template_name='Buyer Rep',
+            status='signed',
+            signed_file_path='org/tx/buyer-rep-signed.pdf',
+        )
+        db.session.add_all([mine, theirs])
+        db.session.flush()
+        db.session.add(DocumentSignature(
+            organization_id=seed['org_a'],
+            document_id=mine.id,
+            participant_id=seller.id,
+            signer_email='jane@test.com',
+            signer_name='Jane Doe',
+            signer_role='seller',
+            status='signed',
+        ))
+        db.session.add(DocumentSignature(
+            organization_id=seed['org_a'],
+            document_id=theirs.id,
+            signer_email=OTHER_PARTY_EMAIL,
+            signer_name='Hidden Buyer',
+            signer_role='buyer',
+            status='signed',
+        ))
+        db.session.commit()
+        code = access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+    docs = client.get(
+        '/api/client/v1/documents', headers=_auth_headers(token),
+    ).get_json()
+    names = [row['name'] for row in docs['completed']]
+    assert 'Listing Agreement' in names
+    assert 'Buyer Rep' not in names
+    listing = next(row for row in docs['completed'] if row['name'] == 'Listing Agreement')
+    assert listing['view_url'].startswith('https://signed.example/')
+
+
+def test_showing_approve_decline_only_when_pending(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '906 Showing Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        pending = SellerShowing(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            showing_agent_name='Tour Agent',
+            showing_agent_brokerage='Visitor Realty',
+            scheduled_start_at=datetime.utcnow() + timedelta(days=2),
+            status=SellerShowing.STATUS_PENDING_APPROVAL,
+        )
+        scheduled = SellerShowing(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            showing_agent_name='Already Booked',
+            showing_agent_brokerage='Visitor Realty',
+            scheduled_start_at=datetime.utcnow() + timedelta(days=3),
+            status=SellerShowing.STATUS_SCHEDULED,
+        )
+        to_decline = SellerShowing(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            showing_agent_name='Maybe Not',
+            showing_agent_brokerage='Visitor Realty',
+            scheduled_start_at=datetime.utcnow() + timedelta(days=4),
+            status=SellerShowing.STATUS_PENDING_APPROVAL,
+        )
+        db.session.add_all([pending, scheduled, to_decline])
+        db.session.commit()
+        code = access.invite_code
+        pending_id, scheduled_id, decline_id = pending.id, scheduled.id, to_decline.id
+
+    token = _open_session(client, code).get_json()['token']
+    headers = _auth_headers(token)
+
+    denied = client.post(
+        f'/api/client/v1/showings/{scheduled_id}/approve', headers=headers,
+    )
+    assert denied.status_code == 409
+
+    approved = client.post(
+        f'/api/client/v1/showings/{pending_id}/approve', headers=headers,
+    )
+    assert approved.status_code == 200
+    assert approved.get_json()['status'] == 'approved'
+    assert client.post(
+        f'/api/client/v1/showings/{pending_id}/approve', headers=headers,
+    ).status_code == 409
+
+    declined = client.post(
+        f'/api/client/v1/showings/{decline_id}/decline', headers=headers,
+    )
+    assert declined.status_code == 200
+    assert declined.get_json()['status'] == 'declined'
+
+
+def test_session_leave_invalidates_jwt_not_invite(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '907 Leave Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+
+    first = _open_session(client, code)
+    token = first.get_json()['token']
+    assert client.get(
+        '/api/client/v1/deal', headers=_auth_headers(token),
+    ).status_code == 200
+
+    left = client.post(
+        '/api/client/v1/session/leave', headers=_auth_headers(token),
+    )
+    assert left.status_code == 200
+    assert client.get(
+        '/api/client/v1/deal', headers=_auth_headers(token),
+    ).status_code == 401
+
+    again = _open_session(client, code)
+    assert again.status_code == 200
+    assert client.get(
+        '/api/client/v1/deal',
+        headers=_auth_headers(again.get_json()['token']),
+    ).status_code == 200
+
+
+def test_messages_round_trip(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '908 Notes Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.add(PortalMessage(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            participant_id=seller.id,
+            sender='agent',
+            kind='update',
+            body='Inspection is booked for Thursday.',
+            author_user_id=seed['owner_a'],
+        ))
+        db.session.commit()
+        code = access.invite_code
+
+    token = _open_session(client, code).get_json()['token']
+    headers = _auth_headers(token)
+    listed = client.get('/api/client/v1/messages', headers=headers).get_json()
+    assert listed['messages'][0]['body'] == 'Inspection is booked for Thursday.'
+
+    posted = client.post(
+        '/api/client/v1/messages',
+        headers=headers,
+        json={'body': 'Thanks, I can be there.'},
+    )
+    assert posted.status_code == 201
+    again = client.get('/api/client/v1/messages', headers=headers).get_json()
+    bodies = [m['body'] for m in again['messages']]
+    assert 'Thanks, I can be there.' in bodies
+
+
+def test_feature_flag_hides_invite_and_branding(app, seed, owner_b_client):
+    settings = owner_b_client.get('/org/settings')
+    assert settings.status_code == 200
+    html = settings.get_data(as_text=True)
+    assert 'Client app accent' not in html
+    assert 'iPhone app' not in html
+
+    owner_b_client.post('/org/settings/update', data={
+        'name': 'Test Realty B',
+        'brand_accent': '#112233',
+    }, follow_redirects=True)
+    with app.app_context():
+        org_b = db.session.get(Organization, seed['org_b'])
+        assert org_b.brand_accent is None
+
+    invite = owner_b_client.post(
+        f'/transactions/{seed["tx_b"]}/portal/create',
+        json={'participant_id': 1},
+    )
+    assert invite.status_code in (302, 403, 404)
+
+
+def test_branding_fields_persist(app, seed, owner_a_client, client):
+    try:
+        resp = owner_a_client.post('/org/settings/update', data={
+            'name': 'Origen Realty',
+            'logo_url': 'https://example.com/origen.png',
+            'brand_accent': '#ea580c',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'Client app accent' in html
+        assert 'https://example.com/origen.png' in html
+        assert '#ea580c' in html
+
+        with app.app_context():
+            org = db.session.get(Organization, seed['org_a'])
+            assert org.name == 'Origen Realty'
+            assert org.logo_url == 'https://example.com/origen.png'
+            assert org.brand_accent == '#ea580c'
+            tx = _seller_tx(seed, '909 Brand Ln')
+            seller = _participant(seed, tx, contact_id=seed['contact_a'])
+            access = _grant(seed, tx, seller)
+            db.session.commit()
+            code = access.invite_code
+
+        session = _open_session(client, code).get_json()
+        branding = session['branding']
+        assert branding['name'] == 'Origen Realty'
+        assert branding['logo_url'] == 'https://example.com/origen.png'
+        assert branding['accent'] == '#ea580c'
+    finally:
+        with app.app_context():
+            org = db.session.get(Organization, seed['org_a'])
+            org.name = 'Test Realty A'
+            org.logo_url = None
+            org.brand_accent = None
+            db.session.commit()
+
+
+def test_invite_ui_on_transaction_not_old_portal_chrome(app, seed, owner_a_client):
+    with app.app_context():
+        tx = _seller_tx(seed, '910 Invite Ui Ln')
+        _participant(seed, tx, contact_id=seed['contact_a'])
+        db.session.commit()
+        tx_id = tx.id
+
+    page = owner_a_client.get(f'/transactions/{tx_id}')
+    assert page.status_code == 200
+    html = page.get_data(as_text=True)
+    assert 'Client app invite' in html
+    assert 'Create invite' in html
+    assert 'Client portal' not in html
+    assert 'showing approval board' not in html.lower()
+
+
+def test_expired_jwt_is_rejected(app, seed, client):
+    import time
+    from services.client_portal_auth import issue_client_jwt
+
+    with app.app_context():
+        tx = _seller_tx(seed, '912 Expired Jwt Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        token = issue_client_jwt(access, now=int(time.time()) - 120, ttl_seconds=30)
+
+    assert client.get(
+        '/api/client/v1/deal', headers=_auth_headers(token),
+    ).status_code == 401
+
+
+def test_default_branding_uses_product_orange(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '911 Default Brand Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+
+    branding = _open_session(client, code).get_json()['branding']
+    assert branding['accent'] == '#f97316'
+    assert branding['accent_ink'] == '#ea580c'
+    assert branding['name'] == 'Test Realty A'

--- a/tests/test_client_portal_api.py
+++ b/tests/test_client_portal_api.py
@@ -82,12 +82,21 @@ def _auth_headers(token):
     return {'Authorization': f'Bearer {token}'}
 
 
-def _open_session(client, code):
+def _open_session(client, code, key='code'):
     return client.post(
         '/api/client/v1/session',
-        json={'code': code},
+        json={key: code},
         content_type='application/json',
     )
+
+
+def _assert_bearer_session(resp):
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['token']
+    assert body['token_type'] == 'Bearer'
+    assert body['expires_in'] > 0
+    return body
 
 
 def test_invite_code_create_rotate_revoke_binds_one_participant(
@@ -122,8 +131,10 @@ def test_invite_code_create_rotate_revoke_binds_one_participant(
 
     seller_session = _open_session(owner_a_client, seller_code)
     other_session = _open_session(owner_a_client, other_code)
-    assert seller_session.status_code == 200
-    assert other_session.status_code == 200
+    _assert_bearer_session(seller_session)
+    _assert_bearer_session(other_session)
+    assert 'url' not in seller_link
+    assert 'url' not in other_created.get_json()['link']
 
     seller_deal = owner_a_client.get(
         '/api/client/v1/deal',
@@ -142,8 +153,8 @@ def test_invite_code_create_rotate_revoke_binds_one_participant(
     assert rotated.status_code == 200
     new_code = rotated.get_json()['link']['invite_code']
     assert new_code != seller_code
-    assert _open_session(owner_a_client, seller_code).status_code == 401
-    assert _open_session(owner_a_client, new_code).status_code == 200
+    assert _open_session(owner_a_client, seller_code).status_code == 422
+    _assert_bearer_session(_open_session(owner_a_client, new_code))
     assert owner_a_client.get(
         '/api/client/v1/deal',
         headers=_auth_headers(seller_session.get_json()['token']),
@@ -153,7 +164,7 @@ def test_invite_code_create_rotate_revoke_binds_one_participant(
         f"/transactions/{tx_id}/portal/{seller_link['access_id']}/revoke",
     )
     assert revoked.status_code == 200
-    assert _open_session(owner_a_client, new_code).status_code == 401
+    assert _open_session(owner_a_client, new_code).status_code == 422
 
 
 def test_session_exchange_valid_invalid_revoked_expired(app, seed, client):
@@ -183,19 +194,21 @@ def test_session_exchange_valid_invalid_revoked_expired(app, seed, client):
 
     try:
         ok = _open_session(client, valid_code)
-        assert ok.status_code == 200
-        body = ok.get_json()
-        assert body['token']
-        assert body['token_type'] == 'Bearer'
-        assert body['expires_in'] > 0
+        body = _assert_bearer_session(ok)
         branding = body['branding']
         assert branding['name'] == 'Test Realty A'
         assert branding['logo_url'] == 'https://example.com/origen-logo.png'
         assert branding['accent'] == '#123456'
 
-        assert _open_session(client, 'NOTA-CODE').status_code == 401
-        assert _open_session(client, revoked_code).status_code == 401
-        assert _open_session(client, expired_code).status_code == 401
+        assert _open_session(client, 'NOTA-CODE').status_code == 422
+        assert _open_session(client, revoked_code).status_code == 422
+        assert _open_session(client, expired_code).status_code == 422
+        assert client.post(
+            '/api/client/v1/session',
+            json={},
+            content_type='application/json',
+        ).status_code == 422
+        assert client.post('/api/client/v1/session').status_code == 422
     finally:
         with app.app_context():
             org = db.session.get(Organization, seed['org_a'])
@@ -250,6 +263,54 @@ def test_jwt_required_cookie_login_is_not_enough(app, seed, owner_a_client, clie
     assert owner_a_client.delete('/api/client/v1/session').status_code == 401
     leftover = owner_a_client.post('/api/client/v1/session/leave')
     assert leftover.status_code == 404
+
+
+def test_session_accepts_invite_code_or_code(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '914 Session Keys Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        other = _participant(
+            seed, tx, role='co_seller', name='Second Seller',
+            email='second-seller@example.com',
+        )
+        access = _grant(seed, tx, seller)
+        other_access = _grant(seed, tx, other)
+        db.session.commit()
+        valid = access.invite_code_display
+        other_valid = other_access.invite_code_display
+
+    native = _open_session(client, valid, key='invite_code')
+    _assert_bearer_session(native)
+
+    legacy = _open_session(client, other_valid, key='code')
+    _assert_bearer_session(legacy)
+
+    prefer_native = client.post(
+        '/api/client/v1/session',
+        json={'invite_code': valid, 'code': 'NOTA-CODE'},
+        content_type='application/json',
+    )
+    _assert_bearer_session(prefer_native)
+
+    ignore_legacy = client.post(
+        '/api/client/v1/session',
+        json={'invite_code': 'NOTA-CODE', 'code': valid},
+        content_type='application/json',
+    )
+    assert ignore_legacy.status_code == 422
+
+
+def test_session_role_gate_is_case_insensitive(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '915 Role Case Ln')
+        seller = _participant(
+            seed, tx, role='Seller', contact_id=seed['contact_a'],
+        )
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+
+    _assert_bearer_session(_open_session(client, code, key='invite_code'))
 
 
 def test_deal_payload_is_client_safe(app, seed, client):
@@ -667,6 +728,9 @@ def test_invite_ui_on_transaction_not_old_portal_chrome(app, seed, owner_a_clien
     assert 'Create invite' in html
     assert 'Client portal' not in html
     assert 'showing approval board' not in html.lower()
+    assert 'alert(' not in html.split('id="client-app-invite"')[1].split('</script>')[0]
+    assert 'showCrmToast' in html
+    assert 'data-invite-error' in html
 
 
 def test_expired_jwt_is_rejected(app, seed, client):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wraps the existing client portal so Christopher's iPhone app can talk JSON. Native owns iOS. This PR is CRM only. Routes match the iOS client on main exactly.

## Exact routes
- `POST /api/client/v1/session`
- `GET /api/client/v1/deal`
- `GET /api/client/v1/milestones`
- `GET /api/client/v1/messages`
- `POST /api/client/v1/messages`
- `GET /api/client/v1/documents`
- `GET /api/client/v1/documents/{id}/file`
- `GET /api/client/v1/showings`
- `POST /api/client/v1/showings/{id}/approve`
- `POST /api/client/v1/showings/{id}/decline`
- `DELETE /api/client/v1/session`

No `POST /session/leave`. No leftover aliases.

## Auth
`POST /session` reads `invite_code` first, then falls back to `code`. A real redeem returns 200 with a Bearer JWT. Bad, missing, unknown, revoked, or expired invites return 422. Other `/api/client/v1/*` routes still return 401 for a missing or expired JWT. The grant token never goes in a URL. `DELETE /session` bumps `session_version` so that JWT dies. The invite still works until an agent rotates or revokes it. A CRM cookie is not enough.

## Reused
- `ClientPortalAccess` plus generate / rotate / revoke
- `services/portal_service.py` `build_portal_context` as the client-safe DTO
- `PortalMessage` for deal-scoped notes
- `TransactionDocument` signed URLs for that participant's docs only
- `Organization.name` and `logo_url`

## Also added
- Client-safe requirements on `GET /deal`
- Org accent color (`brand_accent`) with product orange `#f97316` / `#ea580c` when unset
- Agent invite controls on the transaction, and accent on org settings, both gated on `TRANSACTIONS`
- Agent portal JSON no longer includes the HTML magic-link URL
- Invite UI uses toast / inline error instead of `alert()`
- Role gates compare case-insensitively

## Deliberately not rebuilt
- The HTML portal
- Agent showings UI (removed on purpose; agents use HAR)
- Lockbox, commissions, RentCast, or other parties' PII
- Free CRM / contacts. Invite and branding stay on paid transactions.

## Tests
`tests/test_client_portal_api.py` covers grant binding, both session keys, 200 + Bearer on redeem, 422 on a bad invite, JWT vs cookie (401), client-safe deal, participant-only docs and file fetch, showings list plus approve/decline only when `pending_approval`, `DELETE /session`, leftover leave path gone, feature-flag hide/block, and branding persist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b01fe64-f637-4b54-bfb4-894e47ff6636?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b01fe64-f637-4b54-bfb4-894e47ff6636&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

