### PR TITLE
feat: add BreadcrumbList JSON-LD on /free-real-estate-crm

### DIFF
--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -74,6 +74,24 @@
               }
             }
           ]
+        },
+        {
+          "@type": "BreadcrumbList",
+          "@id": "{{ app_base_url }}/free-real-estate-crm#breadcrumb",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Home",
+              "item": "{{ app_base_url }}/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Free real estate CRM",
+              "item": "{{ app_base_url }}/free-real-estate-crm"
+            }
+          ]
         }
       ]
     }

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -1,4 +1,5 @@
 """Public /free-real-estate-crm page: route, SEO, sitemap, and copy guards."""
+import json
 import re
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -110,6 +111,14 @@ def _app_base_url(app):
     return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
 
 
+def _json_ld_graph(html):
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, flags=re.S)
+    assert match is not None
+    data = json.loads(match.group(1))
+    assert data.get("@context") == "https://schema.org"
+    return data["@graph"]
+
+
 def _visible_copy(html):
     html = re.sub(r"<script\b[^>]*>.*?</script>", " ", html, flags=re.I | re.S)
     html = re.sub(r"<style\b[^>]*>.*?</style>", " ", html, flags=re.I | re.S)
@@ -187,11 +196,41 @@ class TestFreeRealEstateCrmSeo:
     def test_software_application_json_ld_price_is_zero(self, app, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         base = _app_base_url(app)
+        graph = _json_ld_graph(html)
+        types = [node.get("@type") for node in graph]
+        assert types == [
+            "Organization",
+            "SoftwareApplication",
+            "FAQPage",
+            "BreadcrumbList",
+        ]
+        assert "SearchAction" not in html
+        assert html.count('<script type="application/ld+json">') == 1
         assert '"@type": "SoftwareApplication"' in html
         assert '"price": "0"' in html
         assert '"priceCurrency": "USD"' in html
         assert '"isAccessibleForFree": true' in html
         assert f'"url": "{base}{PAGE_PATH}"' in html
+
+        crumb = next(node for node in graph if node["@type"] == "BreadcrumbList")
+        assert crumb["@id"] == f"{base}{PAGE_PATH}#breadcrumb"
+        assert crumb["itemListElement"] == [
+            {
+                "@type": "ListItem",
+                "position": 1,
+                "name": "Home",
+                "item": f"{base}/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Free real estate CRM",
+                "item": f"{base}{PAGE_PATH}",
+            },
+        ]
+        visible = _visible_copy(html)
+        assert "Home" not in visible
+        assert "breadcrumb" not in visible.lower()
 
 
 class TestFreeRealEstateCrmCopy:
@@ -240,6 +279,8 @@ class TestFreeRealEstateCrmCopy:
 
     def test_faq_matches_json_ld_and_repo_limits(self):
         assert '"@type": "FAQPage"' in PAGE
+        assert '"@type": "BreadcrumbList"' in PAGE
+        assert '"@id": "{{ app_base_url }}/free-real-estate-crm#breadcrumb"' in PAGE
         assert PAGE.count("<summary>") == 4
         assert PAGE.count('"@type": "Question"') == 4
         for question, answer in FAQ_ITEMS:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds one `BreadcrumbList` node to the existing JSON-LD `@graph` on `/free-real-estate-crm`. Organization, SoftwareApplication, and FAQPage stay in the same script. No visible breadcrumb UI. Title, H1, meta, gold B.O.B. FAQ, and FAQPage text are unchanged.

Crumbs are Home (`{{ app_base_url }}/`) then Free real estate CRM (`{{ app_base_url }}/free-real-estate-crm`). Host comes from `app_base_url`, not a hardcoded domain. No SearchAction.

The page test now parses that one graph and expects BreadcrumbList next to the other three types.

## Test plan
- `python3 -m pytest tests/test_free_real_estate_crm.py tests/test_landing_copy.py tests/test_navigation.py -q --tb=short`
- Result: 96 passed
- Rendered JSON-LD is one `@graph` with Organization, SoftwareApplication, FAQPage, BreadcrumbList
- Visible page copy has no Home crumb trail

[Rendered JSON-LD graph types and BreadcrumbList node](https://cursor.com/agents/bc-ab01f33b-0906-4ed6-a42e-9181d3cf2dbe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffree_crm_jsonld_graph.json)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab01f33b-0906-4ed6-a42e-9181d3cf2dbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab01f33b-0906-4ed6-a42e-9181d3cf2dbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

