### PR TITLE
fix: mobile B.O.B. sheet and dark hamburger nav

### DIFF
--- a/static/css/ai_chat.css
+++ b/static/css/ai_chat.css
@@ -1305,7 +1305,7 @@
 /* ===== Mobile Responsive ===== */
 @media (max-width: 768px) {
     .bob-title {
-        font-size: 28px;
+        font-size: 20px;
     }
 }
 
@@ -1936,11 +1936,12 @@ body.bob-fullscreen-open {
    On a 390px phone that modal math goes negative, the sidebar eats
    half the screen, and 100vw blows the page sideways.
 
-   Open state on a phone is a full-viewport sheet: column layout,
-   composer pinned to the visual viewport (JS sets top/height), no
-   sideways overflow. */
+   Open state on a phone is a full-viewport column sheet. Composer sits
+   on the visual viewport (JS writes --bob-sheet-top / --bob-sheet-height).
+   Surfaces use canvas/paper so dark mode is not a white blast. */
 body.bob-sheet-open {
     overflow: hidden !important;
+    overscroll-behavior: none;
 }
 
 @media (max-width: 768px) {
@@ -1954,15 +1955,24 @@ body.bob-sheet-open {
         width: 100% !important;
         max-width: 100% !important;
         min-width: 0 !important;
-        height: var(--bob-sheet-height, 100dvh) !important;
+        height: var(--bob-sheet-height, 100svh) !important;
         max-height: var(--bob-sheet-height, 100%) !important;
         min-height: 0 !important;
         border: none !important;
         border-radius: 0 !important;
         box-shadow: none !important;
         flex-direction: column !important;
+        display: flex !important;
         padding: 0 !important;
         transform: translateY(100%);
+        background: var(--paper, var(--bob-panel-bg)) !important;
+        --bob-panel-bg: var(--paper);
+        --bob-border: var(--hairline);
+        --bob-text: var(--ink);
+        --bob-muted: var(--ink-3);
+        /* Open/close slides. Height/top must snap with the keyboard. */
+        transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .bob-panel.open,
@@ -1974,6 +1984,10 @@ body.bob-sheet-open {
     .bob-panel.modal .bob-history-sidebar,
     .bob-panel.sheet .bob-history-sidebar {
         display: none !important;
+        width: 0 !important;
+        height: 0 !important;
+        min-height: 0 !important;
+        overflow: hidden !important;
     }
 
     .bob-panel .bob-main-area,
@@ -1988,14 +2002,22 @@ body.bob-sheet-open {
         overflow: hidden;
     }
 
-    .bob-header {
-        padding: 10px 12px;
-        padding-top: max(10px, env(safe-area-inset-top, 0px));
+    .bob-header,
+    .bob-panel.modal .bob-header {
+        padding: 8px 10px;
+        padding-top: max(8px, env(safe-area-inset-top, 0px));
+        background: var(--paper, var(--bob-panel-bg)) !important;
+        min-height: 52px;
     }
 
-    .bob-panel.modal .bob-header {
-        padding: 10px 12px;
-        padding-top: max(10px, env(safe-area-inset-top, 0px));
+    .bob-header-btn {
+        width: 44px;
+        height: 44px;
+        touch-action: manipulation;
+    }
+
+    .bob-header-btn:hover {
+        background: var(--paper-2, #f1f5f9);
     }
 
     #bob-expand-btn {
@@ -2010,62 +2032,108 @@ body.bob-sheet-open {
         min-height: 0;
         flex: 1;
         overflow: hidden;
+        background: var(--canvas, #fafafa) !important;
     }
 
     .bob-welcome,
     .bob-panel.modal .bob-welcome {
-        padding: 28px 16px;
+        padding: 16px 16px 12px;
         max-width: 100%;
+        background: var(--canvas, #fafafa) !important;
+        justify-content: flex-start;
     }
 
+    .bob-welcome > :first-child,
+    .bob-welcome > :last-child {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
+    .bob-logo,
     .bob-panel.modal .bob-logo {
-        width: 72px;
-        height: 72px;
-        margin-bottom: 16px;
+        width: 44px;
+        height: 44px;
+        margin-bottom: 8px;
     }
 
+    .bob-logo svg,
     .bob-panel.modal .bob-logo svg {
-        width: 60px;
-        height: 60px;
+        width: 36px;
+        height: 36px;
+    }
+
+    .bob-logo-glow {
+        width: 48px;
+        height: 48px;
+        filter: blur(12px);
     }
 
     .bob-panel.modal .bob-title,
     .bob-title {
-        font-size: 28px;
+        font-size: 20px;
+        margin-bottom: 2px;
     }
 
+    .bob-subtitle,
     .bob-panel.modal .bob-subtitle {
-        font-size: 15px;
+        font-size: 13px;
     }
 
     .bob-panel.modal .bob-tagline,
     .bob-tagline {
         max-width: 100%;
-        padding: 12px 16px;
+        margin-top: 12px;
+        padding: 8px 12px;
+        background: var(--paper-2, #f8fafc);
     }
 
     .bob-messages,
     .bob-panel.modal .bob-messages {
-        padding: 16px;
+        padding: 12px;
         max-width: 100%;
+        background: var(--canvas, #f8fafc) !important;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior: contain;
     }
 
     .bob-panel.modal .bob-message,
     .bob-message {
         max-width: 88%;
+        padding: 10px 14px;
+    }
+
+    .bob-message.assistant {
+        background: var(--paper, #ffffff);
+        color: var(--ink, var(--bob-text));
+        border-color: var(--hairline, var(--bob-border));
+    }
+
+    .bob-message.assistant strong,
+    .bob-message.assistant h1,
+    .bob-message.assistant h2,
+    .bob-message.assistant h3 {
+        color: var(--ink, var(--bob-navy));
     }
 
     .bob-starters,
     .bob-panel.modal .bob-starters {
         display: block;
         max-width: 100%;
-        margin-top: 24px;
+        margin-top: 16px;
         grid-template-columns: none;
         column-gap: 0;
     }
 
-    .bob-panel.modal .bob-starters-group + .bob-starters-group {
-        margin-top: 18px;
+    .bob-panel.modal .bob-starters-group + .bob-starters-group,
+    .bob-starters-group + .bob-starters-group {
+        margin-top: 12px;
+    }
+
+    .bob-starter {
+        min-height: 44px;
+        padding: 12px 14px;
+        background: var(--paper, #f8fafc);
+        touch-action: manipulation;
     }
 
     .bob-input-area,
@@ -2073,7 +2141,8 @@ body.bob-sheet-open {
         width: 100%;
         max-width: 100%;
         align-items: stretch;
-        padding: 12px 12px max(12px, env(safe-area-inset-bottom, 0px));
+        padding: 8px 10px max(8px, env(safe-area-inset-bottom, 0px));
+        background: var(--paper, var(--bob-panel-bg)) !important;
     }
 
     .bob-panel.modal .bob-image-preview,
@@ -2086,16 +2155,63 @@ body.bob-sheet-open {
 
     .bob-panel.modal .bob-input-container,
     .bob-input-container {
-        padding: 12px 12px;
-        border-radius: 16px;
+        padding: 8px 10px;
+        border-radius: 14px;
+        background: var(--paper-2, #f8fafc) !important;
+    }
+
+    .bob-input-container:focus-within {
+        background: var(--paper, #ffffff) !important;
     }
 
     .bob-input-row {
         min-width: 0;
+        align-items: flex-end;
+        gap: 8px;
+    }
+
+    .bob-textarea {
+        font-size: 16px;
+        line-height: 1.4;
+        min-height: 28px;
+        max-height: 96px;
+        padding: 8px 0;
+    }
+
+    .bob-tool-btn {
+        width: 44px;
+        height: 44px;
+        background: var(--paper, #ffffff);
+        touch-action: manipulation;
+    }
+
+    .bob-send-btn {
+        width: 44px;
+        height: 44px;
+        border-radius: 12px;
+        touch-action: manipulation;
+    }
+
+    .bob-history-dropdown {
+        width: min(280px, calc(100vw - 16px));
+        max-width: calc(100vw - 16px);
+        right: 0;
+        background: var(--paper, #ffffff);
+    }
+
+    .bob-history-dropdown-header {
+        background: var(--paper-2, #f8fafc);
+    }
+
+    .bob-history-dropdown-delete {
+        opacity: 1;
+        width: 44px;
+        height: 44px;
     }
 
     .bob-file-preview {
         max-width: 100%;
+        background: var(--paper-2, #f8fafc);
     }
 
     .bob-file-card {

--- a/static/css/ai_chat.css
+++ b/static/css/ai_chat.css
@@ -1947,7 +1947,10 @@ body.bob-sheet-open {
 @media (max-width: 768px) {
     .bob-panel,
     .bob-panel.sheet,
-    .bob-panel.modal {
+    .bob-panel.modal,
+    html.am-skin .bob-panel,
+    html.am-skin .bob-panel.sheet,
+    html.am-skin .bob-panel.modal {
         top: var(--bob-sheet-top, 0px) !important;
         right: 0 !important;
         left: 0 !important;
@@ -1965,8 +1968,13 @@ body.bob-sheet-open {
         display: flex !important;
         padding: 0 !important;
         transform: translateY(100%);
-        background: var(--paper, var(--bob-panel-bg)) !important;
-        --bob-panel-bg: var(--paper);
+        /* Beat am-skin glass. A 42% drawer is fine on desktop; a
+           full-phone sheet that shows Contacts through it is not. */
+        background: var(--canvas) !important;
+        background-color: var(--canvas) !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+        --bob-panel-bg: var(--canvas);
         --bob-border: var(--hairline);
         --bob-text: var(--ink);
         --bob-muted: var(--ink-3);

--- a/static/js/ai_chat.js
+++ b/static/js/ai_chat.js
@@ -418,7 +418,8 @@ class BOBChatPanel {
                             </button>
                         </div>
                         <textarea class="bob-textarea" id="bob-textarea" 
-                            placeholder="Ask anything... Type @ to mention a contact" rows="1"></textarea>
+                            placeholder="Ask anything... Type @ to mention a contact"
+                            rows="1" enterkeyhint="send" autocomplete="off"></textarea>
                         <button class="bob-send-btn" id="bob-send-btn" title="Send">
                             <i class="fas fa-paper-plane"></i>
                         </button>
@@ -609,8 +610,8 @@ class BOBChatPanel {
             this.ensurePageConversation({ seedBriefing: true });
         }
 
-        const textarea = document.getElementById('bob-textarea');
-        if (textarea) textarea.focus();
+        // Do not focus the composer. iOS would open the keyboard on a
+        // 14px field and zoom the sheet. The user taps when they want it.
     }
 
     async ensurePageConversation({ seedBriefing = false, forceBriefing = false } = {}) {
@@ -855,8 +856,9 @@ class BOBChatPanel {
     
     autoResizeTextarea() {
         const textarea = document.getElementById('bob-textarea');
+        const max = this.isNarrow() ? 96 : 120;
         textarea.style.height = 'auto';
-        textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
+        textarea.style.height = Math.min(textarea.scrollHeight, max) + 'px';
     }
     
     // ===== File Attachment =====

--- a/templates/base.html
+++ b/templates/base.html
@@ -291,11 +291,9 @@
             background: var(--accent-soft, #ffedd5);
             color: var(--accent-ink, #c2410c);
         }
-        /* Mobile slide-in menu sits on the dark slate shell, where the light
-           accent-soft chip would glare. Use a translucent ember treatment. */
         #mobileNavMenu .crm-nav-badge {
-            background: rgba(249, 115, 22, 0.18);
-            color: #fdba74;
+            background: var(--accent-soft, #ffedd5);
+            color: var(--accent-ink, #c2410c);
         }
 
         /* Collapsed sidebar clips labels (and the NEW tag with them), so a
@@ -1189,6 +1187,35 @@
         header.text-white .text-white { color: var(--ink) !important; }
         #mobileMenuToggle { color: var(--ink) !important; }
         #mobileMenuToggle:hover { background: var(--paper-2) !important; }
+
+        /* Hamburger drawer. The panel still carries bg-slate-950, and the
+           Atelier remap sends that utility to --ink. --ink is near-white in
+           dark, so the open menu went white. Paint it with canvas/paper
+           instead. Desktop aside#sidebar is a different node. */
+        #mobileNavMenu .crm-mobile-nav-panel {
+            background: var(--canvas) !important;
+            color: var(--ink) !important;
+            border-right: 1px solid var(--hairline);
+        }
+        #mobileNavMenu .crm-mobile-nav-panel .text-white,
+        #mobileNavMenu .crm-mobile-nav-panel a,
+        #mobileNavMenu .crm-mobile-nav-panel button {
+            color: var(--ink) !important;
+        }
+        #mobileNavMenu .crm-mobile-nav-panel .border-slate-800,
+        #mobileNavMenu .crm-mobile-nav-panel .border-t,
+        #mobileNavMenu .crm-mobile-nav-panel .border-b {
+            border-color: var(--hairline) !important;
+        }
+        #mobileNavMenu .crm-mobile-nav-panel a:hover,
+        #mobileNavMenu .crm-mobile-nav-panel button:hover,
+        #mobileNavMenu .crm-mobile-nav-panel .hover\:bg-slate-800:hover {
+            background: var(--paper-2) !important;
+        }
+        #mobileNavMenu .crm-mobile-nav-panel a.bg-slate-800,
+        #mobileNavMenu .crm-mobile-nav-panel [class~="bg-slate-800"] {
+            background: var(--paper) !important;
+        }
 
         /* User dropdown menu */
         .crm-user-dropdown {
@@ -2560,18 +2587,18 @@
         <div class="absolute inset-0 bg-black bg-opacity-50" onclick="toggleMobileNavMenu()"></div>
 
         <!-- Menu Panel -->
-        <div class="absolute left-0 top-0 bottom-0 w-72 bg-slate-950 shadow-xl">
+        <div class="crm-mobile-nav-panel absolute left-0 top-0 bottom-0 w-72 bg-slate-950 shadow-xl flex flex-col overflow-hidden">
             <!-- Header -->
-            <div class="h-14 flex items-center justify-between px-4 border-b border-slate-800">
+            <div class="h-14 flex items-center justify-between px-4 border-b border-slate-800 flex-shrink-0">
                 <span class="text-white font-semibold">Menu</span>
                 <button onclick="toggleMobileNavMenu()"
-                    class="w-8 h-8 flex items-center justify-center text-white hover:bg-slate-800 rounded-lg">
+                    class="w-11 h-11 flex items-center justify-center text-white hover:bg-slate-800 rounded-lg">
                     <i class="fas fa-times"></i>
                 </button>
             </div>
 
             <!-- Navigation Links -->
-            <nav class="py-4">
+            <nav class="py-4 flex-1 overflow-y-auto">
                 <a href="{{ url_for('main.dashboard') }}"
                     class="flex items-center px-6 py-3 text-white hover:bg-slate-800 {% if request.endpoint == 'main.dashboard' %}bg-slate-800 border-l-4 border-orange-500{% endif %}"
                     {% if activation_state is defined and activation_state.mode == 'start' %}data-analytics-nav="dashboard"{% endif %}>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -951,12 +951,17 @@ class CRMTestSuite:
                         const ta = getComputedStyle(document.getElementById('bob-textarea'));
                         const send = document.getElementById('bob-send-btn').getBoundingClientRect();
                         const welcome = document.getElementById('bob-welcome');
+                        const panelBg = getComputedStyle(document.getElementById('bob-panel')).backgroundColor;
+                        const m = panelBg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)(?:,\\s*([\\d.]+))?/);
+                        const alpha = m && m[4] !== undefined ? parseFloat(m[4]) : 1;
                         return {
                             fontPx: parseFloat(ta.fontSize),
                             sendW: Math.round(send.width),
                             sendH: Math.round(send.height),
                             welcomePad: welcome ? getComputedStyle(welcome).paddingTop : '',
                             titlePx: parseFloat(getComputedStyle(document.querySelector('.bob-title')).fontSize),
+                            panelBg,
+                            panelAlpha: alpha,
                         };
                     }"""
                 )
@@ -966,6 +971,8 @@ class CRMTestSuite:
                     raise AssertionError(f"Send tap target too small: {chrome}")
                 if chrome['titlePx'] > 22:
                     raise AssertionError(f"Welcome title still desktop-sized: {chrome}")
+                if chrome['panelAlpha'] < 0.95:
+                    raise AssertionError(f"Phone sheet is still glass: {chrome}")
                 self.page.evaluate(
                     """() => {
                         const panel = document.getElementById('bob-panel');

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -810,6 +810,54 @@ class CRMTestSuite:
                 f"Offenders: {detail}"
             )
 
+    def _set_theme(self, theme):
+        self.page.evaluate(
+            """(theme) => {
+                localStorage.setItem('crm-theme', theme);
+                document.documentElement.dataset.theme = theme;
+            }""",
+            theme,
+        )
+
+    def _nav_panel_luminance(self):
+        return self.page.evaluate(
+            """() => {
+                const panel = document.querySelector('#mobileNavMenu .crm-mobile-nav-panel');
+                if (!panel) return { missing: true };
+                const bg = getComputedStyle(panel).backgroundColor;
+                const m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
+                if (!m) return { bg, lum: null };
+                const toLin = (c) => {
+                    const n = Number(c) / 255;
+                    return n <= 0.04045 ? n / 12.92 : Math.pow((n + 0.055) / 1.055, 2.4);
+                };
+                const lum = 0.2126 * toLin(m[1]) + 0.7152 * toLin(m[2]) + 0.0722 * toLin(m[3]);
+                return { bg, lum };
+            }"""
+        )
+
+    def _open_mobile_nav(self):
+        menu = self.page.locator('#mobileNavMenu')
+        if menu.count() == 0:
+            raise AssertionError('mobileNavMenu missing')
+        if menu.evaluate("el => el.classList.contains('-translate-x-full')"):
+            toggle = self.page.locator('#mobileMenuToggle')
+            if toggle.count() == 0:
+                raise AssertionError('mobileMenuToggle missing')
+            toggle.click()
+            self.page.wait_for_timeout(350)
+
+    def _close_mobile_nav(self):
+        self.page.evaluate(
+            """() => {
+                const menu = document.getElementById('mobileNavMenu');
+                if (!menu) return;
+                menu.classList.add('-translate-x-full');
+                menu.classList.remove('translate-x-0');
+                document.body.style.overflow = '';
+            }"""
+        )
+
     def test_mobile_native_app(self):
         """Phone viewports: no document sideways scroll, B.O.B. opens as a sheet."""
         test_name = "Mobile native app chrome"
@@ -898,6 +946,26 @@ class CRMTestSuite:
                     )
                 if not sheet['textareaOnScreen'] or not sheet['sendOnScreen']:
                     raise AssertionError(f"B.O.B. composer clipped: {sheet}")
+                chrome = self.page.evaluate(
+                    """() => {
+                        const ta = getComputedStyle(document.getElementById('bob-textarea'));
+                        const send = document.getElementById('bob-send-btn').getBoundingClientRect();
+                        const welcome = document.getElementById('bob-welcome');
+                        return {
+                            fontPx: parseFloat(ta.fontSize),
+                            sendW: Math.round(send.width),
+                            sendH: Math.round(send.height),
+                            welcomePad: welcome ? getComputedStyle(welcome).paddingTop : '',
+                            titlePx: parseFloat(getComputedStyle(document.querySelector('.bob-title')).fontSize),
+                        };
+                    }"""
+                )
+                if chrome['fontPx'] < 16:
+                    raise AssertionError(f"Composer font zooms iOS: {chrome}")
+                if chrome['sendW'] < 44 or chrome['sendH'] < 44:
+                    raise AssertionError(f"Send tap target too small: {chrome}")
+                if chrome['titlePx'] > 22:
+                    raise AssertionError(f"Welcome title still desktop-sized: {chrome}")
                 self.page.evaluate(
                     """() => {
                         const panel = document.getElementById('bob-panel');
@@ -923,6 +991,60 @@ class CRMTestSuite:
                 self._assert_no_page_overflow(f"B.O.B. open @ {width}x{height}")
                 self.dismiss_ai_chat_panel()
                 self.log("", "ok")
+
+                self.log("Checking hamburger drawer theme...", "step")
+                self._set_theme('dark')
+                self._open_mobile_nav()
+                dark_nav = self._nav_panel_luminance()
+                if dark_nav.get('missing') or dark_nav.get('lum') is None:
+                    raise AssertionError(f"Dark nav panel missing: {dark_nav}")
+                if dark_nav['lum'] > 0.35:
+                    raise AssertionError(
+                        f"Dark-mode hamburger nav is too light: {dark_nav}"
+                    )
+                self._close_mobile_nav()
+                self._set_theme('light')
+                self._open_mobile_nav()
+                light_nav = self._nav_panel_luminance()
+                if light_nav.get('missing') or light_nav.get('lum') is None:
+                    raise AssertionError(f"Light nav panel missing: {light_nav}")
+                if light_nav['lum'] < 0.7:
+                    raise AssertionError(
+                        f"Light-mode hamburger nav is not light: {light_nav}"
+                    )
+                self._close_mobile_nav()
+                self._set_theme('dark')
+                self.log("", "ok")
+
+            self.log("Checking desktop B.O.B. stays a drawer...", "step")
+            self.page.set_viewport_size({'width': 1280, 'height': 800})
+            self.page.goto(f"{self.base_url}/contacts")
+            self.page.wait_for_load_state('domcontentloaded')
+            desktop_toggle = self.page.locator('#bob-toggle-desktop')
+            if desktop_toggle.count() == 0:
+                raise AssertionError('Desktop B.O.B. toggle missing')
+            desktop_toggle.click()
+            self.page.wait_for_selector('#bob-panel.open', timeout=5000)
+            self.page.wait_for_timeout(350)
+            desktop = self.page.evaluate(
+                """() => {
+                    const panel = document.getElementById('bob-panel');
+                    const pr = panel.getBoundingClientRect();
+                    return {
+                        sheet: panel.classList.contains('sheet'),
+                        modal: panel.classList.contains('modal'),
+                        panelW: Math.round(pr.width),
+                        panelLeft: Math.round(pr.left),
+                        vw: window.innerWidth,
+                    };
+                }"""
+            )
+            if desktop['sheet'] or desktop['modal']:
+                raise AssertionError(f"Desktop B.O.B. opened as sheet/modal: {desktop}")
+            if desktop['panelW'] > 560 or desktop['panelLeft'] < 600:
+                raise AssertionError(f"Desktop B.O.B. is not the side drawer: {desktop}")
+            self.dismiss_ai_chat_panel()
+            self.log("", "ok")
 
             self.log("", "pass")
             self.results.add_pass()

--- a/tests/test_mobile_chrome.py
+++ b/tests/test_mobile_chrome.py
@@ -50,8 +50,17 @@ class TestBobMobileSheet:
         # Desktop modal used calc(50% - 410px); the phone block must
         # override message padding to a real inset.
         mobile = css.split('Phone sheet', 1)[1]
-        assert 'padding: 16px' in mobile
+        assert 'padding: 12px' in mobile
         assert 'flex-direction: column !important' in mobile
+        assert '100svh' in mobile
+        assert 'var(--paper' in mobile
+        assert 'var(--canvas' in mobile
+        assert 'font-size: 16px' in mobile
+        assert 'width: 44px' in mobile
+        assert 'height: 44px' in mobile
+        # Keyboard tracking must snap, not ease height/top.
+        assert 'transition: transform' in mobile
+        assert 'top 0.3s' not in mobile
 
     def test_js_opens_sheet_on_narrow(self):
         js = _read('static/js/ai_chat.js')
@@ -61,6 +70,25 @@ class TestBobMobileSheet:
         assert '--bob-sheet-height' in js
         assert "this.state = 'sheet'" in js
         assert 'max-width: 768px' in js
+        sheet_fn = js.split(
+            'openSheet({ skipEnsure = false } = {}) {', 1
+        )[1].split('async ensurePageConversation', 1)[0]
+        assert 'textarea.focus()' not in sheet_fn
+        assert 'textarea.focus()' in js
+        assert 'isNarrow() ? 96 : 120' in js
+        assert 'enterkeyhint="send"' in js
+
+
+class TestMobileNavTheme:
+    def test_hamburger_drawer_uses_canvas_tokens(self):
+        html = _read('templates/base.html')
+        assert 'crm-mobile-nav-panel' in html
+        block = html.split('#mobileNavMenu .crm-mobile-nav-panel', 1)[1]
+        assert 'background: var(--canvas) !important' in block
+        assert 'color: var(--ink) !important' in block
+        assert 'var(--paper-2)' in block
+        # Desktop sidebar keeps its own rules; this selector is menu-only.
+        assert 'aside#sidebar' not in block.split('User dropdown menu', 1)[0]
 
 
 @pytest.mark.usefixtures('seed')
@@ -72,3 +100,4 @@ class TestBobAssetsOnDashboard:
         assert b'css/ai_chat.css' in resp.data
         assert b'bob-toggle-mobile' in resp.data
         assert b'viewport-fit=cover' in resp.data
+        assert b'crm-mobile-nav-panel' in resp.data

--- a/tests/test_mobile_chrome.py
+++ b/tests/test_mobile_chrome.py
@@ -55,6 +55,8 @@ class TestBobMobileSheet:
         assert '100svh' in mobile
         assert 'var(--paper' in mobile
         assert 'var(--canvas' in mobile
+        assert 'html.am-skin .bob-panel' in mobile
+        assert 'backdrop-filter: none' in mobile
         assert 'font-size: 16px' in mobile
         assert 'width: 44px' in mobile
         assert 'height: 44px' in mobile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 360 put B.O.B. in a full-viewport sheet. On a real phone it still felt like the desktop chat stuffed into 390px, and the hamburger drawer went white in dark mode.

## What was wrong

**B.O.B.** The sheet opened, then leftover desktop rules kept winning. Welcome used a 28px splash and 72px logo. Composer stayed at 14px, which zooms iOS. Header and send sat under 44px. Panel height eased for 300ms, so `visualViewport` lagged the keyboard. am-skin glass on `.bob-panel` is 42% opacity. Fine for the desktop drawer. On a full-phone sheet it showed Contacts through the chat.

**Hamburger.** The drawer still uses `bg-slate-950`. Atelier remaps that utility to `--ink`. `--ink` is near-white in dark, so the open menu painted white. Desktop `aside#sidebar` is a different node and stays as-is.

## What changed

Phone sheet (max-width 768) now uses opaque canvas, a compact welcome, 16px composer, 44px tap targets, and transform-only transitions. History sidebar stays hidden. `openSheet` does not autofocus. Desktop drawer and fullscreen modal are unchanged above 768, including the glass drawer.

Hamburger panel `.crm-mobile-nav-panel` paints with `--canvas` / `--ink` / `--paper-2`. Light stays light. Dark stays dark.

No public-site copy. No checklist names. No Listing package, theme-toggle, or confetti edits.

## Verify

1. Phone or device mode at 390×844 and 430×932, dark mode. Open the hamburger. The drawer matches the dark canvas, not white.
2. Switch to light. Open it again. The drawer stays light.
3. Open B.O.B. Full opaque sheet. Transcript or compact welcome, composer, and Send on screen. Focus the field. The sheet shrinks with the keyboard. Send stays visible.
4. At 1280px, open Assistant. Side drawer, not the phone sheet. Expand still opens the desktop modal.

## Tests

- File pins in `tests/test_mobile_chrome.py` (canvas drawer, 16px composer, 44px send, `100svh`, opaque sheet, no sheet autofocus).
- Playwright `test_mobile_native_app` checks sheet chrome, dark/light nav luminance, opaque sheet, and the desktop drawer at 1280.
- Local: 1865 + 24 IDOR unit, 13 Playwright, all green.

[Mobile dark hamburger nav](https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_dark_hamburger_nav_390.png)
[Mobile light hamburger nav](https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_light_hamburger_nav_390.png)
[Mobile B.O.B. sheet](https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_bob_chat_sheet_390.png)
[Mobile B.O.B. keyboard-safe sheet](https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_bob_chat_keyboard_390.png)
[Desktop B.O.B. drawer](https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_bob_side_drawer_1280.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f66d7ed-3aa7-4529-b7c6-6c453cfbe75c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

