### PR TITLE
chore: set four sitemap lastmod dates to 2026-08-26

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -18,18 +18,18 @@
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/free-real-estate-crm</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-26</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/follow-up-boss-alternative</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-26</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/wise-agent-alternative</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-26</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/kvcore-alternative</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-26</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sets `lastmod` to 2026-08-26 on four public URLs that were still dated 2026-08-25:

- `/free-real-estate-crm`
- `/follow-up-boss-alternative`
- `/wise-agent-alternative`
- `/kvcore-alternative`

Leaves `/`, `/register`, `/login`, and `/terms-privacy` lastmod dates as they are. Same eight locs. No robots or llms.txt edits. No `changefreq` or `priority` added.

No tests pin these lastmod dates, so none were updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14023b75-e2fb-4daf-8281-79680a4e8903?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14023b75-e2fb-4daf-8281-79680a4e8903&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

