### PR TITLE
fix: show checked visual on completed listing-prep rows

### DIFF
--- a/static/css/transitions-bridge.css
+++ b/static/css/transitions-bridge.css
@@ -390,6 +390,22 @@ html[data-theme="dark"] .crm-utility-search.t-clear .t-clear-placeholder {
   border-color: var(--accent, #f97316);
 }
 
+/* DaisyUI Preflight zeroes <button> backgrounds. Manual checklist rows
+   are buttons, so a completed row kept strikethrough and the date while
+   the box stayed an empty ring. Auto rows were <span> and still filled.
+   Element+class beats that reset the same way button.crm-btn-* does. */
+button.t-check {
+  background: var(--paper, #fff);
+  border: 1px solid var(--hairline-strong, #cbd5e1);
+}
+button.t-check[aria-checked="true"] {
+  background: var(--accent, #f97316);
+  border-color: var(--accent, #f97316);
+}
+.t-check[aria-disabled="true"] {
+  cursor: default;
+}
+
 .t-check svg {
   width: 10px;
   height: 10px;
@@ -417,6 +433,16 @@ html[data-theme="dark"] .crm-utility-search.t-clear .t-clear-placeholder {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+#transaction-checklist .t-check-wrap > .t-success-check {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  pointer-events: none;
 }
 
 .t-input.is-error {

--- a/static/js/transitions.js
+++ b/static/js/transitions.js
@@ -674,11 +674,13 @@
     confettiWaiters.push(after);
   }
 
-  function burstConfetti(anchor) {
+  function burstConfetti(anchor, opts) {
     if (!anchor || prefersReducedMotion()) {
       settleConfetti();
       return;
     }
+    opts = opts || {};
+    var useLocalOrigin = !!opts.localOrigin;
     var overlay = ensureConfettiOverlay();
     var canvas = overlay.querySelector('canvas');
     if (!canvas) return;
@@ -735,12 +737,16 @@
     var count = Math.round(readConfettiNum(overlay, '--pv1o', 120));
     var size = readConfettiNum(overlay, '--pv22', 4);
     var spawnWindow = 500;
+    var origin = buttonRect();
+    var originX = (origin.left + origin.right) / 2;
+    var originY = origin.top;
+    var spreadX = Math.max(origin.right - origin.left, 16) * 5;
     for (var i = 0; i < count; i++) {
       particles.push({
         start: now + Math.random() * spawnWindow,
-        x: Math.random() * stageW,
-        y: -12 - Math.random() * 30,
-        py: -12,
+        x: useLocalOrigin ? originX + (Math.random() - 0.5) * spreadX : Math.random() * stageW,
+        y: useLocalOrigin ? originY - 10 - Math.random() * 36 : -12 - Math.random() * 30,
+        py: useLocalOrigin ? originY - 12 : -12,
         vx: (Math.random() - 0.5) * 60,
         vy: 40 + Math.random() * 120,
         w: size * (0.7 + Math.random() * 0.6),
@@ -815,6 +821,9 @@
           }
         }
         if (p.x < -30 || p.x > stageW + 30 || p.y > stageH + 30) {
+          p.dead = true;
+        }
+        if (useLocalOrigin && !p.resting && p.y > b.bottom + 96) {
           p.dead = true;
         }
       }

--- a/templates/transactions/_checklist.html
+++ b/templates/transactions/_checklist.html
@@ -1,4 +1,28 @@
-{% from "components/ui.html" import badge, section_header %}
+{% from "components/ui.html" import badge, section_header, success_check %}
+
+{% macro checklist_check(item) -%}
+<span class="t-check-wrap mt-0.5 shrink-0">
+    {% if item.auto %}
+    <span class="t-check"
+          role="checkbox"
+          aria-checked="{{ 'true' if item.done else 'false' }}"
+          aria-disabled="true"
+          data-checklist-box>
+        <svg viewBox="0 0 10.1668 10.1668" aria-hidden="true"><path d="M1 5.52L3.92 9.17L9.17 1"/></svg>
+    </span>
+    {% else %}
+    <button type="button"
+            class="t-check"
+            role="checkbox"
+            aria-checked="{{ 'true' if item.done else 'false' }}"
+            data-checklist-toggle
+            aria-label="{{ 'Mark incomplete' if item.done else 'Mark complete' }}: {{ item.title }}">
+        <svg viewBox="0 0 10.1668 10.1668" aria-hidden="true"><path d="M1 5.52L3.92 9.17L9.17 1"/></svg>
+    </button>
+    {% endif %}
+    {{ success_check() }}
+</span>
+{%- endmacro %}
 
 {% set deadline_items = checklist|selectattr('kind', 'equalto', 'requirement')|list %}
 {% set dated_deadline_items = deadline_items|selectattr('due_at')|list %}
@@ -31,21 +55,7 @@
                     data-custom="{{ 'true' if item.custom else 'false' }}"
                     data-done="{{ 'true' if item.done else 'false' }}">
                     <div class="flex items-start gap-3">
-                        {% if item.auto %}
-                        <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border {% if item.done %}border-emerald-600 bg-emerald-600 text-white{% else %}border-slate-300 bg-white text-transparent{% endif %}"
-                              data-checklist-box
-                              aria-hidden="true">
-                            <i class="fas fa-check text-[10px]"></i>
-                        </span>
-                        {% else %}
-                        <button type="button"
-                                class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border {% if item.done %}border-emerald-600 bg-emerald-600 text-white{% else %}border-slate-300 bg-white text-transparent hover:border-slate-400{% endif %}"
-                                data-checklist-toggle
-                                aria-pressed="{{ 'true' if item.done else 'false' }}"
-                                aria-label="{{ 'Mark incomplete' if item.done else 'Mark complete' }}: {{ item.title }}">
-                            <i class="fas fa-check text-[10px]"></i>
-                        </button>
-                        {% endif %}
+                        {{ checklist_check(item) }}
                         <div class="min-w-0 flex-1">
                             <div class="flex items-center justify-between gap-3">
                                 <div class="min-w-0 flex items-center gap-2">

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1928,7 +1928,7 @@
     function celebrateChecklistCheck(item) {
         const box = item && item.querySelector('.t-check');
         if (!box || !window.TMotion) return;
-        if (TMotion.burstConfetti) TMotion.burstConfetti(box);
+        if (TMotion.burstConfetti) TMotion.burstConfetti(box, { localOrigin: true });
         const success = item.querySelector('.t-success-check');
         if (success && TMotion.playSuccessCheck) {
             TMotion.playSuccessCheck(success);

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1909,21 +1909,42 @@
         if (count) count.textContent = done + ' of ' + items.length;
     }
 
-    function applyDone(item, done) {
+    function checkMarkSvg() {
+        return '<svg viewBox="0 0 10.1668 10.1668" aria-hidden="true"><path d="M1 5.52L3.92 9.17L9.17 1"/></svg>';
+    }
+
+    function successCheckHtml() {
+        return '<span class="t-success-check" data-state="out" aria-hidden="true">'
+            + '<svg viewBox="0 0 48 48" fill="none"><path d="M10 24.5L20 34.5L38 14" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+            + '</span>';
+    }
+
+    function setChecklistChecked(box, done) {
+        if (!box) return;
+        if (window.TMotion && TMotion.setChecked) TMotion.setChecked(box, done);
+        else box.setAttribute('aria-checked', done ? 'true' : 'false');
+    }
+
+    function celebrateChecklistCheck(item) {
+        const box = item && item.querySelector('.t-check');
+        if (!box || !window.TMotion) return;
+        if (TMotion.burstConfetti) TMotion.burstConfetti(box);
+        const success = item.querySelector('.t-success-check');
+        if (success && TMotion.playSuccessCheck) {
+            TMotion.playSuccessCheck(success);
+            window.setTimeout(function () {
+                success.setAttribute('data-state', 'out');
+            }, 900);
+        }
+    }
+
+    function applyDone(item, done, celebrate) {
         item.dataset.done = done ? 'true' : 'false';
         const box = item.querySelector('[data-checklist-toggle], [data-checklist-box]');
         const title = item.querySelector('[data-checklist-title]');
-        if (box) {
-            box.classList.toggle('border-emerald-600', done);
-            box.classList.toggle('bg-emerald-600', done);
-            box.classList.toggle('text-white', done);
-            box.classList.toggle('border-slate-300', !done);
-            box.classList.toggle('bg-white', !done);
-            box.classList.toggle('text-transparent', !done);
-        }
+        setChecklistChecked(box, done);
         const toggle = item.querySelector('[data-checklist-toggle]');
         if (toggle) {
-            toggle.setAttribute('aria-pressed', done ? 'true' : 'false');
             const name = title ? title.textContent.trim() : 'item';
             toggle.setAttribute('aria-label', (done ? 'Mark incomplete: ' : 'Mark complete: ') + name);
         }
@@ -1932,6 +1953,7 @@
             title.classList.toggle('text-[color:var(--ink-3)]', done);
             title.classList.toggle('text-[color:var(--ink)]', !done);
         }
+        if (celebrate && done) celebrateChecklistCheck(item);
         updateChecklistCount();
     }
 
@@ -2066,9 +2088,12 @@
             : 'text-[color:var(--ink-3)] hover:text-[color:var(--ink)]';
         return ''
             + '<div class="flex items-start gap-3">'
-            + '  <button type="button" class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border border-slate-300 bg-white text-transparent hover:border-slate-400" data-checklist-toggle aria-pressed="false" aria-label="Mark complete: ' + title + '">'
-            + '    <i class="fas fa-check text-[10px]"></i>'
-            + '  </button>'
+            + '  <span class="t-check-wrap mt-0.5 shrink-0">'
+            + '    <button type="button" class="t-check" role="checkbox" aria-checked="false" data-checklist-toggle aria-label="Mark complete: ' + title + '">'
+            + checkMarkSvg()
+            + '    </button>'
+            + successCheckHtml()
+            + '  </span>'
             + '  <div class="min-w-0 flex-1">'
             + '    <div class="flex items-center justify-between gap-3">'
             + '      <div class="min-w-0 flex items-center gap-2">'
@@ -2097,6 +2122,8 @@
         item.dataset.custom = 'true';
         item.dataset.done = 'false';
         item.innerHTML = customRowHtml(data);
+        const check = item.querySelector('.t-check');
+        if (window.TMotion && TMotion.initCheck) TMotion.initCheck(check);
         list.appendChild(item);
         updateChecklistCount();
         item.scrollIntoView({ block: 'nearest' });
@@ -2183,10 +2210,12 @@
             const item = toggle.closest('[data-checklist-item]');
             const reqId = item && item.dataset.requirementId;
             if (!reqId) return;
+            const wasDone = item.dataset.done === 'true';
             toggle.disabled = true;
             try {
                 const data = await postJson(`/transactions/${txId}/requirements/${reqId}/toggle`);
-                applyDone(item, Boolean(data.done));
+                const done = Boolean(data.done);
+                applyDone(item, done, done && !wasDone);
                 upsertTransactionTask(data.task);
             } catch (err) {
                 alert(err.message || 'Could not update this item.');

--- a/tests/test_checklist_render.py
+++ b/tests/test_checklist_render.py
@@ -12,6 +12,7 @@ from models import (
     TransactionType,
     db,
 )
+from services.listing_prep_checklist import seed_listing_prep_checklist
 
 
 def _buyer_type(org_id):
@@ -100,6 +101,74 @@ def test_seller_preparing_to_list_renders_grouped_checklist(app, seed, owner_a_c
         assert 'id="transaction-required-documents"' not in html
         assert 'click any date' not in html.lower()
         assert 'Overdue' not in html.split('id="transaction-checklist"', 1)[1].split('</section>', 1)[0]
+    finally:
+        with app.app_context():
+            _cleanup(seed['org_a'], tx_id)
+
+
+def _checklist_row(html, item_key):
+    marker = f'data-item-key="{item_key}"'
+    start = html.find(marker)
+    assert start != -1, f'missing {item_key}'
+    li_start = html.rfind('<li', 0, start)
+    li_end = html.find('</li>', start)
+    assert li_start != -1 and li_end != -1
+    return html[li_start:li_end + 5]
+
+
+def test_completed_property_details_row_shows_checked_visual(app, seed, owner_a_client):
+    """Manual completed rows must bind the checked visual, not just date/strike."""
+    tx_id = None
+    with app.app_context():
+        tx = _make_tx(
+            seed, side='seller', address='907 Checked Visual Ln',
+            status='preparing_to_list',
+        )
+        tx_id = tx.id
+        seed_listing_prep_checklist(tx, seed['org_a'], actor_id=seed['owner_a'])
+        req = TransactionRequirement.query.filter_by(
+            transaction_id=tx_id,
+            requirement_key='confirm_property_details',
+        ).one()
+        req.work_status = 'completed'
+        req.due_at = datetime(2026, 8, 25)
+        db.session.add(TransactionDocument(
+            organization_id=seed['org_a'],
+            transaction_id=tx_id,
+            template_slug='listing-agreement',
+            template_name='Listing Agreement',
+            status='signed',
+            is_placeholder=False,
+            document_source='completed',
+            signed_file_path='/tmp/listing-agreement.pdf',
+        ))
+        db.session.commit()
+
+    try:
+        response = owner_a_client.get(f'/transactions/{tx_id}')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        checklist = html.split('id="transaction-checklist"', 1)[1].split('</section>', 1)[0]
+
+        details = _checklist_row(checklist, 'confirm_property_details')
+        assert 'Confirm Property Details with Seller' in details
+        assert 'data-done="true"' in details
+        assert 'line-through' in details
+        assert 'Aug 25' in details
+        assert 'class="t-check"' in details
+        assert 'aria-checked="true"' in details
+        assert 'aria-checked="false"' not in details
+        assert 't-check-native' not in details
+        assert 'type="checkbox"' not in details
+        assert 't-success-check' in details
+        assert 'data-state="out"' in details
+
+        agreement = _checklist_row(checklist, 'listing_agreement')
+        assert 'Sign Listing Agreement' in agreement
+        assert 'data-done="true"' in agreement
+        assert 'class="t-check"' in agreement
+        assert 'aria-checked="true"' in agreement
+        assert 'On file' in agreement
     finally:
         with app.app_context():
             _cleanup(seed['org_a'], tx_id)

--- a/tests/test_transitions_hooks.py
+++ b/tests/test_transitions_hooks.py
@@ -126,6 +126,7 @@ class TestChromeHooks:
         assert "t-check-native" not in checklist
         assert "celebrateChecklistCheck" in detail
         assert "burstConfetti" in detail
+        assert "localOrigin: true" in detail
         assert "playSuccessCheck" in detail
         assert "setChecked" in detail
         assert "applyDone(item, done, done && !wasDone)" in detail
@@ -179,6 +180,9 @@ class TestChromeHooks:
         assert "path.getTotalLength" in js
         assert "burstConfetti" in js
         assert "whenConfettiSettled" in js
+        assert "useLocalOrigin" in js
+        assert "originX + (Math.random() - 0.5) * spreadX" in js
+        assert "p.y > b.bottom + 96" in js
         dash = _read("frontend", "controllers", "dashboard_page_controller.js")
         assert "burstConfetti" in dash
         assert "whenConfettiSettled" in dash

--- a/tests/test_transitions_hooks.py
+++ b/tests/test_transitions_hooks.py
@@ -115,6 +115,22 @@ class TestChromeHooks:
         assert "burstConfetti" in todo_js
         assert "whenConfettiSettled" in todo_js
 
+    def test_checklist_has_check_and_confetti_hooks(self):
+        checklist = _read("templates", "transactions", "_checklist.html")
+        detail = _read("templates", "transactions", "detail.html")
+        assert 'class="t-check"' in checklist
+        assert "M1 5.52L3.92 9.17L9.17 1" in checklist
+        assert "{{ 'true' if item.done else 'false' }}" in checklist
+        assert "aria-checked=" in checklist
+        assert "success_check()" in checklist
+        assert "t-check-native" not in checklist
+        assert "celebrateChecklistCheck" in detail
+        assert "burstConfetti" in detail
+        assert "playSuccessCheck" in detail
+        assert "setChecked" in detail
+        assert "applyDone(item, done, done && !wasDone)" in detail
+        assert "if (celebrate && done) celebrateChecklistCheck(item);" in detail
+
     def test_wave2_list_skeletons(self):
         tasks = _read("templates", "tasks", "list.html")
         inbox = _read("templates", "inbox", "home.html")
@@ -225,6 +241,8 @@ class TestRestState:
         bridge = _read("static", "css", "transitions-bridge.css")
         assert "background: var(--accent, #f97316);" in bridge
         assert ".t-check[aria-checked=\"true\"]" in bridge
+        assert "button.t-check[aria-checked=\"true\"]" in bridge
+        assert "#transaction-checklist .t-check-wrap > .t-success-check" in bridge
 
     def test_like_tokens_stay_unhooked(self):
         root = _read("static", "css", "transitions-root.css")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Manual Preparing to List rows could look done (strikethrough, date set) while the checkbox stayed an empty ring. Christopher's case: Confirm Property Details with Seller struck through with Aug 25, box empty. Sign Listing Agreement still showed a filled check.

## Cause

Manual items were `<button>`s with Tailwind emerald fill. DaisyUI Preflight zeroes button backgrounds, so those utilities never painted. Auto items such as Sign Listing Agreement were `<span>`s, so the fill survived. Date and strikethrough bind off `item.done` and were never the broken part.

## Fix

- Checklist boxes now use the same `.t-check` + `aria-checked` control as tasks
- `button.t-check` gets element+class specificity so Preflight cannot empty a completed row
- Check-complete plays the official success-check and the 356 site confetti
- Checklist bursts pass `localOrigin: true` so particles spawn at the checkbox and drop if they fall past it. Task and to-do bursts keep the original sky-fall
- Uncheck does nothing. Reduced motion skips the burst
- No native checkbox sibling, so `initCheck` cannot overwrite `aria-checked`
- Item names are unchanged. Listing package header is untouched

## Tests

- Completed Confirm Property Details with Seller row renders `aria-checked="true"` on `.t-check`
- Hooks for `setChecked`, `playSuccessCheck`, and `burstConfetti` sit on this surface
- Local pytest: 30 passed. GitHub unit and Playwright checks are green

[Completed checklist rows in dark mode](https://cursor.com/agents/bc-69466439-1344-4dff-aef2-b15daabc25d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchecklist_completed_rows_dark_crop.png)
[Completed checklist rows in light mode](https://cursor.com/agents/bc-69466439-1344-4dff-aef2-b15daabc25d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchecklist_completed_rows_light.png)
[checklist_local_confetti_check_uncheck.mp4](https://cursor.com/agents/bc-69466439-1344-4dff-aef2-b15daabc25d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchecklist_local_confetti_check_uncheck.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69466439-1344-4dff-aef2-b15daabc25d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69466439-1344-4dff-aef2-b15daabc25d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

