### PR TITLE
fix: agent API deal detail, tracker dates, and contact groups

### DIFF
--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -21,6 +21,7 @@ from models import (
     DeviceToken,
     Interaction,
     PortalMessage,
+    SellerAcceptedContract,
     SellerContractMilestone,
     SellerListingProfile,
     Task,
@@ -41,10 +42,14 @@ from services.agent_auth import (
     serialize_user,
 )
 from services.agent_dashboard import build_dashboard, me_payload
-from services.contact_group_service import ContactGroupError, resolve_groups_for_owner
+from services.contact_group_service import (
+    ContactGroupError,
+    list_user_groups,
+    resolve_groups_for_owner,
+)
 from services.controlling_contracts import get_active_primary_contract
 from services.device_push import enqueue_portal_push, register_device
-from services.portal_service import CLIENT_PORTAL_ROLES, list_client_messages
+from services.portal_service import CLIENT_PORTAL_ROLES, list_client_messages, portal_tracker
 from services.tenant_service import org_query_for_id
 from services.transaction_auth import (
     CAP_EDIT,
@@ -227,6 +232,14 @@ def _serialize_contact(contact):
         'potential_commission': float(contact.potential_commission or 0),
         'current_objective': contact.current_objective,
         'group_ids': [g.id for g in (contact.groups or [])],
+        'groups': [
+            {
+                'id': g.id,
+                'name': g.name,
+                'category': getattr(g, 'category', None),
+            }
+            for g in (contact.groups or [])
+        ],
         'user_id': contact.user_id,
         'created_at': contact.created_at.isoformat() if contact.created_at else None,
     }
@@ -257,7 +270,9 @@ def _tx_dates(tx):
     }
 
 
-def _serialize_transaction(tx, *, detail=False):
+def _serialize_transaction(tx, *, detail=False, participants=None):
+    people = participants if participants is not None else tx.participants.all()
+    tracker = portal_tracker(tx, rich=detail)
     payload = {
         'id': tx.id,
         'street_address': tx.street_address,
@@ -272,13 +287,54 @@ def _serialize_transaction(tx, *, detail=False):
         ),
         'mls_listing_url': tx.mls_listing_url,
         'created_by_id': tx.created_by_id,
+        'headline_statement': tracker['headline_statement'],
+        'current_stage_index': tracker['current_stage_index'],
+        'stages': tracker['stages'],
+        'participants': [_serialize_participant(p) for p in people],
         **_tx_dates(tx),
     }
     if detail:
-        payload['participants'] = [
-            _serialize_participant(p) for p in tx.participants.all()
+        payload['milestones'] = [
+            _serialize_milestone(m)
+            for m in tx.seller_contract_milestones.order_by(
+                SellerContractMilestone.due_at.asc().nullslast(),
+            ).all()
+        ]
+        payload['documents'] = [
+            _serialize_document(doc)
+            for doc in tx.documents.order_by(
+                TransactionDocument.created_at.desc(),
+            ).all()
         ]
     return payload
+
+
+def _participants_by_transaction(transaction_ids):
+    if not transaction_ids:
+        return {}
+    rows = TransactionParticipant.query.filter(
+        TransactionParticipant.transaction_id.in_(transaction_ids),
+    ).all()
+    grouped = {}
+    for row in rows:
+        grouped.setdefault(row.transaction_id, []).append(row)
+    return grouped
+
+
+def _ensure_primary_contract(tx, user):
+    contract = get_active_primary_contract(tx.id, tx.organization_id)
+    if contract is not None:
+        return contract
+    contract = SellerAcceptedContract(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        created_by_id=user.id,
+        position='primary',
+        status='active',
+    )
+    db.session.add(contract)
+    db.session.flush()
+    return contract
 
 
 def _serialize_participant(participant):
@@ -310,12 +366,15 @@ def _serialize_milestone(milestone):
 
 
 def _serialize_document(doc):
+    title = doc.review_filename or doc.template_name or 'Document'
     return {
         'id': doc.id,
+        'title': title,
         'name': doc.template_name,
         'slug': doc.template_slug,
         'status': doc.status,
         'source': doc.document_source,
+        'original_filename': getattr(doc, 'signed_original_filename', None),
         'has_file': bool(doc.signed_file_path or doc.source_file_path),
         'created_at': doc.created_at.isoformat() if doc.created_at else None,
     }
@@ -568,6 +627,22 @@ def delete_contact(user, contact_id):
     return jsonify({'ok': True})
 
 
+@agent_api_bp.route('/contact-groups', methods=['GET'])
+@agent_jwt_required
+def list_contact_groups(user):
+    groups = list_user_groups(user.organization_id, user.id, active_only=True)
+    return jsonify({
+        'groups': [
+            {
+                'id': group.id,
+                'name': group.name,
+                'category': getattr(group, 'category', None),
+            }
+            for group in groups
+        ],
+    })
+
+
 @agent_api_bp.route('/transactions', methods=['GET'])
 @agent_jwt_required
 @transactions_flag_required
@@ -586,8 +661,15 @@ def list_transactions(user):
             Transaction.city.ilike(like),
         ))
     rows = query.order_by(Transaction.created_at.desc()).limit(200).all()
