### PR TITLE
seo: free-CRM sentence on register

### DIFF
--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -58,6 +58,9 @@
     background: var(--brand-orange);
   }
   .left-muted{ color: hsla(0, 0%, 100%, 0.56); }
+  .left p.text-brand-600{ color: hsla(0, 0%, 100%, 0.56); }
+  .left a.text-brand-800{ color: #fb923c; }
+  .left a.text-brand-800:hover{ color: #f97316; }
   .left-title{
     color: hsla(0, 0%, 100%, 0.92);
     font-weight: 800;
@@ -207,6 +210,9 @@
               </p>
               <p class="mt-3 text-sm lg:text-[15px] left-muted leading-relaxed">
                 No credit card. The free tier stays free. Up to 10,000 contacts, in a CRM built for agents.
+              </p>
+              <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
               </p>
             </div>
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -215,6 +215,9 @@ class TestAuthPagesRender:
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert "Keep your contacts, tasks, and follow-ups in one place." in html
+        assert "More on what's included is on" in html
+        assert "the free real estate CRM page" in html
+        assert 'href="/free-real-estate-crm"' in html
         assert "Contacts and tasks." not in html
         assert "Talk to B.O.B." in html
         assert (

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -327,6 +327,11 @@ class TestRegisterLeftoverCopy:
     def test_keeps_register_h1(self):
         assert "Create your account." in REGISTER
 
+    def test_one_human_link_to_free_real_estate_crm(self):
+        assert REGISTER.count("url_for('main.free_real_estate_crm')") == 1
+        assert REGISTER.count("the free real estate CRM page") == 1
+        assert "More on what's included is on" in REGISTER
+
     def test_register_red_leftover_is_gone(self):
         assert "#fa243c" not in REGISTER
         assert "250, 36, 60" not in REGISTER


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Register is a public 200 in the sitemap with no path to the query page.

More on what's included is on the free real estate CRM page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c10d5c7-133c-461a-9503-08486be50aa7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c10d5c7-133c-461a-9503-08486be50aa7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

