### PR TITLE
feat: /api/agent/v1 for the agent iPhone app

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,7 @@ from routes.inbound_email import inbound_bp
 from routes.partner_directory import partner_directory_bp
 from routes.portal import portal_bp
 from routes.client_api import client_api_bp
+from routes.agent_api import agent_api_bp
 from routes.groups import groups_bp
 from routes.analytics_webhooks import analytics_webhooks_bp
 from routes.bob_telegram import bob_telegram_bp
@@ -270,6 +271,7 @@ def create_app():
     app.register_blueprint(partner_directory_bp)
     app.register_blueprint(portal_bp)
     app.register_blueprint(client_api_bp)
+    app.register_blueprint(agent_api_bp)
     app.register_blueprint(groups_bp)
     app.register_blueprint(analytics_webhooks_bp)
     app.register_blueprint(bob_telegram_bp)
@@ -325,6 +327,8 @@ def create_app():
         2. Check if the user's session has been invalidated
         3. Set the PostgreSQL app.current_org_id for RLS
         """
+        if request.path.startswith('/api/agent/v1'):
+            return
         if not current_user.is_authenticated:
             return
         

--- a/jobs/apns_push.py
+++ b/jobs/apns_push.py
@@ -1,0 +1,72 @@
+"""Send an APNs alert for a PortalMessage.
+
+No-ops when APNS_* env is missing. The RQ worker consumes the apns queue.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from jobs.base import set_job_org_context
+
+logger = logging.getLogger(__name__)
+
+APNS_ENV_KEYS = ('APNS_KEY_ID', 'APNS_TEAM_ID', 'APNS_KEY', 'APNS_BUNDLE_ID')
+
+
+def apns_configured() -> bool:
+    return all((os.environ.get(key) or '').strip() for key in APNS_ENV_KEYS)
+
+
+def send_portal_push(*, message_id: int, org_id: int):
+    """Deliver APNs to the other side of a PortalMessage. Missing env is a no-op."""
+    if not apns_configured():
+        logger.info(
+            'APNs skipped: APNS_* env missing (message_id=%s org_id=%s)',
+            message_id, org_id,
+        )
+        return {'ok': False, 'reason': 'apns_unconfigured'}
+
+    from app import app
+    from models import DeviceToken, PortalMessage
+
+    with app.app_context():
+        set_job_org_context(org_id)
+        msg = PortalMessage.query.filter_by(
+            id=message_id, organization_id=org_id,
+        ).first()
+        if not msg:
+            logger.info('APNs skipped: message %s not found', message_id)
+            return {'ok': False, 'reason': 'message_not_found'}
+
+        if msg.sender == 'client':
+            tokens = DeviceToken.query.filter_by(
+                organization_id=org_id,
+                audience=DeviceToken.AUDIENCE_AGENT,
+            ).all()
+        else:
+            tokens = DeviceToken.query.filter_by(
+                organization_id=org_id,
+                audience=DeviceToken.AUDIENCE_CLIENT,
+                participant_id=msg.participant_id,
+            ).all()
+
+        if not tokens:
+            logger.info('APNs skipped: no device tokens for message %s', message_id)
+            return {'ok': False, 'reason': 'no_tokens'}
+
+        sent = 0
+        for row in tokens:
+            if _send_one(row.token, msg):
+                sent += 1
+        return {'ok': True, 'sent': sent}
+
+
+def _send_one(device_token: str, msg) -> bool:
+    """HTTP/2 APNs post. Isolated so missing env never reaches here."""
+    try:
+        from services.apns_client import send_alert
+        return bool(send_alert(device_token, msg))
+    except Exception:
+        logger.exception('APNs send failed for token suffix %s', device_token[-8:])
+        return False

