### PR TITLE
fix: AgentDesk contacts are the signed-in user's CRM book

### DIFF
--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -138,22 +138,14 @@ def _json_body():
     return data if isinstance(data, dict) else {}
 
 
-def _can_view_all(user):
-    return user.org_role in ('owner', 'admin')
-
-
 def _contacts_query(user):
-    query = org_query_for_id(Contact, user.organization_id)
-    if not _can_view_all(user):
-        query = query.filter_by(user_id=user.id)
-    return query
+    """AgentDesk is personal CRM. Match the web default and /dashboard KPIs."""
+    return org_query_for_id(Contact, user.organization_id).filter_by(user_id=user.id)
 
 
 def _contact_visible(user, contact):
     if contact is None or contact.organization_id != user.organization_id:
         return False
-    if _can_view_all(user):
-        return True
     return contact.user_id == user.id
 
 

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -531,6 +531,15 @@ def test_transaction_routes_round_trip(app, seed, client):
     assert missing.status_code == 404
 
 
+def test_contacts_list_is_mine_for_owner(app, seed, client):
+    token = _owner_token(client)
+    listed = client.get('/api/agent/v1/contacts', headers=_auth(token))
+    assert listed.status_code == 200
+    emails = [c['email'] for c in listed.get_json()['contacts']]
+    assert 'jane@test.com' in emails
+    assert 'john@test.com' not in emails
+
+
 def test_jwt_user_not_cookie_user(app, seed, owner_a_client):
     agent_token = _agent_session(owner_a_client, email='agent_a@test.com').get_json()['token']
     listed = owner_a_client.get(


### PR DESCRIPTION
## Summary
- `/api/agent/v1/contacts` now returns only the logged-in user's contacts, matching the dashboard KPI and the web default.
- Owners/admins were previously getting the whole org, so AgentDesk looked like an iPhone address-book dump.

## Test plan
- [ ] Sign in to AgentDesk against production as an owner
- [ ] Contacts count matches Home and the web "My" list
- [ ] A teammate's contacts do not appear


Made with [Cursor](https://cursor.com)