### PR TITLE
feat: AgentDesk APIs for contacts, tasks, and deal files

### DIFF
--- a/routes/agent_api.py
+++ b/routes/agent_api.py
@@ -221,6 +221,10 @@ def _parse_datetime(value):
         raise ValueError('Use an ISO datetime.') from exc
 
 
+def _iso_date(value):
+    return value.isoformat() if value else None
+
+
 def _serialize_contact(contact):
     return {
         'id': contact.id,
@@ -235,6 +239,14 @@ def _serialize_contact(contact):
         'notes': contact.notes,
         'potential_commission': float(contact.potential_commission or 0),
         'current_objective': contact.current_objective,
+        'move_timeline': contact.move_timeline,
+        'motivation': contact.motivation,
+        'financial_status': contact.financial_status,
+        'additional_notes': contact.additional_notes,
+        'last_email_date': _iso_date(contact.last_email_date),
+        'last_text_date': _iso_date(contact.last_text_date),
+        'last_phone_call_date': _iso_date(contact.last_phone_call_date),
+        'last_contact_date': _iso_date(contact.last_contact_date),
         'group_ids': [g.id for g in (contact.groups or [])],
         'groups': [
             {
@@ -310,6 +322,11 @@ def _serialize_transaction(tx, *, detail=False, participants=None):
                 TransactionDocument.created_at.desc(),
             ).all()
         ]
+        try:
+            from routes.agent_deal_desk import enrich_transaction_detail
+            enrich_transaction_detail(tx, payload)
+        except ImportError:
+            pass
     return payload
 
 
@@ -521,6 +538,10 @@ def create_contact(user):
         notes=(data.get('notes') or '').strip() or None,
         potential_commission=data.get('potential_commission') or 5000.00,
         current_objective=(data.get('current_objective') or '').strip() or None,
+        move_timeline=(data.get('move_timeline') or '').strip() or None,
+        motivation=(data.get('motivation') or '').strip() or None,
+        financial_status=(data.get('financial_status') or '').strip() or None,
+        additional_notes=(data.get('additional_notes') or '').strip() or None,
     )
     try:
         contact.groups = resolve_groups_for_owner(
@@ -568,7 +589,8 @@ def patch_contact(user, contact_id):
         contact.last_name = last_name
     for field in (
         'email', 'phone', 'street_address', 'city', 'state', 'zip_code',
-        'notes', 'current_objective',
+        'notes', 'current_objective', 'move_timeline', 'motivation',
+        'financial_status', 'additional_notes',
     ):
         if field in data:
             value = data.get(field)
@@ -643,6 +665,27 @@ def list_contact_groups(user):
                 'category': getattr(group, 'category', None),
             }
             for group in groups
+        ],
+    })
+
+
+@agent_api_bp.route('/transaction-types', methods=['GET'])
+@agent_jwt_required
+@transactions_flag_required
+def list_transaction_types(user):
+    rows = (
+        org_query_for_id(TransactionType, user.organization_id)
+        .order_by(TransactionType.sort_order, TransactionType.id)
+        .all()
+    )
+    return jsonify({
+        'transaction_types': [
+            {
+                'id': row.id,
+                'name': row.name,
+                'display_name': row.display_name,
+            }
+            for row in rows
         ],
     })
 
@@ -829,8 +872,8 @@ def post_transaction_status(user, transaction_id):
 def patch_transaction_dates(user, transaction_id):
     """Write portal-visible dates only.
 
-    Do not call seller contract-details replace here. That rebuilds
-    milestones from frozen terms and can wipe dates that were not sent.
+    Option/closing anchors recompute checklist due dates. Do not call
+    seller contract-details replace or create_contract_milestones here.
     """
     tx, error = _load_tx(user, transaction_id, CAP_EDIT)
     if error:
@@ -867,8 +910,26 @@ def patch_transaction_dates(user, transaction_id):
                 contract.closing_date = _parse_date(data.get('closing_date'))
     except ValueError as exc:
         return _json_error(str(exc), 400)
+
+    recompute_changes = {
+        key: data[key]
+        for key in ('expected_close_date', 'effective_date', 'closing_date')
+        if key in data
+    }
+    if recompute_changes:
+        from services.deadline_recompute import recompute_from_changes
+        recompute_from_changes(
+            tx,
+            recompute_changes,
+            actor_id=user.id,
+            source='agent_api_dates',
+        )
     db.session.commit()
-    return jsonify({'ok': True, 'dates': _tx_dates(tx)})
+    return jsonify({
+        'ok': True,
+        'dates': _tx_dates(tx),
+        'transaction': _serialize_transaction(tx, detail=True),
+    })
 
 
 @agent_api_bp.route('/transactions/<int:transaction_id>/participants', methods=['GET'])
@@ -1264,3 +1325,24 @@ def post_conversation_message(user, participant_id):
     )
     listed = list_client_messages(access)
     return jsonify({'message': listed[-1] if listed else None}), 201
+
+
+def _register_desk_extensions():
+    try:
+        from routes import agent_contact_desk
+        agent_contact_desk.register(agent_api_bp)
+    except ImportError:
+        pass
+    try:
+        from routes import agent_task_desk
+        agent_task_desk.register(agent_api_bp)
+    except ImportError:
+        pass
+    try:
+        from routes import agent_deal_desk
+        agent_deal_desk.register(agent_api_bp)
+    except ImportError:
+        pass
+
+
+_register_desk_extensions()

