### PR TITLE
fix: add lastmod dates to sitemap.xml

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -2,26 +2,34 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://agentflow.origentechnolog.com/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/register</loc>
+    <lastmod>2026-08-20</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/login</loc>
+    <lastmod>2026-08-20</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/terms-privacy</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/free-real-estate-crm</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/follow-up-boss-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/wise-agent-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/kvcore-alternative</loc>
+    <lastmod>2026-08-25</lastmod>
   </url>
 </urlset>

--- a/tests/test_canonical_host.py
+++ b/tests/test_canonical_host.py
@@ -20,10 +20,24 @@ PUBLIC_PATHS = (
     "/wise-agent-alternative",
     "/kvcore-alternative",
 )
+SITEMAP_LASTMOD = {
+    "/": "2026-08-18",
+    "/register": "2026-08-20",
+    "/login": "2026-08-20",
+    "/terms-privacy": "2026-08-18",
+    "/free-real-estate-crm": "2026-08-25",
+    "/follow-up-boss-alternative": "2026-08-25",
+    "/wise-agent-alternative": "2026-08-25",
+    "/kvcore-alternative": "2026-08-25",
+}
 
 
 def test_default_app_base_url_is_agentflow():
     assert DEFAULT_APP_BASE_URL == "https://agentflow.origentechnolog.com"
+
+
+def _sitemap_path(loc):
+    return loc.replace("https://agentflow.origentechnolog.com", "", 1) or "/"
 
 
 def test_sitemap_locs_use_agentflow_host():
@@ -35,6 +49,20 @@ def test_sitemap_locs_use_agentflow_host():
     for loc in locs:
         assert loc.startswith("https://agentflow.origentechnolog.com"), loc
         assert "www.origentechnolog.com" not in loc
+
+
+def test_sitemap_has_one_lastmod_per_url():
+    urls = ET.parse(SITEMAP).getroot().findall("sm:url", SITEMAP_NS)
+    lastmods = {}
+    for url in urls:
+        loc = url.findtext("sm:loc", default="", namespaces=SITEMAP_NS) or ""
+        path = _sitemap_path(loc)
+        mods = [el.text for el in url.findall("sm:lastmod", SITEMAP_NS)]
+        assert len(mods) == 1, path
+        lastmods[path] = mods[0]
+        tags = [child.tag.split("}")[-1] for child in list(url)]
+        assert tags == ["loc", "lastmod"], path
+    assert lastmods == SITEMAP_LASTMOD
 
 
 def test_robots_sitemap_points_at_agentflow():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GSC last read the sitemap Aug 21. Eight public locs, zero lastmod. PR 349 added crawlable links to the free CRM page, so lastmod is the recrawl hint.

One lastmod under each url. Dates from git:

- `/` 2026-08-18, last public-copy merge on `templates/landing.html`, PR 321
- `/register` and `/login` 2026-08-20, PR 335
- `/terms-privacy` 2026-08-18, PR 319 rebrand copy. PR 322 was polish only.
- `/free-real-estate-crm`, `/follow-up-boss-alternative`, `/wise-agent-alternative`, `/kvcore-alternative` 2026-08-25, PR 349 live plus the new inbound links on the free CRM page

locs stay the same. `robots.txt` and `llms.txt` untouched. No changefreq or priority.

`tests/test_canonical_host.py` now pins one lastmod per url so CI catches date drift. Local sitemap pin and loc tests passed, 11/11. Flask `/sitemap.xml` served the same eight dates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf700c47-041c-4287-b2a0-f953ac4136eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf700c47-041c-4287-b2a0-f953ac4136eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

