### PR TITLE
feat: pin AgentDesk file GET JSON and deal status persist

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,4 +507,4 @@ if __name__ == '__main__':
     if database_url and database_url.startswith('sqlite'):
         with app.app_context():
             db.create_all()
-    app.run(host='0.0.0.0', port=5013, debug=True)
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT') or 5011), debug=True)

--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -2,6 +2,11 @@
 
 Auth is an agent JWT (typ=agent). Flask-Login cookies are ignored.
 Do not reuse /transactions/api/* or the client_portal JWT.
+
+Document file GET returns JSON ``{"url": "<signed url>"}``. Native downloads
+that URL. It does not 302. Status persist is POST (also PATCH)
+``/transactions/<id>/status``. PATCH ``/transactions/<id>`` does not write
+status or type.
 """
 from __future__ import annotations
 
@@ -785,7 +790,7 @@ def delete_transaction(user, transaction_id):
     return jsonify({'ok': True})
 
 
-@agent_api_bp.route('/transactions/<int:transaction_id>/status', methods=['POST'])
+@agent_api_bp.route('/transactions/<int:transaction_id>/status', methods=['POST', 'PATCH'])
 @agent_jwt_required
 @transactions_flag_required
 def post_transaction_status(user, transaction_id):

--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -3,10 +3,13 @@
 Auth is an agent JWT (typ=agent). Flask-Login cookies are ignored.
 Do not reuse /transactions/api/* or the client_portal JWT.
 
-Document file GET returns JSON ``{"url": "<signed url>"}``. Native downloads
-that URL. It does not 302. Status persist is POST (also PATCH)
-``/transactions/<id>/status``. PATCH ``/transactions/<id>`` does not write
-status or type.
+File GET is JSON only: ``{"url": "<signed url>"}``. Native downloads that
+URL. This route does not 302 and does not stream bytes.
+
+Status persist is ``POST /transactions/<id>/status``. That writes the
+status and returns ``{"ok": true, "status": "<new>"}``.
+``PATCH /transactions/<id>`` rejects status and type. It does not write
+them.
 """
 from __future__ import annotations
 
@@ -96,6 +99,10 @@ ROLE_MAP = {
 }
 
 MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+_DEAL_PATCH_STATUS_TYPE_KEYS = frozenset({
+    'status', 'type', 'transaction_type', 'transaction_type_id',
+})
 
 
 def _json_error(message, status=401, code=None):
@@ -763,6 +770,11 @@ def patch_transaction(user, transaction_id):
     if error:
         return error
     data = _json_body()
+    if _DEAL_PATCH_STATUS_TYPE_KEYS.intersection(data):
+        return _json_error(
+            'Status and type are not writable here. POST /transactions/<id>/status.',
+            400,
+        )
     for field in (
         'street_address', 'city', 'state', 'zip_code', 'county',
         'ownership_status', 'mls_listing_url',
@@ -790,14 +802,18 @@ def delete_transaction(user, transaction_id):
     return jsonify({'ok': True})
 
 
-@agent_api_bp.route('/transactions/<int:transaction_id>/status', methods=['POST', 'PATCH'])
+@agent_api_bp.route('/transactions/<int:transaction_id>/status', methods=['POST'])
 @agent_jwt_required
 @transactions_flag_required
 def post_transaction_status(user, transaction_id):
+    """Write deal status. Native reloads the deal to read it back."""
     tx, error = _load_tx(user, transaction_id, CAP_EDIT)
     if error:
         return error
-    new_status = (_json_body().get('status') or '').strip()
+    raw_status = _json_body().get('status')
+    if not isinstance(raw_status, str):
+        return _json_error('Invalid status.', 400)
+    new_status = raw_status.strip()
     tx_type_name = tx.transaction_type.name if tx.transaction_type else 'seller'
     valid = STATUS_OPTIONS_BY_TYPE.get(tx_type_name, STATUS_OPTIONS_BY_TYPE['seller'])
     if new_status not in valid:
@@ -1086,6 +1102,10 @@ def upload_document(user, transaction_id):
 @agent_jwt_required
 @transactions_flag_required
 def get_document_file(user, transaction_id, doc_id):
+    """Return JSON ``{"url": "<signed url>"}``. Native downloads that URL.
+
+    This is not a 302. List metadata stays on GET .../documents.
+    """
     tx, error = _load_tx(user, transaction_id, CAP_VIEW)
     if error:
         return error
@@ -1104,6 +1124,8 @@ def get_document_file(user, transaction_id, doc_id):
         url = get_transaction_document_url(path, expires_in=3600)
     except Exception:
         logger.exception('Agent API signed URL failed')
+        return _json_error('Could not create a file link.', 502)
+    if not isinstance(url, str) or not url.strip():
         return _json_error('Could not create a file link.', 502)
     return jsonify({'url': url})
 

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -612,7 +612,6 @@ def test_document_file_returns_json_signed_url(app, seed, client, monkeypatch):
 
 
 def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monkeypatch):
-    from models import Organization
     from services.client_portal_auth import issue_client_jwt
 
     monkeypatch.setattr(
@@ -633,16 +632,9 @@ def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monke
     assert rejected.status_code == 401
     assert rejected.content_type.startswith('application/json')
 
-    with app.app_context():
-        org_b = Organization.query.get(seed['org_b'])
-        flags = dict(org_b.feature_flags or {})
-        flags['TRANSACTIONS'] = True
-        org_b.feature_flags = flags
-        db.session.commit()
-
     other = client.get(
-        file_url,
-        headers=_auth(_agent_session(client, email='owner_b@test.com').get_json()['token']),
+        f'/api/agent/v1/transactions/{seed["tx_b"]}/documents/{doc_id}/file',
+        headers=_auth(_owner_token(client)),
     )
     assert other.status_code == 404
     assert other.content_type.startswith('application/json')

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -598,17 +598,34 @@ def test_document_file_returns_json_signed_url(app, seed, client, monkeypatch):
     )
     assert cookie_only.status_code == 401
     assert cookie_only.content_type.startswith('application/json')
+    assert not cookie_only.is_redirect
 
     resp = client.get(
         f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file',
-        headers=headers,
+        headers={**headers, 'Accept': 'application/pdf'},
     )
     assert resp.status_code == 200
     assert resp.content_type.startswith('application/json')
+    assert not resp.is_redirect
     body = resp.get_json()
     assert set(body.keys()) == {'url'}
     assert body['url'].startswith('https://signed.example/transactions/410/listing.pdf')
     assert 'Location' not in resp.headers
+
+    with app.app_context():
+        tx = db.session.get(Transaction, tx_id)
+        bare = _document_with_file(seed, tx, path=None)
+        db.session.commit()
+        bare_id = bare.id
+
+    missing = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/documents/{bare_id}/file',
+        headers=headers,
+    )
+    assert missing.status_code == 404
+    assert missing.content_type.startswith('application/json')
+    assert not missing.is_redirect
+    assert 'url' not in (missing.get_json() or {})
 
 
 def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monkeypatch):
@@ -638,6 +655,15 @@ def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monke
     )
     assert other.status_code == 404
     assert other.content_type.startswith('application/json')
+    assert not other.is_redirect
+
+    free = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    gated = client.get(file_url, headers=_auth(free))
+    assert gated.status_code == 403
+    assert gated.get_json() == {
+        'code': 'transactions_required',
+        'error': 'Transactions are not on this plan.',
+    }
 
 
 def test_status_persist_reload_and_guards(app, seed, client):
@@ -662,22 +688,35 @@ def test_status_persist_reload_and_guards(app, seed, client):
     assert reloaded.status_code == 200
     assert reloaded.get_json()['transaction']['status'] == 'under_contract'
 
-    via_patch_status = client.patch(
-        f'/api/agent/v1/transactions/{tx_id}/status',
-        headers=headers,
-        json={'status': 'closed'},
-    )
-    assert via_patch_status.status_code == 200
-    assert via_patch_status.get_json()['status'] == 'closed'
+    with app.app_context():
+        assert db.session.get(Transaction, tx_id).status == 'under_contract'
 
-    ignored = client.patch(
+    refused = client.patch(
         f'/api/agent/v1/transactions/{tx_id}',
         headers=headers,
-        json={'status': 'cancelled', 'transaction_type': 'buyer'},
+        json={
+            'city': 'Dallas',
+            'status': 'cancelled',
+            'transaction_type': 'buyer',
+        },
     )
-    assert ignored.status_code == 200
-    assert ignored.get_json()['transaction']['status'] == 'closed'
-    assert ignored.get_json()['transaction']['transaction_type'] == 'seller'
+    assert refused.status_code == 400
+    assert refused.content_type.startswith('application/json')
+    assert refused.get_json()['error']
+
+    after_refuse = client.get(f'/api/agent/v1/transactions/{tx_id}', headers=headers)
+    assert after_refuse.get_json()['transaction']['status'] == 'under_contract'
+    assert after_refuse.get_json()['transaction']['transaction_type'] == 'seller'
+    assert after_refuse.get_json()['transaction']['city'] == 'Austin'
+
+    address_only = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+        json={'city': 'Dallas'},
+    )
+    assert address_only.status_code == 200
+    assert address_only.get_json()['transaction']['city'] == 'Dallas'
+    assert address_only.get_json()['transaction']['status'] == 'under_contract'
 
     bad = client.post(
         f'/api/agent/v1/transactions/{tx_id}/status',
@@ -687,6 +726,9 @@ def test_status_persist_reload_and_guards(app, seed, client):
     assert bad.status_code == 400
     assert bad.content_type.startswith('application/json')
     assert bad.get_json()['error']
+    assert client.get(
+        f'/api/agent/v1/transactions/{tx_id}', headers=headers,
+    ).get_json()['transaction']['status'] == 'under_contract'
 
     cookie_only = client.post(
         f'/api/agent/v1/transactions/{tx_id}/status',
@@ -702,4 +744,7 @@ def test_status_persist_reload_and_guards(app, seed, client):
         json={'status': 'active'},
     )
     assert gated.status_code == 403
-    assert gated.get_json()['code'] == 'transactions_required'
+    assert gated.get_json() == {
+        'code': 'transactions_required',
+        'error': 'Transactions are not on this plan.',
+    }

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -10,6 +10,7 @@ from models import (
     SellerAcceptedContract,
     Task,
     Transaction,
+    TransactionDocument,
     TransactionParticipant,
     db,
 )
@@ -550,3 +551,163 @@ def test_jwt_user_not_cookie_user(app, seed, owner_a_client):
     emails = [c['email'] for c in listed.get_json()['contacts']]
     assert 'john@test.com' in emails
     assert 'jane@test.com' not in emails
+
+
+def _document_with_file(seed, tx, path='transactions/406/listing.pdf'):
+    doc = TransactionDocument(
+        organization_id=seed['org_a'],
+        transaction_id=tx.id,
+        template_slug='listing-agreement',
+        template_name='Listing Agreement',
+        status='signed',
+        document_source='external',
+        signed_file_path=path,
+        signed_original_filename='listing.pdf',
+    )
+    db.session.add(doc)
+    db.session.flush()
+    return doc
+
+
+def test_document_file_returns_json_signed_url(app, seed, client, monkeypatch):
+    monkeypatch.setattr(
+        'services.supabase_storage.get_transaction_document_url',
+        lambda path, expires_in=3600: f'https://signed.example/{path}?exp={expires_in}',
+    )
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        tx, _seller, _access = _seller_thread(seed, '410 File Json Ln')
+        doc = _document_with_file(seed, tx, 'transactions/410/listing.pdf')
+        db.session.commit()
+        tx_id = tx.id
+        doc_id = doc.id
+
+    listed = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/documents',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    row = next(item for item in listed.get_json()['documents'] if item['id'] == doc_id)
+    assert row['has_file'] is True
+    assert 'url' not in row
+
+    cookie_only = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file',
+    )
+    assert cookie_only.status_code == 401
+    assert cookie_only.content_type.startswith('application/json')
+
+    resp = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file',
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.content_type.startswith('application/json')
+    body = resp.get_json()
+    assert set(body.keys()) == {'url'}
+    assert body['url'].startswith('https://signed.example/transactions/410/listing.pdf')
+    assert 'Location' not in resp.headers
+
+
+def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monkeypatch):
+    from models import Organization
+    from services.client_portal_auth import issue_client_jwt
+
+    monkeypatch.setattr(
+        'services.supabase_storage.get_transaction_document_url',
+        lambda path, expires_in=3600: f'https://signed.example/{path}',
+    )
+
+    with app.app_context():
+        tx, _seller, access = _seller_thread(seed, '411 File Auth Ln')
+        doc = _document_with_file(seed, tx, 'transactions/411/listing.pdf')
+        db.session.commit()
+        tx_id = tx.id
+        doc_id = doc.id
+        client_token = issue_client_jwt(access)
+
+    file_url = f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file'
+    rejected = client.get(file_url, headers=_auth(client_token))
+    assert rejected.status_code == 401
+    assert rejected.content_type.startswith('application/json')
+
+    with app.app_context():
+        org_b = Organization.query.get(seed['org_b'])
+        flags = dict(org_b.feature_flags or {})
+        flags['TRANSACTIONS'] = True
+        org_b.feature_flags = flags
+        db.session.commit()
+
+    other = client.get(
+        file_url,
+        headers=_auth(_agent_session(client, email='owner_b@test.com').get_json()['token']),
+    )
+    assert other.status_code == 404
+    assert other.content_type.startswith('application/json')
+
+
+def test_status_persist_reload_and_guards(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        tx, _seller, _access = _seller_thread(seed, '412 Status Persist Ln')
+        db.session.commit()
+        tx_id = tx.id
+
+    posted = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        headers=headers,
+        json={'status': 'under_contract'},
+    )
+    assert posted.status_code == 200
+    assert posted.content_type.startswith('application/json')
+    assert posted.get_json() == {'ok': True, 'status': 'under_contract'}
+
+    reloaded = client.get(f'/api/agent/v1/transactions/{tx_id}', headers=headers)
+    assert reloaded.status_code == 200
+    assert reloaded.get_json()['transaction']['status'] == 'under_contract'
+
+    via_patch_status = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        headers=headers,
+        json={'status': 'closed'},
+    )
+    assert via_patch_status.status_code == 200
+    assert via_patch_status.get_json()['status'] == 'closed'
+
+    ignored = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+        json={'status': 'cancelled', 'transaction_type': 'buyer'},
+    )
+    assert ignored.status_code == 200
+    assert ignored.get_json()['transaction']['status'] == 'closed'
+    assert ignored.get_json()['transaction']['transaction_type'] == 'seller'
+
+    bad = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        headers=headers,
+        json={'status': 'not_a_real_status'},
+    )
+    assert bad.status_code == 400
+    assert bad.content_type.startswith('application/json')
+    assert bad.get_json()['error']
+
+    cookie_only = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        json={'status': 'active'},
+    )
+    assert cookie_only.status_code == 401
+    assert cookie_only.content_type.startswith('application/json')
+
+    free = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    gated = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/status',
+        headers=_auth(free),
+        json={'status': 'active'},
+    )
+    assert gated.status_code == 403
+    assert gated.get_json()['code'] == 'transactions_required'

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -20,6 +20,12 @@ def _auth(token):
     return {'Authorization': f'Bearer {token}'}
 
 
+def _assert_json_not_redirect(resp):
+    assert resp.status_code not in (301, 302, 303, 307, 308)
+    assert 'Location' not in resp.headers
+    assert resp.content_type.startswith('application/json')
+
+
 def _agent_session(client, *, email=None, username=None, password='password123'):
     body = {'password': password}
     if email is not None:
@@ -597,20 +603,17 @@ def test_document_file_returns_json_signed_url(app, seed, client, monkeypatch):
         f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file',
     )
     assert cookie_only.status_code == 401
-    assert cookie_only.content_type.startswith('application/json')
-    assert not cookie_only.is_redirect
+    _assert_json_not_redirect(cookie_only)
 
     resp = client.get(
         f'/api/agent/v1/transactions/{tx_id}/documents/{doc_id}/file',
         headers={**headers, 'Accept': 'application/pdf'},
     )
     assert resp.status_code == 200
-    assert resp.content_type.startswith('application/json')
-    assert not resp.is_redirect
+    _assert_json_not_redirect(resp)
     body = resp.get_json()
     assert set(body.keys()) == {'url'}
     assert body['url'].startswith('https://signed.example/transactions/410/listing.pdf')
-    assert 'Location' not in resp.headers
 
     with app.app_context():
         tx = db.session.get(Transaction, tx_id)
@@ -623,8 +626,7 @@ def test_document_file_returns_json_signed_url(app, seed, client, monkeypatch):
         headers=headers,
     )
     assert missing.status_code == 404
-    assert missing.content_type.startswith('application/json')
-    assert not missing.is_redirect
+    _assert_json_not_redirect(missing)
     assert 'url' not in (missing.get_json() or {})
 
 
@@ -654,8 +656,7 @@ def test_document_file_rejects_client_jwt_and_other_org(app, seed, client, monke
         headers=_auth(_owner_token(client)),
     )
     assert other.status_code == 404
-    assert other.content_type.startswith('application/json')
-    assert not other.is_redirect
+    _assert_json_not_redirect(other)
 
     free = _agent_session(client, email='owner_b@test.com').get_json()['token']
     gated = client.get(file_url, headers=_auth(free))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
AgentDesk talks to production `/api/agent/v1`. This PR pins two contracts only.

## File GET

`GET /api/agent/v1/transactions/<id>/documents/<did>/file` returns JSON `{"url": "<signedUrl>"}`. Native downloads that URL. This is not a 302 and does not stream bytes.

List stays metadata (`has_file`, no URL). Cookie is 401. `typ=client_portal` is 401. Other-org is 404. Free plan is 403 `{ "code": "transactions_required" }`.

## Status persist

`POST /api/agent/v1/transactions/<id>/status` writes the status and returns `{"ok": true, "status": "<new>"}`. Reload reads it back.

`PATCH /api/agent/v1/transactions/<id>` rejects `status` and type with 400. It does not persist them.

Bad status is 400. Cookie is 401. Free plan is 403 `{ "code": "transactions_required" }`.

Parked on purpose: `GET /transaction-types`, tasks CRUD, offers, contracts, date-stub 409.

## CI notes

`tests/test_agent_api.py::test_status_persist_reload_and_guards` was 404 because a prior test wrote `TRANSACTIONS=True` onto org B. Other-org file GET now uses owner A against org B's deal.

Playwright failed at Start Flask app (`curl` exit 7) because `app.py` listened on 5013 while the workflow curls 5011. Local default is 5011 again.

## Tests

`pytest tests/test_agent_api.py`. Do not weaken `/api/client/v1` contracts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd0b43e2-e476-45ae-a00a-7fe1ad770d58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd0b43e2-e476-45ae-a00a-7fe1ad770d58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