--- a/routes/agent_contact_desk.py
+++ b/routes/agent_contact_desk.py
@@ -33,6 +33,7 @@ from routes.agent_api import (
     _serialize_transaction,
     agent_api_bp,
     agent_jwt_required,
+    transactions_flag_required,
 )
 from routes.contacts import (
     format_email,
@@ -179,6 +180,7 @@ def contact_desk_tasks(user, contact_id):
 
 
 @agent_jwt_required
+@transactions_flag_required
 def contact_desk_transactions(user, contact_id):
     contact, error = _load_contact(user, contact_id)
     if error:

--- a/routes/agent_contact_desk.py
+++ b/routes/agent_contact_desk.py
@@ -1,0 +1,764 @@
+"""Contact-detail JSON for the agent iPhone app.
+
+Attach via ``register(bp)``. File and voice-memo GET return JSON
+``{"url": "<signed url>"}`` only — no 302, no streamed bytes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time, timedelta
+
+from flask import jsonify, request
+from sqlalchemy import case
+from sqlalchemy.orm import joinedload
+
+from feature_flags import org_has_feature
+from models import (
+    Contact,
+    ContactEmail,
+    ContactFile,
+    ContactVoiceMemo,
+    Interaction,
+    Task,
+    Transaction,
+    TransactionParticipant,
+    UserEmailIntegration,
+    db,
+)
+from routes.agent_api import (
+    _contact_visible,
+    _json_body,
+    _json_error,
+    _parse_date,
+    _serialize_transaction,
+    agent_api_bp,
+    agent_jwt_required,
+)
+from routes.contacts import (
+    format_email,
+    format_file,
+    format_interaction,
+    format_task,
+    format_voice_memo,
+    get_user_timezone,
+)
+from services import supabase_storage
+from services.tenant_service import org_query_for_id
+
+logger = logging.getLogger(__name__)
+
+_registered = False
+
+ACTIVITY_TYPES = frozenset({'call', 'email', 'text', 'meeting', 'other'})
+TASK_STATUS_FILTERS = frozenset({'pending', 'completed', 'all'})
+TIMELINE_FILTERS = frozenset({
+    'all', 'interaction', 'email', 'task', 'file', 'voice_memo',
+})
+VOICE_MEMO_MAX_BYTES = 10 * 1024 * 1024
+
+
+def _load_contact(user, contact_id):
+    contact = org_query_for_id(Contact, user.organization_id).filter_by(
+        id=contact_id,
+    ).first()
+    if not _contact_visible(user, contact):
+        return None, _json_error('Contact not found.', 404)
+    return contact, None
+
+
+def _iso(value):
+    return value.isoformat() if value is not None else None
+
+
+def _serialize_contact_task(task):
+    return {
+        'id': task.id,
+        'subject': task.subject,
+        'status': task.status,
+        'priority': task.priority,
+        'due_date': _iso(task.due_date),
+        'type': task.task_type.name if task.task_type else None,
+        'subtype': task.task_subtype.name if task.task_subtype else None,
+        'transaction_id': task.transaction_id,
+        'description': task.description,
+    }
+
+
+def _serialize_contact_file(row):
+    return {
+        'id': row.id,
+        'original_filename': row.original_filename,
+        'file_type': row.file_type,
+        'file_size': row.file_size,
+        'created_at': _iso(row.created_at),
+        'is_image': bool(row.is_image),
+    }
+
+
+def _serialize_voice_memo(memo):
+    return {
+        'id': memo.id,
+        'created_at': _iso(memo.created_at),
+        'duration_seconds': memo.duration_seconds,
+        'transcription': memo.transcription,
+        'transcription_status': memo.transcription_status,
+    }
+
+
+def _serialize_activity(interaction):
+    return {
+        'id': interaction.id,
+        'type': interaction.type,
+        'notes': interaction.notes,
+        'date': _iso(interaction.date),
+        'follow_up_date': _iso(interaction.follow_up_date),
+        'created_at': _iso(interaction.created_at),
+    }
+
+
+def _apply_activity_dates(contact, activity_type, activity_date):
+    if activity_type == 'call':
+        if contact.last_phone_call_date is None or activity_date > contact.last_phone_call_date:
+            contact.last_phone_call_date = activity_date
+    elif activity_type == 'email':
+        if contact.last_email_date is None or activity_date > contact.last_email_date:
+            contact.last_email_date = activity_date
+    elif activity_type == 'text':
+        if contact.last_text_date is None or activity_date > contact.last_text_date:
+            contact.last_text_date = activity_date
+    elif activity_type in ('meeting', 'other'):
+        if contact.last_contact_date is None or activity_date > contact.last_contact_date:
+            contact.last_contact_date = activity_date
+    contact.update_last_contact_date()
+
+
+def _gmail_connected(user):
+    integration = UserEmailIntegration.query.filter_by(user_id=user.id).first()
+    return bool(integration and integration.sync_enabled)
+
+
+def _signed_file_url(bucket, storage_path):
+    url = supabase_storage.get_signed_url(bucket, storage_path, expires_in=3600)
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError('empty signed url')
+    return url
+
+
+def _suggestions_allowed(user):
+    if org_has_feature('AI_TASK_SUGGESTIONS', user.organization):
+        return None
+    return _json_error(
+        'Task suggestions are not on this plan.',
+        403,
+        code='feature_required',
+    )
+
+
+@agent_jwt_required
+def contact_desk_tasks(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    status = (request.args.get('status') or 'pending').strip().lower()
+    if status not in TASK_STATUS_FILTERS:
+        return _json_error('status must be pending, completed, or all.', 400)
+    query = Task.query.options(
+        joinedload(Task.task_type),
+        joinedload(Task.task_subtype),
+    ).filter_by(
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    )
+    if status != 'all':
+        query = query.filter(Task.status == status)
+    tasks = query.order_by(
+        case((Task.status == 'pending', 0), else_=1),
+        Task.due_date.asc(),
+    ).all()
+    return jsonify({'tasks': [_serialize_contact_task(task) for task in tasks]})
+
+
+@agent_jwt_required
+def contact_desk_transactions(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    tx_ids = [
+        row.transaction_id
+        for row in TransactionParticipant.query.filter_by(
+            contact_id=contact.id,
+            organization_id=user.organization_id,
+        ).all()
+    ]
+    if not tx_ids:
+        return jsonify({'transactions': []})
+    txs = (
+        org_query_for_id(Transaction, user.organization_id)
+        .filter(Transaction.id.in_(tx_ids))
+        .options(joinedload(Transaction.transaction_type))
+        .order_by(Transaction.created_at.desc())
+        .all()
+    )
+    return jsonify({
+        'transactions': [_serialize_transaction(tx) for tx in txs],
+    })
+
+
+@agent_jwt_required
+def contact_desk_files(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    rows = ContactFile.query.filter_by(
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).order_by(ContactFile.created_at.desc()).all()
+    return jsonify({'files': [_serialize_contact_file(row) for row in rows]})
+
+
+@agent_jwt_required
+def contact_desk_upload_file(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    uploaded = request.files.get('file')
+    if uploaded is None or not uploaded.filename:
+        return _json_error('Upload a file.', 400)
+    if not ContactFile.allowed_file(uploaded.filename):
+        allowed = ', '.join(sorted(ContactFile.ALLOWED_EXTENSIONS))
+        return _json_error(f'File type not allowed. Allowed types: {allowed}', 400)
+    file_data = uploaded.read()
+    if len(file_data) > ContactFile.MAX_FILE_SIZE:
+        max_mb = ContactFile.MAX_FILE_SIZE / (1024 * 1024)
+        return _json_error(f'File too large. Maximum size is {max_mb:.0f}MB.', 400)
+    try:
+        result = supabase_storage.upload_contact_file(
+            contact_id=contact.id,
+            file_data=file_data,
+            original_filename=uploaded.filename,
+            content_type=uploaded.content_type,
+        )
+    except Exception:
+        logger.exception('Agent contact desk file upload failed')
+        return _json_error('Could not store that file.', 500)
+    row = ContactFile(
+        organization_id=user.organization_id,
+        contact_id=contact.id,
+        user_id=user.id,
+        filename=result['filename'],
+        original_filename=uploaded.filename,
+        file_type=uploaded.content_type,
+        file_size=result['size'],
+        storage_path=result['path'],
+    )
+    db.session.add(row)
+    db.session.commit()
+    return jsonify({'file': _serialize_contact_file(row)}), 201
+
+
+@agent_jwt_required
+def contact_desk_file_url(user, contact_id, file_id):
+    """Return JSON ``{"url": "<signed url>"}``. Native downloads that URL."""
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    row = ContactFile.query.filter_by(
+        id=file_id,
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not row:
+        return _json_error('File not found.', 404)
+    if not row.storage_path:
+        return _json_error('That file has no file yet.', 404)
+    try:
+        url = _signed_file_url(
+            supabase_storage.CONTACT_FILES_BUCKET,
+            row.storage_path,
+        )
+    except Exception:
+        logger.exception('Agent contact desk signed file URL failed')
+        return _json_error('Could not create a file link.', 502)
+    return jsonify({'url': url})
+
+
+@agent_jwt_required
+def contact_desk_delete_file(user, contact_id, file_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    row = ContactFile.query.filter_by(
+        id=file_id,
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not row:
+        return _json_error('File not found.', 404)
+    try:
+        if row.storage_path:
+            supabase_storage.delete_file(
+                supabase_storage.CONTACT_FILES_BUCKET,
+                row.storage_path,
+            )
+        db.session.delete(row)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('Agent contact desk file delete failed')
+        return _json_error('Could not delete that file.', 500)
+    return jsonify({'ok': True})
+
+
+@agent_jwt_required
+def contact_desk_voice_memos(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    memos = ContactVoiceMemo.query.filter_by(
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).order_by(ContactVoiceMemo.created_at.desc()).all()
+    return jsonify({
+        'voice_memos': [_serialize_voice_memo(memo) for memo in memos],
+    })
+
+
+@agent_jwt_required
+def contact_desk_upload_voice_memo(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    uploaded = request.files.get('file')
+    if uploaded is None or not uploaded.filename:
+        return _json_error('Upload an audio file.', 400)
+    audio_data = uploaded.read()
+    if len(audio_data) > VOICE_MEMO_MAX_BYTES:
+        return _json_error('Audio file too large. Maximum size is 10MB.', 400)
+    duration_seconds = request.form.get('duration', type=int)
+    filename = uploaded.filename or 'memo.webm'
+    try:
+        result = supabase_storage.upload_voice_memo(
+            contact_id=contact.id,
+            file_data=audio_data,
+            original_filename=filename,
+            content_type=uploaded.content_type or 'audio/webm',
+        )
+    except Exception:
+        logger.exception('Agent contact desk voice memo upload failed')
+        return _json_error('Could not store that voice memo.', 500)
+    memo = ContactVoiceMemo(
+        organization_id=user.organization_id,
+        contact_id=contact.id,
+        user_id=user.id,
+        storage_path=result['path'],
+        file_name=result['filename'],
+        duration_seconds=duration_seconds,
+        file_size=result['size'],
+        transcription_status='pending',
+    )
+    db.session.add(memo)
+    db.session.commit()
+    try:
+        from services.ai_service import transcribe_audio
+        transcription = transcribe_audio(audio_data=audio_data, filename=filename)
+        memo.transcription = transcription
+        memo.transcription_status = 'completed'
+        db.session.commit()
+    except Exception as transcribe_error:
+        logger.warning(
+            'Transcription failed for memo %s: %s',
+            memo.id,
+            transcribe_error,
+        )
+        memo.transcription_status = 'failed'
+        db.session.commit()
+    return jsonify({'voice_memo': _serialize_voice_memo(memo)}), 201
+
+
+@agent_jwt_required
+def contact_desk_voice_memo_url(user, contact_id, memo_id):
+    """Return JSON ``{"url": "<signed url>"}``. Native plays that URL."""
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    memo = ContactVoiceMemo.query.filter_by(
+        id=memo_id,
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not memo:
+        return _json_error('Voice memo not found.', 404)
+    if not memo.storage_path:
+        return _json_error('That voice memo has no file yet.', 404)
+    try:
+        url = supabase_storage.get_voice_memo_url(memo.storage_path, expires_in=3600)
+    except Exception:
+        logger.exception('Agent contact desk signed voice-memo URL failed')
+        return _json_error('Could not create a file link.', 502)
+    if not isinstance(url, str) or not url.strip():
+        return _json_error('Could not create a file link.', 502)
+    return jsonify({'url': url})
+
+
+@agent_jwt_required
+def contact_desk_delete_voice_memo(user, contact_id, memo_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    memo = ContactVoiceMemo.query.filter_by(
+        id=memo_id,
+        contact_id=contact.id,
+        organization_id=user.organization_id,
+    ).first()
+    if not memo:
+        return _json_error('Voice memo not found.', 404)
+    try:
+        if memo.storage_path:
+            supabase_storage.delete_voice_memo(memo.storage_path)
+        db.session.delete(memo)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('Agent contact desk voice memo delete failed')
+        return _json_error('Could not delete that voice memo.', 500)
+    return jsonify({'ok': True})
+
+
+def _timeline_payload(user, contact, filter_type, page, per_page):
+    activities = []
+    counts = {
+        'all': 0,
+        'interaction': 0,
+        'email': 0,
+        'task': 0,
+        'file': 0,
+        'voice_memo': 0,
+    }
+
+    if filter_type in ('all', 'interaction'):
+        interactions = Interaction.query.filter_by(contact_id=contact.id).all()
+        counts['interaction'] = len(interactions)
+        activities.extend(format_interaction(row) for row in interactions)
+    else:
+        counts['interaction'] = Interaction.query.filter_by(
+            contact_id=contact.id,
+        ).count()
+
+    if filter_type in ('all', 'email'):
+        emails = ContactEmail.query.filter_by(
+            contact_id=contact.id,
+            user_id=user.id,
+        ).all()
+        counts['email'] = len(emails)
+        activities.extend(format_email(row) for row in emails)
+    else:
+        counts['email'] = ContactEmail.query.filter_by(
+            contact_id=contact.id,
+            user_id=user.id,
+        ).count()
+
+    if filter_type in ('all', 'task'):
+        tasks = Task.query.filter_by(contact_id=contact.id).all()
+        task_count = 0
+        for task in tasks:
+            activities.append(format_task(task, 'created'))
+            task_count += 1
+            if task.status == 'completed' and task.completed_at:
+                activities.append(format_task(task, 'completed'))
+                task_count += 1
+        counts['task'] = task_count
+    else:
+        task_count = Task.query.filter_by(contact_id=contact.id).count()
+        completed_count = Task.query.filter_by(
+            contact_id=contact.id,
+            status='completed',
+        ).count()
+        counts['task'] = task_count + completed_count
+
+    if filter_type in ('all', 'file'):
+        files = ContactFile.query.filter_by(contact_id=contact.id).all()
+        counts['file'] = len(files)
+        activities.extend(format_file(row) for row in files)
+    else:
+        counts['file'] = ContactFile.query.filter_by(contact_id=contact.id).count()
+
+    if filter_type in ('all', 'voice_memo'):
+        memos = ContactVoiceMemo.query.filter_by(
+            contact_id=contact.id,
+            organization_id=user.organization_id,
+        ).all()
+        counts['voice_memo'] = len(memos)
+        activities.extend(format_voice_memo(memo) for memo in memos)
+    else:
+        counts['voice_memo'] = ContactVoiceMemo.query.filter_by(
+            contact_id=contact.id,
+            organization_id=user.organization_id,
+        ).count()
+
+    counts['all'] = (
+        counts['interaction']
+        + counts['email']
+        + counts['task']
+        + counts['file']
+        + counts['voice_memo']
+    )
+    activities.sort(key=lambda item: item['timestamp'] or '', reverse=True)
+    total = len(activities)
+    start = (page - 1) * per_page
+    return {
+        'activities': activities[start:start + per_page],
+        'counts': counts,
+        'page': page,
+        'per_page': per_page,
+        'total': total,
+    }
+
+
+@agent_jwt_required
+def contact_desk_timeline(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    filter_type = (request.args.get('filter') or 'all').strip()
+    if filter_type not in TIMELINE_FILTERS:
+        filter_type = 'all'
+    page = max(request.args.get('page', 1, type=int) or 1, 1)
+    per_page = request.args.get('per_page', 20, type=int) or 20
+    per_page = min(max(per_page, 1), 50)
+    return jsonify(_timeline_payload(user, contact, filter_type, page, per_page))
+
+
+@agent_jwt_required
+def contact_desk_log_activity(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    data = _json_body()
+    activity_type = (data.get('type') or '').strip().lower()
+    if not activity_type:
+        return _json_error('Activity type is required.', 400)
+    if activity_type not in ACTIVITY_TYPES:
+        return _json_error(
+            'Activity type must be call, email, text, meeting, or other.',
+            400,
+        )
+    notes = (data.get('notes') or '').strip() or None
+    try:
+        activity_date = _parse_date(data.get('date'))
+        follow_up_date = _parse_date(data.get('follow_up_date'))
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    user_tz = get_user_timezone()
+    if activity_date is None:
+        activity_date = datetime.now(user_tz).date()
+    activity_dt = user_tz.localize(datetime.combine(activity_date, datetime.min.time()))
+    follow_up_dt = None
+    if follow_up_date is not None:
+        follow_up_dt = user_tz.localize(
+            datetime.combine(follow_up_date, datetime.min.time()),
+        )
+    interaction = Interaction(
+        organization_id=user.organization_id,
+        contact_id=contact.id,
+        user_id=user.id,
+        type=activity_type,
+        notes=notes,
+        date=activity_dt,
+        follow_up_date=follow_up_dt,
+    )
+    db.session.add(interaction)
+    _apply_activity_dates(contact, activity_type, activity_date)
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('Agent contact desk activity log failed')
+        return _json_error('Could not log that activity.', 500)
+    return jsonify({'activity': _serialize_activity(interaction)}), 201
+
+
+@agent_jwt_required
+def contact_desk_emails(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    if not _gmail_connected(user):
+        return jsonify({'emails': [], 'connected': False})
+    from services import gmail_service
+    emails = gmail_service.get_email_threads_for_contact(contact.id, user.id)
+    return jsonify({'emails': emails, 'connected': True})
+
+
+@agent_jwt_required
+def contact_desk_email_thread(user, contact_id, thread_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    emails = ContactEmail.query.filter_by(
+        contact_id=contact.id,
+        user_id=user.id,
+        gmail_thread_id=thread_id,
+    ).order_by(ContactEmail.sent_at.asc()).all()
+    if not emails:
+        return _json_error('Email thread not found.', 404)
+    return jsonify({'emails': [row.to_dict() for row in emails]})
+
+
+@agent_jwt_required
+def contact_desk_task_suggestions(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    blocked = _suggestions_allowed(user)
+    if blocked:
+        return blocked
+    from services.task_suggestions import generate_task_suggestions
+    try:
+        suggestions = generate_task_suggestions(
+            contact_id=contact.id,
+            org_id=user.organization_id,
+            user_id=user.id,
+        )
+    except ValueError as exc:
+        return _json_error(str(exc), 422)
+    except Exception:
+        logger.exception('Agent contact desk task suggestions failed')
+        return _json_error('Could not generate suggestions right now.', 500)
+    return jsonify({'suggestions': suggestions})
+
+
+@agent_jwt_required
+def contact_desk_create_suggested_task(user, contact_id):
+    contact, error = _load_contact(user, contact_id)
+    if error:
+        return error
+    blocked = _suggestions_allowed(user)
+    if blocked:
+        return blocked
+    data = _json_body()
+    subject = (data.get('subject') or '').strip()
+    if not subject:
+        return _json_error('Subject is required.', 400)
+    from services.task_suggestions import resolve_type_ids
+    suggestion = {
+        'task_type': data.get('task_type') or 'Call',
+        'task_subtype': data.get('task_subtype') or 'Follow-up',
+    }
+    task_type, task_subtype = resolve_type_ids(suggestion, user.organization_id)
+    if not task_type or not task_subtype:
+        return _json_error('Could not resolve task type.', 400)
+    try:
+        due_in_days = int(data.get('due_in_days', 3))
+    except (TypeError, ValueError):
+        due_in_days = 3
+    if due_in_days < 1:
+        due_in_days = 3
+    priority = (data.get('priority') or 'medium').strip().lower()
+    if priority not in ('low', 'medium', 'high'):
+        priority = 'medium'
+    from routes.tasks import convert_to_utc, get_user_timezone as task_timezone
+    user_tz = task_timezone()
+    due_local = datetime.now(user_tz) + timedelta(days=due_in_days)
+    due_local = datetime.combine(due_local.date(), time(23, 59, 59))
+    utc_due_date = convert_to_utc(due_local, user_tz)
+    description = (data.get('description') or '').strip()[:500] or None
+    task = Task(
+        organization_id=user.organization_id,
+        contact_id=contact.id,
+        assigned_to_id=user.id,
+        created_by_id=user.id,
+        type_id=task_type.id,
+        subtype_id=task_subtype.id,
+        subject=subject[:200],
+        description=description,
+        priority=priority,
+        due_date=utc_due_date,
+    )
+    db.session.add(task)
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('Agent contact desk suggested task create failed')
+        return _json_error('Could not create that task.', 500)
+    try:
+        from services import calendar_service
+        integration = UserEmailIntegration.query.filter_by(user_id=user.id).first()
+        if integration and integration.calendar_sync_enabled:
+            calendar_service.sync_task_to_calendar(task, request.url_root.rstrip('/'))
+    except Exception:
+        logger.warning('Calendar sync failed for suggested task %s', task.id)
+    return jsonify({'task': _serialize_contact_task(task)}), 201
+
+
+def register(bp):
+    """Attach all contact-desk routes to the agent_api blueprint."""
+    global _registered
+    if _registered:
+        return
+    _registered = True
+    rules = (
+        ('/contacts/<int:contact_id>/tasks', ['GET'], contact_desk_tasks),
+        (
+            '/contacts/<int:contact_id>/transactions',
+            ['GET'],
+            contact_desk_transactions,
+        ),
+        ('/contacts/<int:contact_id>/files', ['GET'], contact_desk_files),
+        ('/contacts/<int:contact_id>/files', ['POST'], contact_desk_upload_file),
+        (
+            '/contacts/<int:contact_id>/files/<int:file_id>/file',
+            ['GET'],
+            contact_desk_file_url,
+        ),
+        (
+            '/contacts/<int:contact_id>/files/<int:file_id>',
+            ['DELETE'],
+            contact_desk_delete_file,
+        ),
+        (
+            '/contacts/<int:contact_id>/voice-memos',
+            ['GET'],
+            contact_desk_voice_memos,
+        ),
+        (
+            '/contacts/<int:contact_id>/voice-memos',
+            ['POST'],
+            contact_desk_upload_voice_memo,
+        ),
+        (
+            '/contacts/<int:contact_id>/voice-memos/<int:memo_id>/file',
+            ['GET'],
+            contact_desk_voice_memo_url,
+        ),
+        (
+            '/contacts/<int:contact_id>/voice-memos/<int:memo_id>',
+            ['DELETE'],
+            contact_desk_delete_voice_memo,
+        ),
+        ('/contacts/<int:contact_id>/timeline', ['GET'], contact_desk_timeline),
+        ('/contacts/<int:contact_id>/activity', ['POST'], contact_desk_log_activity),
+        ('/contacts/<int:contact_id>/emails', ['GET'], contact_desk_emails),
+        (
+            '/contacts/<int:contact_id>/emails/<thread_id>',
+            ['GET'],
+            contact_desk_email_thread,
+        ),
+        (
+            '/contacts/<int:contact_id>/task-suggestions',
+            ['POST'],
+            contact_desk_task_suggestions,
+        ),
+        (
+            '/contacts/<int:contact_id>/task-suggestions/create',
+            ['POST'],
+            contact_desk_create_suggested_task,
+        ),
+    )
+    for rule, methods, view in rules:
+        bp.add_url_rule(rule, view.__name__, view, methods=methods)
+
+
+# Safe self-register if this module is imported from app.
+# Agent A will also call register(). Make register() idempotent.
+register(agent_api_bp)

--- a/routes/agent_deal_desk.py
+++ b/routes/agent_deal_desk.py
@@ -1,0 +1,1090 @@
+"""AgentDesk deal-file APIs: listing, offers, contract, checklist, notes, parties.
+
+Attaches to the agent_api blueprint. Live checklist is TransactionRequirement
+(deadline packs). SellerContractMilestone stays on agent_api /milestones.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import jsonify
+from sqlalchemy.orm.attributes import flag_modified
+
+from models import (
+    SellerListingProfile,
+    SellerOffer,
+    SellerOfferVersion,
+    Task,
+    TransactionRequirement,
+    TransactionParticipant,
+    db,
+)
+from routes.agent_api import (
+    _json_body,
+    _json_error,
+    _load_tx,
+    _parse_date,
+    _parse_datetime,
+    _serialize_transaction,
+    agent_api_bp,
+    agent_jwt_required,
+    transactions_flag_required,
+)
+from services.controlling_contracts import (
+    ControllingContractConflict,
+    ControllingContractSeedError,
+    create_baseline_from_accepted_offer,
+    get_active_primary_contract,
+)
+from services.deadline_recompute import recompute_from_changes
+from services.listing_prep_checklist import AUTO_KEYS
+from services.offer_compare import OfferCompareService
+from services.offer_side import opening_direction_for_side, side_for_transaction, supports_offers
+from services.requirements_service import RequirementsService
+from services.seller_workflow import (
+    ACTIVE_OFFER_STATUSES,
+    apply_offer_terms,
+    create_offer_activity,
+)
+from services.transaction_auth import CAP_EDIT, CAP_VIEW
+
+logger = logging.getLogger(__name__)
+
+_registered = False
+
+_LISTING_OVERRIDE_KEYS = frozenset({
+    'list_price',
+    'go_live_date',
+    'listing_start_date',
+    'listing_end_date',
+    'total_commission',
+    'listing_side_commission',
+    'buyer_commission',
+})
+_PROFILE_LISTING_KEYS = frozenset({'list_price', 'go_live_date', 'mls_number', 'occupancy'})
+_OFFER_TERM_KEYS = frozenset({
+    'offer_price',
+    'sales_price',
+    'financing_type',
+    'earnest_money',
+    'option_fee',
+    'option_period_days',
+    'option_days',
+    'seller_concessions_amount',
+    'concessions',
+    'proposed_close_date',
+    'closing_date',
+    'response_deadline_at',
+    'cash_down_payment',
+    'financing_amount',
+    'additional_earnest_money',
+    'possession_type',
+    'leaseback_days',
+    'appraisal_contingency',
+    'financing_contingency',
+    'sale_of_other_property_contingency',
+    'buyer_agent_commission_percent',
+    'buyer_agent_commission_flat',
+    'survey_furnished_by',
+    'residential_service_contract',
+    'title_policy_payer',
+    'survey_payer',
+})
+_OFFER_PARTY_KEYS = (
+    'buyer_names',
+    'buyer_agent_name',
+    'buyer_agent_email',
+    'buyer_agent_phone',
+    'buyer_agent_brokerage',
+)
+_OFFER_STATUSES = {
+    'new',
+    'reviewing',
+    'needs_review',
+    'countered',
+    'declined',
+    'withdrawn',
+    'expired',
+}
+_ACCEPT_STATUSES = frozenset({'accepted_primary', 'accepted_backup'})
+_OFFERS_UNSUPPORTED = 'Offers are only available for buyer and seller transactions.'
+_ACCEPT_SELLER_ONLY = (
+    'Accepting an offer as a contract is only available for seller transactions.'
+)
+_LISTING_ONLY = 'Listing edits are only available for seller listings.'
+_COMPARE_SELLER_ONLY = 'Offer compare is only available for seller transactions.'
+_NO_CONTRACT = 'Accept an offer or set dates first.'
+
+
+def register(bp):
+    """Idempotent attach."""
+    global _registered
+    if _registered:
+        return
+    _registered = True
+    rules = (
+        (
+            '/transactions/<int:transaction_id>/listing',
+            'deal_desk_patch_listing',
+            patch_listing,
+            ['PATCH'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers',
+            'deal_desk_list_offers',
+            list_offers,
+            ['GET'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers',
+            'deal_desk_create_offer',
+            create_offer,
+            ['POST'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers/compare',
+            'deal_desk_compare_offers',
+            compare_offers,
+            ['GET'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers/<int:offer_id>',
+            'deal_desk_patch_offer',
+            patch_offer,
+            ['PATCH'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers/<int:offer_id>/expire',
+            'deal_desk_expire_offer',
+            expire_offer,
+            ['POST'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/offers/<int:offer_id>/accept',
+            'deal_desk_accept_offer',
+            accept_offer,
+            ['POST'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/contract',
+            'deal_desk_get_contract',
+            get_contract,
+            ['GET'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/contract',
+            'deal_desk_patch_contract',
+            patch_contract,
+            ['PATCH'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/requirements',
+            'deal_desk_list_requirements',
+            list_requirements,
+            ['GET'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/requirements/<int:requirement_id>/due-date',
+            'deal_desk_requirement_due_date',
+            set_requirement_due_date,
+            ['POST'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/requirements/<int:requirement_id>/toggle',
+            'deal_desk_toggle_requirement',
+            toggle_requirement,
+            ['POST'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/participants/<int:participant_id>',
+            'deal_desk_delete_participant',
+            delete_participant,
+            ['DELETE'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/notes',
+            'deal_desk_list_notes',
+            list_notes,
+            ['GET'],
+        ),
+        (
+            '/transactions/<int:transaction_id>/notes',
+            'deal_desk_add_note',
+            add_note,
+            ['POST'],
+        ),
+    )
+    for rule, endpoint, view, methods in rules:
+        bp.add_url_rule(rule, endpoint=endpoint, view_func=view, methods=methods)
+
+
+def enrich_transaction_detail(tx, payload: dict) -> None:
+    """Mutate payload in place. Called from _serialize_transaction(detail=True)."""
+    payload['listing'] = serialize_listing(tx)
+    payload['contract'] = serialize_contract(
+        get_active_primary_contract(tx.id, tx.organization_id),
+    )
+    offers = (
+        SellerOffer.query.filter_by(
+            transaction_id=tx.id,
+            organization_id=tx.organization_id,
+        )
+        .order_by(SellerOffer.received_at.desc())
+        .all()
+    )
+    payload['offers'] = [serialize_offer(offer) for offer in offers]
+    requirements = (
+        TransactionRequirement.query.filter_by(
+            transaction_id=tx.id,
+            organization_id=tx.organization_id,
+        )
+        .order_by(TransactionRequirement.due_at.asc().nullslast())
+        .all()
+    )
+    payload['requirements'] = [serialize_requirement(row) for row in requirements]
+    tasks = (
+        Task.query.filter_by(
+            transaction_id=tx.id,
+            organization_id=tx.organization_id,
+        )
+        .order_by(Task.due_date.asc())
+        .all()
+    )
+    payload['tasks'] = [serialize_task(task) for task in tasks]
+    payload['notes'] = list((tx.extra_data or {}).get('bob_notes') or [])
+
+
+def _money_json(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, Decimal):
+        amount = value
+    else:
+        try:
+            amount = Decimal(str(value).replace(',', '').replace('$', '').strip())
+        except (InvalidOperation, AttributeError, ValueError):
+            return None
+    if amount == amount.to_integral_value():
+        return int(amount)
+    return float(amount)
+
+
+def _as_date_str(value):
+    if value in (None, ''):
+        return None
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()[:10]
+    return str(value)[:10]
+
+
+def _decimal(value):
+    if value in (None, ''):
+        return None
+    try:
+        return Decimal(str(value).replace(',', '').replace('$', '').strip())
+    except (InvalidOperation, AttributeError, ValueError) as exc:
+        raise ValueError('Enter a valid amount.') from exc
+
+
+def _truthy(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in ('1', 'true', 'yes', 'on')
+    return False
+
+
+def _tx_type_name(tx):
+    tx_type = getattr(tx, 'transaction_type', None)
+    return getattr(tx_type, 'name', None)
+
+
+def _listing_editable(tx):
+    name = _tx_type_name(tx)
+    if name == 'seller':
+        return True
+    if name == 'landlord' and tx.seller_listing_profile is not None:
+        return True
+    return False
+
+
+def _ensure_listing_profile(tx, user):
+    profile = tx.seller_listing_profile
+    if profile is not None:
+        return profile
+    profile = SellerListingProfile(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        created_by_id=user.id,
+    )
+    db.session.add(profile)
+    db.session.flush()
+    return profile
+
+
+def _extra(tx):
+    return dict(tx.extra_data or {})
+
+
+def serialize_listing(tx):
+    extra = tx.extra_data or {}
+    overrides = extra.get('listing_info_overrides') or {}
+    profile = getattr(tx, 'seller_listing_profile', None)
+    list_price = None
+    if profile is not None and profile.current_list_price is not None:
+        list_price = _money_json(profile.current_list_price)
+    elif overrides.get('list_price') not in (None, ''):
+        list_price = _money_json(overrides.get('list_price'))
+    go_live = None
+    if profile is not None and profile.go_live_date:
+        go_live = profile.go_live_date.isoformat()
+    elif overrides.get('go_live_date'):
+        go_live = _as_date_str(overrides.get('go_live_date'))
+    listing = {
+        'list_price': list_price,
+        'go_live_date': go_live,
+        'listing_start_date': _as_date_str(overrides.get('listing_start_date')),
+        'listing_end_date': _as_date_str(overrides.get('listing_end_date')),
+        'mls_listing_url': tx.mls_listing_url,
+        'mls_number': profile.mls_number if profile is not None else None,
+        'lockbox_combo': extra.get('lockbox_combo'),
+    }
+    for key in ('total_commission', 'listing_side_commission', 'buyer_commission'):
+        if overrides.get(key) not in (None, ''):
+            listing[key] = overrides[key]
+    occupancy = profile.occupancy_status if profile is not None else None
+    if occupancy:
+        listing['occupancy'] = occupancy
+    return listing
+
+
+def serialize_offer(offer):
+    extra = offer.extra_data or {}
+    return {
+        'id': offer.id,
+        'status': offer.status,
+        'offer_price': _money_json(offer.offer_price),
+        'financing_type': offer.financing_type,
+        'earnest_money': _money_json(offer.earnest_money),
+        'option_fee': _money_json(offer.option_fee),
+        'option_days': offer.option_period_days,
+        'concessions': _money_json(offer.seller_concessions_amount),
+        'proposed_close_date': (
+            offer.proposed_close_date.isoformat() if offer.proposed_close_date else None
+        ),
+        'response_deadline_at': (
+            offer.response_deadline_at.isoformat() if offer.response_deadline_at else None
+        ),
+        'buyer_name': offer.buyer_names,
+        'notes': extra.get('notes'),
+        'created_at': offer.created_at.isoformat() if offer.created_at else None,
+    }
+
+
+def serialize_contract(contract):
+    if contract is None:
+        return None
+    return {
+        'id': contract.id,
+        'status': contract.status,
+        'position': contract.position,
+        'accepted_price': _money_json(contract.accepted_price),
+        'effective_date': (
+            contract.effective_date.isoformat() if contract.effective_date else None
+        ),
+        'closing_date': (
+            contract.closing_date.isoformat() if contract.closing_date else None
+        ),
+        'option_period_days': contract.option_period_days,
+        'financing_type': contract.financing_type,
+        'financing_approval_deadline': (
+            contract.financing_approval_deadline.isoformat()
+            if contract.financing_approval_deadline else None
+        ),
+    }
+
+
+def serialize_requirement(req):
+    return {
+        'id': req.id,
+        'title': req.title,
+        'name': req.title,
+        'requirement_key': req.requirement_key,
+        'group': req.phase_key,
+        'due_at': req.due_at.isoformat() if req.due_at else None,
+        'work_status': req.work_status,
+        'timing_state': req.timing_state,
+        'risk_level': req.risk_level,
+        'due_at_manual_override': bool(req.due_at_manual_override),
+        'is_auto': req.requirement_key in AUTO_KEYS,
+    }
+
+
+def serialize_task(task):
+    return {
+        'id': task.id,
+        'subject': task.subject,
+        'status': task.status,
+        'priority': task.priority,
+        'due_date': task.due_date.isoformat() if task.due_date else None,
+        'contact_id': task.contact_id,
+    }
+
+
+def _detail_transaction(tx):
+    return _serialize_transaction(tx, detail=True)
+
+
+def _load_offer(tx, offer_id):
+    offer = SellerOffer.query.filter_by(
+        id=offer_id,
+        transaction_id=tx.id,
+        organization_id=tx.organization_id,
+    ).first()
+    if offer is None:
+        return None, _json_error('Offer not found.', 404)
+    return offer, None
+
+
+def _load_requirement(tx, requirement_id):
+    req = TransactionRequirement.query.filter_by(
+        id=requirement_id,
+        transaction_id=tx.id,
+        organization_id=tx.organization_id,
+    ).first()
+    if req is None:
+        return None, _json_error('Requirement not found.', 404)
+    return req, None
+
+
+def _incoming_offer_terms(data):
+    terms = {}
+    nested = data.get('terms_data') or data.get('terms')
+    if isinstance(nested, dict):
+        terms.update(nested)
+    for key in _OFFER_TERM_KEYS:
+        if key in data:
+            terms[key] = data[key]
+    if 'option_days' in terms and terms.get('option_period_days') in (None, ''):
+        terms['option_period_days'] = terms.get('option_days')
+    if 'concessions' in terms and terms.get('seller_concessions_amount') in (None, ''):
+        terms['seller_concessions_amount'] = terms.get('concessions')
+    if isinstance(terms.get('response_deadline_at'), str):
+        try:
+            terms['response_deadline_at'] = _parse_datetime(terms['response_deadline_at'])
+        except ValueError:
+            terms['response_deadline_at'] = None
+    return terms
+
+
+def _apply_offer_party_fields(offer, data):
+    if 'buyer_name' in data or 'buyer_names' in data:
+        offer.buyer_names = (
+            data.get('buyer_names') or data.get('buyer_name') or None
+        )
+        if isinstance(offer.buyer_names, str):
+            offer.buyer_names = offer.buyer_names.strip() or None
+    for field in _OFFER_PARTY_KEYS:
+        if field == 'buyer_names':
+            continue
+        if field in data:
+            value = data.get(field)
+            setattr(offer, field, (value or '').strip() or None if isinstance(value, str) else value)
+    note = data.get('notes')
+    if note is not None:
+        extra = dict(offer.extra_data or {})
+        extra['notes'] = (str(note).strip() or None)
+        offer.extra_data = extra
+        flag_modified(offer, 'extra_data')
+
+
+def _current_offer_version(offer):
+    if not offer.current_version_id:
+        return None
+    return SellerOfferVersion.query.filter_by(
+        id=offer.current_version_id,
+        offer_id=offer.id,
+        organization_id=offer.organization_id,
+    ).first()
+
+
+def _merged_offer_terms(offer, data):
+    merged = {}
+    version = _current_offer_version(offer)
+    if version is not None:
+        merged.update(version.terms_data or {})
+    if isinstance(offer.terms_summary, dict):
+        merged.update(offer.terms_summary)
+    merged.update(_incoming_offer_terms(data))
+    return merged, version
+
+
+@agent_jwt_required
+@transactions_flag_required
+def patch_listing(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    if not _listing_editable(tx):
+        return _json_error(_LISTING_ONLY, 400)
+
+    data = _json_body()
+    try:
+        extra = _extra(tx)
+        overrides = dict(extra.get('listing_info_overrides') or {})
+        needs_profile = any(key in data for key in _PROFILE_LISTING_KEYS)
+        profile = tx.seller_listing_profile
+        if needs_profile:
+            profile = _ensure_listing_profile(tx, user)
+
+        for field in _LISTING_OVERRIDE_KEYS:
+            if field not in data:
+                continue
+            value = data.get(field)
+            if value in (None, ''):
+                overrides.pop(field, None)
+                continue
+            if field in ('go_live_date', 'listing_start_date', 'listing_end_date'):
+                parsed = _parse_date(value)
+                overrides[field] = parsed.isoformat() if parsed else None
+                if overrides[field] is None:
+                    overrides.pop(field, None)
+            else:
+                overrides[field] = str(value).strip()
+
+        if overrides:
+            extra['listing_info_overrides'] = overrides
+        else:
+            extra.pop('listing_info_overrides', None)
+
+        if 'list_price' in data and profile is not None:
+            profile.current_list_price = _decimal(data.get('list_price'))
+        if 'go_live_date' in data and profile is not None:
+            profile.go_live_date = _parse_date(data.get('go_live_date'))
+        if 'mls_number' in data and profile is not None:
+            profile.mls_number = (str(data.get('mls_number') or '').strip() or None)
+        if 'occupancy' in data and profile is not None:
+            profile.occupancy_status = (str(data.get('occupancy') or '').strip() or None)
+        if 'mls_listing_url' in data:
+            tx.mls_listing_url = (str(data.get('mls_listing_url') or '').strip() or None)
+        if 'lockbox_combo' in data:
+            combo = str(data.get('lockbox_combo') or '').strip()
+            if combo:
+                extra['lockbox_combo'] = combo
+            else:
+                extra.pop('lockbox_combo', None)
+
+        tx.extra_data = extra
+        flag_modified(tx, 'extra_data')
+        db.session.commit()
+    except ValueError as exc:
+        db.session.rollback()
+        return _json_error(str(exc), 400)
+
+    return jsonify({'transaction': _detail_transaction(tx)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def list_offers(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    if not supports_offers(tx):
+        return _json_error(_OFFERS_UNSUPPORTED, 400)
+    offers = (
+        tx.seller_offers.order_by(SellerOffer.received_at.desc()).all()
+    )
+    return jsonify({'offers': [serialize_offer(offer) for offer in offers]})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def create_offer(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    if not supports_offers(tx):
+        return _json_error(_OFFERS_UNSUPPORTED, 400)
+
+    data = _json_body()
+    terms = _incoming_offer_terms(data)
+    try:
+        response_deadline_at = data.get('response_deadline_at')
+        if response_deadline_at:
+            response_deadline_at = _parse_datetime(response_deadline_at)
+        else:
+            response_deadline_at = terms.get('response_deadline_at')
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+
+    side = side_for_transaction(tx)
+    offer = SellerOffer(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        created_by_id=user.id,
+        source_showing_id=data.get('source_showing_id') or None,
+        received_at=datetime.utcnow(),
+        creation_source=data.get('creation_source') or 'manual_entry',
+        status='new',
+        response_deadline_at=response_deadline_at,
+        response_deadline_source='manual' if response_deadline_at else None,
+    )
+    _apply_offer_party_fields(offer, data)
+    apply_offer_terms(offer, terms)
+    version = SellerOfferVersion(
+        organization_id=user.organization_id,
+        transaction_id=tx.id,
+        offer=offer,
+        created_by_id=user.id,
+        version_number=1,
+        direction=opening_direction_for_side(side),
+        status='reviewed',
+        submitted_at=offer.received_at,
+        terms_data=terms,
+        extraction_reviewed_at=datetime.utcnow(),
+        extraction_reviewed_by_id=user.id,
+    )
+    try:
+        db.session.add(offer)
+        db.session.add(version)
+        db.session.flush()
+        offer.current_version_id = version.id
+        create_offer_activity(
+            offer,
+            'offer_created',
+            'Offer logged manually',
+            actor_id=user.id,
+            version_id=version.id,
+        )
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('AgentDesk create offer failed tx=%s', transaction_id)
+        return _json_error('Could not log this offer.', 500)
+    return jsonify({'offer': serialize_offer(offer)}), 201
+
+
+@agent_jwt_required
+@transactions_flag_required
+def patch_offer(user, transaction_id, offer_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    if not supports_offers(tx):
+        return _json_error(_OFFERS_UNSUPPORTED, 400)
+    offer, error = _load_offer(tx, offer_id)
+    if error:
+        return error
+
+    data = _json_body()
+    status = data.get('status')
+    if status in _ACCEPT_STATUSES:
+        return _json_error(
+            'Accept the offer through POST /transactions/<id>/offers/<offer_id>/accept.',
+            400,
+        )
+    if status and status not in _OFFER_STATUSES:
+        return _json_error('Invalid offer status.', 400)
+
+    try:
+        if 'response_deadline_at' in data:
+            offer.response_deadline_at = _parse_datetime(data.get('response_deadline_at'))
+            offer.response_deadline_source = (
+                'manual' if offer.response_deadline_at else None
+            )
+        if data.get('received_at'):
+            offer.received_at = _parse_datetime(data.get('received_at')) or offer.received_at
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+
+    _apply_offer_party_fields(offer, data)
+    if status:
+        offer.status = status
+
+    merged_terms, version = _merged_offer_terms(offer, data)
+    side = side_for_transaction(tx)
+    try:
+        if version is not None:
+            version.terms_data = merged_terms
+            version.status = 'reviewed'
+        else:
+            version = SellerOfferVersion(
+                organization_id=user.organization_id,
+                transaction_id=tx.id,
+                offer_id=offer.id,
+                created_by_id=user.id,
+                version_number=offer.versions.count() + 1,
+                direction=opening_direction_for_side(side),
+                status='reviewed',
+                submitted_at=offer.received_at,
+                terms_data=merged_terms,
+                extraction_reviewed_at=datetime.utcnow(),
+                extraction_reviewed_by_id=user.id,
+            )
+            db.session.add(version)
+            db.session.flush()
+            offer.current_version_id = version.id
+        apply_offer_terms(offer, merged_terms)
+        create_offer_activity(
+            offer,
+            'offer_updated',
+            'Offer details updated',
+            actor_id=user.id,
+            version_id=version.id,
+        )
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('AgentDesk patch offer failed offer=%s', offer_id)
+        return _json_error('Could not update this offer.', 500)
+    return jsonify({'offer': serialize_offer(offer)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def expire_offer(user, transaction_id, offer_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    if not supports_offers(tx):
+        return _json_error(_OFFERS_UNSUPPORTED, 400)
+    offer, error = _load_offer(tx, offer_id)
+    if error:
+        return error
+    if offer.status not in ACTIVE_OFFER_STATUSES and offer.status != 'expired':
+        return _json_error(
+            f'Offer {offer.id} is {offer.status} and cannot be expired.',
+            400,
+        )
+    if offer.status != 'expired':
+        now = datetime.utcnow()
+        offer.status = 'expired'
+        offer.expired_at = now
+        offer.next_action = None
+        offer.next_deadline_at = None
+        create_offer_activity(offer, 'expired', 'Offer expired', actor_id=user.id)
+        db.session.commit()
+    return jsonify({'offer': serialize_offer(offer)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def accept_offer(user, transaction_id, offer_id):
+    """Accept as controlling contract via create_baseline_from_accepted_offer."""
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    if not supports_offers(tx):
+        return _json_error(_OFFERS_UNSUPPORTED, 400)
+    if side_for_transaction(tx) != 'seller':
+        return _json_error(_ACCEPT_SELLER_ONLY, 400)
+    offer, error = _load_offer(tx, offer_id)
+    if error:
+        return error
+
+    data = _json_body()
+    position = 'backup' if _truthy(data.get('as_backup')) else 'primary'
+    version = _current_offer_version(offer)
+    try:
+        effective_date = (
+            _parse_date(data.get('effective_date')) if data.get('effective_date') else None
+        )
+        effective_at = (
+            _parse_datetime(data.get('effective_at')) if data.get('effective_at') else None
+        )
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+
+    try:
+        accepted_contract = create_baseline_from_accepted_offer(
+            transaction=tx,
+            offer=offer,
+            actor_id=user.id,
+            position=position,
+            version=version,
+            effective_date=effective_date,
+            effective_at=effective_at,
+            backup_position=data.get('backup_position') if position == 'backup' else None,
+            backup_addendum_document_id=(
+                data.get('backup_addendum_document_id') or None
+                if position == 'backup' else None
+            ),
+            seed_requirements=True,
+        )
+        db.session.commit()
+    except ControllingContractConflict as exc:
+        db.session.rollback()
+        payload = {'error': str(exc), 'code': exc.code}
+        if exc.existing_contract_id:
+            payload['existing_contract_id'] = exc.existing_contract_id
+        return jsonify(payload), exc.status
+    except ControllingContractSeedError as exc:
+        db.session.rollback()
+        return jsonify({'error': str(exc), 'code': exc.code}), 500
+    except ValueError as exc:
+        db.session.rollback()
+        return _json_error(str(exc), 400)
+    except Exception:
+        db.session.rollback()
+        logger.exception(
+            'AgentDesk accept offer failed offer=%s tx=%s', offer_id, transaction_id,
+        )
+        return _json_error('Could not accept this offer.', 500)
+
+    return jsonify({
+        'transaction': _detail_transaction(tx),
+        'offer': serialize_offer(offer),
+        'contract': serialize_contract(accepted_contract),
+    })
+
+
+@agent_jwt_required
+@transactions_flag_required
+def compare_offers(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    if side_for_transaction(tx) != 'seller':
+        return _json_error(_COMPARE_SELLER_ONLY, 400)
+    result = OfferCompareService.compare_offers(tx, include_terminal=True)
+    rows = []
+    for column in result.get('offers') or []:
+        offer = SellerOffer.query.filter_by(
+            id=column.get('offer_id'),
+            transaction_id=tx.id,
+            organization_id=tx.organization_id,
+        ).first()
+        if offer is None:
+            continue
+        row = serialize_offer(offer)
+        terms = column.get('terms') or {}
+        row['net'] = _money_json(
+            offer.net_to_seller_estimate or terms.get('net_to_seller_estimate'),
+        )
+        if not row['financing_type']:
+            row['financing_type'] = terms.get('financing_type')
+        if row['offer_price'] is None:
+            row['offer_price'] = _money_json(terms.get('offer_price'))
+        rows.append(row)
+    return jsonify({'offers': rows})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def get_contract(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    contract = get_active_primary_contract(tx.id, tx.organization_id)
+    return jsonify({'contract': serialize_contract(contract)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def patch_contract(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    contract = get_active_primary_contract(tx.id, tx.organization_id)
+    if contract is None:
+        return _json_error(_NO_CONTRACT, 400)
+
+    data = _json_body()
+    changes = {}
+    try:
+        if 'accepted_price' in data:
+            contract.accepted_price = _decimal(data.get('accepted_price'))
+        if 'effective_date' in data:
+            contract.effective_date = _parse_date(data.get('effective_date'))
+            changes['effective_date'] = contract.effective_date
+        if 'closing_date' in data:
+            contract.closing_date = _parse_date(data.get('closing_date'))
+            changes['closing_date'] = contract.closing_date
+        option_raw = (
+            data['option_period_days'] if 'option_period_days' in data
+            else data.get('option_days') if 'option_days' in data
+            else None
+        )
+        if 'option_period_days' in data or 'option_days' in data:
+            if option_raw in (None, ''):
+                contract.option_period_days = None
+            else:
+                contract.option_period_days = int(option_raw)
+            changes['option_period_days'] = contract.option_period_days
+        if 'financing_type' in data:
+            contract.financing_type = (str(data.get('financing_type') or '').strip() or None)
+        if 'financing_approval_deadline' in data:
+            contract.financing_approval_deadline = _parse_date(
+                data.get('financing_approval_deadline'),
+            )
+        if 'concessions' in data or 'seller_concessions_amount' in data:
+            contract.seller_concessions_amount = _decimal(
+                data.get('seller_concessions_amount', data.get('concessions')),
+            )
+        if 'buyer_agent_commission_percent' in data and hasattr(
+            contract, 'buyer_agent_commission_percent',
+        ):
+            contract.buyer_agent_commission_percent = _decimal(
+                data.get('buyer_agent_commission_percent'),
+            )
+        if 'buyer_agent_commission_flat' in data and hasattr(
+            contract, 'buyer_agent_commission_flat',
+        ):
+            contract.buyer_agent_commission_flat = _decimal(
+                data.get('buyer_agent_commission_flat'),
+            )
+    except (TypeError, ValueError) as exc:
+        return _json_error(str(exc), 400)
+
+    if changes:
+        recompute_from_changes(
+            tx, changes, actor_id=user.id, source='agent_desk',
+        )
+    db.session.commit()
+    return jsonify({
+        'contract': serialize_contract(contract),
+        'transaction': _detail_transaction(tx),
+    })
+
+
+@agent_jwt_required
+@transactions_flag_required
+def list_requirements(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    rows = (
+        TransactionRequirement.query.filter_by(
+            transaction_id=tx.id,
+            organization_id=user.organization_id,
+        )
+        .order_by(TransactionRequirement.due_at.asc().nullslast())
+        .all()
+    )
+    return jsonify({'requirements': [serialize_requirement(row) for row in rows]})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def set_requirement_due_date(user, transaction_id, requirement_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    req, error = _load_requirement(tx, requirement_id)
+    if error:
+        return error
+
+    data = _json_body()
+    if 'due_at' not in data and 'due_date' not in data:
+        return _json_error('due_at is required.', 400)
+    raw = data['due_at'] if 'due_at' in data else data.get('due_date')
+    due_at = None
+    if raw not in (None, ''):
+        try:
+            due_at = datetime.strptime(str(raw)[:10], '%Y-%m-%d')
+        except ValueError:
+            return _json_error('Use YYYY-MM-DD for dates.', 400)
+    try:
+        updated = RequirementsService.update_due_at(
+            req.id, due_at, actor_id=user.id, manual=True,
+        )
+        db.session.commit()
+    except ValueError as exc:
+        db.session.rollback()
+        return _json_error(str(exc), 400)
+    except Exception:
+        db.session.rollback()
+        logger.exception('AgentDesk requirement due-date failed req=%s', requirement_id)
+        return _json_error('Could not update the due date.', 500)
+    return jsonify({'requirement': serialize_requirement(updated)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def toggle_requirement(user, transaction_id, requirement_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    req, error = _load_requirement(tx, requirement_id)
+    if error:
+        return error
+    if req.requirement_key in AUTO_KEYS:
+        return _json_error('This item checks itself when the work is on file.', 400)
+
+    current = (req.work_status or 'pending').lower()
+    new_status = 'pending' if current == 'completed' else 'completed'
+    try:
+        updated = RequirementsService.update_work_status(
+            req.id, new_status, actor_id=user.id,
+        )
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception('AgentDesk requirement toggle failed req=%s', requirement_id)
+        return _json_error('Could not update this item.', 500)
+    return jsonify({
+        'requirement': serialize_requirement(updated),
+        'work_status': updated.work_status,
+        'done': updated.work_status == 'completed',
+    })
+
+
+@agent_jwt_required
+@transactions_flag_required
+def delete_participant(user, transaction_id, participant_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    participant = TransactionParticipant.query.filter_by(
+        id=participant_id,
+        transaction_id=tx.id,
+        organization_id=user.organization_id,
+    ).first()
+    if participant is None:
+        return _json_error('Participant not found.', 404)
+    db.session.delete(participant)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+def _bob_notes(tx):
+    return list((tx.extra_data or {}).get('bob_notes') or [])
+
+
+@agent_jwt_required
+@transactions_flag_required
+def list_notes(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_VIEW)
+    if error:
+        return error
+    return jsonify({'notes': _bob_notes(tx)})
+
+
+@agent_jwt_required
+@transactions_flag_required
+def add_note(user, transaction_id):
+    tx, error = _load_tx(user, transaction_id, CAP_EDIT)
+    if error:
+        return error
+    data = _json_body()
+    text = (data.get('text') or data.get('note') or data.get('body') or '').strip()
+    if not text:
+        return _json_error('Note text is required.', 400)
+    text = text[:4000]
+    extra = _extra(tx)
+    notes = list(extra.get('bob_notes') or [])
+    stamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')
+    notes.append({'at': stamp, 'user_id': user.id, 'text': text})
+    extra['bob_notes'] = notes[-50:]
+    tx.extra_data = extra
+    flag_modified(tx, 'extra_data')
+    db.session.commit()
+    return jsonify({'notes': extra['bob_notes']}), 201
+
+
+register(agent_api_bp)

--- a/routes/agent_task_desk.py
+++ b/routes/agent_task_desk.py
@@ -1,0 +1,553 @@
+"""Agent iPhone Tasks API. Attaches to the agent_api blueprint.
+
+Scope is always assigned-to-me. Owners and admins are not given an implicit
+org-wide list — AgentDesk is a personal CRM.
+"""
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+
+from flask import jsonify, request
+from sqlalchemy.orm import joinedload
+
+from models import Contact, Task, TaskSubtype, TaskType, db
+from routes.agent_api import (  # noqa: F401
+    _contact_visible,
+    _json_body,
+    _json_error,
+    _parse_date,
+    _parse_datetime,
+    agent_api_bp,
+    agent_jwt_required,
+)
+from services.bob_tools.common import (
+    TASK_PRIORITIES,
+    TASK_STATUSES,
+    ToolError,
+    due_bucket,
+    due_datetime_utc,
+    parse_local_date,
+    parse_local_time,
+    task_scope,
+    to_local_date_string,
+)
+from services.bob_tools.context import BobContext
+from services.bob_tools.tasks import (
+    _clean,
+    _record_task_completed,
+    _record_task_created,
+    complete_task,
+    delete_task,
+)
+from services.tenant_service import org_query_for_id
+from services.transaction_auth import CAP_VIEW, get_transaction_for_user
+
+_registered = False
+
+TASK_BUCKETS = ('today', 'overdue', 'upcoming', 'all')
+
+
+def register(bp):
+    """Idempotent. Attach task routes to agent_api blueprint."""
+    global _registered
+    if _registered:
+        return
+    _registered = True
+    bp.add_url_rule(
+        '/task-types',
+        endpoint='agent_task_types',
+        view_func=api_list_task_types,
+        methods=['GET'],
+    )
+    bp.add_url_rule(
+        '/tasks',
+        endpoint='agent_tasks_list',
+        view_func=api_list_tasks,
+        methods=['GET'],
+    )
+    bp.add_url_rule(
+        '/tasks',
+        endpoint='agent_tasks_create',
+        view_func=api_create_task,
+        methods=['POST'],
+    )
+    bp.add_url_rule(
+        '/tasks/<int:task_id>',
+        endpoint='agent_task_get',
+        view_func=api_get_task,
+        methods=['GET'],
+    )
+    bp.add_url_rule(
+        '/tasks/<int:task_id>',
+        endpoint='agent_task_patch',
+        view_func=api_patch_task,
+        methods=['PATCH'],
+    )
+    bp.add_url_rule(
+        '/tasks/<int:task_id>',
+        endpoint='agent_task_delete',
+        view_func=api_delete_task,
+        methods=['DELETE'],
+    )
+    bp.add_url_rule(
+        '/tasks/<int:task_id>/complete',
+        endpoint='agent_task_complete',
+        view_func=api_complete_task,
+        methods=['POST'],
+    )
+
+
+def _ctx(user) -> BobContext:
+    return BobContext.from_user(user, surface='agent_api')
+
+
+def _mine(ctx: BobContext):
+    """Assigned-to-me only. Admins do not get a silent org-wide list."""
+    return task_scope(ctx).filter(Task.assigned_to_id == ctx.user_id).options(
+        joinedload(Task.contact),
+        joinedload(Task.task_type),
+        joinedload(Task.task_subtype),
+        joinedload(Task.transaction),
+    )
+
+
+def _get_mine(ctx: BobContext, task_id: int):
+    return _mine(ctx).filter(Task.id == task_id).first()
+
+
+def _iso(value):
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        aware = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return aware.isoformat()
+    return str(value)
+
+
+def _scheduled_hhmm(value, ctx: BobContext):
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        aware = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return aware.astimezone(ctx.tzinfo).strftime('%H:%M')
+    if isinstance(value, time):
+        return value.strftime('%H:%M')
+    return None
+
+
+def serialize_task(task: Task, ctx: BobContext) -> dict:
+    contact = task.contact
+    return {
+        'id': task.id,
+        'subject': task.subject,
+        'description': task.description or None,
+        'status': task.status,
+        'priority': task.priority,
+        'due_date': to_local_date_string(task.due_date, ctx),
+        'scheduled_time': _scheduled_hhmm(task.scheduled_time, ctx),
+        'type_id': task.type_id,
+        'subtype_id': task.subtype_id,
+        'type': task.task_type.name if task.task_type else None,
+        'subtype': task.task_subtype.name if task.task_subtype else None,
+        'contact_id': task.contact_id,
+        'contact_name': (
+            f'{contact.first_name} {contact.last_name}'.strip()
+            if contact else None
+        ),
+        'transaction_id': task.transaction_id,
+        'property_address': task.property_address or None,
+        'outcome': task.outcome or None,
+        'completed_at': _iso(task.completed_at),
+    }
+
+
+def _as_int(value, field_name):
+    if value in (None, ''):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ToolError(f'{field_name} must be a number.') from exc
+
+
+def _load_contact(user, contact_id):
+    contact = org_query_for_id(Contact, user.organization_id).filter_by(
+        id=contact_id,
+    ).first()
+    if not _contact_visible(user, contact):
+        return None
+    return contact
+
+
+def _load_transaction(user, transaction_id):
+    tx, decision = get_transaction_for_user(
+        transaction_id, user=user, capability=CAP_VIEW,
+    )
+    if tx is None:
+        return None, (
+            404 if getattr(decision, 'reason', None) == 'not_found' else 403
+        )
+    return tx, None
+
+
+def _resolve_type_pair(org_id, type_id, subtype_id):
+    types = (
+        TaskType.query
+        .filter_by(organization_id=org_id)
+        .order_by(TaskType.sort_order, TaskType.id)
+        .all()
+    )
+    if not types:
+        raise ToolError(
+            'This organization has no task types configured yet, so tasks '
+            'cannot be created.'
+        )
+
+    task_type = None
+    if type_id is not None:
+        task_type = next((row for row in types if row.id == type_id), None)
+        if task_type is None:
+            raise ToolError('Task type not found.')
+    elif subtype_id is not None:
+        subtype = TaskSubtype.query.filter_by(
+            id=subtype_id, organization_id=org_id,
+        ).first()
+        if subtype is None:
+            raise ToolError('Task subtype not found.')
+        task_type = next(
+            (row for row in types if row.id == subtype.task_type_id), None,
+        )
+        if task_type is None:
+            raise ToolError('Task type not found.')
+        return task_type, subtype
+    else:
+        task_type = types[0]
+
+    subtypes = (
+        TaskSubtype.query
+        .filter_by(organization_id=org_id, task_type_id=task_type.id)
+        .order_by(TaskSubtype.sort_order, TaskSubtype.id)
+        .all()
+    )
+    if not subtypes:
+        raise ToolError(
+            f'The "{task_type.name}" task type has no subtypes configured.'
+        )
+    if subtype_id is not None:
+        subtype = next((row for row in subtypes if row.id == subtype_id), None)
+        if subtype is None:
+            raise ToolError('Task subtype not found.')
+        return task_type, subtype
+    return task_type, subtypes[0]
+
+
+def _page_args():
+    page = request.args.get('page', 1, type=int) or 1
+    page = max(page, 1)
+    per_page = request.args.get('per_page', 50, type=int) or 50
+    per_page = min(max(per_page, 1), 100)
+    return page, per_page
+
+
+@agent_jwt_required
+def api_list_task_types(user):
+    types = (
+        TaskType.query
+        .filter_by(organization_id=user.organization_id)
+        .order_by(TaskType.sort_order, TaskType.id)
+        .all()
+    )
+    return jsonify({
+        'task_types': [
+            {
+                'id': task_type.id,
+                'name': task_type.name,
+                'subtypes': [
+                    {'id': subtype.id, 'name': subtype.name}
+                    for subtype in sorted(
+                        task_type.subtypes,
+                        key=lambda row: (row.sort_order or 0, row.id),
+                    )
+                ],
+            }
+            for task_type in types
+        ],
+    })
+
+
+@agent_jwt_required
+def api_list_tasks(user):
+    ctx = _ctx(user)
+    status = (request.args.get('status') or 'pending').strip().lower()
+    if status not in TASK_STATUSES + ('all',):
+        return _json_error(
+            'status must be pending, completed, cancelled, or all.', 400,
+        )
+    bucket = (request.args.get('bucket') or 'all').strip().lower()
+    if bucket not in TASK_BUCKETS:
+        return _json_error(
+            'bucket must be today, overdue, upcoming, or all.', 400,
+        )
+
+    query = _mine(ctx)
+    if status != 'all':
+        query = query.filter(Task.status == status)
+    contact_id = request.args.get('contact_id', type=int)
+    if contact_id:
+        query = query.filter(Task.contact_id == contact_id)
+    transaction_id = request.args.get('transaction_id', type=int)
+    if transaction_id:
+        query = query.filter(Task.transaction_id == transaction_id)
+
+    rows = query.order_by(Task.due_date.asc(), Task.id.asc()).all()
+    if bucket != 'all':
+        rows = [task for task in rows if due_bucket(task, ctx) == bucket]
+
+    page, per_page = _page_args()
+    total = len(rows)
+    start = (page - 1) * per_page
+    items = rows[start:start + per_page]
+    return jsonify({
+        'tasks': [serialize_task(task, ctx) for task in items],
+        'page': page,
+        'per_page': per_page,
+        'total': total,
+    })
+
+
+@agent_jwt_required
+def api_get_task(user, task_id):
+    ctx = _ctx(user)
+    task = _get_mine(ctx, task_id)
+    if task is None:
+        return _json_error('Task not found.', 404)
+    return jsonify({'task': serialize_task(task, ctx)})
+
+
+@agent_jwt_required
+def api_create_task(user):
+    data = _json_body()
+    ctx = _ctx(user)
+    try:
+        contact_id = _as_int(data.get('contact_id'), 'contact_id')
+        transaction_id = _as_int(data.get('transaction_id'), 'transaction_id')
+        if contact_id is None and transaction_id is None:
+            return _json_error(
+                'A contact or a transaction is required.', 400,
+            )
+
+        contact = None
+        transaction = None
+        if contact_id is not None:
+            contact = _load_contact(user, contact_id)
+            if contact is None:
+                return _json_error('Contact not found.', 404)
+        if transaction_id is not None:
+            transaction, status = _load_transaction(user, transaction_id)
+            if transaction is None:
+                return _json_error('Transaction not found.', status)
+
+        subject = (data.get('subject') or '').strip()
+        if not subject:
+            return _json_error('A subject is required.', 400)
+        subject = subject[:200]
+
+        due_date = parse_local_date(data.get('due_date'), 'due_date')
+        scheduled = parse_local_time(data.get('scheduled_time'))
+        utc_due = due_datetime_utc(ctx, due_date, scheduled)
+
+        priority = (data.get('priority') or 'medium').strip().lower()
+        if priority not in TASK_PRIORITIES:
+            return _json_error(
+                f'priority must be one of: {", ".join(TASK_PRIORITIES)}.',
+                400,
+            )
+
+        type_id = _as_int(data.get('type_id'), 'type_id')
+        subtype_id = _as_int(data.get('subtype_id'), 'subtype_id')
+        task_type, subtype = _resolve_type_pair(
+            user.organization_id, type_id, subtype_id,
+        )
+
+        property_address = _clean(data.get('property_address'))
+        if not property_address and transaction is not None:
+            property_address = _clean(getattr(transaction, 'street_address', None))
+
+        description = (data.get('description') or '').strip() or None
+
+        task = Task(
+            organization_id=user.organization_id,
+            contact_id=contact.id if contact else None,
+            transaction_id=transaction.id if transaction else None,
+            assigned_to_id=user.id,
+            created_by_id=user.id,
+            type_id=task_type.id,
+            subtype_id=subtype.id,
+            subject=subject,
+            description=description,
+            priority=priority,
+            due_date=utc_due,
+            scheduled_time=utc_due if scheduled else None,
+            property_address=property_address,
+        )
+        db.session.add(task)
+        db.session.commit()
+    except ToolError as exc:
+        db.session.rollback()
+        return _json_error(str(exc), 400)
+    except Exception:
+        db.session.rollback()
+        return _json_error('The task could not be saved.', 500)
+
+    _record_task_created(ctx, user, task)
+    task = _get_mine(ctx, task.id)
+    return jsonify({'task': serialize_task(task, ctx)}), 201
+
+
+@agent_jwt_required
+def api_patch_task(user, task_id):
+    ctx = _ctx(user)
+    task = _get_mine(ctx, task_id)
+    if task is None:
+        return _json_error('Task not found.', 404)
+
+    data = _json_body()
+    was_completed = task.status == 'completed'
+    try:
+        if 'subject' in data:
+            subject = (data.get('subject') or '').strip()
+            if not subject:
+                raise ToolError('subject cannot be blank.')
+            task.subject = subject[:200]
+        if 'description' in data:
+            value = data.get('description')
+            task.description = (value or '').strip() or None
+        if 'priority' in data:
+            priority = (data.get('priority') or '').strip().lower()
+            if priority not in TASK_PRIORITIES:
+                raise ToolError(
+                    f'priority must be one of: {", ".join(TASK_PRIORITIES)}.'
+                )
+            task.priority = priority
+        if 'status' in data:
+            status = (data.get('status') or '').strip().lower()
+            if status not in TASK_STATUSES:
+                raise ToolError(
+                    f'status must be one of: {", ".join(TASK_STATUSES)}.'
+                )
+            task.status = status
+        if 'property_address' in data:
+            task.property_address = _clean(data.get('property_address'))
+
+        if 'type_id' in data or 'subtype_id' in data:
+            type_id = (
+                _as_int(data.get('type_id'), 'type_id')
+                if 'type_id' in data else task.type_id
+            )
+            subtype_id = (
+                _as_int(data.get('subtype_id'), 'subtype_id')
+                if 'subtype_id' in data else task.subtype_id
+            )
+            task_type, subtype = _resolve_type_pair(
+                user.organization_id, type_id, subtype_id,
+            )
+            task.type_id = task_type.id
+            task.subtype_id = subtype.id
+
+        if 'contact_id' in data:
+            raw = data.get('contact_id')
+            if raw in (None, ''):
+                task.contact_id = None
+            else:
+                contact = _load_contact(user, _as_int(raw, 'contact_id'))
+                if contact is None:
+                    db.session.rollback()
+                    return _json_error('Contact not found.', 404)
+                task.contact_id = contact.id
+        if 'transaction_id' in data:
+            raw = data.get('transaction_id')
+            if raw in (None, ''):
+                task.transaction_id = None
+            else:
+                transaction, tx_status = _load_transaction(
+                    user, _as_int(raw, 'transaction_id'),
+                )
+                if transaction is None:
+                    db.session.rollback()
+                    return _json_error('Transaction not found.', tx_status)
+                task.transaction_id = transaction.id
+
+        if task.contact_id is None and task.transaction_id is None:
+            raise ToolError('A contact or a transaction is required.')
+
+        if 'due_date' in data or 'scheduled_time' in data:
+            if 'due_date' in data:
+                due_date = parse_local_date(data.get('due_date'), 'due_date')
+            else:
+                due_date = parse_local_date(
+                    to_local_date_string(task.due_date, ctx), 'due_date',
+                )
+            if 'scheduled_time' in data:
+                scheduled = parse_local_time(data.get('scheduled_time'))
+            elif task.scheduled_time is not None:
+                hhmm = _scheduled_hhmm(task.scheduled_time, ctx)
+                scheduled = parse_local_time(hhmm)
+            else:
+                scheduled = None
+            utc_due = due_datetime_utc(ctx, due_date, scheduled)
+            task.due_date = utc_due
+            task.scheduled_time = utc_due if scheduled else None
+
+        if task.status == 'completed' and not was_completed:
+            task.completed_at = datetime.now(timezone.utc)
+        elif task.status != 'completed':
+            task.completed_at = None
+
+        db.session.commit()
+    except ToolError as exc:
+        db.session.rollback()
+        return _json_error(str(exc), 400)
+    except Exception:
+        db.session.rollback()
+        return _json_error('The task could not be updated.', 500)
+
+    if task.status == 'completed' and not was_completed:
+        _record_task_completed(ctx, user, task)
+    task = _get_mine(ctx, task.id)
+    return jsonify({'task': serialize_task(task, ctx)})
+
+
+@agent_jwt_required
+def api_complete_task(user, task_id):
+    ctx = _ctx(user)
+    task = _get_mine(ctx, task_id)
+    if task is None:
+        return _json_error('Task not found.', 404)
+
+    data = _json_body()
+    try:
+        complete_task(
+            {'task_id': task.id, 'outcome': data.get('outcome')},
+            ctx,
+        )
+    except ToolError as exc:
+        return _json_error(str(exc), 400)
+
+    task = _get_mine(ctx, task_id)
+    return jsonify({'task': serialize_task(task, ctx)})
+
+
+@agent_jwt_required
+def api_delete_task(user, task_id):
+    ctx = _ctx(user)
+    task = _get_mine(ctx, task_id)
+    if task is None:
+        return _json_error('Task not found.', 404)
+    try:
+        delete_task({'task_id': task.id}, ctx)
+    except ToolError as exc:
+        return _json_error(str(exc), 400)
+    return jsonify({'ok': True})
+
+
+register(agent_api_bp)

--- a/services/agent_dashboard.py
+++ b/services/agent_dashboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import pytz
 from sqlalchemy import case, func, or_
 from sqlalchemy.orm import joinedload
 
@@ -11,6 +12,8 @@ from models import Contact, Task, Transaction, TransactionParticipant
 from services.agent_auth import serialize_org, serialize_user
 from services.contact_group_service import aggregate_group_stats
 from services.tenant_service import org_query_for_id
+
+_CHICAGO = pytz.timezone('America/Chicago')
 
 
 def build_dashboard(user):
@@ -61,9 +64,14 @@ def me_payload(user):
 
 
 def _today_tasks(user, org_id):
-    utc_now = datetime.utcnow()
-    start = utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
-    end = start + timedelta(days=1)
+    today = datetime.now(_CHICAGO).date()
+    start_local = _CHICAGO.localize(datetime.combine(today, datetime.min.time()))
+    end_local = _CHICAGO.localize(
+        datetime.combine(today + timedelta(days=1), datetime.min.time()),
+    )
+    start = start_local.astimezone(pytz.UTC).replace(tzinfo=None)
+    end = end_local.astimezone(pytz.UTC).replace(tzinfo=None)
+    now_utc = datetime.now(_CHICAGO).astimezone(pytz.UTC).replace(tzinfo=None)
     rows = (
         org_query_for_id(Task, org_id)
         .options(joinedload(Task.contact), joinedload(Task.task_type))
@@ -74,7 +82,7 @@ def _today_tasks(user, org_id):
             or_(Task.due_date < start, Task.due_date.between(start, end)),
         )
         .order_by(
-            case((Task.due_date < utc_now, 0), else_=1),
+            case((Task.due_date < now_utc, 0), else_=1),
             Task.due_date.asc(),
         )
         .limit(20)

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -749,3 +749,92 @@ def test_status_persist_reload_and_guards(app, seed, client):
         'code': 'transactions_required',
         'error': 'Transactions are not on this plan.',
     }
+
+
+def test_transaction_types_list(app, seed, client):
+    token = _owner_token(client)
+    resp = client.get('/api/agent/v1/transaction-types', headers=_auth(token))
+    assert resp.status_code == 200
+    rows = resp.get_json()['transaction_types']
+    by_name = {row['name']: row for row in rows}
+    assert 'seller' in by_name
+    assert 'buyer' in by_name
+    assert by_name['seller']['id'] == seed['tx_type_a']
+    assert by_name['buyer']['id'] == seed['tx_type_a2']
+    assert by_name['seller']['display_name']
+    assert by_name['buyer']['display_name']
+
+    free = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    gated = client.get('/api/agent/v1/transaction-types', headers=_auth(free))
+    assert gated.status_code == 403
+    assert gated.get_json()['code'] == 'transactions_required'
+
+
+def test_contact_serialize_includes_client_fields(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    created = client.post(
+        '/api/agent/v1/contacts',
+        headers=headers,
+        json={
+            'first_name': 'Dana',
+            'last_name': 'ClientFields',
+            'move_timeline': '30-60 days',
+            'motivation': 'Job relocation',
+            'financial_status': 'Pre-approved',
+            'additional_notes': 'Prefers texts',
+            'group_ids': [seed['group_a1']],
+        },
+    )
+    assert created.status_code == 201
+    contact = created.get_json()['contact']
+    assert contact['move_timeline'] == '30-60 days'
+    assert contact['motivation'] == 'Job relocation'
+    assert contact['financial_status'] == 'Pre-approved'
+    assert contact['additional_notes'] == 'Prefers texts'
+    assert contact['last_email_date'] is None
+    assert contact['last_text_date'] is None
+    assert contact['last_phone_call_date'] is None
+    assert contact['last_contact_date'] is None
+
+    patched = client.patch(
+        f'/api/agent/v1/contacts/{contact["id"]}',
+        headers=headers,
+        json={
+            'move_timeline': 'This month',
+            'motivation': 'School district',
+            'financial_status': 'Cash',
+            'additional_notes': 'Call after 6',
+        },
+    )
+    assert patched.status_code == 200
+    body = patched.get_json()['contact']
+    assert body['move_timeline'] == 'This month'
+    assert body['motivation'] == 'School district'
+    assert body['financial_status'] == 'Cash'
+    assert body['additional_notes'] == 'Call after 6'
+
+
+def test_dates_recompute_does_not_500(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        tx, _seller, _access = _seller_thread(seed, '420 Recompute Dates Ln')
+        db.session.commit()
+        tx_id = tx.id
+
+    updated = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/dates',
+        headers=headers,
+        json={'closing_date': '2026-07-15'},
+    )
+    assert updated.status_code == 200
+    body = updated.get_json()
+    assert body['ok'] is True
+    assert body['dates']['closing_date'] == '2026-07-15'
+    assert body['transaction']['id'] == tx_id
+    assert 'milestones' in body['transaction']
+    assert 'documents' in body['transaction']
+

--- a/tests/test_agent_api_contacts.py
+++ b/tests/test_agent_api_contacts.py
@@ -90,6 +90,8 @@ def test_log_activity_creates_interaction(app, seed, client):
         assert row.contact_id == seed['contact_a']
         assert row.type == 'call'
         assert row.notes == 'Left a voicemail'
+        db.session.delete(row)
+        db.session.commit()
 
 
 def test_timeline_returns_count_keys(app, seed, client):

--- a/tests/test_agent_api_contacts.py
+++ b/tests/test_agent_api_contacts.py
@@ -169,6 +169,20 @@ def test_file_get_returns_json_url(app, seed, client, monkeypatch):
     assert body['url'] == 'https://signed.example/contacts/1/listing.pdf'
 
 
+def test_free_plan_cannot_read_contact_transactions(app, seed, client):
+    token = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_b"]}/transactions',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+    _assert_json_not_redirect(resp)
+    assert resp.get_json() == {
+        'code': 'transactions_required',
+        'error': 'Transactions are not on this plan.',
+    }
+
+
 def test_task_suggestions_require_jwt_and_feature(app, seed, client):
     unauth = client.post(
         f'/api/agent/v1/contacts/{seed["contact_a"]}/task-suggestions',

--- a/tests/test_agent_api_contacts.py
+++ b/tests/test_agent_api_contacts.py
@@ -1,0 +1,201 @@
+"""Agent iPhone API: contact-desk tasks, files, timeline, email, suggestions."""
+from __future__ import annotations
+
+from models import ContactFile, Interaction, db
+
+import routes.agent_contact_desk  # noqa: F401 — attach routes before create_app
+
+
+def _auth(token):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _assert_json_not_redirect(resp):
+    assert resp.status_code not in (301, 302, 303, 307, 308)
+    assert 'Location' not in resp.headers
+    assert resp.content_type.startswith('application/json')
+
+
+def _agent_session(client, *, email=None, username=None, password='password123'):
+    body = {'password': password}
+    if email is not None:
+        body['email'] = email
+    if username is not None:
+        body['username'] = username
+    return client.post(
+        '/api/agent/v1/session',
+        json=body,
+        content_type='application/json',
+    )
+
+
+def _owner_token(client):
+    resp = _agent_session(client, email='owner_a@test.com')
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_owner_lists_contact_a_tasks(app, seed, client):
+    token = _owner_token(client)
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/tasks',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+    _assert_json_not_redirect(resp)
+    tasks = resp.get_json()['tasks']
+    assert any(row['subject'] == 'Call Jane' for row in tasks)
+    jane = next(row for row in tasks if row['subject'] == 'Call Jane')
+    assert jane['status'] == 'pending'
+    assert set(jane) >= {
+        'id', 'subject', 'status', 'priority', 'due_date',
+        'type', 'subtype', 'transaction_id', 'description',
+    }
+
+
+def test_agent_cannot_see_owner_contact_tasks(app, seed, client):
+    token = _agent_session(client, email='agent_a@test.com').get_json()['token']
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/tasks',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 404
+    _assert_json_not_redirect(resp)
+    assert resp.get_json()['error'] == 'Contact not found.'
+
+
+def test_cookie_is_not_enough_for_contact_desk(app, seed, owner_a_client):
+    resp = owner_a_client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/tasks',
+    )
+    assert resp.status_code == 401
+    _assert_json_not_redirect(resp)
+
+
+def test_log_activity_creates_interaction(app, seed, client):
+    token = _owner_token(client)
+    resp = client.post(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/activity',
+        headers=_auth(token),
+        json={'type': 'call', 'notes': 'Left a voicemail', 'date': '2026-08-20'},
+    )
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body['activity']['type'] == 'call'
+    assert body['activity']['notes'] == 'Left a voicemail'
+    assert body['activity']['id']
+    with app.app_context():
+        row = db.session.get(Interaction, body['activity']['id'])
+        assert row is not None
+        assert row.contact_id == seed['contact_a']
+        assert row.type == 'call'
+        assert row.notes == 'Left a voicemail'
+
+
+def test_timeline_returns_count_keys(app, seed, client):
+    token = _owner_token(client)
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/timeline',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body['counts']) == {
+        'all', 'interaction', 'email', 'task', 'file', 'voice_memo',
+    }
+    assert 'activities' in body
+    assert body['page'] == 1
+    assert body['per_page'] == 20
+    assert isinstance(body['total'], int)
+    assert body['counts']['task'] >= 1
+
+
+def test_files_list_empty_and_upload_requires_file(app, seed, client):
+    token = _owner_token(client)
+    headers = _auth(token)
+    listed = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/files',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    assert listed.get_json()['files'] == []
+
+    missing = client.post(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/files',
+        headers=headers,
+    )
+    assert missing.status_code == 400
+    _assert_json_not_redirect(missing)
+    assert missing.get_json()['error']
+
+
+def test_file_get_returns_json_url(app, seed, client, monkeypatch):
+    monkeypatch.setattr(
+        'services.supabase_storage.get_signed_url',
+        lambda bucket, path, expires_in=3600: f'https://signed.example/{path}',
+    )
+    token = _owner_token(client)
+    headers = _auth(token)
+
+    with app.app_context():
+        row = ContactFile(
+            organization_id=seed['org_a'],
+            contact_id=seed['contact_a'],
+            user_id=seed['owner_a'],
+            filename='abc.pdf',
+            original_filename='listing.pdf',
+            file_type='application/pdf',
+            file_size=128,
+            storage_path='contacts/1/listing.pdf',
+        )
+        db.session.add(row)
+        db.session.commit()
+        file_id = row.id
+
+    cookie_only = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/files/{file_id}/file',
+    )
+    assert cookie_only.status_code == 401
+    _assert_json_not_redirect(cookie_only)
+
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/files/{file_id}/file',
+        headers={**headers, 'Accept': 'application/pdf'},
+    )
+    assert resp.status_code == 200
+    _assert_json_not_redirect(resp)
+    body = resp.get_json()
+    assert set(body.keys()) == {'url'}
+    assert body['url'] == 'https://signed.example/contacts/1/listing.pdf'
+
+
+def test_task_suggestions_require_jwt_and_feature(app, seed, client):
+    unauth = client.post(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/task-suggestions',
+    )
+    assert unauth.status_code == 401
+    _assert_json_not_redirect(unauth)
+
+    token = _agent_session(client, email='owner_b@test.com').get_json()['token']
+    resp = client.post(
+        f'/api/agent/v1/contacts/{seed["contact_b"]}/task-suggestions',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+    _assert_json_not_redirect(resp)
+    body = resp.get_json()
+    assert body['code'] == 'feature_required'
+    assert body.get('error')
+
+
+def test_emails_without_gmail_are_empty_and_disconnected(app, seed, client):
+    token = _owner_token(client)
+    resp = client.get(
+        f'/api/agent/v1/contacts/{seed["contact_a"]}/emails',
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+    _assert_json_not_redirect(resp)
+    body = resp.get_json()
+    assert body['connected'] is False
+    assert body['emails'] == []

--- a/tests/test_agent_api_deals.py
+++ b/tests/test_agent_api_deals.py
@@ -1,0 +1,312 @@
+"""AgentDesk deal-file APIs: listing, offers, contract, checklist, notes, parties."""
+from __future__ import annotations
+
+from models import (
+    SellerAcceptedContract,
+    SellerListingProfile,
+    Transaction,
+    TransactionParticipant,
+    TransactionRequirement,
+    db,
+)
+
+
+def _auth(token):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _owner_token(client):
+    resp = client.post(
+        '/api/agent/v1/session',
+        json={'email': 'owner_a@test.com', 'password': 'password123'},
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def _as_money(value):
+    if value in (None, ''):
+        return None
+    return float(str(value).replace(',', '').replace('$', '').strip())
+
+
+def _fresh_seller(app, seed, address):
+    with app.app_context():
+        tx = Transaction(
+            organization_id=seed['org_a'],
+            created_by_id=seed['owner_a'],
+            transaction_type_id=seed['tx_type_a'],
+            street_address=address,
+            city='Austin',
+            state='TX',
+            status='active',
+        )
+        db.session.add(tx)
+        db.session.commit()
+        return tx.id
+
+
+def test_get_offers_on_seller_tx(app, seed, client):
+    headers = _auth(_owner_token(client))
+    resp = client.get(
+        f'/api/agent/v1/transactions/{seed["tx_a"]}/offers',
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.content_type.startswith('application/json')
+    body = resp.get_json()
+    assert isinstance(body.get('offers'), list)
+
+
+def test_post_offer_then_get(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = _fresh_seller(app, seed, '510 Offer Create Ln')
+
+    created = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/offers',
+        headers=headers,
+        json={
+            'offer_price': 425000,
+            'financing_type': 'conventional',
+            'earnest_money': 4000,
+            'option_fee': 200,
+            'option_days': 7,
+            'concessions': 2500,
+            'proposed_close_date': '2026-09-15',
+            'buyer_name': 'Casey Buyer',
+            'notes': 'Verbal, waiting on PDF',
+        },
+    )
+    assert created.status_code == 201, created.get_json()
+    offer = created.get_json()['offer']
+    assert offer['id']
+    assert offer['status'] == 'new'
+    assert _as_money(offer['offer_price']) == 425000
+    assert offer['financing_type']
+    assert offer['option_days'] == 7
+    assert _as_money(offer['concessions']) == 2500
+    assert offer['proposed_close_date'] == '2026-09-15'
+    assert offer['buyer_name'] == 'Casey Buyer'
+    assert offer['notes'] == 'Verbal, waiting on PDF'
+    offer_id = offer['id']
+
+    listed = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/offers',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    ids = [row['id'] for row in listed.get_json()['offers']]
+    assert offer_id in ids
+
+
+def test_expire_offer(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = _fresh_seller(app, seed, '511 Offer Expire Ln')
+    created = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/offers',
+        headers=headers,
+        json={'offer_price': 300000, 'buyer_name': 'Expiring Buyer'},
+    )
+    assert created.status_code == 201
+    offer_id = created.get_json()['offer']['id']
+
+    expired = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/offers/{offer_id}/expire',
+        headers=headers,
+        json={},
+    )
+    assert expired.status_code == 200, expired.get_json()
+    assert expired.get_json()['offer']['status'] == 'expired'
+
+
+def test_accept_creates_seller_accepted_contract(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = seed['tx_a']
+
+    created = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/offers',
+        headers=headers,
+        json={
+            'offer_price': 500000,
+            'financing_type': 'conventional',
+            'earnest_money': 5000,
+            'option_days': 10,
+            'proposed_close_date': '2026-10-20',
+            'buyer_name': 'Jordan Buyer',
+        },
+    )
+    assert created.status_code == 201, created.get_json()
+    offer_id = created.get_json()['offer']['id']
+
+    accepted = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/offers/{offer_id}/accept',
+        headers=headers,
+        json={'as_backup': False, 'effective_date': '2026-08-05'},
+    )
+    assert accepted.status_code == 200, accepted.get_json()
+    body = accepted.get_json()
+    assert body['offer']['status'] == 'accepted_primary'
+    assert body['contract']['id']
+    assert body['contract']['position'] == 'primary'
+    assert _as_money(body['contract']['accepted_price']) == 500000
+    assert body['transaction']['id'] == tx_id
+
+    with app.app_context():
+        row = SellerAcceptedContract.query.filter_by(
+            transaction_id=tx_id,
+            offer_id=offer_id,
+            status='active',
+        ).one()
+        assert row.position == 'primary'
+        assert (row.extra_data or {}).get('created_via') == (
+            'controlling_contracts.create_baseline_from_accepted_offer'
+        )
+
+
+def test_patch_listing_persists_and_enrich_shows_price(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = _fresh_seller(app, seed, '512 Listing Price Ln')
+
+    patched = client.patch(
+        f'/api/agent/v1/transactions/{tx_id}/listing',
+        headers=headers,
+        json={'list_price': 425000, 'lockbox_combo': '4321'},
+    )
+    assert patched.status_code == 200, patched.get_json()
+    listing = patched.get_json()['transaction']['listing']
+    assert _as_money(listing['list_price']) == 425000
+    assert listing['lockbox_combo'] == '4321'
+
+    detail = client.get(
+        f'/api/agent/v1/transactions/{tx_id}',
+        headers=headers,
+    )
+    assert detail.status_code == 200
+    shown = detail.get_json()['transaction'].get('listing') or {}
+    assert _as_money(shown.get('list_price')) == 425000
+
+    with app.app_context():
+        tx = Transaction.query.get(tx_id)
+        overrides = (tx.extra_data or {}).get('listing_info_overrides') or {}
+        assert _as_money(overrides.get('list_price')) == 425000
+        assert (tx.extra_data or {}).get('lockbox_combo') == '4321'
+        profile = SellerListingProfile.query.filter_by(transaction_id=tx_id).first()
+        assert profile is not None
+        assert _as_money(profile.current_list_price) == 425000
+
+
+def test_requirement_due_date(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = _fresh_seller(app, seed, '513 Requirement Due Ln')
+    with app.app_context():
+        req = TransactionRequirement(
+            organization_id=seed['org_a'],
+            transaction_id=tx_id,
+            package_key='listing_prep',
+            phase_key='property_prep',
+            requirement_key='agent_desk_due_date_test',
+            title='Confirm lockbox',
+            work_status='pending',
+        )
+        db.session.add(req)
+        db.session.commit()
+        req_id = req.id
+
+    updated = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/requirements/{req_id}/due-date',
+        headers=headers,
+        json={'due_at': '2026-09-01'},
+    )
+    assert updated.status_code == 200, updated.get_json()
+    row = updated.get_json()['requirement']
+    assert row['due_at'].startswith('2026-09-01')
+    assert row['due_at_manual_override'] is True
+
+    listed = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/requirements',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    keys = [item['requirement_key'] for item in listed.get_json()['requirements']]
+    assert 'agent_desk_due_date_test' in keys
+
+
+def test_delete_participant(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = seed['tx_a']
+    with app.app_context():
+        party = TransactionParticipant(
+            organization_id=seed['org_a'],
+            transaction_id=tx_id,
+            role='title_company',
+            name='Desk Title Co',
+            is_primary=False,
+        )
+        db.session.add(party)
+        db.session.commit()
+        party_id = party.id
+
+    removed = client.delete(
+        f'/api/agent/v1/transactions/{tx_id}/participants/{party_id}',
+        headers=headers,
+    )
+    assert removed.status_code == 200
+    assert removed.get_json() == {'ok': True}
+
+    missing = client.delete(
+        f'/api/agent/v1/transactions/{tx_id}/participants/{party_id}',
+        headers=headers,
+    )
+    assert missing.status_code == 404
+
+    with app.app_context():
+        assert TransactionParticipant.query.get(party_id) is None
+
+
+def test_post_note_then_get(app, seed, client):
+    headers = _auth(_owner_token(client))
+    tx_id = _fresh_seller(app, seed, '514 Notes Ln')
+
+    created = client.post(
+        f'/api/agent/v1/transactions/{tx_id}/notes',
+        headers=headers,
+        json={'text': 'Called seller about photos.'},
+    )
+    assert created.status_code == 201, created.get_json()
+    notes = created.get_json()['notes']
+    assert notes
+    assert notes[-1]['text'] == 'Called seller about photos.'
+    assert notes[-1]['user_id'] == seed['owner_a']
+    assert notes[-1]['at']
+
+    listed = client.get(
+        f'/api/agent/v1/transactions/{tx_id}/notes',
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    texts = [row['text'] for row in listed.get_json()['notes']]
+    assert 'Called seller about photos.' in texts
+
+
+def test_deal_routes_require_jwt(app, seed, client):
+    tx_id = seed['tx_a']
+    resp = client.get(f'/api/agent/v1/transactions/{tx_id}/offers')
+    assert resp.status_code == 401
+    assert resp.content_type.startswith('application/json')
+    assert 'token' not in (resp.get_json() or {})
+
+
+def test_org_b_cannot_see_org_a_tx(app, seed, client):
+    other = client.post(
+        '/api/agent/v1/session',
+        json={'email': 'owner_b@test.com', 'password': 'password123'},
+        content_type='application/json',
+    )
+    assert other.status_code == 200
+    resp = client.get(
+        f'/api/agent/v1/transactions/{seed["tx_a"]}/offers',
+        headers=_auth(other.get_json()['token']),
+    )
+    assert resp.status_code in (403, 404)
+    assert resp.content_type.startswith('application/json')

--- a/tests/test_agent_api_tasks.py
+++ b/tests/test_agent_api_tasks.py
@@ -1,0 +1,302 @@
+"""Agent iPhone Tasks API."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from models import Transaction, User
+from services.bob_tools.context import BobContext
+
+import routes.agent_task_desk  # noqa: F401  — self-registers before Agent A's hook
+
+
+TASK_KEYS = {
+    'id', 'subject', 'description', 'status', 'priority',
+    'due_date', 'scheduled_time', 'type_id', 'subtype_id',
+    'type', 'subtype', 'contact_id', 'contact_name',
+    'transaction_id', 'property_address', 'outcome', 'completed_at',
+}
+
+
+def _auth(token):
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _owner_token(client):
+    resp = client.post(
+        '/api/agent/v1/session',
+        json={'email': 'owner_a@test.com', 'password': 'password123'},
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def _agent_token(client):
+    resp = client.post(
+        '/api/agent/v1/session',
+        json={'email': 'agent_a@test.com', 'password': 'password123'},
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def _chicago_dates(app, user_id):
+    with app.app_context():
+        ctx = BobContext.from_user(User.query.get(user_id))
+        return (
+            (ctx.today() - timedelta(days=1)).isoformat(),
+            ctx.today().isoformat(),
+        )
+
+
+def test_task_types_include_call_and_follow_up(app, seed, client):
+    headers = _auth(_owner_token(client))
+    resp = client.get('/api/agent/v1/task-types', headers=headers)
+    assert resp.status_code == 200
+    types = resp.get_json()['task_types']
+    names = {row['name']: row for row in types}
+    assert 'Call' in names
+    assert names['Call']['id'] == seed['task_type_a']
+    subtype_names = {row['name'] for row in names['Call']['subtypes']}
+    assert 'Follow Up' in subtype_names
+    follow = next(
+        row for row in names['Call']['subtypes'] if row['name'] == 'Follow Up'
+    )
+    assert follow['id'] == seed['subtype_a']
+
+
+def test_owner_lists_own_tasks_only(app, seed, client):
+    headers = _auth(_owner_token(client))
+    resp = client.get('/api/agent/v1/tasks', headers=headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body) >= {'tasks', 'page', 'per_page', 'total'}
+    subjects = {row['subject'] for row in body['tasks']}
+    assert 'Call Jane' in subjects
+    assert 'Follow up John' not in subjects
+    assert 'Task B Only' not in subjects
+    jane = next(row for row in body['tasks'] if row['subject'] == 'Call Jane')
+    assert set(jane) == TASK_KEYS
+    assert jane['id'] == seed['task_a']
+    assert jane['contact_id'] == seed['contact_a']
+    assert jane['contact_name'] == 'Jane Doe'
+    assert jane['status'] == 'pending'
+
+
+def test_task_buckets_overdue_and_today(app, seed, client):
+    headers = _auth(_owner_token(client))
+    yesterday, today = _chicago_dates(app, seed['owner_a'])
+    overdue = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Overdue bucket probe',
+            'due_date': yesterday,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+        },
+        headers=headers,
+    )
+    assert overdue.status_code == 201
+    overdue_id = overdue.get_json()['task']['id']
+
+    due_today = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Today bucket probe',
+            'due_date': today,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+        },
+        headers=headers,
+    )
+    assert due_today.status_code == 201
+    today_id = due_today.get_json()['task']['id']
+
+    listed_overdue = client.get(
+        '/api/agent/v1/tasks?bucket=overdue', headers=headers,
+    )
+    assert listed_overdue.status_code == 200
+    overdue_ids = {row['id'] for row in listed_overdue.get_json()['tasks']}
+    assert overdue_id in overdue_ids
+    assert today_id not in overdue_ids
+
+    listed_today = client.get(
+        '/api/agent/v1/tasks?bucket=today', headers=headers,
+    )
+    assert listed_today.status_code == 200
+    today_ids = {row['id'] for row in listed_today.get_json()['tasks']}
+    assert today_id in today_ids
+    assert overdue_id not in today_ids
+
+    client.delete(f'/api/agent/v1/tasks/{overdue_id}', headers=headers)
+    client.delete(f'/api/agent/v1/tasks/{today_id}', headers=headers)
+
+
+def test_create_task_with_contact(app, seed, client):
+    headers = _auth(_owner_token(client))
+    _, today = _chicago_dates(app, seed['owner_a'])
+    resp = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Call Jane from iPhone',
+            'due_date': today,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+            'priority': 'high',
+            'description': 'Ask about the listing',
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    task = resp.get_json()['task']
+    assert set(task) == TASK_KEYS
+    assert task['subject'] == 'Call Jane from iPhone'
+    assert task['contact_id'] == seed['contact_a']
+    assert task['contact_name'] == 'Jane Doe'
+    assert task['priority'] == 'high'
+    assert task['due_date'] == today
+    assert task['type'] == 'Call'
+    assert task['subtype'] == 'Follow Up'
+    assert task['status'] == 'pending'
+    client.delete(f'/api/agent/v1/tasks/{task["id"]}', headers=headers)
+
+
+def test_create_task_transaction_only(app, seed, client):
+    headers = _auth(_owner_token(client))
+    _, today = _chicago_dates(app, seed['owner_a'])
+    with app.app_context():
+        tx = Transaction.query.filter_by(
+            organization_id=seed['org_a'],
+            street_address='100 Main St',
+        ).first()
+        assert tx is not None
+        tx_id = tx.id
+        assert tx_id == seed['tx_a']
+
+    resp = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Order HOA docs',
+            'due_date': today,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'transaction_id': tx_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    task = resp.get_json()['task']
+    assert task['transaction_id'] == tx_id
+    assert task['contact_id'] is None
+    assert task['property_address'] == '100 Main St'
+    client.delete(f'/api/agent/v1/tasks/{task["id"]}', headers=headers)
+
+
+def test_complete_task(app, seed, client):
+    headers = _auth(_owner_token(client))
+    _, today = _chicago_dates(app, seed['owner_a'])
+    created = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Complete me',
+            'due_date': today,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+        },
+        headers=headers,
+    )
+    task_id = created.get_json()['task']['id']
+    resp = client.post(
+        f'/api/agent/v1/tasks/{task_id}/complete',
+        json={'outcome': 'Left a voicemail'},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    task = resp.get_json()['task']
+    assert task['status'] == 'completed'
+    assert task['outcome'] == 'Left a voicemail'
+    assert task['completed_at']
+
+    again = client.post(
+        f'/api/agent/v1/tasks/{task_id}/complete',
+        json={},
+        headers=headers,
+    )
+    assert again.status_code == 200
+    assert again.get_json()['task']['status'] == 'completed'
+    client.delete(f'/api/agent/v1/tasks/{task_id}', headers=headers)
+
+
+def test_patch_due_date(app, seed, client):
+    headers = _auth(_owner_token(client))
+    yesterday, today = _chicago_dates(app, seed['owner_a'])
+    created = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Reschedule me',
+            'due_date': yesterday,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+        },
+        headers=headers,
+    )
+    task_id = created.get_json()['task']['id']
+    resp = client.patch(
+        f'/api/agent/v1/tasks/{task_id}',
+        json={'due_date': today},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    task = resp.get_json()['task']
+    assert task['due_date'] == today
+    client.delete(f'/api/agent/v1/tasks/{task_id}', headers=headers)
+
+
+def test_delete_task(app, seed, client):
+    headers = _auth(_owner_token(client))
+    _, today = _chicago_dates(app, seed['owner_a'])
+    created = client.post(
+        '/api/agent/v1/tasks',
+        json={
+            'subject': 'Delete me',
+            'due_date': today,
+            'type_id': seed['task_type_a'],
+            'subtype_id': seed['subtype_a'],
+            'contact_id': seed['contact_a'],
+        },
+        headers=headers,
+    )
+    task_id = created.get_json()['task']['id']
+    resp = client.delete(f'/api/agent/v1/tasks/{task_id}', headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()['ok'] is True
+    missing = client.get(f'/api/agent/v1/tasks/{task_id}', headers=headers)
+    assert missing.status_code == 404
+
+
+def test_agent_cannot_complete_someone_elses_task(app, seed, client):
+    headers = _auth(_agent_token(client))
+    resp = client.post(
+        f'/api/agent/v1/tasks/{seed["task_a"]}/complete',
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code in (403, 404)
+
+
+def test_tasks_require_jwt(app, seed, client):
+    resp = client.get('/api/agent/v1/tasks')
+    assert resp.status_code == 401
+    assert resp.content_type.startswith('application/json')
+
+
+def test_cookie_is_not_enough_for_tasks(app, seed, owner_a_client):
+    resp = owner_a_client.get('/api/agent/v1/tasks')
+    assert resp.status_code == 401
+    assert resp.content_type.startswith('application/json')


### PR DESCRIPTION
## Summary
- Expand `/api/agent/v1` so AgentDesk can run the same contact, task, and deal work as the web CRM (files, memos, timeline, activity, emails, task ideas, full task CRUD, listing/offers/contract/checklist/notes).
- Persist deal dates without rebuilding milestones; option/closing writes recompute the live checklist (`TransactionRequirement`).
- Home `today_tasks` uses America/Chicago so the phone and Tasks tab agree. 54 agent API tests pass.

The iPhone app still talks to production (`https://agentflow.origentechnolog.com`). This PR is Flask only.

## Test plan
- [ ] `pytest tests/test_agent_api.py tests/test_agent_api_contacts.py tests/test_agent_api_tasks.py tests/test_agent_api_deals.py -q`
- [ ] After deploy, sign in on AgentDesk against prod (no `AGENTFLOW_API_BASE_URL` override)
- [ ] Contact: log activity, add a task, upload a file; confirm it shows on the web contact page
- [ ] Tasks: create / complete / Today vs Overdue buckets
- [ ] Deal: set closing date, add an offer, accept as primary; confirm contract + checklist appear in the web file


Made with [Cursor](https://cursor.com)