+    people = _participants_by_transaction([tx.id for tx in rows])
     return jsonify({
-        'transactions': [_serialize_transaction(tx) for tx in rows],
+        'transactions': [
+            _serialize_transaction(
+                tx,
+                participants=people.get(tx.id, []),
+            )
+            for tx in rows
+        ],
     })
 
 
@@ -765,12 +847,7 @@ def patch_transaction_dates(user, transaction_id):
                 db.session.add(profile)
             profile.go_live_date = _parse_date(data.get('go_live_date'))
         if 'effective_date' in data or 'closing_date' in data:
-            contract = get_active_primary_contract(tx.id, tx.organization_id)
-            if contract is None:
-                return _json_error(
-                    'No controlling contract to date. Do not send a contract-details dump.',
-                    400,
-                )
+            contract = _ensure_primary_contract(tx, user)
             if 'effective_date' in data:
                 contract.effective_date = _parse_date(data.get('effective_date'))
             if 'closing_date' in data:

--- a/services/portal_service.py
+++ b/services/portal_service.py
@@ -380,6 +380,18 @@ def _build_buyer_stages(tx):
     else:
         current = 0
 
+    effective = _as_date(primary_contract.effective_date) if primary_contract else None
+    closing = _as_date(primary_contract.closing_date) if primary_contract else None
+    if not closing:
+        closing = _as_date(getattr(tx, 'expected_close_date', None))
+    closed_on = _as_date(getattr(tx, 'actual_close_date', None))
+    stage_dates = {
+        'showing': None,
+        'under_contract': effective,
+        'closing': closing,
+        'closed': closed_on or closing,
+    }
+
     stages = []
     for i, (key, label, icon) in enumerate(BUYER_STAGE_DEFS):
         if i < current:
@@ -388,7 +400,14 @@ def _build_buyer_stages(tx):
             state = 'current'
         else:
             state = 'upcoming'
-        stages.append({'key': key, 'label': label, 'icon': icon, 'state': state})
+        stages.append({
+            'key': key,
+            'label': label,
+            'icon': icon,
+            'state': state,
+            'date': _day(stage_dates.get(key)),
+            'index': i,
+        })
     return stages, current
 
 
@@ -421,6 +440,8 @@ def _build_stages(tx, profile):
     first_offer = _first_offer_date(tx)
     effective = _as_date(primary_contract.effective_date) if primary_contract else None
     closing = _as_date(primary_contract.closing_date) if primary_contract else None
+    if not closing:
+        closing = _as_date(getattr(tx, 'expected_close_date', None))
     closed_on = _as_date(getattr(tx, 'actual_close_date', None))
     stage_dates = {
         'preparing': _as_date(getattr(tx, 'created_at', None)),
@@ -447,6 +468,70 @@ def _build_stages(tx, profile):
             'state': state,
             'date': _day(stage_dates.get(key)),
             'index': idx,
+        })
+    return stages, current
+
+
+def portal_tracker(tx, *, rich=True):
+    """Pizza-tracker stages the client app already renders.
+
+    ``rich=False`` uses status only so list endpoints stay cheap.
+    """
+    tx_type = tx.transaction_type.name if getattr(tx, 'transaction_type', None) else 'seller'
+    is_buyer = tx_type in {'buyer', 'tenant'}
+    if rich:
+        if is_buyer:
+            stages, current = _build_buyer_stages(tx)
+        else:
+            stages, current = _build_stages(
+                tx, getattr(tx, 'seller_listing_profile', None),
+            )
+    else:
+        stages, current = _status_only_stages(tx, is_buyer=is_buyer)
+    key = stages[current]['key'] if stages else None
+    default = 'Under contract' if is_buyer else 'Live on the market'
+    return {
+        'stages': stages,
+        'current_stage_index': current,
+        'headline_statement': STAGE_STATEMENTS.get(key, default),
+    }
+
+
+def _status_only_stages(tx, *, is_buyer):
+    status = tx.status
+    if is_buyer:
+        defs = BUYER_STAGE_DEFS
+        if status == 'closed':
+            current = 3
+        elif status == 'under_contract':
+            current = 1
+        else:
+            current = 0
+    else:
+        defs = STAGE_DEFS
+        if status == 'closed':
+            current = 6
+        elif status == 'under_contract':
+            current = 4
+        elif status in {'active', 'cancelled'}:
+            current = 1
+        else:
+            current = 0
+    stages = []
+    for index, (key, label, icon) in enumerate(defs):
+        if index < current:
+            state = 'done'
+        elif index == current:
+            state = 'current'
+        else:
+            state = 'upcoming'
+        stages.append({
+            'key': key,
+            'label': label,
+            'icon': icon,
+            'state': state,
+            'date': None,
+            'index': index,
         })
     return stages, current
 

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -227,6 +227,58 @@ def test_transactions_flag_403_json(app, seed, client):
     assert resp.get_json().get('error')
 
 
