### PR TITLE
fix: APNs topic from device audience so both iPhone apps can get sandbox pushes

### DIFF
--- a/jobs/apns_push.py
+++ b/jobs/apns_push.py
@@ -11,7 +11,7 @@ from jobs.base import set_job_org_context
 
 logger = logging.getLogger(__name__)
 
-APNS_ENV_KEYS = ('APNS_KEY_ID', 'APNS_TEAM_ID', 'APNS_KEY', 'APNS_BUNDLE_ID')
+APNS_ENV_KEYS = ('APNS_KEY_ID', 'APNS_TEAM_ID', 'APNS_KEY')
 
 
 def apns_configured() -> bool:
@@ -57,16 +57,16 @@ def send_portal_push(*, message_id: int, org_id: int):
 
         sent = 0
         for row in tokens:
-            if _send_one(row.token, msg):
+            if _send_one(row.token, msg, row.audience):
                 sent += 1
         return {'ok': True, 'sent': sent}
 
 
-def _send_one(device_token: str, msg) -> bool:
+def _send_one(device_token: str, msg, audience) -> bool:
     """HTTP/2 APNs post. Isolated so missing env never reaches here."""
     try:
         from services.apns_client import send_alert
-        return bool(send_alert(device_token, msg))
+        return bool(send_alert(device_token, msg, audience=audience))
     except Exception:
         logger.exception('APNs send failed for token suffix %s', device_token[-8:])
         return False

--- a/services/apns_client.py
+++ b/services/apns_client.py
@@ -8,13 +8,26 @@ import time
 
 logger = logging.getLogger(__name__)
 
+_TOPIC_BY_AUDIENCE = {
+    'agent': ('APNS_BUNDLE_ID_AGENT', 'com.agentflow.agent'),
+    'client': ('APNS_BUNDLE_ID_CLIENT', 'com.agentflow.client'),
+}
 
-def send_alert(device_token: str, msg) -> bool:
+
+def topic_for_audience(audience=None) -> str:
+    spec = _TOPIC_BY_AUDIENCE.get((audience or '').strip().lower())
+    if spec:
+        env_key, default = spec
+        return (os.environ.get(env_key) or '').strip() or default
+    return (os.environ.get('APNS_BUNDLE_ID') or '').strip()
+
+
+def send_alert(device_token: str, msg, audience=None) -> bool:
     key_id = (os.environ.get('APNS_KEY_ID') or '').strip()
     team_id = (os.environ.get('APNS_TEAM_ID') or '').strip()
     key_pem = (os.environ.get('APNS_KEY') or '').strip()
-    bundle_id = (os.environ.get('APNS_BUNDLE_ID') or '').strip()
-    if not (key_id and team_id and key_pem and bundle_id and device_token):
+    topic = topic_for_audience(audience)
+    if not (key_id and team_id and key_pem and topic and device_token):
         return False
 
     host = 'api.push.apple.com'
