### PR TITLE
feat(sitemap): add lastmod to each public url

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -2,26 +2,34 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agentflow.origentechnolog.com/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/register</loc>
+    <lastmod>2026-08-20</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/login</loc>
+    <lastmod>2026-08-20</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/terms-privacy</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/free-real-estate-crm</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/follow-up-boss-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/wise-agent-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/kvcore-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Search engines treat sitemap lastmod as a recrawl hint. The eight public URLs had none. These dates come from the last public-copy merge on each page, not from today's date on every row.

## Scope

`static/sitemap.xml` gains one `<lastmod>` child under each of the eight `<url>` rows. Loc URLs stay the same.

- `/` and `/terms-privacy`: 2026-08-18
- `/register` and `/login`: 2026-08-20
- `/free-real-estate-crm`, `/follow-up-boss-alternative`, `/wise-agent-alternative`, `/kvcore-alternative`: 2026-08-25

No change to `robots.txt`, `llms.txt`, routes, or page copy. No test pinned the exact XML, so no test file changed.

## Blast Radius

Crawlers that already fetch `/sitemap.xml` now see lastmod. Existing tests parse `sm:url/sm:loc` only, so the path set stays the same.

## Verification

Parsed `static/sitemap.xml` and the live `GET /sitemap.xml` body. Both have eight locs and eight lastmods with the dates above. Content-Type was `application/xml`.

`pytest` sitemap filters on `tests/test_canonical_host.py`, `tests/test_free_real_estate_crm.py`, `tests/test_follow_up_boss_alternative.py`, `tests/test_wise_agent_alternative.py`, and `tests/test_kvcore_alternative.py`: 6 passed, 112 deselected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0e152e8-4f72-4b29-b1f5-303297e34980?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0e152e8-4f72-4b29-b1f5-303297e34980&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