+def test_contact_groups_catalog(app, seed, client):
+    token = _owner_token(client)
+    resp = client.get('/api/agent/v1/contact-groups', headers=_auth(token))
+    assert resp.status_code == 200
+    names = [row['name'] for row in resp.get_json()['groups']]
+    assert names
+
+
+def test_dates_without_contract_write_portal_fields(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        tx, _seller, _access = _seller_thread(seed, '408 No Contract Dates Ln')
+        db.session.commit()
+        tx_id = tx.id
+
+    updated = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/dates',
+        headers=headers,
+        json={
+            'go_live_date': '2026-03-15',
+            'expected_close_date': '2026-06-01',
+            'effective_date': '2026-04-02',
+            'closing_date': '2026-05-20',
+        },
+    )
+    assert updated.status_code == 200
+    dates = updated.get_json()['dates']
+    assert dates['go_live_date'] == '2026-03-15'
+    assert dates['expected_close_date'] == '2026-06-01'
+    assert dates['effective_date'] == '2026-04-02'
+    assert dates['closing_date'] == '2026-05-20'
+
+    from tests.test_client_portal_api import _auth_headers, _open_session
+
+    with app.app_context():
+        access = ClientPortalAccess.query.filter_by(transaction_id=tx_id).first()
+        invite = access.invite_code
+
+    client_token = _open_session(client, invite).get_json()['token']
+    deal = client.get(
+        '/api/client/v1/deal',
+        headers=_auth_headers(client_token),
+    )
+    assert deal.status_code == 200
+    stages = {row['key']: row for row in deal.get_json()['stages']}
+    assert stages['active']['date']
+    assert stages['under_contract']['date']
+    assert stages['closing']['date']
+
+
 def test_dates_allowlist(app, seed, client):
     token = _owner_token(client)
     headers = _auth(token)
@@ -391,7 +443,20 @@ def test_transaction_routes_round_trip(app, seed, client):
 
     listed = client.get('/api/agent/v1/transactions', headers=headers)
     assert listed.status_code == 200
-    assert any(row['id'] == tx_id for row in listed.get_json()['transactions'])
+    listed_row = next(
+        row for row in listed.get_json()['transactions'] if row['id'] == tx_id
+    )
+    assert listed_row['participants']
+    assert listed_row['stages']
+    assert listed_row['headline_statement']
+
+    detail = client.get(f'/api/agent/v1/transactions/{tx_id}', headers=headers)
+    assert detail.status_code == 200
+    body = detail.get_json()['transaction']
+    assert body['participants']
+    assert body['stages']
+    assert 'documents' in body
+    assert 'milestones' in body
 
     patched = client.patch(
         f'/api/agent/v1/transactions/{tx_id}',


### PR DESCRIPTION
## Summary
- Agent deal list/detail now includes participants, pizza-tracker stages, and (on detail) documents and milestones.
- Date PATCH no longer 400s without a controlling contract — it creates one so Listed / Contract / Closing dates reach the client portal tracker.
- Adds `GET /api/agent/v1/contact-groups` and nested `groups` on contacts so AgentDesk can show CRM labels instead of a bare name list.

## Test plan
- [ ] `pytest tests/test_agent_api.py`
- [ ] Open a deal in AgentDesk after deploy: people, docs, and stages present
- [ ] Set Listed / Contract / Closing dates on a deal with no contract; confirm they appear on the client app pizza tracker
- [ ] Contacts tab still shows CRM people with group chips


Made with [Cursor](https://cursor.com)