### PR TITLE
fix: rest 352 motion leftovers on search and segments

### DIFF
--- a/static/css/transitions-bridge.css
+++ b/static/css/transitions-bridge.css
@@ -39,10 +39,6 @@ html[data-theme="dark"] .t-clear-glow {
   pointer-events: auto;
 }
 
-.crm-user-dropdown.t-dropdown {
-  background: var(--paper);
-}
-
 /* Badge: keep the orange pill, let .t-badge own the slot. */
 .crm-utility-icon-btn--bell .t-badge {
   top: 0.1rem;
@@ -116,9 +112,17 @@ html[data-theme="dark"] .t-clear-glow {
   min-height: 16rem;
 }
 
-/* Contacts list <-> detail: give the absolute pages a real height. */
+/* Contacts list <-> detail: the active page stays in flow so the
+   slider sizes to content on first paint. The other page stays
+   absolute for the slide. JS can still pin height during a swap. */
 .crm-contacts-pages.t-page-slide {
-  min-height: 50vh;
+  min-height: 0;
+}
+
+.crm-contacts-pages.t-page-slide[data-page="1"] .t-page[data-page-id="1"],
+.crm-contacts-pages.t-page-slide[data-page="2"] .t-page[data-page-id="2"] {
+  position: relative;
+  inset: auto;
 }
 
 .crm-contacts-page-body {
@@ -147,11 +151,25 @@ html[data-theme="dark"] .t-clear-glow {
   box-shadow: none;
 }
 
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item,
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.t-tab,
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.t-tab[aria-selected="true"],
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.t-tab[aria-pressed="true"],
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.t-tab[aria-current="page"],
+.crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.t-tab.is-active,
+html.am-skin .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.is-active,
+html.am-skin .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item[aria-pressed="true"],
+html.am-skin .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item[aria-selected="true"],
+html.am-skin[data-theme="dark"] .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item.is-active,
+html.am-skin[data-theme="dark"] .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item[aria-pressed="true"],
+html.am-skin[data-theme="dark"] .crm-segment.t-tabs:has(.t-tabs-pill) .crm-segment__item[aria-selected="true"] {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
 .crm-segment.t-tabs .crm-segment__item.t-tab[aria-selected="true"],
 .crm-segment.t-tabs .crm-segment__item.t-tab.is-active {
   color: var(--ink);
-  background: transparent;
-  box-shadow: none;
 }
 
 .crm-segment.t-tabs .t-tabs-pill {
@@ -160,6 +178,10 @@ html[data-theme="dark"] .t-clear-glow {
   border-radius: 5px;
   background: var(--paper);
   box-shadow: 0 1px 2px oklch(0% 0 0 / 0.04), 0 0 0 1px var(--hairline);
+}
+
+html.am-skin .crm-segment.t-tabs .t-tabs-pill {
+  border-radius: 1000px;
 }
 
 [data-theme="dark"] .crm-segment.t-tabs {
@@ -190,10 +212,17 @@ html[data-theme="dark"] .t-clear-glow {
   border-radius: 999px;
 }
 
+.crm-activity-tabs.t-tabs:has(.t-tabs-pill[data-ready]) .crm-chip.is-active,
+.crm-activity-tabs.t-tabs:has(.t-tabs-pill[data-ready]) .t-tab.is-active,
+.crm-activity-tabs.t-tabs:has(.t-tabs-pill[data-ready]) .t-tab[aria-selected="true"] {
+  background: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
 .crm-activity-tabs .t-tabs-pill {
   top: 0;
   height: auto;
-  min-height: 100%;
   border-radius: 999px;
   background: var(--ink);
 }
@@ -205,6 +234,75 @@ html[data-theme="dark"] .t-clear-glow {
 
 .crm-toast.t-toast.is-open {
   opacity: 1;
+}
+
+/* Clear layers stay off the native placeholder and focus ring
+   unless a clear is running. Isolate so mix-blend cannot tint
+   the settings chip or other header chrome. */
+.crm-utility-search.t-clear,
+.crm-toolbar__search.t-clear {
+  overflow: visible;
+  isolation: isolate;
+}
+
+.crm-utility-search.t-clear .t-clear-mirror,
+.crm-utility-search.t-clear .t-clear-placeholder,
+.crm-utility-search.t-clear .t-clear-glow,
+.crm-toolbar__search.t-clear .t-clear-mirror,
+.crm-toolbar__search.t-clear .t-clear-placeholder,
+.crm-toolbar__search.t-clear .t-clear-glow {
+  opacity: 0;
+  visibility: hidden;
+  filter: none;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.crm-utility-search.t-clear.has-value .t-clear-mirror,
+.crm-toolbar__search.t-clear.has-value .t-clear-mirror {
+  opacity: 1;
+  visibility: visible;
+}
+
+.crm-utility-search.t-clear.is-clearing .t-clear-mirror,
+.crm-utility-search.t-clear.is-clearing .t-clear-placeholder,
+.crm-utility-search.t-clear.is-clearing .t-clear-glow,
+.crm-toolbar__search.t-clear.is-clearing .t-clear-mirror,
+.crm-toolbar__search.t-clear.is-clearing .t-clear-placeholder,
+.crm-toolbar__search.t-clear.is-clearing .t-clear-glow {
+  visibility: visible;
+}
+
+.crm-utility-search.t-clear.has-value .t-clear-placeholder,
+.crm-toolbar__search.t-clear.has-value .t-clear-placeholder,
+.crm-utility-search.t-clear:not(.is-clearing) .t-clear-glow,
+.crm-toolbar__search.t-clear:not(.is-clearing) .t-clear-glow {
+  opacity: 0;
+  visibility: hidden;
+  background: none;
+  filter: none;
+}
+
+.crm-utility-search.t-clear .t-clear-glow,
+.crm-toolbar__search.t-clear .t-clear-glow {
+  border-radius: 1000px;
+  mix-blend-mode: multiply;
+}
+
+html.am-skin .crm-utility-search.t-clear input:focus,
+html.am-skin .crm-toolbar__search.t-clear .crm-search:focus,
+.crm-utility-search.t-clear input:focus,
+.crm-toolbar__search.t-clear .crm-search:focus {
+  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.28) !important;
+}
+
+html.am-skin .crm-theme-btn,
+html.am-skin .crm-utility-btn,
+html.am-skin .crm-utility-icon-btn,
+.crm-theme-btn,
+.crm-utility-btn,
+.crm-utility-icon-btn {
+  filter: none;
 }
 
 /* Clear button sits on the existing search fields. */
@@ -276,8 +374,8 @@ html[data-theme="dark"] .crm-utility-search.t-clear .t-clear-placeholder {
 }
 
 .t-check[aria-checked="true"] {
-  background: var(--ink, #0f172a);
-  border-color: var(--ink, #0f172a);
+  background: var(--accent, #f97316);
+  border-color: var(--accent, #f97316);
 }
 
 .t-check svg {

--- a/static/css/transitions-bridge.css
+++ b/static/css/transitions-bridge.css
@@ -258,10 +258,10 @@ html.am-skin .crm-segment.t-tabs .t-tabs-pill {
   pointer-events: none;
 }
 
-.crm-utility-search.t-clear.has-value .t-clear-mirror,
-.crm-toolbar__search.t-clear.has-value .t-clear-mirror {
-  opacity: 1;
-  visibility: visible;
+.crm-utility-search.t-clear:not(.is-clearing) input,
+.crm-toolbar__search.t-clear:not(.is-clearing) input,
+.crm-toolbar__search.t-clear:not(.is-clearing) .crm-search {
+  -webkit-text-fill-color: inherit;
 }
 
 .crm-utility-search.t-clear.is-clearing .t-clear-mirror,
@@ -291,6 +291,10 @@ html.am-skin .crm-segment.t-tabs .t-tabs-pill {
 
 html.am-skin .crm-utility-search.t-clear input:focus,
 html.am-skin .crm-toolbar__search.t-clear .crm-search:focus,
+html.am-skin main#mainContent .crm-toolbar__search.t-clear input:focus,
+html.am-skin main#mainContent .crm-toolbar__search.t-clear .crm-search:focus,
+html.am-skin .content-wrapper .crm-toolbar__search.t-clear input:focus,
+html.am-skin .content-wrapper .crm-toolbar__search.t-clear .crm-search:focus,
 .crm-utility-search.t-clear input:focus,
 .crm-toolbar__search.t-clear .crm-search:focus {
   box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.28) !important;

--- a/static/css/transitions-root.css
+++ b/static/css/transitions-root.css
@@ -127,8 +127,10 @@
   --shake-ease: cubic-bezier(0.22, 1, 0.36, 1);
   --revert-hold: 3000ms;
   --revert-dur: 280ms;
-  /* Input clear with dissolve */
-  --clear-dur: 1000ms;
+  /* Input clear with dissolve.
+     400ms matches the out/in legs. The official 1000ms beat left
+     glow and placeholder layers painted after the text had settled. */
+  --clear-dur: 400ms;
   --clear-out-dur: 400ms;
   --clear-in-dur: 400ms;
   --clear-out-fly: 12px;

--- a/static/css/transitions-snippets.css
+++ b/static/css/transitions-snippets.css
@@ -345,14 +345,12 @@
   z-index: 2;
 }
 .t-clear-mirror { opacity: 0; visibility: hidden; }
-.t-clear.has-value .t-clear-mirror,
 .t-clear.is-clearing .t-clear-mirror {
   opacity: 1;
   visibility: visible;
 }
-/* Hide the input's own glyphs while the mirror owns them so
-   the cleared text doesn't double-render with the fly-up. */
-.t-clear.has-value > input,
+/* Native glyphs stay visible at rest. Hide them only while the
+   dissolve mirror owns the clear. */
 .t-clear.is-clearing > input {
   -webkit-text-fill-color: transparent;
 }

--- a/static/css/transitions-snippets.css
+++ b/static/css/transitions-snippets.css
@@ -344,16 +344,24 @@
   overflow: hidden;
   z-index: 2;
 }
-.t-clear-mirror { opacity: 0; }
+.t-clear-mirror { opacity: 0; visibility: hidden; }
 .t-clear.has-value .t-clear-mirror,
-.t-clear.is-clearing .t-clear-mirror { opacity: 1; }
+.t-clear.is-clearing .t-clear-mirror {
+  opacity: 1;
+  visibility: visible;
+}
 /* Hide the input's own glyphs while the mirror owns them so
    the cleared text doesn't double-render with the fly-up. */
 .t-clear.has-value > input,
 .t-clear.is-clearing > input {
   -webkit-text-fill-color: transparent;
 }
-.t-clear.has-value .t-clear-placeholder { opacity: 0; }
+/* Official snippet paints this layer at rest. Our chrome already
+   has a native placeholder, so keep this layer hidden until a clear
+   is actually running. */
+.t-clear-placeholder { opacity: 0; visibility: hidden; }
+.t-clear.has-value .t-clear-placeholder { opacity: 0; visibility: hidden; }
+.t-clear.is-clearing .t-clear-placeholder { opacity: 1; visibility: visible; }
 /* The streak overlay: empty by default; JS writes a stack of
    `radial-gradient(...)` layers into background during a clear,
    then animates opacity. mix-blend-mode: multiply darkens the
@@ -364,9 +372,11 @@
   inset: 0;
   pointer-events: none;
   opacity: 0;
+  visibility: hidden;
   z-index: 3;
   mix-blend-mode: multiply;
 }
+.t-clear.is-clearing .t-clear-glow { visibility: visible; }
 
 /* The transitions live in JS (per-frame transform/opacity/
    filter writes), so this stylesheet only owns the resting

--- a/static/js/transitions.js
+++ b/static/js/transitions.js
@@ -124,16 +124,21 @@
     if (!bar || !tab) return;
     var pill = bar.querySelector('.t-tabs-pill');
     if (!pill) return;
+    var place = function () {
+      pill.style.transform = 'translateX(' + tab.offsetLeft + 'px)';
+      pill.style.width = tab.offsetWidth + 'px';
+      pill.style.height = tab.offsetHeight + 'px';
+      pill.style.top = tab.offsetTop + 'px';
+      pill.setAttribute('data-ready', 'true');
+    };
     if (!animate) {
       var prev = pill.style.transition;
       pill.style.transition = 'none';
-      pill.style.transform = 'translateX(' + tab.offsetLeft + 'px)';
-      pill.style.width = tab.offsetWidth + 'px';
+      place();
       void pill.offsetWidth;
       pill.style.transition = prev;
     } else {
-      pill.style.transform = 'translateX(' + tab.offsetLeft + 'px)';
-      pill.style.width = tab.offsetWidth + 'px';
+      place();
     }
   }
 
@@ -262,7 +267,7 @@
       var keepFocus = document.activeElement === input;
       mirror.textContent = input.value.replace(/ /g, '\u00a0');
 
-      var total = cssMs('--clear-dur', 1000);
+      var total = cssMs('--clear-dur', 400);
       var outDur = cssMs('--clear-out-dur', 400);
       var inDur = cssMs('--clear-in-dur', 400);
       var outFly = cssMs('--clear-out-fly', 12);
@@ -311,6 +316,8 @@
           mirror.textContent = '';
           glow.style.opacity = '0';
           glow.style.background = '';
+          glow.style.filter = '';
+          glow.style.visibility = 'hidden';
           clearing = false;
           input.dispatchEvent(new Event('input', { bubbles: true }));
           wrap.dispatchEvent(new CustomEvent('t:cleared', { bubbles: true }));
@@ -328,6 +335,9 @@
       clearWithAnimation();
     });
     input.addEventListener('input', sync);
+    glow.style.opacity = '0';
+    glow.style.background = '';
+    glow.style.visibility = 'hidden';
     sync();
   }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3246,10 +3246,13 @@
             function clearHide() { if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; } }
             function hide() {
                 clearHide();
-                if (window.TMotion) TMotion.closeDropdown(pop);
-                else pop.classList.remove('is-open');
-                pop.setAttribute('aria-hidden', 'true');
                 btn.setAttribute('aria-expanded', 'false');
+                var finish = function () { pop.setAttribute('aria-hidden', 'true'); };
+                if (window.TMotion) TMotion.closeDropdown(pop, finish);
+                else {
+                    pop.classList.remove('is-open');
+                    finish();
+                }
             }
             function show() {
                 clearHide();

--- a/tests/test_transitions_hooks.py
+++ b/tests/test_transitions_hooks.py
@@ -127,6 +127,16 @@ class TestRestState:
         bridge = _read("static", "css", "transitions-bridge.css")
         assert "0 0 0 2px rgba(249, 115, 22, 0.28)" in bridge
         assert "0 0 0 4px rgba(249, 115, 22, 0.35)" not in bridge
+        assert "main#mainContent .crm-toolbar__search.t-clear" in bridge
+
+    def test_clear_mirror_stays_off_at_rest(self):
+        snippets = _read("static", "css", "transitions-snippets.css")
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert ".t-clear.has-value .t-clear-mirror" not in snippets
+        assert ".t-clear.has-value > input" not in snippets
+        assert ".t-clear.is-clearing .t-clear-mirror" in snippets
+        assert ".t-clear.is-clearing > input" in snippets
+        assert ".t-clear.has-value .t-clear-mirror" not in bridge
 
     def test_segment_selected_chip_yields_to_sliding_pill(self):
         bridge = _read("static", "css", "transitions-bridge.css")

--- a/tests/test_transitions_hooks.py
+++ b/tests/test_transitions_hooks.py
@@ -111,3 +111,59 @@ class TestChromeHooks:
         assert "openModal" in js
         assert "openToast" in js
         assert "path.getTotalLength" in js
+
+
+class TestRestState:
+    def test_clear_layers_stay_hidden_at_rest(self):
+        snippets = _read("static", "css", "transitions-snippets.css")
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert ".t-clear-placeholder { opacity: 0; visibility: hidden; }" in snippets
+        assert ".t-clear.is-clearing .t-clear-placeholder" in snippets
+        assert ".t-clear.is-clearing .t-clear-glow { visibility: visible; }" in snippets
+        assert "isolation: isolate" in bridge
+        assert ".t-clear:not(.is-clearing) .t-clear-glow" in bridge
+
+    def test_search_focus_ring_is_thin(self):
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert "0 0 0 2px rgba(249, 115, 22, 0.28)" in bridge
+        assert "0 0 0 4px rgba(249, 115, 22, 0.35)" not in bridge
+
+    def test_segment_selected_chip_yields_to_sliding_pill(self):
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert ".crm-segment.t-tabs:has(.t-tabs-pill)" in bridge
+        assert "background: transparent !important;" in bridge
+        assert "box-shadow: none !important;" in bridge
+        assert ".crm-activity-tabs.t-tabs:has(.t-tabs-pill[data-ready])" in bridge
+
+    def test_clear_duration_is_not_the_long_beat(self):
+        root = _read("static", "css", "transitions-root.css")
+        js = _read("static", "js", "transitions.js")
+        assert "--clear-dur: 400ms;" in root
+        assert "--clear-dur: 1000ms;" not in root
+        assert "cssMs('--clear-dur', 400)" in js
+
+    def test_contacts_slider_does_not_reserve_fifty_vh(self):
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert "min-height: 50vh" not in bridge
+        assert "position: relative" in bridge
+        assert 'data-page="1"] .t-page[data-page-id="1"]' in bridge
+
+    def test_user_dropdown_does_not_force_paper(self):
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert ".crm-user-dropdown.t-dropdown {\n  background: var(--paper);\n}" not in bridge
+
+    def test_checked_task_uses_accent(self):
+        bridge = _read("static", "css", "transitions-bridge.css")
+        assert "background: var(--accent, #f97316);" in bridge
+        assert ".t-check[aria-checked=\"true\"]" in bridge
+
+    def test_like_tokens_stay_unhooked(self):
+        root = _read("static", "css", "transitions-root.css")
+        snippets = _read("static", "css", "transitions-snippets.css")
+        bridge = _read("static", "css", "transitions-bridge.css")
+        js = _read("static", "js", "transitions.js")
+        assert "--like-color: #f40051;" in root
+        for blob in (snippets, bridge, js):
+            assert "--like-color" not in blob
+            assert "confetti" not in blob
+            assert "t-tilt" not in blob


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 352 stacked official transitions.dev layers on chrome that already had placeholders, focus rings, and selected chips. Rest state was the casualty.

This trims the official snippets where they fight existing chrome. Motion still runs on an actual clear or tab change. Reduced-motion stays on every remaining snippet.

## Root cause

**Ghost placeholders.** Snippet 13 paints `.t-clear-placeholder` at rest. CRM already has a native `placeholder`. Empty header and contacts search showed two copies of the same string. `.t-clear-mirror` also stayed visible on `.has-value`, and `-webkit-text-fill-color: transparent` hid the real glyphs so the overlay owned typed text at rest.

**Fat peach halo.** `.t-clear-glow` plus mix-blend sat on top of the existing 4px orange ring. Header search picked up the leftover glow even when idle. The settings chip inherited the blend. Contacts search then lost the 2px override to `html.am-skin main#mainContent input:focus` (ID selector, 4px / 0.28).

**Double pills.** Tabs-sliding injects `.t-tabs-pill`. `html.am-skin .crm-segment__item.is-active` still painted a white chip with `!important`. Two selected backgrounds.

## What changed

- Hide `.t-clear-mirror`, `.t-clear-placeholder`, and `.t-clear-glow` at rest. They only paint during `.is-clearing`.
- Native input text stays visible at rest. Transparent fill only during the dissolve.
- Thin 2px `#f97316` ring on search focus, including `main#mainContent` so contacts wins.
- Isolate search wraps. Theme / utility chips do not inherit glow.
- Selected `.crm-segment__item` and activity chips go transparent when the sliding pill is present.
- `--clear-dur` 400ms (was 1000ms).
- Contacts slider `min-height: 0`. Active page stays in flow so first paint is not 50vh.
- `.t-check[aria-checked="true"]` uses `#f97316`.
- Dropped the user-dropdown `background: var(--paper)` force so Apple Music glass stays.

## Leftover audit

- `--like-color: #f40051` is still in `transitions-root.css`. Tilt / like / confetti are not hooked. Left unused on purpose.
- Menu, modal, and notification finishers already wait for `closeDropdown` / `closeModal`. Search close only uses the 120ms `hidden` fallback when TMotion is missing. Not a rest-state paint bug.
- Rail still uses `t-panel-slide` for reveal. Old overflow finishers on non-352 menus (task priority, tax protest) were left alone.

## Proof

Playwright computed styles on light theme: overlay layers `opacity: 0` / `visibility: hidden`, search focus `0 0 0 2px rgba(249, 115, 22, 0.28)`, selected segment chips `background-color: rgba(0,0,0,0)`, one `.t-tabs-pill[data-ready]`, checked task `rgb(249, 115, 22)`, user dropdown `rgba(255,255,255,0.48)` plus `blur(28px)`.

Headed walkthrough: header + contacts search, My/All, Active/Completed, activity chips, user menu.

## Out of scope

No SEO / public pages. Placeholder strings are unchanged. No merge.

## Tests

Local: `pytest tests/test_transitions_hooks.py tests/test_document_definitions.py` — 38 passed.

GitHub: unit and playwright both green on this head.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f128ca71-bb80-4602-8de3-e4a03d3ea1ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f128ca71-bb80-4602-8de3-e4a03d3ea1ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

