### PR TITLE
feat(comparison): add the free CRM page link

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -517,6 +517,9 @@
                     <p class="faq-answer">If you can do something in AgentFlow, you can ask B.O.B. to do it for you.</p>
                 </details>
             </div>
+            <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
+            </p>
         </div>
     </section>
 

--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -507,6 +507,9 @@
                     <p class="faq-answer">That depends. If you need IDX websites, lead generation, recruiting, BackOffice, or the rest of the BoldTrail ecosystem, AgentFlow doesn't currently try to duplicate all of that.</p>
                 </details>
             </div>
+            <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
+            </p>
         </div>
     </section>
 

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -497,6 +497,9 @@
                     <p class="faq-answer">Their pricing page lists CRM at $49 a month, or $499 a year ($42 a month billed annually). There is a 14-day free trial. There is no published free plan.</p>
                 </details>
             </div>
+            <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
+            </p>
         </div>
     </section>
 

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -260,11 +260,12 @@ class TestFollowUpBossAlternativeCopy:
         assert "Start Free" in PAGE
         assert "Try AgentFlow Free" in PAGE
         assert "url_for('auth.register')" in PAGE
-        assert "url_for('main.free_real_estate_crm')" not in PAGE
+        assert PAGE.count("url_for('main.free_real_estate_crm')") == 1
         assert "url_for('main.landing')" in PAGE
         assert "More on Origen is on" not in PAGE
         assert "More on AgentFlow is on" not in PAGE
-        assert "the free real estate CRM page" not in PAGE
+        assert PAGE.count("the free real estate CRM page") == 1
+        assert "More on what's included is on" in PAGE
         assert DISCLAIMER in PAGE
         assert PAGE.count(DISCLAIMER) == 1
 

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -278,7 +278,9 @@ class TestKvcoreAlternativeCopy:
         assert "Start Free" in PAGE
         assert "Try AgentFlow Free" in PAGE
         assert "url_for('auth.register')" in PAGE
-        assert "url_for('main.free_real_estate_crm')" not in PAGE
+        assert PAGE.count("url_for('main.free_real_estate_crm')") == 1
+        assert PAGE.count("the free real estate CRM page") == 1
+        assert "More on what's included is on" in PAGE
         assert "url_for('main.landing')" in PAGE
         assert DISCLAIMER in PAGE
         assert PAGE.count(DISCLAIMER) == 1

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -268,7 +268,9 @@ class TestWiseAgentAlternativeCopy:
         assert "Start Free" in PAGE
         assert "Try AgentFlow Free" in PAGE
         assert "url_for('auth.register')" in PAGE
-        assert "url_for('main.free_real_estate_crm')" not in PAGE
+        assert PAGE.count("url_for('main.free_real_estate_crm')") == 1
+        assert PAGE.count("the free real estate CRM page") == 1
+        assert "More on what's included is on" in PAGE
         assert "url_for('main.landing')" in PAGE
         assert DISCLAIMER in PAGE
         assert PAGE.count(DISCLAIMER) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The three CRM alternative pages had no internal path to `/free-real-estate-crm`. The homepage already has one sentence that does that job. This PR puts that same sentence on each comparison page.

## Scope

Adds the homepage sentence once, after the last FAQ, on:

- `templates/follow_up_boss_alternative.html`
- `templates/wise_agent_alternative.html`
- `templates/kvcore_alternative.html`

The href is `url_for('main.free_real_estate_crm')`, the same same-origin style those pages already use. Visible text is:

More on what's included is on the free real estate CRM page.

Flips the copy guards that forbade that sentence in:

- `tests/test_follow_up_boss_alternative.py`
- `tests/test_wise_agent_alternative.py`
- `tests/test_kvcore_alternative.py`

Out of scope: H1s, titles, meta, B.O.B. FAQ, comparison positioning, homepage, register, and `/free-real-estate-crm`.

## Blast Radius

Public HTML on `/follow-up-boss-alternative`, `/wise-agent-alternative`, and `/kvcore-alternative` only. FAQ JSON-LD is unchanged. The free-CRM page does not change.

## Verification

Parent re-ran `pytest` on the three comparison test files plus `tests/test_landing_copy.py` and `tests/test_free_real_estate_crm.py`. 144 passed.

Flask test client and the live server on port 5011 both rendered the exact homepage HTML block once on each comparison route, with `href="/free-real-estate-crm"`. Homepage still has that block once. `/free-real-estate-crm` still does not.

Browser pass on `http://127.0.0.1:5011`: sentence visible after the last FAQ on all three pages. Click from Follow Up Boss reached `/free-real-estate-crm`.

[comparison_pages_free_crm_link.mp4](https://cursor.com/agents/bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomparison_pages_free_crm_link.mp4)
[Follow Up Boss FAQ link](https://cursor.com/agents/bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffollow_up_boss_faq_free_crm_link.webp)
[Wise Agent FAQ link](https://cursor.com/agents/bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwise_agent_faq_free_crm_link.webp)
[kvCORE FAQ link](https://cursor.com/agents/bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkvcore_faq_free_crm_link.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08d3d389-feaa-417f-bfb9-fe72ecba86ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

