### PR TITLE
fix: center theme toggle icons and restore full-screen checklist confetti

### DIFF
--- a/static/css/transitions-bridge.css
+++ b/static/css/transitions-bridge.css
@@ -456,8 +456,12 @@ button.t-check[aria-checked="true"] {
 }
 
 .crm-theme-btn .t-icon-swap {
+  display: grid;
+  place-items: center;
+  place-content: center;
   width: 0.9rem;
   height: 0.9rem;
+  line-height: 0;
 }
 
 .crm-sidebar-toggle .t-icon-swap {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1480,6 +1480,8 @@
             justify-content: center;
             height: 2.25rem;
             width: 2.25rem;
+            padding: 0;
+            line-height: 0;
             border-radius: 0.5rem;
             border: 1px solid var(--hairline);
             background: var(--paper);
@@ -1492,8 +1494,20 @@
             color: var(--ink);
             border-color: var(--ink-5);
         }
+        .crm-theme-btn .t-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 0;
+        }
         .crm-theme-btn .t-icon-swap .crm-theme-btn__sun,
-        .crm-theme-btn .t-icon-swap .crm-theme-btn__moon { display: inline; }
+        .crm-theme-btn .t-icon-swap .crm-theme-btn__moon {
+            display: block;
+            line-height: 1;
+            width: 1em;
+            height: 1em;
+            font-size: 0.9rem;
+        }
 
         /* Smooth transition when toggling */
         html.crm-theme-transition,

--- a/templates/transactions/detail.html
+++ b/templates/transactions/detail.html
@@ -1928,7 +1928,7 @@
     function celebrateChecklistCheck(item) {
         const box = item && item.querySelector('.t-check');
         if (!box || !window.TMotion) return;
-        if (TMotion.burstConfetti) TMotion.burstConfetti(box, { localOrigin: true });
+        if (TMotion.burstConfetti) TMotion.burstConfetti(box);
         const success = item.querySelector('.t-success-check');
         if (success && TMotion.playSuccessCheck) {
             TMotion.playSuccessCheck(success);

--- a/tests/test_transitions_hooks.py
+++ b/tests/test_transitions_hooks.py
@@ -125,8 +125,8 @@ class TestChromeHooks:
         assert "success_check()" in checklist
         assert "t-check-native" not in checklist
         assert "celebrateChecklistCheck" in detail
-        assert "burstConfetti" in detail
-        assert "localOrigin: true" in detail
+        assert "TMotion.burstConfetti(box)" in detail
+        assert "localOrigin" not in detail
         assert "playSuccessCheck" in detail
         assert "setChecked" in detail
         assert "applyDone(item, done, done && !wasDone)" in detail
@@ -169,6 +169,19 @@ class TestChromeHooks:
         assert 'className = \'t-tt\'' in base or 'tip.className = \'t-tt\'' in base
         assert "t-morph" not in settings
         assert "t-acc" not in settings
+
+    def test_theme_toggle_glyphs_are_centered(self):
+        base = _read("templates", "base.html")
+        bridge = _read("static", "css", "transitions-bridge.css")
+        theme_btn = base.split(".crm-theme-btn {", 1)[1].split("/* Smooth transition", 1)[0]
+        assert "padding: 0;" in theme_btn
+        assert "line-height: 0;" in theme_btn
+        assert ".crm-theme-btn .t-icon {" in theme_btn
+        assert "display: block;" in theme_btn
+        assert "font-size: 0.9rem;" in theme_btn
+        assert "display: inline;" not in theme_btn
+        assert "place-content: center;" in bridge
+        assert "width: 0.9rem;" in bridge.split(".crm-theme-btn .t-icon-swap {", 1)[1]
 
     def test_orchestration_reads_css_ms(self):
         js = _read("static", "js", "transitions.js")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two production UI fixes on current main (`cc6b861`).

## Theme toggle icons

Sun and moon in the signed-in topbar sat low. Official `t-icon-swap` plus a leftover `display: inline` / line-height on a 0.9rem box pushed the Font Awesome glyph off the optical center of the circle.

The control is the same size, shape, and swap. I zeroed button padding and line-height, made the glyphs block-level at 0.9rem, and grid-centered the swap. Dark and light, rest and after toggle.

Tooltip still drops below the topbar icon. I did not move it.

## Checklist confetti

PR 358 localized deal-file confetti to the checkbox so particles died just past the box. Christopher wants the same full-screen sky-fall as client tasks and personal to-dos.

`celebrateChecklistCheck` now calls `TMotion.burstConfetti(box)` with no `localOrigin`. Particles spawn across the top of the viewport and fall the full overlay. Uncheck still does nothing. `prefersReducedMotion` still skips. Task and to-do callers are unchanged. The helper still has the local-origin path. Nothing uses it.

Checklist item names, Listing package header, and Upload remaining are untouched.

## How to verify

1. Sign in. Look at the topbar theme button in dark mode and light mode. Moon and sun should sit in the middle of the circle before and after you toggle.
2. Open a seller deal with Preparing to List. Check an incomplete item. Confetti should start at the top of the screen and fill the viewport, same as checking a client task on `/tasks`.
3. Uncheck that item. No burst.
4. `pytest tests/test_transitions_hooks.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-150fff42-aded-4d8a-9076-cd9a93b1ffe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-150fff42-aded-4d8a-9076-cd9a93b1ffe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

