### PR TITLE
fix: make public SEO share images absolute

### DIFF
--- a/templates/components/seo_meta.html
+++ b/templates/components/seo_meta.html
@@ -1,5 +1,7 @@
 {# First-HTML public SEO. Keep titles/descriptions exact. #}
 {% macro public_seo(title, description, canonical) -%}
+{#- Macros do not see app_base_url. Take the host from the already-absolute canonical. -#}
+{%- set share_image = canonical.split('/')[:3]|join('/') ~ '/static/images/og-share.png' -%}
 <meta name="description" content="{{ description }}">
 <link rel="canonical" href="{{ canonical }}">
 <meta name="theme-color" content="#f97316">
@@ -8,7 +10,7 @@
 <meta property="og:title" content="{{ title }}">
 <meta property="og:description" content="{{ description }}">
 <meta property="og:url" content="{{ canonical }}">
-<meta property="og:image" content="{{ app_base_url }}/static/images/og-share.png">
+<meta property="og:image" content="{{ share_image }}">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -16,5 +18,5 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ title }}">
 <meta name="twitter:description" content="{{ description }}">
-<meta name="twitter:image" content="{{ app_base_url }}/static/images/og-share.png">
+<meta name="twitter:image" content="{{ share_image }}">
 {%- endmacro %}

--- a/tests/test_canonical_host.py
+++ b/tests/test_canonical_host.py
@@ -20,10 +20,19 @@ PUBLIC_PATHS = (
     "/wise-agent-alternative",
     "/kvcore-alternative",
 )
+SHARE_IMAGE = "https://agentflow.origentechnolog.com/static/images/og-share.png"
 
 
 def test_default_app_base_url_is_agentflow():
     assert DEFAULT_APP_BASE_URL == "https://agentflow.origentechnolog.com"
+
+
+def test_public_seo_share_images_use_absolute_agentflow_url(client):
+    for path in PUBLIC_PATHS:
+        html = client.get(path).get_data(as_text=True)
+        assert f'property="og:image" content="{SHARE_IMAGE}"' in html, path
+        assert f'name="twitter:image" content="{SHARE_IMAGE}"' in html, path
+        assert 'content="/static/images/og-share.png"' not in html, path
 
 
 def test_sitemap_locs_use_agentflow_host():

--- a/tests/test_follow_up_boss_alternative.py
+++ b/tests/test_follow_up_boss_alternative.py
@@ -227,6 +227,10 @@ class TestFollowUpBossAlternativeSeo:
         assert f'property="og:title" content="{TITLE}"' in page
         assert f'property="og:url" content="{page_url}"' in page
         assert f'property="og:description" content="{META}"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in page
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in home
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in home
 
         assert f"<title>{HOME_TITLE}</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -186,6 +186,10 @@ class TestFreeRealEstateCrmSeo:
         assert 'property="og:title" content="Free real estate CRM | AgentFlow"' in page
         assert f'property="og:url" content="{page_url}"' in page
         assert 'property="og:description" content="Built for agents, by agents. The free tier stays free. No card. About two minutes."' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in page
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in home
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in home
 
         assert "<title>Free Real Estate CRM | AgentFlow</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -245,6 +245,10 @@ class TestKvcoreAlternativeSeo:
         assert f'property="og:title" content="{TITLE}"' in page
         assert f'property="og:url" content="{page_url}"' in page
         assert f'property="og:description" content="{META}"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in page
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in home
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in home
 
         assert f"<title>{HOME_TITLE}</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -235,6 +235,10 @@ class TestWiseAgentAlternativeSeo:
         assert f'property="og:title" content="{TITLE}"' in page
         assert f'property="og:url" content="{page_url}"' in page
         assert f'property="og:description" content="{META}"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in page
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in page
+        assert f'property="og:image" content="{base}/static/images/og-share.png"' in home
+        assert f'name="twitter:image" content="{base}/static/images/og-share.png"' in home
 
         assert f"<title>{HOME_TITLE}</title>" in home
         assert f'rel="canonical" href="{home_url}"' in home


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Facebook and Twitter need an absolute image URL. Live `og:image` and `twitter:image` on the public pages still render as `/static/images/og-share.png` because `public_seo` reads `app_base_url` inside the macro, and macros do not get that context. Canonical already works because callers pass the full URL.

## Scope

`templates/components/seo_meta.html`: take the host from the already-absolute `canonical` argument and reuse it for both share-image tags.

Tests in `tests/test_canonical_host.py` plus the existing OG tests now pin `https://agentflow.origentechnolog.com/static/images/og-share.png`.

Out of scope: titles, descriptions, H1s, FAQ, comparison copy, sitemap, BreadcrumbList, robots, llms.txt, SearchAction, mobile/B.O.B.

## Tradeoffs

I used the canonical host instead of hardcoding the production URL or flipping the import to `with context`. Same result on these pages, and we stay off the broken `app_base_url` lookup.

## Blast radius

Public first-HTML SEO only. Same file for every `public_seo` page. Crawlers get a fetchable image. No signed-in chrome.

## Verification

Live today on `/free-real-estate-crm`: canonical is already `https://agentflow.origentechnolog.com/free-real-estate-crm`, while `og:image` and `twitter:image` are still `/static/images/og-share.png`.

After this change, rendered HTML on `/`, `/free-real-estate-crm`, `/register`, `/login`, `/terms-privacy`, and the three comparison pages emits `https://agentflow.origentechnolog.com/static/images/og-share.png` for both tags. Titles unchanged.

`pytest tests/test_canonical_host.py tests/test_free_real_estate_crm.py tests/test_follow_up_boss_alternative.py tests/test_wise_agent_alternative.py tests/test_kvcore_alternative.py tests/test_landing_copy.py`: 153 passed.

GitHub `Tests / unit` and `Tests / playwright` on this branch both passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb96c25-0122-4b5f-ad57-59af34d0c7d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb96c25-0122-4b5f-ad57-59af34d0c7d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