@@ -48,7 +61,7 @@ def send_alert(device_token: str, msg) -> bool:
     url = f'https://{host}/3/device/{device_token}'
     headers = {
         'authorization': f'bearer {token}',
-        'apns-topic': bundle_id,
+        'apns-topic': topic,
         'apns-push-type': 'alert',
         'apns-priority': '10',
         'apns-expiration': '0',

--- a/tests/test_apns_push.py
+++ b/tests/test_apns_push.py
@@ -1,0 +1,293 @@
+"""APNs sender: audience topic, sandbox host, missing-env no-op."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from models import DeviceToken, PortalMessage, Transaction, TransactionParticipant, db
+
+
+TEST_P8 = (
+    '-----BEGIN PRIVATE KEY-----\n'
+    'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgloWaYwhRgAbK7ghR\n'
+    'dgJFwDTqKCe5s71OH3LG+C7GBBehRANCAARGF0uxHGoJa+Et1Eng8ZDj5y9Zskhi\n'
+    'rZCagWSeebZxKXxs41X/Mn2dECxth+TZ0UwfVIPkPqZtWLK0JJQXTK7a\n'
+    '-----END PRIVATE KEY-----'
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_device_tokens(app):
+    yield
+    with app.app_context():
+        DeviceToken.query.delete()
+        db.session.commit()
+
+
+def _clear_apns_env(monkeypatch):
+    for key in (
+        'APNS_KEY_ID',
+        'APNS_TEAM_ID',
+        'APNS_KEY',
+        'APNS_BUNDLE_ID',
+        'APNS_BUNDLE_ID_AGENT',
+        'APNS_BUNDLE_ID_CLIENT',
+        'APNS_ENVIRONMENT',
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _set_apns_keys(monkeypatch, **overrides):
+    _clear_apns_env(monkeypatch)
+    values = {
+        'APNS_KEY_ID': 'KEYID1234',
+        'APNS_TEAM_ID': 'TEAMID1234',
+        'APNS_KEY': TEST_P8,
+    }
+    values.update(overrides)
+    for key, value in values.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+
+class _OkResponse:
+    status_code = 200
+
+
+def _capture_httpx(monkeypatch):
+    import httpx
+
+    calls = []
+
+    def post(url, headers=None, content=None, timeout=None):
+        calls.append({
+            'url': url,
+            'headers': dict(headers or {}),
+            'content': content,
+        })
+        return _OkResponse()
+
+    monkeypatch.setattr(httpx, 'post', post)
+    return calls
+
+
+def _thread(seed, address):
+    tx = Transaction(
+        organization_id=seed['org_a'],
+        created_by_id=seed['owner_a'],
+        transaction_type_id=seed['tx_type_a'],
+        street_address=address,
+        city='Austin',
+        state='TX',
+        status='active',
+    )
+    db.session.add(tx)
+    db.session.flush()
+    seller = TransactionParticipant(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        contact_id=seed['contact_a'],
+        role='seller',
+        is_primary=True,
+    )
+    db.session.add(seller)
+    db.session.flush()
+    return tx, seller
+
+
+def _portal_message(seed, tx, seller, sender, body):
+    msg = PortalMessage(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        participant_id=seller.id,
+        sender=sender,
+        kind='message',
+        body=body,
+        author_user_id=seed['owner_a'] if sender == 'agent' else None,
+    )
+    db.session.add(msg)
+    db.session.flush()
+    return msg
+
+
+def _device(seed, audience, token, participant_id=None):
+    row = DeviceToken(
+        organization_id=seed['org_a'],
+        audience=audience,
+        token=token,
+        platform='ios',
+        user_id=seed['owner_a'] if audience == DeviceToken.AUDIENCE_AGENT else None,
+        participant_id=(
+            participant_id if audience == DeviceToken.AUDIENCE_CLIENT else None
+        ),
+    )
+    db.session.add(row)
+    db.session.flush()
+    return row
+
+
+def test_missing_env_still_noops(app, seed, monkeypatch):
+    from jobs.apns_push import apns_configured, send_portal_push
+    from services.device_push import enqueue_portal_push
+
+    _clear_apns_env(monkeypatch)
+    calls = _capture_httpx(monkeypatch)
+
+    assert apns_configured() is False
+    assert send_portal_push(message_id=1, org_id=seed['org_a']) == {
+        'ok': False,
+        'reason': 'apns_unconfigured',
+    }
+    assert calls == []
+
+    with app.app_context():
+        tx, seller = _thread(seed, '500 Missing Env Ln')
+        msg = _portal_message(seed, tx, seller, 'agent', 'Still no push.')
+        db.session.commit()
+        skipped = enqueue_portal_push(msg)
+    assert skipped['reason'] == 'apns_unconfigured'
+
+
+def test_configured_without_legacy_bundle_id(monkeypatch):
+    from jobs.apns_push import apns_configured
+
+    _set_apns_keys(monkeypatch)
+    assert apns_configured() is True
+
+
+def test_send_uses_audience_topics_and_sandbox_host(app, seed, monkeypatch):
+    from jobs.apns_push import send_portal_push
+
+    _set_apns_keys(monkeypatch, APNS_ENVIRONMENT='sandbox')
+    calls = _capture_httpx(monkeypatch)
+
+    with app.app_context():
+        tx, seller = _thread(seed, '501 Topic Ln')
+        client_msg = _portal_message(seed, tx, seller, 'client', 'From the seller.')
+        agent_msg = _portal_message(seed, tx, seller, 'agent', 'From the agent.')
+        _device(seed, DeviceToken.AUDIENCE_AGENT, 'agent-device-token')
+        _device(
+            seed, DeviceToken.AUDIENCE_CLIENT, 'client-device-token',
+            participant_id=seller.id,
+        )
+        db.session.commit()
+        client_msg_id = client_msg.id
+        agent_msg_id = agent_msg.id
+        org_id = seed['org_a']
+
+    to_agent = send_portal_push(message_id=client_msg_id, org_id=org_id)
+    to_client = send_portal_push(message_id=agent_msg_id, org_id=org_id)
+
+    assert to_agent == {'ok': True, 'sent': 1}
+    assert to_client == {'ok': True, 'sent': 1}
+    assert len(calls) == 2
+
+    agent_call = next(c for c in calls if c['url'].endswith('/agent-device-token'))
+    client_call = next(c for c in calls if c['url'].endswith('/client-device-token'))
+
+    assert agent_call['url'] == (
+        'https://api.sandbox.push.apple.com/3/device/agent-device-token'
+    )
+    assert client_call['url'] == (
+        'https://api.sandbox.push.apple.com/3/device/client-device-token'
+    )
+    assert agent_call['headers']['apns-topic'] == 'com.agentflow.agent'
+    assert client_call['headers']['apns-topic'] == 'com.agentflow.client'
+
+
+def test_audience_env_overrides_default_topics(app, seed, monkeypatch):
+    from jobs.apns_push import send_portal_push
+
+    _set_apns_keys(
+        monkeypatch,
+        APNS_ENVIRONMENT='sandbox',
+        APNS_BUNDLE_ID='com.legacy.shared',
+        APNS_BUNDLE_ID_AGENT='com.custom.agent',
+        APNS_BUNDLE_ID_CLIENT='com.custom.client',
+    )
+    calls = _capture_httpx(monkeypatch)
+
+    with app.app_context():
+        tx, seller = _thread(seed, '502 Override Ln')
+        client_msg = _portal_message(seed, tx, seller, 'client', 'Override agent.')
+        agent_msg = _portal_message(seed, tx, seller, 'agent', 'Override client.')
+        _device(seed, DeviceToken.AUDIENCE_AGENT, 'override-agent-token')
+        _device(
+            seed, DeviceToken.AUDIENCE_CLIENT, 'override-client-token',
+            participant_id=seller.id,
+        )
+        db.session.commit()
+        client_msg_id = client_msg.id
+        agent_msg_id = agent_msg.id
+        org_id = seed['org_a']
+
+    send_portal_push(message_id=client_msg_id, org_id=org_id)
+    send_portal_push(message_id=agent_msg_id, org_id=org_id)
+
+    topics = {c['url'].rsplit('/', 1)[-1]: c['headers']['apns-topic'] for c in calls}
+    assert topics['override-agent-token'] == 'com.custom.agent'
+    assert topics['override-client-token'] == 'com.custom.client'
+
+
+def test_legacy_bundle_id_does_not_replace_audience_defaults(app, seed, monkeypatch):
+    from jobs.apns_push import send_portal_push
+
+    _set_apns_keys(
+        monkeypatch,
+        APNS_ENVIRONMENT='sandbox',
+        APNS_BUNDLE_ID='com.legacy.shared',
+    )
+    calls = _capture_httpx(monkeypatch)
+
+    with app.app_context():
+        tx, seller = _thread(seed, '503 Legacy Ln')
+        client_msg = _portal_message(seed, tx, seller, 'client', 'Legacy agent.')
+        _device(seed, DeviceToken.AUDIENCE_AGENT, 'legacy-agent-token')
+        db.session.commit()
+        result = send_portal_push(message_id=client_msg.id, org_id=seed['org_a'])
+
+    assert result == {'ok': True, 'sent': 1}
+    assert calls[0]['headers']['apns-topic'] == 'com.agentflow.agent'
+
+
+def test_production_host_when_environment_is_production(monkeypatch):
+    from services.apns_client import send_alert
+
+    _set_apns_keys(monkeypatch, APNS_ENVIRONMENT='production')
+    calls = _capture_httpx(monkeypatch)
+    msg = SimpleNamespace(
+        id=9,
+        body='Production host.',
+        sender='client',
+        transaction_id=1,
+        participant_id=2,
+    )
+
+    assert send_alert('prod-device-token', msg, audience='agent') is True
+    assert calls[0]['url'] == (
+        'https://api.push.apple.com/3/device/prod-device-token'
+    )
+    assert calls[0]['headers']['apns-topic'] == 'com.agentflow.agent'
+
+
+def test_production_host_when_environment_unset(monkeypatch):
+    from services.apns_client import send_alert
+
+    _set_apns_keys(monkeypatch)
+    calls = _capture_httpx(monkeypatch)
+    msg = SimpleNamespace(
+        id=10,
+        body='Default host.',
+        sender='agent',
+        transaction_id=1,
+        participant_id=2,
+    )
+
+    assert send_alert('default-host-token', msg, audience='client') is True
+    assert calls[0]['url'] == (
+        'https://api.push.apple.com/3/device/default-host-token'
+    )
+    assert calls[0]['headers']['apns-topic'] == 'com.agentflow.client'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Xcode-installed Agent and Client apps were sharing one `apns-topic`. Production CRM talking to sandbox APNs could not address both bundles.

**What was broken.** `send_alert` always set `apns-topic` from `APNS_BUNDLE_ID`. The worker already selected `device_tokens` by audience, then dropped that field before the HTTP call. `apns_configured()` also required `APNS_BUNDLE_ID`, so signing keys alone no-oped.

**Root cause.** Confirmed on the sender with mocked `httpx`. With `APNS_BUNDLE_ID=com.legacy.shared` and `APNS_BUNDLE_ID_AGENT=com.custom.agent`, the captured header was still `com.legacy.shared`. With keys set and no `APNS_BUNDLE_ID`, the worker logged `apns_unconfigured` and never posted.

**Fix.** `topic_for_audience()` maps `device_tokens.audience` to `APNS_BUNDLE_ID_AGENT` / `APNS_BUNDLE_ID_CLIENT`, defaulting to `com.agentflow.agent` and `com.agentflow.client`. `APNS_BUNDLE_ID` is last-resort only. Host selection is unchanged. `APNS_ENVIRONMENT=sandbox` still uses `api.sandbox.push.apple.com`. Missing `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_KEY` still no-ops.

No client or agent route contracts changed. No OneSignal or Firebase.

**Verify.** Failing-then-passing on `tests/test_apns_push.py` plus the existing missing-env no-op.

Before (HEAD `1f3508e`):

```
FAILED test_configured_without_legacy_bundle_id
FAILED test_send_uses_audience_topics_and_sandbox_host  (reason: apns_unconfigured)
FAILED test_audience_env_overrides_default_topics
  assert 'com.legacy.shared' == 'com.custom.agent'
FAILED test_legacy_bundle_id_does_not_replace_audience_defaults
  assert 'com.legacy.shared' == 'com.agentflow.agent'
```

After:

```
8 passed  (7 new APNs tests + test_apns_noop_when_env_missing)
```

Production CRM still needs `APNS_ENVIRONMENT=sandbox` when the installed app is Xcode/dev. That env already existed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e4afc09-dd58-4484-9ae3-3284232a6b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e4afc09-dd58-4484-9ae3-3284232a6b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