--- a/migrations/versions/add_agent_api_tokens.py
+++ b/migrations/versions/add_agent_api_tokens.py
@@ -1,0 +1,121 @@
+"""Agent API session version and device tokens.
+
+Revision ID: add_agent_api_tokens
+Revises: add_tx_mls_listing_url
+Create Date: 2026-08-20
+
+Adds:
+- user.session_version (invalidates issued agent JWTs)
+- device_tokens (APNs tokens for agent and client apps)
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = 'add_agent_api_tokens'
+down_revision = 'add_tx_mls_listing_url'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table_name, column_name):
+    tables = inspect(conn).get_table_names()
+    if table_name not in tables:
+        return False
+    return column_name in {
+        col['name'] for col in inspect(conn).get_columns(table_name)
+    }
+
+
+def _table_exists(conn, table_name):
+    return table_name in inspect(conn).get_table_names()
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not _column_exists(conn, 'user', 'session_version'):
+        op.add_column(
+            'user',
+            sa.Column(
+                'session_version',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('1'),
+            ),
+        )
+
+    if not _table_exists(conn, 'device_tokens'):
+        op.create_table(
+            'device_tokens',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('organization_id', sa.Integer(), nullable=False),
+            sa.Column('audience', sa.String(length=20), nullable=False),
+            sa.Column('token', sa.String(length=255), nullable=False),
+            sa.Column('platform', sa.String(length=20), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=True),
+            sa.Column('participant_id', sa.Integer(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=False),
+            sa.Column('last_seen_at', sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint('id', name='pk_device_tokens'),
+            sa.ForeignKeyConstraint(
+                ['organization_id'], ['organizations.id'],
+                name='fk_device_tokens_org', ondelete='RESTRICT',
+            ),
+            sa.ForeignKeyConstraint(
+                ['user_id'], ['user.id'],
+                name='fk_device_tokens_user', ondelete='CASCADE',
+            ),
+            sa.ForeignKeyConstraint(
+                ['participant_id'], ['transaction_participants.id'],
+                name='fk_device_tokens_participant', ondelete='CASCADE',
+            ),
+            sa.UniqueConstraint(
+                'audience', 'token', name='uq_device_tokens_audience_token',
+            ),
+        )
+        op.create_index(
+            'ix_device_tokens_organization_id',
+            'device_tokens',
+            ['organization_id'],
+        )
+        op.create_index('ix_device_tokens_audience', 'device_tokens', ['audience'])
+        op.create_index('ix_device_tokens_user_id', 'device_tokens', ['user_id'])
+        op.create_index(
+            'ix_device_tokens_participant_id',
+            'device_tokens',
+            ['participant_id'],
+        )
+        op.create_index(
+            'ix_device_tokens_org_audience',
+            'device_tokens',
+            ['organization_id', 'audience'],
+        )
+
+    if conn.dialect.name == 'postgresql' and _table_exists(conn, 'device_tokens'):
+        op.execute('ALTER TABLE device_tokens ENABLE ROW LEVEL SECURITY')
+        op.execute('DROP POLICY IF EXISTS tenant_isolation_device_tokens ON device_tokens')
+        op.execute("""
+            CREATE POLICY tenant_isolation_device_tokens ON device_tokens
+            FOR ALL
+            USING (
+                organization_id = current_setting(
+                    'app.current_org_id', true
+                )::integer
+            )
+            WITH CHECK (
+                organization_id = current_setting(
+                    'app.current_org_id', true
+                )::integer
+            )
+        """)
+
+
+def downgrade():
+    conn = op.get_bind()
+    if conn.dialect.name == 'postgresql' and _table_exists(conn, 'device_tokens'):
+        op.execute('DROP POLICY IF EXISTS tenant_isolation_device_tokens ON device_tokens')
+    if _table_exists(conn, 'device_tokens'):
+        op.drop_table('device_tokens')
+    if _column_exists(conn, 'user', 'session_version'):
+        op.drop_column('user', 'session_version')

--- a/models.py
+++ b/models.py
@@ -232,6 +232,8 @@ class User(UserMixin, db.Model):
     
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     last_login = db.Column(db.DateTime)
+    # Bumped on agent API sign-out so issued agent JWTs stop working.
+    session_version = db.Column(db.Integer, nullable=False, default=1)
     
     # Optional profile fields
     phone = db.Column(db.String(20))
@@ -267,6 +269,9 @@ class User(UserMixin, db.Model):
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
+
+    def bump_session(self):
+        self.session_version = (self.session_version or 1) + 1
 
     def get_reset_token(self):
         s = Serializer(current_app.config['SECRET_KEY'])
@@ -4248,6 +4253,43 @@ class PortalMessage(db.Model):
     def __repr__(self):
         return (f'<PortalMessage {self.id} tx={self.transaction_id} '
                 f'sender={self.sender} kind={self.kind}>')
+
+
+class DeviceToken(db.Model):
+    """APNs device token for the agent or client iPhone app."""
+    __tablename__ = 'device_tokens'
+
+    AUDIENCE_AGENT = 'agent'
+    AUDIENCE_CLIENT = 'client'
+    AUDIENCES = {AUDIENCE_AGENT, AUDIENCE_CLIENT}
+
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id',
+                                ondelete='RESTRICT'), nullable=False, index=True)
+    audience = db.Column(db.String(20), nullable=False, index=True)
+    token = db.Column(db.String(255), nullable=False)
+    platform = db.Column(db.String(20), nullable=False, default='ios')
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'),
+                        nullable=True, index=True)
+    participant_id = db.Column(
+        db.Integer,
+        db.ForeignKey('transaction_participants.id', ondelete='CASCADE'),
+        nullable=True,
+        index=True,
+    )
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    last_seen_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    user = db.relationship('User', foreign_keys=[user_id])
+    participant = db.relationship('TransactionParticipant', foreign_keys=[participant_id])
+
+    __table_args__ = (
+        db.UniqueConstraint('audience', 'token', name='uq_device_tokens_audience_token'),
+        db.Index('ix_device_tokens_org_audience', 'organization_id', 'audience'),
+    )
+
+    def __repr__(self):
+        return f'<DeviceToken {self.audience} user={self.user_id} participant={self.participant_id}>'
 
 
 class McpOAuthClient(db.Model):

--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -1,0 +1,1170 @@
+"""JSON API for the agent iPhone app.
+
+Auth is an agent JWT (typ=agent). Flask-Login cookies are ignored.
+Do not reuse /transactions/api/* or the client_portal JWT.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from functools import wraps
+from types import SimpleNamespace
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy import or_, text
+from sqlalchemy.orm import joinedload, selectinload
+
+from feature_flags import get_org_features, org_has_feature
+from models import (
+    Contact,
+    ContactGroup,
+    DeviceToken,
+    Interaction,
+    PortalMessage,
+    SellerContractMilestone,
+    SellerListingProfile,
+    Task,
+    Transaction,
+    TransactionDocument,
+    TransactionParticipant,
+    TransactionType,
+    db,
+)
+from services.agent_auth import (
+    JWT_TTL_SECONDS,
+    find_login_user,
+    issue_agent_jwt,
+    load_user_from_jwt,
+    login_input_from_body,
+    org_is_active,
+    serialize_org,
+    serialize_user,
+)
+from services.agent_dashboard import build_dashboard, me_payload
+from services.contact_group_service import ContactGroupError, resolve_groups_for_owner
+from services.controlling_contracts import get_active_primary_contract
+from services.device_push import enqueue_portal_push, register_device
+from services.portal_service import CLIENT_PORTAL_ROLES, list_client_messages
+from services.tenant_service import org_query_for_id
+from services.transaction_auth import (
+    CAP_EDIT,
+    CAP_VIEW,
+    get_transaction_for_user,
+    transactions_visible_query,
+)
+
+logger = logging.getLogger(__name__)
+
+agent_api_bp = Blueprint('agent_api', __name__, url_prefix='/api/agent/v1')
+
+PORTAL_DATE_FIELDS = frozenset({
+    'expected_close_date',
+    'go_live_date',
+    'effective_date',
+    'closing_date',
+    'actual_close_date',
+})
+
+STATUS_OPTIONS_BY_TYPE = {
+    'seller': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'buyer': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'landlord': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+    'tenant': ['showing', 'under_contract', 'closed', 'cancelled'],
+    'referral': ['preparing_to_list', 'active', 'under_contract', 'closed', 'cancelled'],
+}
+
+MILESTONE_STATUSES = {
+    'not_started', 'waiting', 'due_soon', 'overdue', 'completed', 'not_applicable',
+}
+
+ROLE_MAP = {
+    'seller': 'seller',
+    'buyer': 'buyer',
+    'landlord': 'landlord',
+    'tenant': 'tenant',
+    'referral': 'referral_client',
+}
+
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+
+def _json_error(message, status=401, code=None):
+    payload = {'error': message}
+    if code:
+        payload['code'] = code
+    return jsonify(payload), status
+
+
+def _set_org_context(org_id: int) -> None:
+    try:
+        db.session.execute(
+            text("SELECT set_config('app.current_org_id', :org_id, false)"),
+            {'org_id': str(org_id)},
+        )
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+@agent_api_bp.teardown_request
+def _reset_org_context(exc=None):
+    try:
+        db.session.execute(text('RESET app.current_org_id'))
+        db.session.commit()
+    except Exception:
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
+
+
+def _bearer_token():
+    header = request.headers.get('Authorization') or ''
+    if header.lower().startswith('bearer '):
+        return header[7:].strip()
+    return ''
+
+
+def _json_body():
+    data = request.get_json(silent=True)
+    return data if isinstance(data, dict) else {}
+
+
+def _can_view_all(user):
+    return user.org_role in ('owner', 'admin')
+
+
+def _contacts_query(user):
+    query = org_query_for_id(Contact, user.organization_id)
+    if not _can_view_all(user):
+        query = query.filter_by(user_id=user.id)
+    return query
+
+
+def _contact_visible(user, contact):
+    if contact is None or contact.organization_id != user.organization_id:
+        return False
+    if _can_view_all(user):
+        return True
+    return contact.user_id == user.id
+
+
+def agent_jwt_required(view):
+    """Authorize from the agent JWT only. A CRM cookie is not enough."""
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        token = _bearer_token()
+        if not token:
+            return _json_error('Sign in with your email and password.', 401)
+        user, error = load_user_from_jwt(token)
+        if error:
+            return _json_error(error, 401)
+        _set_org_context(user.organization_id)
+        g.agent_user = user
+        return view(user, *args, **kwargs)
+
+    return wrapper
+
+
+def transactions_flag_required(view):
+    @wraps(view)
+    def wrapper(user, *args, **kwargs):
+        if not org_has_feature('TRANSACTIONS', user.organization):
+            return jsonify({
+                'code': 'transactions_required',
+                'error': 'Transactions are not on this plan.',
+            }), 403
+        return view(user, *args, **kwargs)
+
+    return wrapper
+
+
+def _parse_date(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.strptime(str(value)[:10], '%Y-%m-%d').date()
+    except (TypeError, ValueError) as exc:
+        raise ValueError('Use YYYY-MM-DD for dates.') from exc
+
+
+def _parse_datetime(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, datetime):
+        return value
+    text_value = str(value).strip()
+    for fmt in ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S.%f'):
+        try:
+            return datetime.strptime(text_value[:26], fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.combine(_parse_date(text_value), datetime.min.time())
+    except ValueError as exc:
+        raise ValueError('Use an ISO datetime.') from exc
+
+
+def _serialize_contact(contact):
+    return {
+        'id': contact.id,
+        'first_name': contact.first_name,
+        'last_name': contact.last_name,
+        'email': contact.email,
+        'phone': contact.phone,
+        'street_address': contact.street_address,
+        'city': contact.city,
+        'state': contact.state,
+        'zip_code': contact.zip_code,
+        'notes': contact.notes,
+        'potential_commission': float(contact.potential_commission or 0),
+        'current_objective': contact.current_objective,
+        'group_ids': [g.id for g in (contact.groups or [])],
+        'user_id': contact.user_id,
+        'created_at': contact.created_at.isoformat() if contact.created_at else None,
+    }
+
+
+def _tx_dates(tx):
+    profile = getattr(tx, 'seller_listing_profile', None)
+    contract = get_active_primary_contract(tx.id, tx.organization_id)
+    return {
+        'expected_close_date': (
+            tx.expected_close_date.isoformat() if tx.expected_close_date else None
+        ),
+        'actual_close_date': (
+            tx.actual_close_date.isoformat() if tx.actual_close_date else None
+        ),
+        'go_live_date': (
+            profile.go_live_date.isoformat()
+            if profile and profile.go_live_date else None
+        ),
+        'effective_date': (
+            contract.effective_date.isoformat()
+            if contract and contract.effective_date else None
+        ),
+        'closing_date': (
+            contract.closing_date.isoformat()
+            if contract and contract.closing_date else None
+        ),
+    }
+
+
+def _serialize_transaction(tx, *, detail=False):
+    payload = {
+        'id': tx.id,
+        'street_address': tx.street_address,
+        'city': tx.city,
+        'state': tx.state,
+        'zip_code': tx.zip_code,
+        'county': tx.county,
+        'status': tx.status,
+        'transaction_type_id': tx.transaction_type_id,
+        'transaction_type': (
+            tx.transaction_type.name if tx.transaction_type else None
+        ),
+        'mls_listing_url': tx.mls_listing_url,
+        'created_by_id': tx.created_by_id,
+        **_tx_dates(tx),
+    }
+    if detail:
+        payload['participants'] = [
+            _serialize_participant(p) for p in tx.participants.all()
+        ]
+    return payload
+
+
+def _serialize_participant(participant):
+    return {
+        'id': participant.id,
+        'role': participant.role,
+        'name': participant.display_name,
+        'email': participant.display_email,
+        'phone': participant.display_phone,
+        'contact_id': participant.contact_id,
+        'is_primary': bool(participant.is_primary),
+    }
+
+
+def _serialize_milestone(milestone):
+    return {
+        'id': milestone.id,
+        'title': milestone.title,
+        'milestone_key': milestone.milestone_key,
+        'due_at': milestone.due_at.isoformat() if milestone.due_at else None,
+        'status': milestone.status,
+        'responsible_party': milestone.responsible_party,
+        'source': milestone.source,
+        'notes': milestone.notes,
+        'completed_at': (
+            milestone.completed_at.isoformat() if milestone.completed_at else None
+        ),
+    }
+
+
+def _serialize_document(doc):
+    return {
+        'id': doc.id,
+        'name': doc.template_name,
+        'slug': doc.template_slug,
+        'status': doc.status,
+        'source': doc.document_source,
+        'has_file': bool(doc.signed_file_path or doc.source_file_path),
+        'created_at': doc.created_at.isoformat() if doc.created_at else None,
+    }
+
+
+def _load_tx(user, transaction_id, capability=CAP_VIEW):
+    tx, decision = get_transaction_for_user(
+        transaction_id, user=user, capability=capability,
+    )
+    if not tx:
+        status = 404 if decision.reason == 'not_found' else 403
+        return None, _json_error('Transaction not found.', status)
+    return tx, None
+
+
+@agent_api_bp.route('/session', methods=['POST'])
+def create_session():
+    data = _json_body()
+    password = data.get('password') or ''
+    login_input = login_input_from_body(data)
+    user = find_login_user(login_input)
+    if not user or not user.check_password(password):
+        return _json_error('Invalid email or password.', 401)
+    if not org_is_active(user):
+        return _json_error('This account is not active.', 401)
+
+    user.last_login = datetime.utcnow()
+    db.session.commit()
+    _set_org_context(user.organization_id)
+    token = issue_agent_jwt(user)
+    return jsonify({
+        'token': token,
+        'token_type': 'Bearer',
+        'expires_in': JWT_TTL_SECONDS,
+        'user': serialize_user(user),
+        'org': serialize_org(user.organization),
+        'features': get_org_features(user.organization),
+    })
+
+
+@agent_api_bp.route('/session', methods=['DELETE'])
+@agent_jwt_required
+def delete_session(user):
+    user.bump_session()
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@agent_api_bp.route('/me', methods=['GET'])
+@agent_jwt_required
+def get_me(user):
+    return jsonify(me_payload(user))
+
+
+@agent_api_bp.route('/devices', methods=['POST'])
+@agent_jwt_required
+def register_agent_device(user):
+    data = _json_body()
+    try:
+        row = register_device(
+            organization_id=user.organization_id,
+            audience=DeviceToken.AUDIENCE_AGENT,
+            token=data.get('token'),
+            platform=data.get('platform'),
+            user_id=user.id,
+        )
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    return jsonify({
+        'ok': True,
+        'device_id': row.id,
+        'platform': row.platform,
+    }), 201
+
+
+@agent_api_bp.route('/dashboard', methods=['GET'])
+@agent_jwt_required
+def get_dashboard(user):
+    return jsonify(build_dashboard(user))
+
+
+@agent_api_bp.route('/contacts', methods=['GET'])
+@agent_jwt_required
+def list_contacts(user):
+    query = _contacts_query(user).options(selectinload(Contact.groups))
+    q = (request.args.get('q') or '').strip()
+    if q:
+        like = f'%{q}%'
+        query = query.filter(or_(
+            Contact.first_name.ilike(like),
+            Contact.last_name.ilike(like),
+            Contact.email.ilike(like),
+            Contact.phone.ilike(like),
+        ))
+    group_id = request.args.get('group_id', type=int)
+    if group_id:
+        query = query.join(Contact.groups).filter(ContactGroup.id == group_id)
+    page = max(request.args.get('page', 1, type=int) or 1, 1)
+    per_page = request.args.get('per_page', 50, type=int) or 50
+    per_page = min(max(per_page, 1), 100)
+    pagination = query.order_by(Contact.last_name, Contact.first_name).paginate(
+        page=page, per_page=per_page, error_out=False,
+    )
+    return jsonify({
+        'contacts': [_serialize_contact(c) for c in pagination.items],
+        'page': pagination.page,
+        'per_page': pagination.per_page,
+        'total': pagination.total,
+        'pages': pagination.pages,
+    })
+
+
+@agent_api_bp.route('/contacts', methods=['POST'])
+@agent_jwt_required
+def create_contact(user):
+    data = _json_body()
+    first_name = (data.get('first_name') or '').strip()
+    last_name = (data.get('last_name') or '').strip()
+    if not first_name or not last_name:
+        return _json_error('First name and last name are required.', 400)
+
+    org = user.organization
+    if org and org.max_contacts is not None:
+        current_count = org_query_for_id(Contact, user.organization_id).count()
+        if current_count >= org.max_contacts:
+            return _json_error('Contact limit reached.', 403)
+
+    contact = Contact(
+        organization_id=user.organization_id,
+        user_id=user.id,
+        created_by_id=user.id,
+        first_name=first_name,
+        last_name=last_name,
+        email=(data.get('email') or '').strip() or None,
+        phone=(data.get('phone') or '').strip() or None,
+        street_address=(data.get('street_address') or '').strip() or None,
+        city=(data.get('city') or '').strip() or None,
+        state=(data.get('state') or '').strip() or None,
+        zip_code=(data.get('zip_code') or '').strip() or None,
+        notes=(data.get('notes') or '').strip() or None,
+        potential_commission=data.get('potential_commission') or 5000.00,
+        current_objective=(data.get('current_objective') or '').strip() or None,
+    )
+    try:
+        contact.groups = resolve_groups_for_owner(
+            user.organization_id,
+            user.id,
+            data.get('group_ids') or [],
+            active_only=True,
+        )
+    except ContactGroupError as exc:
+        return _json_error(exc.message, exc.status_code)
+    db.session.add(contact)
+    db.session.commit()
+    return jsonify({'contact': _serialize_contact(contact)}), 201
+
+
+@agent_api_bp.route('/contacts/<int:contact_id>', methods=['GET'])
+@agent_jwt_required
+def get_contact(user, contact_id):
+    contact = org_query_for_id(Contact, user.organization_id).filter_by(
+        id=contact_id,
+    ).first()
+    if not _contact_visible(user, contact):
+        return _json_error('Contact not found.', 404)
+    return jsonify({'contact': _serialize_contact(contact)})
+
+
+@agent_api_bp.route('/contacts/<int:contact_id>', methods=['PATCH'])
+@agent_jwt_required
+def patch_contact(user, contact_id):
+    contact = org_query_for_id(Contact, user.organization_id).filter_by(
+        id=contact_id,
+    ).first()
+    if not _contact_visible(user, contact):
+        return _json_error('Contact not found.', 404)
+    data = _json_body()
+    if 'first_name' in data:
+        first_name = (data.get('first_name') or '').strip()
+        if not first_name:
+            return _json_error('First name and last name are required.', 400)
+        contact.first_name = first_name
+    if 'last_name' in data:
+        last_name = (data.get('last_name') or '').strip()
+        if not last_name:
+            return _json_error('First name and last name are required.', 400)
+        contact.last_name = last_name
+    for field in (
+        'email', 'phone', 'street_address', 'city', 'state', 'zip_code',
+        'notes', 'current_objective',
+    ):
+        if field in data:
+            value = data.get(field)
+            setattr(contact, field, (value or '').strip() or None)
+    if 'potential_commission' in data and data.get('potential_commission') is not None:
+        contact.potential_commission = data.get('potential_commission')
+    if 'group_ids' in data:
+        try:
+            contact.groups = resolve_groups_for_owner(
+                user.organization_id,
+                contact.user_id,
+                data.get('group_ids') or [],
+                active_only=True,
+            )
+        except ContactGroupError as exc:
+            return _json_error(exc.message, exc.status_code)
+    db.session.commit()
+    return jsonify({'contact': _serialize_contact(contact)})
+
+
+@agent_api_bp.route('/contacts/<int:contact_id>', methods=['DELETE'])
+@agent_jwt_required
+def delete_contact(user, contact_id):
+    contact = org_query_for_id(Contact, user.organization_id).filter_by(
+        id=contact_id,
+    ).first()
+    if not _contact_visible(user, contact):
+        return _json_error('Contact not found.', 404)
+
+    task_count = Task.query.filter_by(contact_id=contact_id).count()
+    interaction_count = Interaction.query.filter_by(contact_id=contact_id).count()
+    force = (
+        str(request.args.get('force') or '').lower() == 'true'
+        or str(_json_body().get('force') or '').lower() == 'true'
+    )
+    if (task_count > 0 or interaction_count > 0) and not force:
+        parts = []
+        if task_count:
+            parts.append(f'{task_count} task{"s" if task_count != 1 else ""}')
+        if interaction_count:
+            parts.append(
+                f'{interaction_count} interaction{"s" if interaction_count != 1 else ""}'
+            )
+        return jsonify({
+            'error': (
+                'Cannot delete contact. It has '
+                + ' and '.join(parts)
+                + '. Pass force=true to delete them too.'
+            ),
+            'has_associated_data': True,
+            'task_count': task_count,
+            'interaction_count': interaction_count,
+        }), 400
+
+    if force:
+        Task.query.filter_by(contact_id=contact_id).delete()
+        Interaction.query.filter_by(contact_id=contact_id).delete()
+    db.session.delete(contact)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@agent_api_bp.route('/transactions', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_transactions(user):
+    query = transactions_visible_query(user).options(
+        joinedload(Transaction.transaction_type),
+    )
+    status_filter = (request.args.get('status') or '').strip()
+    if status_filter:
+        query = query.filter_by(status=status_filter)
+    q = (request.args.get('q') or '').strip()
+    if q:
+        like = f'%{q}%'
+        query = query.filter(or_(
+            Transaction.street_address.ilike(like),
+            Transaction.city.ilike(like),
+        ))
+    rows = query.order_by(Transaction.created_at.desc()).limit(200).all()
+    return jsonify({
+        'transactions': [_serialize_transaction(tx) for tx in rows],
+    })
+
+
+@agent_api_bp.route('/transactions', methods=['POST'])
+@agent_jwt_required
+@transactions_flag_required
+def create_transaction(user):
+    data = _json_body()
+    street_address = (data.get('street_address') or '').strip()
+    transaction_type_id = data.get('transaction_type_id')
+    if not street_address:
+        return _json_error('A property address is required.', 400)
+    if not transaction_type_id:
+        return _json_error('A transaction type is required.', 400)
+    tx_type = TransactionType.query.filter_by(
+        id=int(transaction_type_id),
+        organization_id=user.organization_id,
+    ).first()
+    if not tx_type:
+        return _json_error('Transaction type not found.', 400)
+
+    contact_ids = data.get('contact_ids') or []
+    contacts = []
+    for raw_id in contact_ids:
+        contact = org_query_for_id(Contact, user.organization_id).filter_by(
+            id=int(raw_id),
+        ).first()
+        if not _contact_visible(user, contact):
+            return _json_error('One or more contacts were not found.', 400)
+        contacts.append(contact)
+
+    default_status = (
+        'showing' if tx_type.name in {'buyer', 'tenant'} else 'preparing_to_list'
+    )
+    transaction = Transaction(
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+        transaction_type_id=tx_type.id,
+        street_address=street_address,
+        city=(data.get('city') or '').strip() or None,
+        state=(data.get('state') or 'TX').strip() or 'TX',
+        zip_code=(data.get('zip_code') or '').strip() or None,
+        county=(data.get('county') or '').strip() or None,
+        ownership_status=(data.get('ownership_status') or '').strip() or None,
+        status=default_status,
+    )
+    db.session.add(transaction)
+    db.session.flush()
+
+    participant_role = ROLE_MAP.get(tx_type.name, 'client')
+    for index, contact in enumerate(contacts):
+        role = participant_role if index == 0 else f'co_{participant_role}'
+        db.session.add(TransactionParticipant(
+            organization_id=user.organization_id,
+            transaction_id=transaction.id,
+            contact_id=contact.id,
+            role=role,
+            name=f'{contact.first_name} {contact.last_name}',
+            email=contact.email,
+            phone=contact.phone,
+            is_primary=(index == 0),
+        ))
+
+    agent_role = (
+        'listing_agent' if tx_type.name in ('seller', 'landlord') else 'buyers_agent'
+    )
+    if tx_type.name in ('seller', 'landlord', 'buyer', 'tenant'):
+        db.session.add(TransactionParticipant(
+            organization_id=user.organization_id,
+            transaction_id=transaction.id,
+            user_id=user.id,
+            role=agent_role,
+            is_primary=True,
+        ))
+    db.session.commit()
+    return jsonify({'transaction': _serialize_transaction(transaction, detail=True)}), 201
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def get_transaction(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    return jsonify({'transaction': _serialize_transaction(tx, detail=True)})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>', methods=['PATCH'])
+@agent_jwt_required
+@transactions_flag_required
+def patch_transaction(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    data = _json_body()
+    for field in (
+        'street_address', 'city', 'state', 'zip_code', 'county',
+        'ownership_status', 'mls_listing_url',
+    ):
+        if field in data:
+            value = (data.get(field) or '').strip()
+            if field == 'street_address' and not value:
+                return _json_error('A property address is required.', 400)
+            setattr(tx, field, value or None)
+    db.session.commit()
+    return jsonify({'transaction': _serialize_transaction(tx, detail=True)})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>', methods=['DELETE'])
+@agent_jwt_required
+@transactions_flag_required
+def delete_transaction(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    from services.transaction_helpers import purge_transaction_dependent_rows
+    purge_transaction_dependent_rows(tx.id)
+    db.session.delete(tx)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/status', methods=['POST'])
+@agent_jwt_required
+@transactions_flag_required
+def post_transaction_status(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    new_status = (_json_body().get('status') or '').strip()
+    tx_type_name = tx.transaction_type.name if tx.transaction_type else 'seller'
+    valid = STATUS_OPTIONS_BY_TYPE.get(tx_type_name, STATUS_OPTIONS_BY_TYPE['seller'])
+    if new_status not in valid:
+        return _json_error('Invalid status.', 400)
+    tx.status = new_status
+    db.session.commit()
+    return jsonify({'ok': True, 'status': tx.status})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/dates', methods=['PATCH'])
+@agent_jwt_required
+@transactions_flag_required
+def patch_transaction_dates(user, transaction_id):
+    """Write portal-visible dates only.
+
+    Do not call seller contract-details replace here. That rebuilds
+    milestones from frozen terms and can wipe dates that were not sent.
+    """
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    data = _json_body()
+    unknown = [key for key in data.keys() if key not in PORTAL_DATE_FIELDS]
+    if unknown:
+        return _json_error(
+            'Only portal-visible dates can be updated: '
+            + ', '.join(sorted(PORTAL_DATE_FIELDS))
+            + '.',
+            400,
+        )
+    try:
+        if 'expected_close_date' in data:
+            tx.expected_close_date = _parse_date(data.get('expected_close_date'))
+        if 'actual_close_date' in data:
+            tx.actual_close_date = _parse_date(data.get('actual_close_date'))
+        if 'go_live_date' in data:
+            profile = tx.seller_listing_profile
+            if profile is None:
+                profile = SellerListingProfile(
+                    organization_id=user.organization_id,
+                    transaction_id=tx.id,
+                    created_by_id=user.id,
+                )
+                db.session.add(profile)
+            profile.go_live_date = _parse_date(data.get('go_live_date'))
+        if 'effective_date' in data or 'closing_date' in data:
+            contract = get_active_primary_contract(tx.id, tx.organization_id)
+            if contract is None:
+                return _json_error(
+                    'No controlling contract to date. Do not send a contract-details dump.',
+                    400,
+                )
+            if 'effective_date' in data:
+                contract.effective_date = _parse_date(data.get('effective_date'))
+            if 'closing_date' in data:
+                contract.closing_date = _parse_date(data.get('closing_date'))
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    db.session.commit()
+    return jsonify({'ok': True, 'dates': _tx_dates(tx)})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/participants', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_participants(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    return jsonify({
+        'participants': [_serialize_participant(p) for p in tx.participants.all()],
+    })
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/participants', methods=['POST'])
+@agent_jwt_required
+@transactions_flag_required
+def add_participant(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    data = _json_body()
+    role = (data.get('role') or '').strip()
+    if not role:
+        return _json_error('Role is required.', 400)
+    contact_id = data.get('contact_id')
+    if contact_id:
+        contact = org_query_for_id(Contact, user.organization_id).filter_by(
+            id=int(contact_id),
+        ).first()
+        if not _contact_visible(user, contact):
+            return _json_error('Contact not found.', 404)
+        if not contact.first_name or not contact.last_name:
+            return _json_error('This contact is missing a name.', 400)
+        participant = TransactionParticipant(
+            organization_id=user.organization_id,
+            transaction_id=tx.id,
+            role=role,
+            contact_id=contact.id,
+            name=f'{contact.first_name} {contact.last_name}',
+            email=contact.email,
+            phone=contact.phone,
+            is_primary=False,
+        )
+    else:
+        name = (data.get('name') or '').strip()
+        if not name:
+            return _json_error('Select a contact or provide a name.', 400)
+        participant = TransactionParticipant(
+            organization_id=user.organization_id,
+            transaction_id=tx.id,
+            role=role,
+            name=name,
+            email=(data.get('email') or '').strip() or None,
+            phone=(data.get('phone') or '').strip() or None,
+            is_primary=False,
+        )
+    db.session.add(participant)
+    db.session.commit()
+    return jsonify({'participant': _serialize_participant(participant)}), 201
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/milestones', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_milestones(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    rows = SellerContractMilestone.query.filter_by(
+        transaction_id=tx.id,
+        organization_id=user.organization_id,
+    ).order_by(SellerContractMilestone.due_at.asc().nullslast()).all()
+    return jsonify({'milestones': [_serialize_milestone(m) for m in rows]})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/milestones', methods=['POST'])
+@agent_jwt_required
+@transactions_flag_required
+def create_milestone(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    contract = get_active_primary_contract(tx.id, tx.organization_id)
+    if contract is None:
+        return _json_error('Add a controlling contract before adding milestones.', 400)
+    data = _json_body()
+    title = (data.get('title') or '').strip()
+    if not title:
+        return _json_error('Milestone title is required.', 400)
+    status = data.get('status') or 'not_started'
+    if status not in MILESTONE_STATUSES:
+        return _json_error('Invalid milestone status.', 400)
+    try:
+        due_at = _parse_datetime(data.get('due_at'))
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    milestone = SellerContractMilestone(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        accepted_contract_id=contract.id,
+        created_by_id=user.id,
+        milestone_key=(data.get('milestone_key') or 'manual').strip() or 'manual',
+        title=title,
+        due_at=due_at,
+        status=status,
+        responsible_party=(data.get('responsible_party') or '').strip() or None,
+        notes=(data.get('notes') or '').strip() or None,
+        source='manual',
+    )
+    if status == 'completed':
+        milestone.completed_at = datetime.utcnow()
+    db.session.add(milestone)
+    db.session.commit()
+    return jsonify({'milestone': _serialize_milestone(milestone)}), 201
+
+
+@agent_api_bp.route(
+    '/transactions/<int:transaction_id>/milestones/<int:milestone_id>',
+    methods=['PATCH'],
+)
+@agent_jwt_required
+@transactions_flag_required
+def patch_milestone(user, transaction_id, milestone_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    milestone = SellerContractMilestone.query.filter_by(
+        id=milestone_id,
+        transaction_id=tx.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not milestone:
+        return _json_error('Milestone not found.', 404)
+    data = _json_body()
+    if 'title' in data:
+        title = (data.get('title') or '').strip()
+        if not title:
+            return _json_error('Milestone title is required.', 400)
+        milestone.title = title
+    if 'status' in data:
+        status = data.get('status')
+        if status not in MILESTONE_STATUSES:
+            return _json_error('Invalid milestone status.', 400)
+        milestone.status = status
+        if status == 'completed':
+            milestone.completed_at = milestone.completed_at or datetime.utcnow()
+        else:
+            milestone.completed_at = None
+    if 'due_at' in data:
+        try:
+            milestone.due_at = _parse_datetime(data.get('due_at'))
+        except ValueError as exc:
+            return _json_error(str(exc), 400)
+    if 'responsible_party' in data:
+        milestone.responsible_party = (data.get('responsible_party') or '').strip() or None
+    if 'notes' in data:
+        milestone.notes = (data.get('notes') or '').strip() or None
+    milestone.source = 'manual'
+    db.session.commit()
+    return jsonify({'milestone': _serialize_milestone(milestone)})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/documents', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_documents(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    docs = TransactionDocument.query.filter_by(
+        transaction_id=tx.id,
+        organization_id=user.organization_id,
+    ).order_by(TransactionDocument.created_at.desc()).all()
+    return jsonify({'documents': [_serialize_document(doc) for doc in docs]})
+
+
+@agent_api_bp.route('/transactions/<int:transaction_id>/documents', methods=['POST'])
+@agent_jwt_required
+@transactions_flag_required
+def upload_document(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    uploaded = request.files.get('file')
+    if uploaded is None or not uploaded.filename:
+        return _json_error('Upload a PDF.', 400)
+    filename = uploaded.filename
+    ext = filename.rsplit('.', 1)[-1].lower() if '.' in filename else ''
+    if ext != 'pdf':
+        return _json_error('PDF only.', 400)
+    file_data = uploaded.read()
+    if len(file_data) > MAX_UPLOAD_BYTES:
+        return _json_error('File too large. Maximum size is 25MB.', 400)
+    document_name = (
+        (request.form.get('name') or _json_body().get('name') or '').strip()
+        or filename.rsplit('.', 1)[0]
+    )
+    from services.supabase_storage import upload_external_document
+
+    try:
+        result = upload_external_document(
+            transaction_id=tx.id,
+            file_data=file_data,
+            original_filename=filename,
+            content_type='application/pdf',
+        )
+    except Exception:
+        logger.exception('Agent API document upload failed')
+        return _json_error('Could not store that PDF.', 502)
+
+    doc = TransactionDocument(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        template_slug='external',
+        template_name=document_name,
+        status='pending',
+        document_source='external',
+        source_file_path=result.get('path'),
+        signed_original_filename=filename,
+    )
+    db.session.add(doc)
+    db.session.commit()
+    return jsonify({'document': _serialize_document(doc)}), 201
+
+
+@agent_api_bp.route(
+    '/transactions/<int:transaction_id>/documents/<int:doc_id>/file',
+    methods=['GET'],
+)
+@agent_jwt_required
+@transactions_flag_required
+def get_document_file(user, transaction_id, doc_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    doc = TransactionDocument.query.filter_by(
+        id=doc_id,
+        transaction_id=tx.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not doc:
+        return _json_error('Document not found.', 404)
+    path = doc.signed_file_path or doc.source_file_path
+    if not path:
+        return _json_error('That document has no file yet.', 404)
+    from services.supabase_storage import get_transaction_document_url
+    try:
+        url = get_transaction_document_url(path, expires_in=3600)
+    except Exception:
+        logger.exception('Agent API signed URL failed')
+        return _json_error('Could not create a file link.', 502)
+    return jsonify({'url': url})
+
+
+@agent_api_bp.route('/conversations', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_conversations(user):
+    txs = transactions_visible_query(user).options(
+        joinedload(Transaction.transaction_type),
+    ).all()
+    tx_ids = [tx.id for tx in txs]
+    if not tx_ids:
+        return jsonify({'conversations': []})
+
+    participants = TransactionParticipant.query.filter(
+        TransactionParticipant.organization_id == user.organization_id,
+        TransactionParticipant.transaction_id.in_(tx_ids),
+        TransactionParticipant.role.in_(tuple(CLIENT_PORTAL_ROLES)),
+    ).options(joinedload(TransactionParticipant.contact)).all()
+
+    messages = PortalMessage.query.filter(
+        PortalMessage.organization_id == user.organization_id,
+        PortalMessage.transaction_id.in_(tx_ids),
+    ).order_by(PortalMessage.created_at.desc()).all()
+
+    latest_by_participant = {}
+    unread_by_participant = {}
+    for msg in messages:
+        latest_by_participant.setdefault(msg.participant_id, msg)
+        if msg.sender == 'client' and msg.read_by_agent_at is None:
+            unread_by_participant[msg.participant_id] = (
+                unread_by_participant.get(msg.participant_id, 0) + 1
+            )
+
+    tx_by_id = {tx.id: tx for tx in txs}
+    conversations = []
+    for participant in participants:
+        tx = tx_by_id.get(participant.transaction_id)
+        if tx is None:
+            continue
+        last = latest_by_participant.get(participant.id)
+        conversations.append({
+            'transaction_id': tx.id,
+            'address': tx.street_address,
+            'participant_id': participant.id,
+            'name': participant.display_name,
+            'role': participant.role,
+            'last_preview': last.body if last else None,
+            'last_at': last.created_at.isoformat() if last and last.created_at else None,
+            'unread': unread_by_participant.get(participant.id, 0),
+        })
+    conversations.sort(key=lambda row: row['last_at'] or '', reverse=True)
+    return jsonify({'conversations': conversations})
+
+
+def _conversation_access(user, participant_id):
+    participant = TransactionParticipant.query.filter_by(
+        id=participant_id,
+        organization_id=user.organization_id,
+    ).first()
+    if (
+        participant is None
+        or (participant.role or '').strip().lower() not in CLIENT_PORTAL_ROLES
+    ):
+        return None, None, _json_error('Conversation not found.', 404)
+    tx, error = _load_tx(user, participant.transaction_id, CAP_VIEW)
+    if error:
+        return None, None, error
+    return tx, participant, None
+
+
+@agent_api_bp.route(
+    '/conversations/<int:participant_id>/messages',
+    methods=['GET'],
+)
+@agent_jwt_required
+@transactions_flag_required
+def list_conversation_messages(user, participant_id):
+    tx, participant, error = _conversation_access(user, participant_id)
+    if error:
+        return error
+    access = SimpleNamespace(
+        transaction_id=tx.id,
+        participant_id=participant.id,
+        participant=participant,
+    )
+    messages = list_client_messages(access)
+    unread = PortalMessage.query.filter_by(
+        transaction_id=tx.id,
+        participant_id=participant.id,
+        sender='client',
+    ).filter(PortalMessage.read_by_agent_at.is_(None)).all()
+    now = datetime.utcnow()
+    for msg in unread:
+        msg.read_by_agent_at = now
+    if unread:
+        db.session.commit()
+    return jsonify({'messages': messages})
+
+
+@agent_api_bp.route(
+    '/conversations/<int:participant_id>/messages',
+    methods=['POST'],
+)
+@agent_jwt_required
+@transactions_flag_required
+def post_conversation_message(user, participant_id):
+    tx, participant, error = _conversation_access(user, participant_id)
+    if error:
+        return error
+    body = (_json_body().get('body') or '').strip()
+    if not body:
+        return _json_error('Write a message before sending.', 400)
+    if len(body) > 4000:
+        body = body[:4000]
+    msg = PortalMessage(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        participant_id=participant.id,
+        sender='agent',
+        kind='message',
+        body=body,
+        author_user_id=user.id,
+    )
+    db.session.add(msg)
+    db.session.commit()
+    try:
+        enqueue_portal_push(msg)
+    except Exception:
+        logger.exception('Agent API: failed to enqueue APNs for agent message.')
+    access = SimpleNamespace(
+        transaction_id=tx.id,
+        participant_id=participant.id,
+        participant=participant,
+    )
+    listed = list_client_messages(access)
+    return jsonify({'message': listed[-1] if listed else None}), 201

--- a/routes/client_api.py
+++ b/routes/client_api.py
@@ -12,7 +12,7 @@ from functools import wraps
 from flask import Blueprint, g, jsonify, redirect, request
 from sqlalchemy import text
 
-from models import db, PortalMessage, SellerShowing
+from models import DeviceToken, db, PortalMessage, SellerShowing
 from services.client_portal_auth import (
     JWT_TTL_SECONDS,
     branding_for_access,
@@ -196,6 +196,12 @@ def post_message(access):
     db.session.commit()
 
     try:
+        from services.device_push import enqueue_portal_push
+        enqueue_portal_push(msg)
+    except Exception:
+        logger.exception('Client API: failed to enqueue APNs for client message.')
+
+    try:
         from routes.portal import _notify_agent_of_message
         _notify_agent_of_message(access, body)
     except Exception:
@@ -227,6 +233,28 @@ def get_document_file(access, doc_id):
             return _json_error('That document is not yours.', 403)
         return _json_error('Document not found.', 404)
     return redirect(url)
+
+
+@client_api_bp.route('/devices', methods=['POST'])
+@client_jwt_required
+def register_client_device(access):
+    data = request.get_json(silent=True) or {}
+    try:
+        from services.device_push import register_device
+        row = register_device(
+            organization_id=access.organization_id,
+            audience=DeviceToken.AUDIENCE_CLIENT,
+            token=data.get('token'),
+            platform=data.get('platform') or request.form.get('platform'),
+            participant_id=access.participant_id,
+        )
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    return jsonify({
+        'ok': True,
+        'device_id': row.id,
+        'platform': row.platform,
+    }), 201
 
 
 @client_api_bp.route('/showings', methods=['GET'])

--- a/routes/portal.py
+++ b/routes/portal.py
@@ -194,6 +194,12 @@ def post_message(access):
     db.session.add(msg)
     db.session.commit()
 
+    try:
+        from services.device_push import enqueue_portal_push
+        enqueue_portal_push(msg)
+    except Exception:
+        logger.exception('Portal: failed to enqueue APNs for client message.')
+
     # Notify the agent in-app (best-effort; never block the seller's action).
     try:
         _notify_agent_of_message(access, body)

--- a/services/agent_auth.py
+++ b/services/agent_auth.py
@@ -1,0 +1,154 @@
+"""Password login and long-lived JWT for the agent iPhone app.
+
+Mirrors the client portal JWT crypto. typ=agent. Flask-Login cookies
+are not consulted here.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+from flask import current_app
+
+from models import Organization, User
+
+
+JWT_TTL_SECONDS = 30 * 24 * 60 * 60
+JWT_TYP = 'agent'
+JWT_ISS = 'agentflow-agent'
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')
+
+
+def _b64url_decode(value: str) -> bytes:
+    pad = '=' * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + pad)
+
+
+def _secret() -> bytes:
+    key = current_app.config.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
+    if isinstance(key, bytes):
+        return key
+    return str(key).encode('utf-8')
+
+
+def find_login_user(login_input):
+    """Look up email first, then username. Same order as web login."""
+    value = (login_input or '').strip()
+    if not value:
+        return None
+    user = User.query.filter(User.email == value).first()
+    if not user:
+        user = User.query.filter(User.username == value).first()
+    return user
+
+
+def login_input_from_body(data):
+    """Prefer email, then username. Accepts either key."""
+    if not isinstance(data, dict):
+        return ''
+    email = (data.get('email') or '').strip()
+    if email:
+        return email
+    return (data.get('username') or '').strip()
+
+
+def org_is_active(user):
+    org = user.organization if user else None
+    return bool(org and org.status == 'active')
+
+
+def issue_agent_jwt(user, now=None, ttl_seconds=JWT_TTL_SECONDS):
+    now = int(now if now is not None else time.time())
+    payload = {
+        'typ': JWT_TYP,
+        'uid': user.id,
+        'oid': user.organization_id,
+        'sv': user.session_version or 1,
+        'iat': now,
+        'exp': now + int(ttl_seconds),
+        'iss': JWT_ISS,
+    }
+    header = {'alg': 'HS256', 'typ': 'JWT'}
+    header_b64 = _b64url_encode(json.dumps(header, separators=(',', ':')).encode())
+    body_b64 = _b64url_encode(json.dumps(payload, separators=(',', ':')).encode())
+    signing = f'{header_b64}.{body_b64}'.encode('ascii')
+    sig = hmac.new(_secret(), signing, hashlib.sha256).digest()
+    return f'{header_b64}.{body_b64}.{_b64url_encode(sig)}'
+
+
+def decode_agent_jwt(token):
+    if not token or token.count('.') != 2:
+        return None
+    header_b64, body_b64, sig_b64 = token.split('.')
+    signing = f'{header_b64}.{body_b64}'.encode('ascii')
+    try:
+        expected = hmac.new(_secret(), signing, hashlib.sha256).digest()
+        given = _b64url_decode(sig_b64)
+    except (ValueError, TypeError):
+        return None
+    if not hmac.compare_digest(expected, given):
+        return None
+    try:
+        claims = json.loads(_b64url_decode(body_b64))
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(claims, dict) or claims.get('typ') != JWT_TYP:
+        return None
+    return claims
+
+
+def jwt_is_expired(claims, now=None):
+    now = int(now if now is not None else time.time())
+    try:
+        return int(claims.get('exp') or 0) <= now
+    except (TypeError, ValueError):
+        return True
+
+
+def load_user_from_jwt(token, now=None):
+    """Return (user, error_message) for a Bearer agent JWT."""
+    claims = decode_agent_jwt(token)
+    if not claims:
+        return None, 'Sign in with your email and password.'
+    if jwt_is_expired(claims, now=now):
+        return None, 'Your session expired. Sign in again.'
+    user = User.query.get(claims.get('uid'))
+    if not user:
+        return None, 'Sign in with your email and password.'
+    if int(user.session_version or 1) != int(claims.get('sv') or 0):
+        return None, 'Your session is no longer valid. Sign in again.'
+    if user.organization_id != claims.get('oid'):
+        return None, 'Sign in with your email and password.'
+    org = Organization.query.get(user.organization_id)
+    if not org or org.status != 'active':
+        return None, 'This account is not active.'
+    return user, None
+
+
+def serialize_user(user):
+    return {
+        'id': user.id,
+        'email': user.email,
+        'username': user.username,
+        'first_name': user.first_name,
+        'last_name': user.last_name,
+        'org_role': user.org_role,
+    }
+
+
+def serialize_org(org):
+    if org is None:
+        return None
+    return {
+        'id': org.id,
+        'name': org.name,
+        'slug': org.slug,
+        'subscription_tier': org.subscription_tier,
+        'status': org.status,
+    }

--- a/services/agent_dashboard.py
+++ b/services/agent_dashboard.py
@@ -1,0 +1,200 @@
+"""Agent iPhone dashboard payload. Reuses the web dashboard queries."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import case, func, or_
+from sqlalchemy.orm import joinedload
+
+from feature_flags import can_access_transactions, get_org_features, org_has_feature
+from models import Contact, Task, Transaction, TransactionParticipant
+from services.agent_auth import serialize_org, serialize_user
+from services.contact_group_service import aggregate_group_stats
+from services.tenant_service import org_query_for_id
+
+
+def build_dashboard(user):
+    org = user.organization
+    org_id = user.organization_id
+    contact_query = org_query_for_id(Contact, org_id).filter_by(user_id=user.id)
+
+    stats = contact_query.with_entities(
+        func.count(Contact.id).label('total'),
+        func.coalesce(func.sum(Contact.potential_commission), 0).label('total_commission'),
+        func.avg(Contact.potential_commission).label('avg_commission'),
+    ).first()
+
+    group_stats = aggregate_group_stats(
+        org_id, owner_user_id=user.id, show_all=False,
+    )
+
+    today_tasks = _today_tasks(user, org_id)
+    pipeline_by_status = []
+    pipeline_value = 0
+    ytd_closed_value = 0
+    if can_access_transactions(user):
+        pipeline_by_status, pipeline_value, ytd_closed_value = _pipeline(user, org_id)
+
+    return {
+        'user': serialize_user(user),
+        'kpis': {
+            'total_contacts': int(stats.total or 0),
+            'total_commission': float(stats.total_commission or 0),
+            'avg_commission': float(stats.avg_commission or 0),
+            'pipeline_value': float(pipeline_value or 0),
+            'ytd_closed_value': float(ytd_closed_value or 0),
+            'transactions_enabled': org_has_feature('TRANSACTIONS', org),
+        },
+        'today_tasks': today_tasks,
+        'pipeline_by_status': pipeline_by_status,
+        'group_stats': group_stats,
+        'features': get_org_features(org),
+    }
+
+
+def me_payload(user):
+    return {
+        'user': serialize_user(user),
+        'org': serialize_org(user.organization),
+        'features': get_org_features(user.organization),
+    }
+
+
+def _today_tasks(user, org_id):
+    utc_now = datetime.utcnow()
+    start = utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    rows = (
+        org_query_for_id(Task, org_id)
+        .options(joinedload(Task.contact), joinedload(Task.task_type))
+        .filter(
+            Task.assigned_to_id == user.id,
+            Task.status != 'completed',
+            Task.due_date.isnot(None),
+            or_(Task.due_date < start, Task.due_date.between(start, end)),
+        )
+        .order_by(
+            case((Task.due_date < utc_now, 0), else_=1),
+            Task.due_date.asc(),
+        )
+        .limit(20)
+        .all()
+    )
+    out = []
+    for task in rows:
+        contact = task.contact
+        out.append({
+            'id': task.id,
+            'subject': task.subject,
+            'status': task.status,
+            'priority': task.priority,
+            'due_date': task.due_date.isoformat() if task.due_date else None,
+            'contact_id': task.contact_id,
+            'contact_name': (
+                f'{contact.first_name} {contact.last_name}'.strip()
+                if contact else None
+            ),
+        })
+    return out
+
+
+def _pipeline(user, org_id):
+    now = datetime.utcnow()
+    current_year = now.year
+    tx_query = org_query_for_id(Transaction, org_id).filter_by(created_by_id=user.id)
+    all_transactions = tx_query.options(
+        joinedload(Transaction.transaction_type)
+    ).order_by(Transaction.created_at.desc()).all()
+
+    tx_ids = [tx.id for tx in all_transactions]
+    if tx_ids:
+        participants_query = TransactionParticipant.query.options(
+            joinedload(TransactionParticipant.contact)
+        ).filter(
+            TransactionParticipant.transaction_id.in_(tx_ids),
+            TransactionParticipant.is_primary == True,  # noqa: E712
+            TransactionParticipant.role.in_(['seller', 'buyer', 'landlord', 'tenant']),
+        ).all()
+        participants_by_tx = {p.transaction_id: p for p in participants_query}
+    else:
+        participants_by_tx = {}
+
+    status_config = {
+        'early': {
+            'label': 'Early Stage',
+            'statuses': ['preparing_to_list', 'showing'],
+        },
+        'active': {
+            'label': 'Active / Listed',
+            'statuses': ['active'],
+        },
+        'pending': {
+            'label': 'Pending',
+            'statuses': ['under_contract'],
+        },
+        'closed': {
+            'label': 'Closed YTD',
+            'statuses': ['closed'],
+        },
+    }
+    columns = {
+        key: {
+            'key': key,
+            'label': cfg['label'],
+            'count': 0,
+            'transactions': [],
+        }
+        for key, cfg in status_config.items()
+    }
+
+    pipeline_value = 0
+    ytd_closed_value = 0
+    for tx in all_transactions:
+        if tx.status == 'closed':
+            if tx.actual_close_date and tx.actual_close_date.year == current_year:
+                pass
+            elif tx.created_at and tx.created_at.year == current_year:
+                pass
+            else:
+                continue
+
+        primary_client = participants_by_tx.get(tx.id)
+        commission = 0
+        client_name = 'No client'
+        if primary_client and primary_client.contact:
+            commission = float(primary_client.contact.potential_commission or 0)
+            client_name = (
+                f'{primary_client.contact.first_name} '
+                f'{primary_client.contact.last_name}'
+            )
+        elif primary_client:
+            client_name = primary_client.display_name
+
+        tx_data = {
+            'id': tx.id,
+            'address': tx.street_address,
+            'city': tx.city,
+            'client_name': client_name,
+            'expected_close_date': (
+                tx.expected_close_date.isoformat() if tx.expected_close_date else None
+            ),
+            'actual_close_date': (
+                tx.actual_close_date.isoformat() if tx.actual_close_date else None
+            ),
+            'commission': commission,
+            'status': tx.status,
+            'type': (
+                tx.transaction_type.display_name if tx.transaction_type else 'Unknown'
+            ),
+        }
+        for column_key, column_config in status_config.items():
+            if tx.status in column_config['statuses']:
+                columns[column_key]['transactions'].append(tx_data)
+                columns[column_key]['count'] += 1
+                break
+        if tx.status != 'closed':
+            pipeline_value += commission
+        else:
+            ytd_closed_value += commission
+
+    return list(columns.values()), pipeline_value, ytd_closed_value

--- a/services/apns_client.py
+++ b/services/apns_client.py
@@ -1,0 +1,85 @@
+"""HTTP/2 APNs sender. Only imported when APNS_* env is present."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def send_alert(device_token: str, msg) -> bool:
+    key_id = (os.environ.get('APNS_KEY_ID') or '').strip()
+    team_id = (os.environ.get('APNS_TEAM_ID') or '').strip()
+    key_pem = (os.environ.get('APNS_KEY') or '').strip()
+    bundle_id = (os.environ.get('APNS_BUNDLE_ID') or '').strip()
+    if not (key_id and team_id and key_pem and bundle_id and device_token):
+        return False
+
+    host = 'api.push.apple.com'
+    if (os.environ.get('APNS_ENVIRONMENT') or '').strip().lower() == 'sandbox':
+        host = 'api.sandbox.push.apple.com'
+
+    preview = (msg.body or '').strip()
+    if len(preview) > 120:
+        preview = preview[:117] + '...'
+    title = 'New message' if msg.sender == 'client' else 'Update from your agent'
+    payload = {
+        'aps': {
+            'alert': {'title': title, 'body': preview or 'Open AgentFlow'},
+            'sound': 'default',
+        },
+        'transaction_id': msg.transaction_id,
+        'participant_id': msg.participant_id,
+        'message_id': msg.id,
+    }
+
+    token = _apns_jwt(key_id, team_id, key_pem)
+    if not token:
+        return False
+
+    try:
+        import httpx
+    except ImportError:
+        logger.info('APNs skipped: httpx is not installed')
+        return False
+
+    url = f'https://{host}/3/device/{device_token}'
+    headers = {
+        'authorization': f'bearer {token}',
+        'apns-topic': bundle_id,
+        'apns-push-type': 'alert',
+        'apns-priority': '10',
+        'apns-expiration': '0',
+    }
+    try:
+        response = httpx.post(url, headers=headers, content=json.dumps(payload), timeout=10.0)
+    except Exception:
+        logger.exception('APNs HTTP request failed')
+        return False
+    if response.status_code == 200:
+        return True
+    logger.info('APNs rejected token suffix %s: %s', device_token[-8:], response.status_code)
+    return False
+
+
+def _apns_jwt(key_id, team_id, key_pem):
+    try:
+        import jwt
+    except ImportError:
+        logger.info('APNs skipped: PyJWT is not installed')
+        return None
+    if 'BEGIN' not in key_pem:
+        key_pem = (
+            '-----BEGIN PRIVATE KEY-----\n'
+            + key_pem
+            + '\n-----END PRIVATE KEY-----'
+        )
+    now = int(time.time())
+    return jwt.encode(
+        {'iss': team_id, 'iat': now},
+        key_pem,
+        algorithm='ES256',
+        headers={'kid': key_id},
+    )

--- a/services/device_push.py
+++ b/services/device_push.py
@@ -1,0 +1,99 @@
+"""Register APNs device tokens and enqueue a push on new PortalMessage."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from models import DeviceToken, db
+
+logger = logging.getLogger(__name__)
+
+QUEUE_NAME = 'apns'
+
+
+def normalize_platform(value):
+    raw = (value or '').strip().lower()
+    if raw in ('ios', 'iphone', 'ipad'):
+        return 'ios'
+    if raw in ('android',):
+        return 'android'
+    return 'ios'
+
+
+def register_device(*, organization_id, audience, token, platform,
+                    user_id=None, participant_id=None):
+    token = (token or '').strip()
+    if not token:
+        raise ValueError('A device token is required.')
+    if audience not in DeviceToken.AUDIENCES:
+        raise ValueError('Unknown device audience.')
+    if audience == DeviceToken.AUDIENCE_AGENT and not user_id:
+        raise ValueError('Agent devices need a user.')
+    if audience == DeviceToken.AUDIENCE_CLIENT and not participant_id:
+        raise ValueError('Client devices need a participant.')
+
+    platform = normalize_platform(platform)
+    row = DeviceToken.query.filter_by(audience=audience, token=token).first()
+    if row:
+        row.organization_id = organization_id
+        row.platform = platform
+        row.user_id = user_id if audience == DeviceToken.AUDIENCE_AGENT else None
+        row.participant_id = (
+            participant_id if audience == DeviceToken.AUDIENCE_CLIENT else None
+        )
+        row.last_seen_at = datetime.utcnow()
+        db.session.commit()
+        return row
+
+    row = DeviceToken(
+        organization_id=organization_id,
+        audience=audience,
+        token=token,
+        platform=platform,
+        user_id=user_id if audience == DeviceToken.AUDIENCE_AGENT else None,
+        participant_id=(
+            participant_id if audience == DeviceToken.AUDIENCE_CLIENT else None
+        ),
+    )
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def enqueue_portal_push(message):
+    """Ask the RQ worker to notify the other side. Missing APNS_* is a no-op."""
+    from jobs.apns_push import apns_configured
+
+    if message is None or not getattr(message, 'id', None):
+        return {'ok': False, 'reason': 'no_message'}
+    if not apns_configured():
+        logger.info(
+            'APNs skipped: APNS_* env missing (message_id=%s)',
+            message.id,
+        )
+        return {'ok': False, 'reason': 'apns_unconfigured'}
+
+    try:
+        from redis import Redis
+        from rq import Queue
+        from config import Config
+
+        conn = Redis.from_url(
+            Config.REDIS_URL,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        conn.ping()
+        Queue(QUEUE_NAME, connection=conn).enqueue(
+            'jobs.apns_push.send_portal_push',
+            message_id=message.id,
+            org_id=message.organization_id,
+            job_timeout=60,
+        )
+        return {'ok': True, 'queued': True}
+    except Exception:
+        logger.exception(
+            'APNs enqueue failed for message %s; skipping push',
+            message.id,
+        )
+        return {'ok': False, 'reason': 'enqueue_failed'}

--- a/services/transaction_comms.py
+++ b/services/transaction_comms.py
@@ -471,6 +471,12 @@ class TransactionCommsService:
         comm.communication_metadata = meta
         db.session.flush()
 
+        try:
+            from services.device_push import enqueue_portal_push
+            enqueue_portal_push(msg)
+        except Exception:
+            logger.exception('Portal comms: failed to enqueue APNs for update.')
+
         return {
             'outcome': 'sent',
             'provider': 'portal',

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -1,0 +1,383 @@
+"""Agent iPhone API: password JWT, CRM resources, portal messages."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from models import (
+    ClientPortalAccess,
+    DeviceToken,
+    PortalMessage,
+    SellerAcceptedContract,
+    Task,
+    Transaction,
+    TransactionParticipant,
+    db,
+)
+
+
+def _auth(token):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _agent_session(client, *, email=None, username=None, password='password123'):
+    body = {'password': password}
+    if email is not None:
+        body['email'] = email
+    if username is not None:
+        body['username'] = username
+    return client.post(
+        '/api/agent/v1/session',
+        json=body,
+        content_type='application/json',
+    )
+
+
+def _owner_token(client):
+    resp = _agent_session(client, email='owner_a@test.com')
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def _seller_thread(seed, address='400 Agent Api Ln'):
+    tx = Transaction(
+        organization_id=seed['org_a'],
+        created_by_id=seed['owner_a'],
+        transaction_type_id=seed['tx_type_a'],
+        street_address=address,
+        city='Austin',
+        state='TX',
+        status='active',
+    )
+    db.session.add(tx)
+    db.session.flush()
+    seller = TransactionParticipant(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        contact_id=seed['contact_a'],
+        role='seller',
+        is_primary=True,
+    )
+    db.session.add(seller)
+    db.session.flush()
+    access = ClientPortalAccess(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        participant_id=seller.id,
+        token=ClientPortalAccess.generate_token(),
+        invite_code=ClientPortalAccess.generate_invite_code(),
+        session_version=1,
+        is_active=True,
+    )
+    db.session.add(access)
+    db.session.flush()
+    return tx, seller, access
+
+
+def test_session_email_and_username(app, seed, client):
+    by_email = _agent_session(client, email='owner_a@test.com')
+    assert by_email.status_code == 200
+    body = by_email.get_json()
+    assert body['token']
+    assert body['token_type'] == 'Bearer'
+    assert body['expires_in'] == 30 * 24 * 60 * 60
+    assert body['user']['email'] == 'owner_a@test.com'
+
+    by_username = _agent_session(client, username='owner_a')
+    assert by_username.status_code == 200
+    assert by_username.get_json()['token']
+
+
+def test_session_bad_creds_401(app, seed, client):
+    resp = _agent_session(client, email='owner_a@test.com', password='nope')
+    assert resp.status_code == 401
+    assert 'token' not in (resp.get_json() or {})
+
+
+def test_cookie_is_not_enough(app, seed, owner_a_client):
+    resp = owner_a_client.get('/api/agent/v1/me')
+    assert resp.status_code == 401
+    assert resp.content_type.startswith('application/json')
+
+
+def test_rejects_client_portal_jwt(app, seed, client):
+    from services.client_portal_auth import issue_client_jwt
+
+    with app.app_context():
+        tx, seller, access = _seller_thread(seed, '401 Client Jwt Ln')
+        db.session.commit()
+        client_token = issue_client_jwt(access)
+
+    resp = client.get('/api/agent/v1/me', headers=_auth(client_token))
+    assert resp.status_code == 401
+
+
+def test_me_and_dashboard_shape(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    me = client.get('/api/agent/v1/me', headers=headers)
+    assert me.status_code == 200
+    payload = me.get_json()
+    assert set(payload.keys()) == {'user', 'org', 'features'}
+    assert payload['user']['username'] == 'owner_a'
+    assert payload['org']['name'] == 'Test Realty A'
+    assert 'TRANSACTIONS' in payload['features']
+
+    dash = client.get('/api/agent/v1/dashboard', headers=headers)
+    assert dash.status_code == 200
+    body = dash.get_json()
+    assert set(body.keys()) == {
+        'user', 'kpis', 'today_tasks', 'pipeline_by_status',
+        'group_stats', 'features',
+    }
+    assert 'total_contacts' in body['kpis']
+    assert isinstance(body['today_tasks'], list)
+    assert isinstance(body['pipeline_by_status'], list)
+    assert isinstance(body['group_stats'], list)
+
+
+def test_session_revoke_bumps_sv(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+    assert client.get('/api/agent/v1/me', headers=headers).status_code == 200
+    left = client.delete('/api/agent/v1/session', headers=headers)
+    assert left.status_code == 200
+    assert client.get('/api/agent/v1/me', headers=headers).status_code == 401
+    again = _owner_token(client)
+    assert client.get('/api/agent/v1/me', headers=_auth(again)).status_code == 200
+
+
+def test_contacts_crud_and_force_delete(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    missing = client.post(
+        '/api/agent/v1/contacts',
+        headers=headers,
+        json={'first_name': 'Only'},
+    )
+    assert missing.status_code == 400
+
+    created = client.post(
+        '/api/agent/v1/contacts',
+        headers=headers,
+        json={
+            'first_name': 'Pat',
+            'last_name': 'Nguyen',
+            'email': 'pat-agent-api@test.com',
+            'group_ids': [seed['group_a1']],
+        },
+    )
+    assert created.status_code == 201
+    contact_id = created.get_json()['contact']['id']
+
+    listed = client.get(
+        '/api/agent/v1/contacts?q=Nguyen',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    names = [c['last_name'] for c in listed.get_json()['contacts']]
+    assert 'Nguyen' in names
+
+    patched = client.patch(
+        f'/api/agent/v1/contacts/{contact_id}',
+        headers=headers,
+        json={'phone': '5550001111'},
+    )
+    assert patched.status_code == 200
+    assert patched.get_json()['contact']['phone'] == '5550001111'
+
+    with app.app_context():
+        db.session.add(Task(
+            organization_id=seed['org_a'],
+            contact_id=contact_id,
+            assigned_to_id=seed['owner_a'],
+            created_by_id=seed['owner_a'],
+            type_id=seed['task_type_a'],
+            subtype_id=seed['subtype_a'],
+            subject='Keep this contact',
+            priority='low',
+            status='pending',
+            due_date=datetime.utcnow() + timedelta(days=2),
+        ))
+        db.session.commit()
+
+    blocked = client.delete(
+        f'/api/agent/v1/contacts/{contact_id}',
+        headers=headers,
+    )
+    assert blocked.status_code == 400
+    assert blocked.get_json()['has_associated_data'] is True
+
+    forced = client.delete(
+        f'/api/agent/v1/contacts/{contact_id}?force=true',
+        headers=headers,
+    )
+    assert forced.status_code == 200
+    gone = client.get(f'/api/agent/v1/contacts/{contact_id}', headers=headers)
+    assert gone.status_code == 404
+
+
+def test_transactions_flag_403_json(app, seed, client):
+    token = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    resp = client.get('/api/agent/v1/transactions', headers=_auth(token))
+    assert resp.status_code == 403
+    assert resp.content_type.startswith('application/json')
+    assert resp.get_json()['code'] == 'transactions_required'
+    assert resp.get_json().get('error')
+
+
+def test_dates_allowlist(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        tx, seller, _access = _seller_thread(seed, '402 Dates Ln')
+        contract = SellerAcceptedContract(
+            organization_id=seed['org_a'],
+            transaction_id=tx.id,
+            created_by_id=seed['owner_a'],
+            position='primary',
+            status='active',
+            accepted_price=350000,
+            effective_date=date(2026, 4, 1),
+            closing_date=date(2026, 5, 15),
+        )
+        db.session.add(contract)
+        db.session.commit()
+        tx_id = tx.id
+
+    rejected = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/dates',
+        headers=headers,
+        json={'option_period_days': 10, 'expected_close_date': '2026-06-01'},
+    )
+    assert rejected.status_code == 400
+
+    updated = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/dates',
+        headers=headers,
+        json={
+            'expected_close_date': '2026-06-01',
+            'actual_close_date': '2026-06-02',
+            'go_live_date': '2026-03-15',
+            'effective_date': '2026-04-02',
+            'closing_date': '2026-05-20',
+        },
+    )
+    assert updated.status_code == 200
+    dates = updated.get_json()['dates']
+    assert dates['expected_close_date'] == '2026-06-01'
+    assert dates['go_live_date'] == '2026-03-15'
+    assert dates['effective_date'] == '2026-04-02'
+    assert dates['closing_date'] == '2026-05-20'
+    assert dates['actual_close_date'] == '2026-06-02'
+
+
+def test_conversations_include_empty_threads(app, seed, client):
+    token = _owner_token(client)
+    with app.app_context():
+        tx, seller, _access = _seller_thread(seed, '403 Empty Thread Ln')
+        db.session.commit()
+        participant_id = seller.id
+        assert PortalMessage.query.filter_by(participant_id=participant_id).count() == 0
+
+    listed = client.get('/api/agent/v1/conversations', headers=_auth(token))
+    assert listed.status_code == 200
+    rows = listed.get_json()['conversations']
+    ids = [row['participant_id'] for row in rows]
+    assert participant_id in ids
+    empty = next(row for row in rows if row['participant_id'] == participant_id)
+    assert empty['last_preview'] is None
+    assert empty['unread'] == 0
+    assert empty['address'] == '403 Empty Thread Ln'
+
+
+def test_agent_message_visible_on_client_list(app, seed, client):
+    from tests.test_client_portal_api import _auth_headers, _open_session
+
+    with app.app_context():
+        tx, seller, access = _seller_thread(seed, '404 Cross Talk Ln')
+        db.session.commit()
+        participant_id = seller.id
+        invite = access.invite_code
+
+    agent_token = _owner_token(client)
+    posted = client.post(
+        f'/api/agent/v1/conversations/{participant_id}/messages',
+        headers=_auth(agent_token),
+        json={'body': 'Inspection is booked for Thursday.'},
+    )
+    assert posted.status_code == 201
+    assert posted.get_json()['message']['sender'] == 'agent'
+    assert posted.get_json()['message']['kind'] == 'message'
+
+    client_token = _open_session(client, invite).get_json()['token']
+    listed = client.get(
+        '/api/client/v1/messages',
+        headers=_auth_headers(client_token),
+    )
+    assert listed.status_code == 200
+    bodies = [m['body'] for m in listed.get_json()['messages']]
+    assert 'Inspection is booked for Thursday.' in bodies
+    kinds = [m['kind'] for m in listed.get_json()['messages']]
+    assert 'message' in kinds
+
+
+def test_devices_register(app, seed, client):
+    token = _owner_token(client)
+    resp = client.post(
+        '/api/agent/v1/devices',
+        headers=_auth(token),
+        json={'token': 'apns-agent-token-1', 'platform': 'ios'},
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()['ok'] is True
+    with app.app_context():
+        row = DeviceToken.query.filter_by(token='apns-agent-token-1').first()
+        assert row is not None
+        assert row.audience == DeviceToken.AUDIENCE_AGENT
+        assert row.user_id == seed['owner_a']
+
+
+def test_apns_noop_when_env_missing(app, seed, client, monkeypatch):
+    from jobs.apns_push import apns_configured, send_portal_push
+    from services.device_push import enqueue_portal_push
+
+    for key in ('APNS_KEY_ID', 'APNS_TEAM_ID', 'APNS_KEY', 'APNS_BUNDLE_ID'):
+        monkeypatch.delenv(key, raising=False)
+
+    assert apns_configured() is False
+    result = send_portal_push(message_id=1, org_id=seed['org_a'])
+    assert result['reason'] == 'apns_unconfigured'
+
+    token = _owner_token(client)
+    with app.app_context():
+        tx, seller, _access = _seller_thread(seed, '405 Push Ln')
+        db.session.commit()
+        participant_id = seller.id
+
+    posted = client.post(
+        f'/api/agent/v1/conversations/{participant_id}/messages',
+        headers=_auth(token),
+        json={'body': 'See you at the house.'},
+    )
+    assert posted.status_code == 201
+    with app.app_context():
+        msg = PortalMessage.query.filter_by(
+            participant_id=participant_id, sender='agent',
+        ).order_by(PortalMessage.id.desc()).first()
+        skipped = enqueue_portal_push(msg)
+        assert skipped['reason'] == 'apns_unconfigured'
+
+
+def test_jwt_user_not_cookie_user(app, seed, owner_a_client):
+    agent_token = _agent_session(owner_a_client, email='agent_a@test.com').get_json()['token']
+    listed = owner_a_client.get(
+        '/api/agent/v1/contacts',
+        headers=_auth(agent_token),
+    )
+    assert listed.status_code == 200
+    emails = [c['email'] for c in listed.get_json()['contacts']]
+    assert 'john@test.com' in emails
+    assert 'jane@test.com' not in emails

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -371,6 +371,101 @@ def test_apns_noop_when_env_missing(app, seed, client, monkeypatch):
         assert skipped['reason'] == 'apns_unconfigured'
 
 
+def test_transaction_routes_round_trip(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    created = client.post(
+        '/api/agent/v1/transactions',
+        headers=headers,
+        json={
+            'transaction_type_id': seed['tx_type_a'],
+            'street_address': '406 Round Trip Ln',
+            'city': 'Austin',
+            'state': 'TX',
+            'contact_ids': [seed['contact_a']],
+        },
+    )
+    assert created.status_code == 201
+    tx_id = created.get_json()['transaction']['id']
+
+    listed = client.get('/api/agent/v1/transactions', headers=headers)
+    assert listed.status_code == 200
+    assert any(row['id'] == tx_id for row in listed.get_json()['transactions'])
+
+    patched = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+        json={'city': 'Dallas'},
+    )
+    assert patched.status_code == 200
+    assert patched.get_json()['transaction']['city'] == 'Dallas'
+
+    status = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        headers=headers,
+        json={'status': 'under_contract'},
+    )
+    assert status.status_code == 200
+    assert status.get_json()['status'] == 'under_contract'
+
+    added = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/participants',
+        headers=headers,
+        json={'role': 'co_seller', 'name': 'Riley CoSeller'},
+    )
+    assert added.status_code == 201
+    parts = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/participants',
+        headers=headers,
+    )
+    names = [p['name'] for p in parts.get_json()['participants']]
+    assert 'Riley CoSeller' in names
+
+    with app.app_context():
+        db.session.add(SellerAcceptedContract(
+            organization_id=seed['org_a'],
+            transaction_id=tx_id,
+            created_by_id=seed['owner_a'],
+            position='primary',
+            status='active',
+        ))
+        db.session.commit()
+
+    milestone = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/milestones',
+        headers=headers,
+        json={'title': 'Option period', 'status': 'not_started'},
+    )
+    assert milestone.status_code == 201
+    mid = milestone.get_json()['milestone']['id']
+    updated = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/milestones/{mid}',
+        headers=headers,
+        json={'status': 'completed'},
+    )
+    assert updated.status_code == 200
+    assert updated.get_json()['milestone']['status'] == 'completed'
+
+    docs = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/documents',
+        headers=headers,
+    )
+    assert docs.status_code == 200
+    assert 'documents' in docs.get_json()
+
+    deleted = client.delete(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+    )
+    assert deleted.status_code == 200
+    missing = client.get(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+    )
+    assert missing.status_code == 404
+
+
 def test_jwt_user_not_cookie_user(app, seed, owner_a_client):
     agent_token = _agent_session(owner_a_client, email='agent_a@test.com').get_json()['token']
     listed = owner_a_client.get(

--- a/tests/test_client_portal_api.py
+++ b/tests/test_client_portal_api.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 from models import (
     ClientPortalAccess,
+    DeviceToken,
     DocumentSignature,
     Organization,
     PortalMessage,
@@ -818,3 +819,108 @@ def test_mls_listing_url_round_trip_on_deal(app, seed, owner_a_client, client):
         '/api/client/v1/deal', headers=_auth_headers(token),
     ).get_json()
     assert cleared_deal['mls_listing_url'] is None
+
+
+CLIENT_SESSION_KEYS = {
+    'token', 'token_type', 'expires_in',
+    'participant_first_name', 'role', 'branding',
+}
+CLIENT_MESSAGE_KEYS = {
+    'id', 'sender', 'kind', 'body', 'author', 'created_at', 'date',
+}
+
+
+def test_client_v1_session_deal_messages_contract_unchanged(app, seed, client):
+    from services.portal_service import _DEAL_KEYS
+
+    with app.app_context():
+        tx = _seller_tx(seed, '920 Contract Pin Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+
+    session = _open_session(client, code)
+    body = _assert_bearer_session(session)
+    assert set(body.keys()) == CLIENT_SESSION_KEYS
+
+    token = body['token']
+    headers = _auth_headers(token)
+    deal = client.get('/api/client/v1/deal', headers=headers)
+    assert deal.status_code == 200
+    deal_body = deal.get_json()
+    assert set(_DEAL_KEYS).issubset(deal_body.keys())
+    assert 'branding' in deal_body
+    blob = json.dumps(deal_body).lower()
+    assert LOCKBOX_SECRET.lower() not in blob
+    assert RENTCAST_SECRET.lower() not in blob
+    assert 'commission' not in blob
+
+    messages = client.get('/api/client/v1/messages', headers=headers)
+    assert messages.status_code == 200
+    assert set(messages.get_json().keys()) == {'messages'}
+    posted = client.post(
+        '/api/client/v1/messages',
+        headers=headers,
+        json={'body': 'Pin the messages contract.'},
+    )
+    assert posted.status_code == 201
+    assert set(posted.get_json().keys()) == {'message'}
+    assert set(posted.get_json()['message'].keys()) == CLIENT_MESSAGE_KEYS
+
+
+def test_client_devices_register(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '921 Client Device Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        code = access.invite_code
+        participant_id = seller.id
+
+    token = _open_session(client, code).get_json()['token']
+    resp = client.post(
+        '/api/client/v1/devices',
+        headers=_auth_headers(token),
+        json={'token': 'apns-client-token-1', 'platform': 'ios'},
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()['ok'] is True
+    with app.app_context():
+        row = DeviceToken.query.filter_by(token='apns-client-token-1').first()
+        assert row is not None
+        assert row.audience == DeviceToken.AUDIENCE_CLIENT
+        assert row.participant_id == participant_id
+
+
+def test_agent_posted_message_appears_on_client_list(app, seed, client):
+    with app.app_context():
+        tx = _seller_tx(seed, '922 Agent Visible Ln')
+        seller = _participant(seed, tx, contact_id=seed['contact_a'])
+        access = _grant(seed, tx, seller)
+        db.session.commit()
+        participant_id = seller.id
+        code = access.invite_code
+
+    agent = client.post(
+        '/api/agent/v1/session',
+        json={'email': 'owner_a@test.com', 'password': 'password123'},
+    )
+    assert agent.status_code == 200
+    posted = client.post(
+        f'/api/agent/v1/conversations/{participant_id}/messages',
+        headers=_auth_headers(agent.get_json()['token']),
+        json={'body': 'Closing docs are in your packet.'},
+    )
+    assert posted.status_code == 201
+
+    token = _open_session(client, code).get_json()['token']
+    listed = client.get(
+        '/api/client/v1/messages',
+        headers=_auth_headers(token),
+    )
+    assert listed.status_code == 200
+    bodies = [m['body'] for m in listed.get_json()['messages']]
+    assert 'Closing docs are in your packet.' in bodies
+    assert listed.get_json()['messages'][-1]['sender'] == 'agent'
+    assert listed.get_json()['messages'][-1]['kind'] == 'message'

--- a/tests/test_worker_queues.py
+++ b/tests/test_worker_queues.py
@@ -2,10 +2,15 @@
 
 
 def test_worker_listens_to_inbox_bootstrap_queue():
+    from services.device_push import QUEUE_NAME as APNS_QUEUE
+    from services.messaging.queue import QUEUE_NAME as TELEGRAM_QUEUE
     from worker import QUEUE_NAMES
 
     assert QUEUE_NAMES == (
         "doc_extraction",
         "bob_telegram",
         "contract_bootstrap",
+        "apns",
     )
+    assert TELEGRAM_QUEUE in QUEUE_NAMES
+    assert APNS_QUEUE in QUEUE_NAMES

--- a/worker.py
+++ b/worker.py
@@ -26,7 +26,8 @@ log = logging.getLogger("worker")
 logging.basicConfig(level=logging.INFO)
 
 # Queues this process must consume. Inbox identification enqueues onto
-# contract_bootstrap; omitting a name here leaves those jobs Queued forever.
+# contract_bootstrap. PortalMessage push enqueues onto apns. Omitting a
+# name here leaves those jobs Queued forever.
 QUEUE_NAMES = (
     "doc_extraction",
     "bob_telegram",

--- a/worker.py
+++ b/worker.py
@@ -31,6 +31,7 @@ QUEUE_NAMES = (
     "doc_extraction",
     "bob_telegram",
     "contract_bootstrap",
+    "apns",
 )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Password login for the agent iPhone app. New blueprint at `/api/agent/v1`. Flask-Login cookies are ignored. Client portal JWTs (`typ=client_portal`) are rejected.

**Auth.** `POST /session` looks up email, then username, same as web login. JWT `typ=agent` with `uid`, `oid`, `sv`. 30-day TTL. `DELETE /session` bumps `user.session_version`.

**Resources.** Dashboard reuses the web dashboard queries (no Market Insights, Magic Inbox, Daily Briefing, or activation HTML). Contacts are org-scoped with hard delete and `force=true`. Transaction routes return JSON 403 `{ "code": "transactions_required" }` when the TRANSACTIONS flag is off.

**Dates.** `PATCH .../dates` writes only portal-visible dates. It does not run contract-details replace, which rebuilds milestones.

**Messages.** Conversations are every buyer/seller participant on visible deals, including empty threads. Agent posts `sender=agent`, `kind=message` on `PortalMessage`. Client `GET /messages` already sees those.

**Devices.** Agent and client `POST /devices`. One `device_tokens` table with `audience`. New PortalMessage enqueues APNs on the existing RQ worker. Missing `APNS_*` env is a no-op.

Client `/api/client/v1` session, deal, and messages contracts are unchanged except the additive `POST /devices`.

**CI unit fix.** `tests/test_worker_listens_to_inbox_bootstrap_queue` failed at `04ef81f` because `QUEUE_NAMES` already included `apns` and the pin still expected the old 3-queue tuple. The pin now includes `apns` and asserts producer queue names stay in the listen list.

**Tests.** Local CI unit suite: `pytest tests/ -x -v` (with the same ignores as `.github/workflows/test.yml`) plus `tests/test_idor_protection.py`. 1716 passed, 6 skipped, then 24 IDOR passed. Targeted: `tests/test_worker_queues.py tests/test_agent_api.py tests/test_client_portal_api.py` 36 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6baeea38-6866-4c43-8fc5-cd807de4a741?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6baeea38-6866-4c43-8fc5-cd807de4a741&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

