### PR TITLE
fix: restore public auth form contrast

### DIFF
--- a/static/css/am_skin.css
+++ b/static/css/am_skin.css
@@ -1553,6 +1553,8 @@ html.am-skin body.crm-auth-page .auth-family {
 html.am-skin body.crm-auth-page .login-page .card,
 html.am-skin body.crm-auth-page .register-page .card {
   background: #ffffff !important;
+  background-color: #ffffff !important;
+  color: rgba(0, 0, 0, 0.88) !important;
   border: 1px solid rgba(0, 0, 0, 0.10) !important;
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.08) !important;
   border-radius: 18px !important;
@@ -1592,17 +1594,56 @@ html.am-skin body.crm-auth-page .register-page .left-icon {
   border-color: rgba(255, 255, 255, 0.10) !important;
   color: #f97316 !important;
 }
+html.am-skin[data-theme="dark"] body.crm-auth-page {
+  color-scheme: light;
+}
 html.am-skin body.crm-auth-page .login-page .input,
-html.am-skin body.crm-auth-page .login-page .icon-btn,
-html.am-skin body.crm-auth-page .register-page .input {
+html.am-skin body.crm-auth-page .login-page .input.crm-input,
+html.am-skin body.crm-auth-page .login-page .input.t-input,
+html.am-skin body.crm-auth-page .login-page input.crm-input,
+html.am-skin body.crm-auth-page .register-page .input,
+html.am-skin body.crm-auth-page .register-page .input.crm-input,
+html.am-skin body.crm-auth-page .register-page input.crm-input {
   background: #ffffff !important;
-  border-color: rgba(0, 0, 0, 0.10) !important;
+  background-color: #ffffff !important;
+  border: 1px solid rgba(0, 0, 0, 0.10) !important;
+  border-radius: 12px !important;
   color: rgba(0, 0, 0, 0.88) !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;
+  caret-color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+  font-size: 15px !important;
+  height: 46px !important;
+  padding: 0 14px !important;
+  color-scheme: light;
+}
+html.am-skin body.crm-auth-page .login-page .icon-btn {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+  border-color: rgba(0, 0, 0, 0.10) !important;
+  color: rgba(0, 0, 0, 0.56) !important;
+  box-shadow: none !important;
+}
+html.am-skin body.crm-auth-page .login-page .input::placeholder,
+html.am-skin body.crm-auth-page .login-page input.crm-input::placeholder,
+html.am-skin body.crm-auth-page .register-page .input::placeholder,
+html.am-skin body.crm-auth-page .register-page input.crm-input::placeholder,
+html.am-skin[data-theme="dark"] body.crm-auth-page .login-page input::placeholder,
+html.am-skin[data-theme="dark"] body.crm-auth-page .register-page input::placeholder {
+  color: rgba(0, 0, 0, 0.35) !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.35) !important;
 }
 html.am-skin body.crm-auth-page .login-page .input:focus,
-html.am-skin body.crm-auth-page .register-page .input:focus {
+html.am-skin body.crm-auth-page .login-page input.crm-input:focus,
+html.am-skin body.crm-auth-page .register-page .input:focus,
+html.am-skin body.crm-auth-page .register-page input.crm-input:focus {
   border-color: #f97316 !important;
   box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.18) !important;
+}
+html.am-skin body.crm-auth-page .t-input:not(:focus),
+html.am-skin body.crm-auth-page .t-input-wrap {
+  box-shadow: none !important;
+  filter: none !important;
 }
 html.am-skin body.crm-auth-page .login-page .btn,
 html.am-skin body.crm-auth-page .register-page .btn,
@@ -1621,18 +1662,36 @@ html.am-skin body.crm-auth-page .login-page .label,
 html.am-skin body.crm-auth-page .register-page .title,
 html.am-skin body.crm-auth-page .register-page .label {
   color: rgba(0, 0, 0, 0.88) !important;
+  background: transparent !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;
 }
 html.am-skin body.crm-auth-page .login-page .subtitle,
 html.am-skin body.crm-auth-page .login-page .kicker,
+html.am-skin body.crm-auth-page .login-page .hint-link,
+html.am-skin body.crm-auth-page .login-page .text-slate-600,
 html.am-skin body.crm-auth-page .register-page .subtitle,
 html.am-skin body.crm-auth-page .register-page .kicker,
-html.am-skin body.crm-auth-page .register-page .legal {
+html.am-skin body.crm-auth-page .register-page .legal,
+html.am-skin body.crm-auth-page .register-page .text-slate-600 {
   color: rgba(0, 0, 0, 0.56) !important;
+  background: transparent !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.56) !important;
 }
 html.am-skin body.crm-auth-page .login-page .footer-link,
 html.am-skin body.crm-auth-page .register-page .footer-link,
 html.am-skin body.crm-auth-page .login-page .support-action {
   color: #ea580c !important;
+  background: transparent !important;
+  -webkit-text-fill-color: #ea580c !important;
+}
+html.am-skin body.crm-auth-page ::selection {
+  background: rgba(0, 0, 0, 0.14);
+  color: rgba(0, 0, 0, 0.88);
+}
+html.am-skin body.crm-auth-page .left ::selection,
+html.am-skin body.crm-auth-page .auth-card ::selection {
+  background: rgba(255, 255, 255, 0.22);
+  color: hsla(0, 0%, 100%, 0.92);
 }
 html.am-skin body.crm-auth-page .auth-card {
   background: #2c2c2e !important;
@@ -1640,10 +1699,31 @@ html.am-skin body.crm-auth-page .auth-card {
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12) !important;
   color: hsla(0, 0%, 100%, 0.92) !important;
 }
-html.am-skin body.crm-auth-page .auth-input {
+html.am-skin body.crm-auth-page .auth-input,
+html.am-skin body.crm-auth-page input.auth-input,
+html.am-skin body.crm-auth-page .auth-card input.crm-input {
   background: #3a3a3c !important;
-  border-color: rgba(255, 255, 255, 0.12) !important;
+  background-color: #3a3a3c !important;
+  border: 1px solid rgba(255, 255, 255, 0.12) !important;
+  border-radius: 12px !important;
   color: hsla(0, 0%, 100%, 0.92) !important;
+  -webkit-text-fill-color: hsla(0, 0%, 100%, 0.92) !important;
+  caret-color: hsla(0, 0%, 100%, 0.92) !important;
+  box-shadow: none !important;
+  font-size: 15px !important;
+  height: 46px !important;
+  padding: 0 14px !important;
+  color-scheme: dark;
+}
+html.am-skin body.crm-auth-page .auth-input::placeholder,
+html.am-skin body.crm-auth-page .auth-card input.crm-input::placeholder {
+  color: hsla(0, 0%, 100%, 0.36) !important;
+  -webkit-text-fill-color: hsla(0, 0%, 100%, 0.36) !important;
+}
+html.am-skin body.crm-auth-page .auth-input:focus,
+html.am-skin body.crm-auth-page .auth-card input.crm-input:focus {
+  border-color: #f97316 !important;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.18) !important;
 }
 html.am-skin body.crm-auth-page .auth-title,
 html.am-skin body.crm-auth-page .auth-label {

--- a/static/css/auth-family.css
+++ b/static/css/auth-family.css
@@ -1,0 +1,213 @@
+/* Public auth family lock.
+   Login/register are a light form on a split card. Reset/invite use a
+   dark glass card. Both sit on body.crm-auth-page.
+
+   These screens inherit html[data-theme=dark], html.am-skin input.crm-input
+   (dark paper + near-white ink, pill radius), DaisyUI .input/.card keyed
+   off the same data-theme, color-scheme: dark, ::selection accent-soft,
+   and leftover .t-input rest shadows from the transitions pass.
+
+   This file loads after app.css, am_skin.css, and the base inline sheet
+   so the shipped auth chrome wins in both document themes. Do not restyle
+   the orange submit buttons or the dark left rail. */
+
+html[data-theme="dark"] body.crm-auth-page,
+html.am-skin[data-theme="dark"] body.crm-auth-page,
+html.am-skin[data-theme="light"] body.crm-auth-page,
+body.crm-auth-page {
+  color-scheme: light;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page, .legal-page, .auth-family),
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page, .legal-page, .auth-family),
+html[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page, .legal-page, .auth-family),
+body.crm-auth-page :is(.login-page, .register-page, .legal-page, .auth-family) {
+  color-scheme: light;
+}
+
+/* DaisyUI .card and base.html .card { color: var(--ink) } were painting
+   near-white inherited type onto the white form panel. */
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) .card,
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) .card,
+html[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) .card,
+body.crm-auth-page :is(.login-page, .register-page) .card {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) :is(.title, .label),
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) :is(.title, .label),
+body.crm-auth-page :is(.login-page, .register-page) :is(.title, .label) {
+  color: rgba(0, 0, 0, 0.88) !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  background-image: none !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;
+  box-shadow: none !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) :is(.subtitle, .kicker, .hint-link, .support-row, .legal, .text-slate-600),
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) :is(.subtitle, .kicker, .hint-link, .support-row, .legal, .text-slate-600),
+body.crm-auth-page :is(.login-page, .register-page) :is(.subtitle, .kicker, .hint-link, .support-row, .legal, .text-slate-600) {
+  color: rgba(0, 0, 0, 0.56) !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  background-image: none !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.56) !important;
+  box-shadow: none !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) :is(.footer-link, .support-action),
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) :is(.footer-link, .support-action),
+body.crm-auth-page :is(.login-page, .register-page) :is(.footer-link, .support-action) {
+  color: #ea580c !important;
+  background: transparent !important;
+  background-color: transparent !important;
+  -webkit-text-fill-color: #ea580c !important;
+  box-shadow: none !important;
+}
+
+/* Beat .crm-input, html.am-skin input.crm-input, DaisyUI .input, and .t-input. */
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"]):not([type="button"]),
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"]):not([type="button"]),
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.input,
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.crm-input,
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.t-input,
+html[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.crm-input,
+html[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.input,
+body.crm-auth-page :is(.login-page, .register-page) input.input,
+body.crm-auth-page :is(.login-page, .register-page) input.crm-input,
+body.crm-auth-page :is(.login-page, .register-page) input.t-input {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+  color: rgba(0, 0, 0, 0.88) !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;
+  caret-color: rgba(0, 0, 0, 0.88) !important;
+  border: 1px solid rgba(0, 0, 0, 0.10) !important;
+  border-radius: 12px !important;
+  box-shadow: none !important;
+  font-size: 15px !important;
+  height: 46px !important;
+  padding: 0 14px !important;
+  color-scheme: light;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input:not([type="hidden"])::placeholder,
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) input:not([type="hidden"])::placeholder,
+html.am-skin body.crm-auth-page :is(.login-page, .register-page) input.input::placeholder,
+html.am-skin body.crm-auth-page :is(.login-page, .register-page) input.crm-input::placeholder,
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input.crm-input::placeholder,
+body.crm-auth-page :is(.login-page, .register-page) input::placeholder {
+  color: rgba(0, 0, 0, 0.35) !important;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.35) !important;
+  opacity: 1 !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) input:focus,
+html.am-skin[data-theme="light"] body.crm-auth-page :is(.login-page, .register-page) input:focus,
+body.crm-auth-page :is(.login-page, .register-page) input.input:focus,
+body.crm-auth-page :is(.login-page, .register-page) input.crm-input:focus,
+body.crm-auth-page :is(.login-page, .register-page) input.t-input:focus {
+  border-color: #f97316 !important;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.18) !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.login-page, .register-page) .icon-btn,
+body.crm-auth-page :is(.login-page, .register-page) .icon-btn {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+  color: rgba(0, 0, 0, 0.56) !important;
+  border: 1px solid rgba(0, 0, 0, 0.10) !important;
+  box-shadow: none !important;
+}
+
+/* t-input leftover: no rest-state glow, halo, or orange slab. */
+html.am-skin body.crm-auth-page .t-input,
+html.am-skin body.crm-auth-page .t-input-wrap,
+html.am-skin body.crm-auth-page .t-input-wrap::before,
+html.am-skin body.crm-auth-page .t-input-wrap::after,
+html.am-skin body.crm-auth-page .t-clear-glow,
+html.am-skin body.crm-auth-page .t-clear-mirror,
+html.am-skin body.crm-auth-page .t-clear-placeholder,
+body.crm-auth-page .t-input-wrap,
+body.crm-auth-page .t-input-wrap::before,
+body.crm-auth-page .t-input-wrap::after,
+body.crm-auth-page .t-input:not(:focus),
+body.crm-auth-page .t-clear-glow,
+body.crm-auth-page .t-clear-mirror,
+body.crm-auth-page .t-clear-placeholder {
+  background-image: none !important;
+  filter: none !important;
+}
+
+body.crm-auth-page .t-input:not(:focus),
+body.crm-auth-page .t-input-wrap {
+  box-shadow: none !important;
+}
+
+/* Dark reset / invite card. Beat the same crm-input leak the other way. */
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card,
+html.am-skin[data-theme="light"] body.crm-auth-page .auth-card,
+body.crm-auth-page .auth-card {
+  background: #2c2c2e !important;
+  background-color: #2c2c2e !important;
+  color: hsla(0, 0%, 100%, 0.92) !important;
+  color-scheme: dark;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"]):not([type="button"]),
+html.am-skin[data-theme="light"] body.crm-auth-page .auth-card input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]):not([type="submit"]):not([type="button"]),
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card input.auth-input,
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card input.crm-input,
+html[data-theme="dark"] body.crm-auth-page .auth-card input.crm-input,
+html[data-theme="light"] body.crm-auth-page .auth-card input.crm-input,
+body.crm-auth-page .auth-card input.auth-input,
+body.crm-auth-page .auth-card input.crm-input {
+  background: #3a3a3c !important;
+  background-color: #3a3a3c !important;
+  color: hsla(0, 0%, 100%, 0.92) !important;
+  -webkit-text-fill-color: hsla(0, 0%, 100%, 0.92) !important;
+  caret-color: hsla(0, 0%, 100%, 0.92) !important;
+  border: 1px solid rgba(255, 255, 255, 0.12) !important;
+  border-radius: 12px !important;
+  box-shadow: none !important;
+  font-size: 15px !important;
+  height: 46px !important;
+  padding: 0 14px !important;
+  color-scheme: dark;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card input::placeholder,
+html.am-skin[data-theme="light"] body.crm-auth-page .auth-card input::placeholder,
+html.am-skin body.crm-auth-page .auth-card input.crm-input::placeholder,
+body.crm-auth-page .auth-card input::placeholder {
+  color: hsla(0, 0%, 100%, 0.36) !important;
+  -webkit-text-fill-color: hsla(0, 0%, 100%, 0.36) !important;
+  opacity: 1 !important;
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page .auth-card input:focus,
+html.am-skin[data-theme="light"] body.crm-auth-page .auth-card input:focus,
+body.crm-auth-page .auth-card input.auth-input:focus,
+body.crm-auth-page .auth-card input.crm-input:focus {
+  border-color: #f97316 !important;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.18) !important;
+}
+
+/* Accent-soft selection was painting orange slabs across the form. */
+html.am-skin[data-theme="dark"] body.crm-auth-page ::selection,
+html.am-skin[data-theme="light"] body.crm-auth-page ::selection,
+html.am-skin body.crm-auth-page ::selection,
+html[data-theme="dark"] body.crm-auth-page ::selection,
+body.crm-auth-page ::selection {
+  background: rgba(0, 0, 0, 0.14);
+  color: rgba(0, 0, 0, 0.88);
+}
+
+html.am-skin[data-theme="dark"] body.crm-auth-page :is(.left, .auth-card) ::selection,
+html.am-skin body.crm-auth-page :is(.left, .auth-card) ::selection,
+body.crm-auth-page :is(.left, .auth-card) ::selection {
+  background: rgba(255, 255, 255, 0.22);
+  color: hsla(0, 0%, 100%, 0.92);
+}

--- a/templates/auth/accept_invite.html
+++ b/templates/auth/accept_invite.html
@@ -24,19 +24,19 @@
           <div>
             <label class="auth-label">Email</label>
             <input type="email" value="{{ invite.email }}" disabled
-                   class="auth-input crm-input">
+                   class="auth-input">
           </div>
 
           <div>
             <label class="auth-label" for="inviteUsername">Username</label>
             <input id="inviteUsername" type="text" name="username" required
-                   class="auth-input crm-input" placeholder="Pick a unique username" autocomplete="username">
+                   class="auth-input" placeholder="Pick a unique username" autocomplete="username">
           </div>
 
           <div>
             <label class="auth-label" for="invitePassword">Password</label>
             <input id="invitePassword" type="password" name="password" required minlength="8"
-                   class="auth-input crm-input" placeholder="Create a secure password" autocomplete="new-password">
+                   class="auth-input" placeholder="Create a secure password" autocomplete="new-password">
             <div class="mt-2">
               <div class="h-2 rounded-full overflow-hidden" style="background: rgba(255,255,255,0.12);">
                 <div id="passwordStrengthBar" class="h-2 w-1/4 bg-rose-400" style="transition: width .3s ease, background-color .3s ease;"></div>
@@ -49,12 +49,12 @@
             <div>
               <label class="auth-label" for="inviteFirstName">First name</label>
               <input id="inviteFirstName" type="text" name="first_name" required
-                     class="auth-input crm-input" placeholder="First name" autocomplete="given-name">
+                     class="auth-input" placeholder="First name" autocomplete="given-name">
             </div>
             <div>
               <label class="auth-label" for="inviteLastName">Last name</label>
               <input id="inviteLastName" type="text" name="last_name" required
-                     class="auth-input crm-input" placeholder="Last name" autocomplete="family-name">
+                     class="auth-input" placeholder="Last name" autocomplete="family-name">
             </div>
           </div>
 
@@ -62,12 +62,12 @@
             <div>
               <label class="auth-label" for="invitePhone">Phone (optional)</label>
               <input id="invitePhone" type="tel" name="phone"
-                     class="auth-input crm-input" placeholder="(555) 123-4567" autocomplete="tel">
+                     class="auth-input" placeholder="(555) 123-4567" autocomplete="tel">
             </div>
             <div>
               <label class="auth-label" for="inviteLicense">License # (optional)</label>
               <input id="inviteLicense" type="text" name="license_number"
-                     class="auth-input crm-input" placeholder="Real estate license">
+                     class="auth-input" placeholder="Real estate license">
             </div>
           </div>
 

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -396,20 +396,18 @@
             <input type="hidden" name="next" id="nextUrl" value="{{ request.args.get('next', '') }}">
 
             <!-- Username -->
-            <div class="t-input-wrap{% if form.username.errors %} is-error{% endif %}">
+            <div>
               <label class="label" for="{{ form.username.id }}">Email or username</label>
-              {{ form.username(class="input crm-input t-input", placeholder="you@company.com", autocomplete="username") }}
+              {{ form.username(class="input", placeholder="you@company.com", autocomplete="username") }}
               {% if form.username.errors %}
                 {% for error in form.username.errors %}
-                  <p class="t-error-msg text-red-600 text-xs mt-1">{{ error }}</p>
+                  <p class="text-red-600 text-xs mt-1">{{ error }}</p>
                 {% endfor %}
-              {% else %}
-              <p class="t-error-msg"></p>
               {% endif %}
             </div>
 
             <!-- Password -->
-            <div class="t-input-wrap{% if form.password.errors %} is-error{% endif %}">
+            <div>
               <div class="flex items-center justify-between">
                 <label class="label" for="{{ form.password.id }}">Password</label>
                 <a href="{{ url_for('auth.reset_request') }}" class="hint-link">Forgot password?</a>
@@ -417,7 +415,7 @@
 
               <div class="flex gap-2">
                 <div class="flex-1">
-                  {{ form.password(class="input crm-input t-input", placeholder="••••••••", autocomplete="current-password") }}
+                  {{ form.password(class="input", placeholder="••••••••", autocomplete="current-password") }}
                 </div>
                 <button type="button" class="icon-btn" id="togglePassword" aria-label="Show password">
                   <i class="fas fa-eye"></i>
@@ -426,10 +424,8 @@
 
               {% if form.password.errors %}
                 {% for error in form.password.errors %}
-                  <p class="t-error-msg text-red-600 text-xs mt-1">{{ error }}</p>
+                  <p class="text-red-600 text-xs mt-1">{{ error }}</p>
                 {% endfor %}
-              {% else %}
-              <p class="t-error-msg"></p>
               {% endif %}
             </div>
 

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -274,20 +274,20 @@
             <div>
               <label class="label" for="company_name">Brokerage or team</label>
               <input type="text" name="company_name" id="company_name" required
-                     class="input crm-input" placeholder="Acme Realty" autocomplete="organization">
+                     class="input" placeholder="Acme Realty" autocomplete="organization">
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label class="label" for="{{ form.first_name.id }}">First name</label>
-                {{ form.first_name(class="input crm-input", placeholder="First", autocomplete="given-name") }}
+                {{ form.first_name(class="input", placeholder="First", autocomplete="given-name") }}
                 {% for error in form.first_name.errors %}
                   <p class="text-red-600 text-xs mt-1">{{ error }}</p>
                 {% endfor %}
               </div>
               <div>
                 <label class="label" for="{{ form.last_name.id }}">Last name</label>
-                {{ form.last_name(class="input crm-input", placeholder="Last", autocomplete="family-name") }}
+                {{ form.last_name(class="input", placeholder="Last", autocomplete="family-name") }}
                 {% for error in form.last_name.errors %}
                   <p class="text-red-600 text-xs mt-1">{{ error }}</p>
                 {% endfor %}
@@ -296,7 +296,7 @@
 
             <div>
               <label class="label" for="{{ form.email.id }}">Email</label>
-              {{ form.email(class="input crm-input", placeholder="you@brokerage.com", autocomplete="email") }}
+              {{ form.email(class="input", placeholder="you@brokerage.com", autocomplete="email") }}
               {% for error in form.email.errors %}
                 <p class="text-red-600 text-xs mt-1">{{ error }}</p>
               {% endfor %}
@@ -304,7 +304,7 @@
 
             <div>
               <label class="label" for="{{ form.password.id }}">Password</label>
-              {{ form.password(class="input crm-input", placeholder="••••••••", autocomplete="new-password") }}
+              {{ form.password(class="input", placeholder="••••••••", autocomplete="new-password") }}
               {% for error in form.password.errors %}
                 <p class="text-red-600 text-xs mt-1">{{ error }}</p>
               {% endfor %}
@@ -312,7 +312,7 @@
 
             <div>
               <label class="label" for="{{ form.confirm_password.id }}">Confirm password</label>
-              {{ form.confirm_password(class="input crm-input", placeholder="Repeat password", autocomplete="new-password") }}
+              {{ form.confirm_password(class="input", placeholder="Repeat password", autocomplete="new-password") }}
               {% for error in form.confirm_password.errors %}
                 <p class="text-red-600 text-xs mt-1">{{ error }}</p>
               {% endfor %}

--- a/templates/auth/reset_password.html
+++ b/templates/auth/reset_password.html
@@ -25,7 +25,7 @@
 
           <div>
             <label class="auth-label" for="{{ form.password.id }}">New password</label>
-            {{ form.password(class="auth-input crm-input", placeholder="New password", autocomplete="new-password") }}
+            {{ form.password(class="auth-input", placeholder="New password", autocomplete="new-password") }}
             {% for error in form.password.errors %}
               <p class="text-red-400 text-xs mt-1">{{ error }}</p>
             {% endfor %}
@@ -33,7 +33,7 @@
 
           <div>
             <label class="auth-label" for="{{ form.confirm_password.id }}">Confirm password</label>
-            {{ form.confirm_password(class="auth-input crm-input", placeholder="Confirm new password", autocomplete="new-password") }}
+            {{ form.confirm_password(class="auth-input", placeholder="Confirm new password", autocomplete="new-password") }}
             {% for error in form.confirm_password.errors %}
               <p class="text-red-400 text-xs mt-1">{{ error }}</p>
             {% endfor %}

--- a/templates/auth/reset_request.html
+++ b/templates/auth/reset_request.html
@@ -25,7 +25,7 @@
 
           <div>
             <label class="auth-label" for="{{ form.email.id }}">Email</label>
-            {{ form.email(class="auth-input crm-input", placeholder="you@brokerage.com", autocomplete="email") }}
+            {{ form.email(class="auth-input", placeholder="you@brokerage.com", autocomplete="email") }}
             {% for error in form.email.errors %}
               <p class="text-red-400 text-xs mt-1">{{ error }}</p>
             {% endfor %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -132,28 +132,60 @@
             min-height: 100%;
             background: #f4f4f4 !important;
         }
-        /* Auth forms: beat the global dark-theme input shell. */
-        body.crm-auth-page .login-page input.input,
-        body.crm-auth-page .register-page input.input {
+        /* Auth forms: beat the global dark-theme input shell.
+           crm-input / t-input / DaisyUI .input still leak without fill-color
+           and radius locks. The full family lock lives in auth-family.css. */
+        body.crm-auth-page {
+            color-scheme: light;
+        }
+        body.crm-auth-page .login-page .card,
+        body.crm-auth-page .register-page .card {
             background: #ffffff !important;
             background-color: #ffffff !important;
             color: rgba(0, 0, 0, 0.88) !important;
+        }
+        body.crm-auth-page .login-page input.input,
+        body.crm-auth-page .login-page input.crm-input,
+        body.crm-auth-page .login-page input.t-input,
+        body.crm-auth-page .register-page input.input,
+        body.crm-auth-page .register-page input.crm-input {
+            background: #ffffff !important;
+            background-color: #ffffff !important;
+            color: rgba(0, 0, 0, 0.88) !important;
+            -webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;
             border-color: rgba(0, 0, 0, 0.10) !important;
+            border-radius: 12px !important;
+            box-shadow: none !important;
             caret-color: rgba(0, 0, 0, 0.88);
+            color-scheme: light;
         }
         body.crm-auth-page .login-page input.input::placeholder,
-        body.crm-auth-page .register-page input.input::placeholder {
+        body.crm-auth-page .login-page input.crm-input::placeholder,
+        body.crm-auth-page .register-page input.input::placeholder,
+        body.crm-auth-page .register-page input.crm-input::placeholder {
             color: rgba(0, 0, 0, 0.35) !important;
+            -webkit-text-fill-color: rgba(0, 0, 0, 0.35) !important;
         }
-        body.crm-auth-page .auth-card input.auth-input {
+        body.crm-auth-page .auth-card input.auth-input,
+        body.crm-auth-page .auth-card input.crm-input {
             background: #3a3a3c !important;
             background-color: #3a3a3c !important;
             color: hsla(0, 0%, 100%, 0.92) !important;
+            -webkit-text-fill-color: hsla(0, 0%, 100%, 0.92) !important;
             border-color: rgba(255, 255, 255, 0.12) !important;
+            border-radius: 12px !important;
+            box-shadow: none !important;
             caret-color: hsla(0, 0%, 100%, 0.92);
+            color-scheme: dark;
         }
-        body.crm-auth-page .auth-card input.auth-input::placeholder {
+        body.crm-auth-page .auth-card input.auth-input::placeholder,
+        body.crm-auth-page .auth-card input.crm-input::placeholder {
             color: hsla(0, 0%, 100%, 0.36) !important;
+            -webkit-text-fill-color: hsla(0, 0%, 100%, 0.36) !important;
+        }
+        body.crm-auth-page .t-input:not(:focus),
+        body.crm-auth-page .t-input-wrap {
+            box-shadow: none !important;
         }
 
         /* Top header: transparent (sits on the shared shell gradient) */
@@ -2336,6 +2368,7 @@
         button.crm-btn-critical:disabled { opacity: 0.6; cursor: default; }
     </style>
     {% block head_scripts %}{% endblock %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/auth-family.css') }}">
 </head>
 
 <body class="crm-shell h-screen flex flex-col{% if request.endpoint in ('auth.login', 'auth.register', 'auth.reset_request', 'auth.reset_password', 'auth.accept_invite', 'auth.complete_invite', 'auth.terms_privacy') %} crm-auth-page{% endif %}">

--- a/tests/auth_family_contrast.py
+++ b/tests/auth_family_contrast.py
@@ -1,0 +1,417 @@
+"""Shared public-auth contrast contracts for Playwright.
+
+Login/register are a light form. Reset/invite use a dark card. Both sit on
+body.crm-auth-page and inherit html[data-theme]. These helpers fail when
+dark-theme crm-input tokens, near-white type, or leftover t-input orange
+slabs win on those screens.
+
+Do not import this from pytest unit tests. CI unit does not install a
+Playwright browser. run_tests.py is the browser job.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from models import OrganizationInvite, User, db
+
+
+AUTH_FAMILY_THEMES = ("dark", "light")
+
+_LIGHT_COPY = (
+    ".title",
+    ".subtitle",
+    ".kicker",
+    ".label",
+    ".hint-link",
+    ".footer-link",
+    ".support-row",
+    ".support-action",
+    ".legal",
+    ".text-slate-600",
+)
+
+_DARK_COPY = (
+    ".auth-title",
+    ".auth-subtitle",
+    ".auth-kicker",
+    ".auth-label",
+    ".auth-back",
+    ".auth-notice",
+)
+
+
+def auth_family_page_specs(reset_path: str, invite_path: str) -> list[dict]:
+    """Return the five public auth screens. Caller supplies live token URLs."""
+    return [
+        {
+            "name": "login",
+            "path": "/login",
+            "form_kind": "light",
+            "scope": ".login-page",
+            "expect_text": ("Sign in", "Forgot password?"),
+            "copy": list(_LIGHT_COPY),
+            "fill": (
+                ("input[name='username']", "agent@example.com"),
+                ("input[name='password']", "not-a-real-password"),
+            ),
+        },
+        {
+            "name": "register",
+            "path": "/register",
+            "form_kind": "light",
+            "scope": ".register-page",
+            "expect_text": (
+                "Create your account.",
+                "More on what's included is on",
+                "the free real estate CRM page",
+            ),
+            "copy": list(_LIGHT_COPY),
+            "fill": (
+                ("input[name='email']", "new-agent@example.com"),
+                ("input[name='password']", "not-a-real-password"),
+            ),
+        },
+        {
+            "name": "forgot-password",
+            "path": "/reset_password",
+            "form_kind": "dark",
+            "scope": ".auth-card",
+            "expect_text": ("Forgot Password?",),
+            "copy": list(_DARK_COPY),
+            "fill": (("input[name='email']", "agent@example.com"),),
+        },
+        {
+            "name": "reset-password",
+            "path": reset_path,
+            "form_kind": "dark",
+            "scope": ".auth-card",
+            "expect_text": ("Create New Password",),
+            "copy": list(_DARK_COPY),
+            "fill": (
+                ("input[name='password']", "not-a-real-password"),
+                ("input[name='confirm_password']", "not-a-real-password"),
+            ),
+        },
+        {
+            "name": "accept-invite",
+            "path": invite_path,
+            "form_kind": "dark",
+            "scope": ".auth-card",
+            "expect_text": ("You're invited to join",),
+            "copy": list(_DARK_COPY),
+            "fill": (
+                ("input[name='username']", "invitee_browser"),
+                ("input[name='first_name']", "Pat"),
+            ),
+        },
+    ]
+
+
+def seed_auth_family_urls(username: str) -> dict[str, str]:
+    """Mint a live reset token and invite against the browser-test database."""
+    from app import create_app
+
+    app = create_app()
+    with app.app_context():
+        user = (
+            User.query.filter_by(email=username).first()
+            or User.query.filter_by(username=username).first()
+        )
+        if user is None:
+            raise RuntimeError(
+                f"Browser test user {username} is missing. "
+                "Run tests/bootstrap_browser_test_db.py first."
+            )
+        reset_token = user.get_reset_token()
+        invite_token = OrganizationInvite.generate_token()
+        db.session.add(
+            OrganizationInvite(
+                organization_id=user.organization_id,
+                email="auth-family-invitee@example.com",
+                invited_by_id=user.id,
+                role="agent",
+                token=invite_token,
+                expires_at=datetime.utcnow() + timedelta(hours=24),
+            )
+        )
+        db.session.commit()
+    return {
+        "reset": f"/reset_password/{reset_token}",
+        "invite": f"/invite/{invite_token}",
+    }
+
+
+def assert_auth_family_report(report: dict, page_name: str, theme: str) -> None:
+    if report.get("error"):
+        raise AssertionError(f"{page_name} theme={theme}: {report['error']}")
+    if report.get("theme") != theme:
+        raise AssertionError(
+            f"{page_name}: html[data-theme] is {report.get('theme')!r}, "
+            f"expected {theme!r}"
+        )
+    failures = report.get("failures") or []
+    if failures:
+        raise AssertionError(f"{page_name} theme={theme}: " + "; ".join(failures))
+
+
+COLLECT_AUTH_FAMILY_REPORT = r"""
+(spec) => {
+  const failures = [];
+  const html = document.documentElement;
+  const theme = html.dataset.theme || "";
+  const formKind = spec.form_kind;
+  const scope = document.querySelector(spec.scope);
+  if (!document.body.classList.contains("crm-auth-page")) {
+    return { error: "body.crm-auth-page missing", theme, failures };
+  }
+  if (!scope) {
+    return { error: `scope ${spec.scope} missing`, theme, failures };
+  }
+
+  const parse = (value) => {
+    if (!value || value === "transparent" || value === "none") return null;
+    const m = String(value).match(
+      /rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/i
+    );
+    if (!m) return null;
+    return {
+      r: Number(m[1]),
+      g: Number(m[2]),
+      b: Number(m[3]),
+      a: m[4] === undefined ? 1 : Number(m[4]),
+    };
+  };
+
+  const lin = (c) => {
+    const n = c / 255;
+    return n <= 0.04045 ? n / 12.92 : Math.pow((n + 0.055) / 1.055, 2.4);
+  };
+
+  const lum = (c) => {
+    if (!c) return null;
+    return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b);
+  };
+
+  const composite = (fg, bg) => {
+    if (!fg) return bg;
+    const a = Math.max(0, Math.min(1, fg.a));
+    const base = bg || { r: 255, g: 255, b: 255, a: 1 };
+    return {
+      r: fg.r * a + base.r * (1 - a),
+      g: fg.g * a + base.g * (1 - a),
+      b: fg.b * a + base.b * (1 - a),
+      a: 1,
+    };
+  };
+
+  const contrast = (a, b) => {
+    const la = lum(a);
+    const lb = lum(b);
+    if (la == null || lb == null) return null;
+    const hi = Math.max(la, lb);
+    const lo = Math.min(la, lb);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  const near = (a, b, tol) => {
+    if (!a || !b) return false;
+    return (
+      Math.abs(a.r - b.r) <= tol &&
+      Math.abs(a.g - b.g) <= tol &&
+      Math.abs(a.b - b.b) <= tol
+    );
+  };
+
+  const isOrange = (c) => {
+    if (!c || c.a < 0.06) return false;
+    const span = Math.max(c.r, c.g, c.b) - Math.min(c.r, c.g, c.b);
+    if (span < 28) return false;
+    return c.r > 180 && c.g > 40 && c.g < 210 && c.b < 140 && c.r - c.b > 50;
+  };
+
+  const orangeIn = (value) => {
+    if (!value || value === "none" || value === "transparent") return false;
+    const re = /rgba?\(([^)]+)\)/gi;
+    let match;
+    while ((match = re.exec(String(value)))) {
+      const parts = match[1].split(",").map((s) => s.trim());
+      const color = {
+        r: Number(parts[0]),
+        g: Number(parts[1]),
+        b: Number(parts[2]),
+        a: parts[3] === undefined ? 1 : Number(parts[3]),
+      };
+      if (isOrange(color)) return true;
+    }
+    return false;
+  };
+
+  const visibleTextColor = (style) => {
+    const fill = parse(style.webkitTextFillColor);
+    if (fill && fill.a > 0.02) return fill;
+    return parse(style.color);
+  };
+
+  const probe = document.createElement("div");
+  probe.style.color = "var(--ink)";
+  probe.style.backgroundColor = "var(--paper)";
+  probe.style.position = "absolute";
+  probe.style.left = "-9999px";
+  document.body.appendChild(probe);
+  const ink = parse(getComputedStyle(probe).color);
+  const paper = parse(getComputedStyle(probe).backgroundColor);
+  probe.remove();
+  const inkLum = lum(ink);
+
+  const skipInput = (el) => {
+    const type = (el.type || "").toLowerCase();
+    if (["hidden", "checkbox", "radio", "submit", "button", "file"].includes(type)) {
+      return true;
+    }
+    if (el.name === "referral_code") return true;
+    if (el.closest(".left")) return true;
+    const box = el.getBoundingClientRect();
+    return box.width < 2 || box.height < 2;
+  };
+
+  const skipCopy = (el) => {
+    if (!el || el.closest(".left")) return true;
+    if (el.closest(".btn, .auth-btn, button[type='submit']")) return true;
+    if (el.closest("#passwordStrengthBar")) return true;
+    const box = el.getBoundingClientRect();
+    return box.width < 2 || box.height < 2;
+  };
+
+  const inputs = [...scope.querySelectorAll("input")].filter((el) => !skipInput(el));
+  if (!inputs.length) {
+    failures.push("no visible inputs in scope");
+  }
+
+  for (const el of inputs) {
+    const cls = el.className || "";
+    const label = `${el.name || el.id || el.type} (${cls})`;
+    if (el.classList.contains("crm-input") || el.classList.contains("t-input")) {
+      failures.push(`${label} still uses crm-input/t-input`);
+    }
+    if (el.closest(".t-input-wrap")) {
+      failures.push(`${label} is still inside t-input-wrap`);
+    }
+
+    const style = getComputedStyle(el);
+    const bg = parse(style.backgroundColor) || { r: 255, g: 255, b: 255, a: 1 };
+    const fg = visibleTextColor(style);
+    const phStyle = getComputedStyle(el, "::placeholder");
+    const ph = visibleTextColor(phStyle);
+    const solidBg = composite(bg, { r: 255, g: 255, b: 255, a: 1 });
+    const textOnBg = composite(fg, solidBg);
+    const phOnBg = composite(ph, solidBg);
+    const bgLum = lum(solidBg);
+    const textLum = lum(textOnBg);
+    const phLum = lum(phOnBg);
+    const textContrast = contrast(textOnBg, solidBg);
+    const phContrast = contrast(phOnBg, solidBg);
+
+    if (document.activeElement === el) {
+      failures.push(`${label} was focused while measuring rest state`);
+    }
+    if (orangeIn(style.boxShadow)) {
+      failures.push(`${label} rest box-shadow still has an orange halo (${style.boxShadow})`);
+    }
+    if (orangeIn(style.backgroundColor) || orangeIn(style.backgroundImage)) {
+      failures.push(`${label} rest background is an orange smear`);
+    }
+
+    if (formKind === "light") {
+      if (bgLum != null && bgLum < 0.75) {
+        failures.push(
+          `${label} light form picked up a dark field background ${style.backgroundColor}`
+        );
+      }
+      if (textLum != null && textLum > 0.62) {
+        failures.push(
+          `${label} typed/value text is near-white on a light field ` +
+            `(fill=${style.webkitTextFillColor}, color=${style.color}, bg=${style.backgroundColor})`
+        );
+      }
+      if (phLum != null && phLum > 0.72) {
+        failures.push(
+          `${label} placeholder is near-white on a light field ` +
+            `(${phStyle.webkitTextFillColor || phStyle.color})`
+        );
+      }
+      if (textContrast != null && textContrast < 3) {
+        failures.push(`${label} value contrast ${textContrast.toFixed(2)} is too low`);
+      }
+      if (phContrast != null && phContrast < 1.35) {
+        failures.push(`${label} placeholder contrast ${phContrast.toFixed(2)} is invisible`);
+      }
+      if (inkLum != null && inkLum > 0.7 && near(fg, ink, 10)) {
+        failures.push(
+          `${label} computed text matches dark-theme var(--ink) (${style.color})`
+        );
+      }
+      if (
+        inkLum != null &&
+        inkLum > 0.7 &&
+        near(fg, ink, 10) &&
+        paper &&
+        near(solidBg, paper, 14)
+      ) {
+        failures.push(
+          `${label} dark-theme crm-input tokens won (var(--ink) on var(--paper))`
+        );
+      }
+      if (/\bdark\b/.test(style.colorScheme) && !/\blight\b/.test(style.colorScheme)) {
+        failures.push(`${label} color-scheme is still dark on a light form`);
+      }
+    } else {
+      if (bgLum != null && bgLum > 0.5) {
+        failures.push(
+          `${label} dark card picked up a light field background ${style.backgroundColor}`
+        );
+      }
+      if (textLum != null && textLum < 0.4) {
+        failures.push(
+          `${label} typed/value text is too dark on the dark card ` +
+            `(${style.webkitTextFillColor}, ${style.color})`
+        );
+      }
+      if (phContrast != null && phContrast < 1.25) {
+        failures.push(`${label} placeholder contrast ${phContrast.toFixed(2)} is invisible`);
+      }
+    }
+  }
+
+  const copyNodes = [];
+  for (const selector of spec.copy || []) {
+    for (const el of scope.querySelectorAll(selector)) {
+      if (!skipCopy(el)) copyNodes.push([selector, el]);
+    }
+  }
+
+  for (const [selector, el] of copyNodes) {
+    const style = getComputedStyle(el);
+    const name = `${selector} "${(el.textContent || "").trim().slice(0, 48)}"`;
+    if (orangeIn(style.backgroundColor) || orangeIn(style.backgroundImage)) {
+      failures.push(`${name} has an orange highlight/ghost background`);
+    }
+    if (orangeIn(style.boxShadow)) {
+      failures.push(`${name} has an orange halo (${style.boxShadow})`);
+    }
+  }
+
+  const sheets = [...document.styleSheets].map((s) => s.href || "");
+  if (!sheets.some((href) => href.includes("auth-family"))) {
+    failures.push("auth-family.css is not loaded");
+  }
+
+  return {
+    theme,
+    formKind,
+    failures,
+    ink,
+    paper,
+    inputCount: inputs.length,
+  };
+}
+"""

--- a/tests/auth_family_contrast.py
+++ b/tests/auth_family_contrast.py
@@ -36,7 +36,6 @@ _DARK_COPY = (
     ".auth-kicker",
     ".auth-label",
     ".auth-back",
-    ".auth-notice",
 )
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -23,6 +23,13 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from playwright.sync_api import sync_playwright, expect
+from tests.auth_family_contrast import (
+    AUTH_FAMILY_THEMES,
+    COLLECT_AUTH_FAMILY_REPORT,
+    assert_auth_family_report,
+    auth_family_page_specs,
+    seed_auth_family_urls,
+)
 from tests.browser_test_support import configure_browser_test_environment, ensure_local_base_url
 
 configure_browser_test_environment(project_root)
@@ -171,6 +178,95 @@ class CRMTestSuite:
         }""")
     
     # ==================== AUTHENTICATION TESTS ====================
+
+    def test_public_auth_family_contrast(self):
+        """Every public auth page, both document themes: readable fields, no orange smear."""
+        test_name = "Public auth family contrast"
+        self.log(test_name, "test")
+
+        try:
+            urls = seed_auth_family_urls(self.test_username)
+            specs = auth_family_page_specs(urls["reset"], urls["invite"])
+            for spec in specs:
+                for theme in AUTH_FAMILY_THEMES:
+                    self.log(f"{spec['name']} data-theme={theme}...", "step")
+                    self._assert_auth_family_page(spec, theme)
+                    self.log("", "ok")
+
+            self.log("", "pass")
+            self.results.add_pass()
+        except Exception as e:
+            self.log(str(e), "error")
+            self.log("", "fail")
+            self.results.add_fail(test_name, str(e))
+
+    def _assert_auth_family_page(self, spec, theme):
+        self.page.evaluate(
+            """(nextTheme) => {
+                try { localStorage.setItem('crm-theme', nextTheme); } catch (e) {}
+            }""",
+            theme,
+        )
+        self.page.goto(f"{self.base_url}{spec['path']}")
+        self.page.wait_for_load_state("domcontentloaded")
+        if spec["name"] == "reset-password" and "/reset_password/" not in self.page.url:
+            raise AssertionError(
+                "reset-password token bounced off /reset_password/<token>. "
+                "SECRET_KEY mismatch between the test process and the app."
+            )
+        if spec["name"] == "accept-invite" and "/invite/" not in self.page.url:
+            raise AssertionError(
+                "accept-invite redirected away from /invite/<token>. "
+                "The seeded invite is missing or expired."
+            )
+
+        self.page.wait_for_function(
+            """() => document.body && document.body.classList.contains('crm-auth-page')""",
+            timeout=8000,
+        )
+        self.page.wait_for_function(
+            """() => [...document.styleSheets].some((sheet) => (sheet.href || '').includes('auth-family'))""",
+            timeout=8000,
+        )
+        self._set_theme(theme)
+        self.page.wait_for_function(
+            """(theme) => document.documentElement.dataset.theme === theme""",
+            theme,
+            timeout=5000,
+        )
+        try:
+            self.page.wait_for_function(
+                """() => [...document.styleSheets].some((sheet) => (sheet.href || '').includes('daisyui'))""",
+                timeout=4000,
+            )
+        except Exception:
+            pass
+
+        body = self.page.locator("body").inner_text()
+        for snippet in spec["expect_text"]:
+            if snippet not in body:
+                raise AssertionError(f"{spec['name']} missing {snippet!r}")
+
+        scope = self.page.locator(spec["scope"]).first
+        if scope.count() == 0:
+            raise AssertionError(f"{spec['name']} missing {spec['scope']}")
+
+        for selector, value in spec["fill"]:
+            field = scope.locator(selector).first
+            field.wait_for(state="visible", timeout=5000)
+            field.fill(value)
+
+        self.page.evaluate(
+            """() => {
+                if (document.activeElement && document.activeElement.blur) {
+                    document.activeElement.blur();
+                }
+            }"""
+        )
+        self.page.wait_for_timeout(80)
+
+        report = self.page.evaluate(COLLECT_AUTH_FAMILY_REPORT, spec)
+        assert_auth_family_report(report, spec["name"], theme)
     
     def test_login(self):
         """Test login with valid credentials."""
@@ -1122,6 +1218,7 @@ class CRMTestSuite:
             self.setup()
             
             # Authentication tests
+            self.test_public_auth_family_contrast()
             self.test_login()
             self.test_dashboard_access()
             

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -231,7 +231,7 @@ class CRMTestSuite:
         self._set_theme(theme)
         self.page.wait_for_function(
             """(theme) => document.documentElement.dataset.theme === theme""",
-            theme,
+            arg=theme,
             timeout=5000,
         )
         try:
@@ -242,9 +242,9 @@ class CRMTestSuite:
         except Exception:
             pass
 
-        body = self.page.locator("body").inner_text()
+        body = self.page.locator("body").inner_text().lower()
         for snippet in spec["expect_text"]:
-            if snippet not in body:
+            if snippet.lower() not in body:
                 raise AssertionError(f"{spec['name']} missing {snippet!r}")
 
         scope = self.page.locator(spec["scope"]).first

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -203,6 +203,16 @@ class TestAuthPagesRender:
             "transactions, and team workspace."
         ) not in html
 
+    def test_login_fields_are_not_crm_input(self, client, seed):
+        resp = client.get('/login')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'crm-auth-page' in html
+        assert 'css/auth-family.css' in html
+        assert 'class="input crm-input' not in html
+        assert 'class="input t-input' not in html
+        assert 'class="t-input-wrap' not in html
+
     def test_register_uses_dark_mark_on_dark_rail(self, client, seed):
         resp = client.get('/register')
         assert resp.status_code == 200
@@ -229,6 +239,16 @@ class TestAuthPagesRender:
         assert "Pipeline and activity without a second tool." not in html
         assert "Ask it to add a contact or count clients in a ZIP." not in html
         assert "Telegram after a QR from your profile" not in html
+
+    def test_register_fields_are_not_crm_input(self, client, seed):
+        resp = client.get('/register')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'crm-auth-page' in html
+        assert 'css/auth-family.css' in html
+        assert 'class="input crm-input' not in html
+        assert "More on what's included is on" in html
+        assert "the free real estate CRM page" in html
 
     def test_reset_request_uses_dark_mark_on_card(self, client, seed):
         resp = client.get('/reset_password')

--- a/tests/test_auth_family_css.py
+++ b/tests/test_auth_family_css.py
@@ -1,0 +1,122 @@
+"""Lock public auth screens off dark-theme crm-input and t-input leftovers."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_AUTH = (
+    "templates/auth/login.html",
+    "templates/auth/register.html",
+    "templates/auth/reset_request.html",
+    "templates/auth/reset_password.html",
+    "templates/auth/accept_invite.html",
+    "templates/auth/_styles.html",
+    "templates/auth/terms_privacy.html",
+)
+
+
+def _read(*parts):
+    return ROOT.joinpath(*parts).read_text()
+
+
+def _public_auth_html():
+    return {path: _read(*path.split("/")) for path in PUBLIC_AUTH}
+
+
+class TestPublicAuthDropsCrmInputLeak:
+    def test_public_auth_fields_do_not_use_crm_input_or_t_input(self):
+        for path, html in _public_auth_html().items():
+            assert "crm-input" not in html, path
+            assert "t-input" not in html, path
+            assert "t-input-wrap" not in html, path
+
+    def test_login_and_register_keep_shipped_input_class(self):
+        login = _read("templates", "auth", "login.html")
+        register = _read("templates", "auth", "register.html")
+        assert 'class="input"' in login
+        assert 'class="input crm-input' not in login
+        assert 'class="input"' in register
+        assert "class=\"input crm-input" not in register
+
+    def test_reset_and_invite_keep_auth_input_only(self):
+        reset_request = _read("templates", "auth", "reset_request.html")
+        reset_password = _read("templates", "auth", "reset_password.html")
+        invite = _read("templates", "auth", "accept_invite.html")
+        styles = _read("templates", "auth", "_styles.html")
+        assert "auth-input" in reset_request
+        assert "auth-input" in reset_password
+        assert "auth-input" in invite
+        assert ".auth-input" in styles
+        assert "crm-input" not in reset_request
+        assert "crm-input" not in reset_password
+        assert "crm-input" not in invite
+
+    def test_register_keeps_free_crm_sentence(self):
+        register = _read("templates", "auth", "register.html")
+        assert "More on what's included is on" in register
+        assert "the free real estate CRM page" in register
+        assert "url_for('main.free_real_estate_crm')" in register
+
+
+class TestAuthFamilyCssLock:
+    def test_base_links_auth_family_sheet_once(self):
+        base = _read("templates", "base.html")
+        assert base.count("css/auth-family.css") == 1
+
+    def test_lock_beats_dark_theme_crm_input_color(self):
+        css = _read("static", "css", "auth-family.css")
+        assert "body.crm-auth-page" in css
+        assert "input.crm-input" in css
+        assert "-webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;" in css
+        assert "color: rgba(0, 0, 0, 0.88) !important;" in css
+        assert "html[data-theme=\"dark\"] body.crm-auth-page" in css
+        assert "html.am-skin[data-theme=\"dark\"] body.crm-auth-page" in css
+        assert "color: var(--ink)" not in css.split("near-white inherited type", 1)[1]
+        assert "background: var(--paper)" not in css.split("near-white inherited type", 1)[1]
+
+    def test_lock_beats_t_input_rest_halo(self):
+        css = _read("static", "css", "auth-family.css")
+        assert "body.crm-auth-page .t-input:not(:focus)" in css
+        assert "body.crm-auth-page .t-input-wrap" in css
+        assert "box-shadow: none !important;" in css
+        wrap = css.split("t-input leftover", 1)[1]
+        assert "box-shadow: none !important;" in wrap
+        assert ".t-clear-glow" in wrap
+
+    def test_light_form_placeholders_are_dark(self):
+        css = _read("static", "css", "auth-family.css")
+        assert "input::placeholder" in css
+        assert "-webkit-text-fill-color: rgba(0, 0, 0, 0.35) !important;" in css
+
+    def test_dark_auth_card_beats_crm_input_too(self):
+        css = _read("static", "css", "auth-family.css")
+        assert "body.crm-auth-page .auth-card input.crm-input" in css
+        assert "-webkit-text-fill-color: hsla(0, 0%, 100%, 0.92) !important;" in css
+        assert "color-scheme: dark;" in css
+
+    def test_selection_is_not_accent_soft(self):
+        css = _read("static", "css", "auth-family.css")
+        assert "body.crm-auth-page ::selection" in css
+        assert "var(--accent-soft)" not in css
+        assert "var(--accent-ink)" not in css
+        assert "background: rgba(0, 0, 0, 0.14);" in css
+
+
+class TestAmSkinAuthDoesNotReintroduceLeak:
+    def test_am_skin_auth_inputs_do_not_use_ink_tokens(self):
+        css = _read("static", "css", "am_skin.css")
+        auth = css.split("/* ── Auth pages", 1)[1].split("/* ── Shared CRM primitives", 1)[0]
+        assert "body.crm-auth-page" in auth
+        assert "var(--ink)" not in auth
+        assert "var(--paper)" not in auth
+        assert "var(--am-control-bg)" not in auth
+        assert "-webkit-text-fill-color: rgba(0, 0, 0, 0.88) !important;" in auth
+        assert "input.crm-input" in auth
+        assert "box-shadow: none !important;" in auth
+        assert "body.crm-auth-page ::selection" in auth
+        assert "var(--accent-soft)" not in auth
+
+    def test_am_skin_global_crm_input_still_exists_for_app(self):
+        css = _read("static", "css", "am_skin.css")
+        global_inputs = css.split("/* ── Auth pages", 1)[0]
+        assert "html.am-skin input.crm-input" in global_inputs
+        assert "color: var(--ink) !important;" in global_inputs

--- a/tests/test_auth_family_ui.py
+++ b/tests/test_auth_family_ui.py
@@ -1,0 +1,96 @@
+"""Rendered HTML contracts for every public auth page.
+
+Browser contrast lives in tests/run_tests.py. This file is the Flask-client
+half: all five public screens stay off crm-input / t-input, keep
+auth-family.css, and register still has the #368 free-CRM sentence.
+
+Do not point these checks at marketing or listing-package chrome.
+Do not weaken tests/test_landing_copy.py TestRegisterLeftoverCopy.
+"""
+import re
+from datetime import datetime, timedelta
+
+from models import OrganizationInvite, User, db
+
+_LEAKY_INPUT = re.compile(
+    r"<input\b[^>]*\bclass=\"[^\"]*\b(?:crm-input|t-input)\b[^\"]*\"",
+    re.I,
+)
+
+
+def _html(resp):
+    assert resp.status_code == 200, resp.status_code
+    return resp.get_data(as_text=True)
+
+
+def _assert_public_auth_lock(html, *must_have):
+    assert "crm-auth-page" in html
+    assert "css/auth-family.css" in html
+    assert 'class="input crm-input' not in html
+    assert 'class="input t-input' not in html
+    assert 'class="t-input-wrap' not in html
+    leaky = _LEAKY_INPUT.findall(html)
+    assert leaky == [], leaky
+    for snippet in must_have:
+        assert snippet in html, snippet
+
+
+class TestPublicAuthPagesStayLocked:
+    def test_login_page(self, client, seed):
+        html = _html(client.get("/login"))
+        _assert_public_auth_lock(html, "Sign in", "Forgot password?")
+
+    def test_register_page_keeps_368_sentence(self, client, seed):
+        html = _html(client.get("/register"))
+        _assert_public_auth_lock(
+            html,
+            "Create your account.",
+            "More on what's included is on",
+            "the free real estate CRM page",
+            'href="/free-real-estate-crm"',
+        )
+        assert html.count("the free real estate CRM page") == 1
+        assert html.count('href="/free-real-estate-crm"') == 1
+
+    def test_forgot_password_page(self, client, seed):
+        html = _html(client.get("/reset_password"))
+        _assert_public_auth_lock(html, "Forgot Password?", "auth-input")
+
+    def test_reset_password_page(self, client, app, seed):
+        with app.app_context():
+            user = db.session.get(User, seed["owner_a"])
+            token = user.get_reset_token()
+        html = _html(client.get(f"/reset_password/{token}"))
+        _assert_public_auth_lock(html, "Create New Password", "auth-input")
+        assert "Forgot Password?" not in html
+
+    def test_accept_invite_page(self, client, app, seed):
+        token = "auth-family-ui-invite-token"
+        with app.app_context():
+            existing = OrganizationInvite.query.filter_by(token=token).first()
+            if existing is None:
+                db.session.add(
+                    OrganizationInvite(
+                        organization_id=seed["org_a"],
+                        email="auth-family-ui@test.com",
+                        invited_by_id=seed["owner_a"],
+                        role="agent",
+                        token=token,
+                        expires_at=datetime.utcnow() + timedelta(days=2),
+                    )
+                )
+                db.session.commit()
+        html = _html(client.get(f"/invite/{token}"))
+        _assert_public_auth_lock(html, "You're invited to join", "auth-input")
+
+
+def test_register_368_source_contract_is_untouched():
+    """Guard the #368 test itself so a later edit cannot dilute it."""
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parent.joinpath("test_landing_copy.py").read_text()
+    assert "class TestRegisterLeftoverCopy" in source
+    assert "def test_one_human_link_to_free_real_estate_crm" in source
+    assert 'assert REGISTER.count("url_for(\'main.free_real_estate_crm\')") == 1' in source
+    assert 'assert REGISTER.count("the free real estate CRM page") == 1' in source
+    assert '"More on what\'s included is on" in REGISTER' in source

--- a/tests/test_auth_family_ui.py
+++ b/tests/test_auth_family_ui.py
@@ -23,13 +23,28 @@ def _html(resp):
     return resp.get_data(as_text=True)
 
 
+def _without_contact_modal(html):
+    """The global contact-us modal still uses t-input. That is not an auth field."""
+    start = html.find("<!-- Contact Us Modal -->")
+    if start < 0:
+        marker = html.find('id="contactUsModal"')
+        if marker < 0:
+            return html
+        start = html.rfind("<div", 0, marker + 1)
+    end = html.find("</script>", start)
+    if start < 0 or end < 0:
+        return html
+    return html[:start] + html[end + len("</script>"):]
+
+
 def _assert_public_auth_lock(html, *must_have):
     assert "crm-auth-page" in html
     assert "css/auth-family.css" in html
-    assert 'class="input crm-input' not in html
-    assert 'class="input t-input' not in html
-    assert 'class="t-input-wrap' not in html
-    leaky = _LEAKY_INPUT.findall(html)
+    scoped = _without_contact_modal(html)
+    assert 'class="input crm-input' not in scoped
+    assert 'class="input t-input' not in scoped
+    assert 'class="t-input-wrap' not in scoped
+    leaky = _LEAKY_INPUT.findall(scoped)
     assert leaky == [], leaky
     for snippet in must_have:
         assert snippet in html, snippet


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public login, register, forgot-password, reset, and invite were inheriting in-app dark theme on a light form. Email/password looked blank. After typing, pale orange slabs sat behind headings, typed values, and footer links. Labels stayed black. The left rail was fine.

## Breaking change

This is not a new look. It undoes a leak from three stacked commits:

- **#322 (`db95dab`)** put `.crm-input` on the public auth family (login, register, reset, invite).
- **#352 (`11cb293`)** put `.t-input` / `.t-input-wrap` on login.
- **#296 (`b50ff9c`)** added `html.am-skin input.crm-input { color: var(--ink) !important; background: var(--am-control-bg) !important; }`.

`html[data-theme=dark]` (the document default) plus DaisyUI `.input` then painted near-white ink and accent-soft selection onto the white panel. Existing auth overrides set `color` but not `-webkit-text-fill-color`, radius, or `color-scheme`, so they lost.

#369 and #370 rebuilt `static/dist/app.css` and shipped the leak live. They are not the design to undo.

## What changed

- Dropped `crm-input` and `t-input` / `t-input-wrap` from public auth templates. In-app profile fields still use `crm-input`.
- Added `static/css/auth-family.css`, loaded last, so both document themes keep dark text on the light form and light text on the dark reset/invite card.
- Closed the same gaps in `am_skin.css` and the `base.html` auth block so the Apple Music skin cannot put `--ink` back on these fields.
- Left the orange Sign In / Create account buttons and the dark left rail alone.
- Left the register free-CRM sentence from #368 alone.

## Tests

Flask client, all five public auth pages:

- `/login`, `/register`, `/reset_password`, `/reset_password/<token>`, `/invite/<token>`
- `crm-auth-page`, `auth-family.css`, no `crm-input` / `t-input` on auth fields
- Register still has the #368 sentence and one link to `/free-real-estate-crm`
- `TestRegisterLeftoverCopy.test_one_human_link_to_free_real_estate_crm` is unchanged

Playwright (`tests/run_tests.py`), both `html[data-theme=dark]` and `light`:

- Fails if input or placeholder text is near-white on a light field
- Fails if headings, helper copy, links, or typed values have leftover orange highlight / halo / ghost backgrounds
- Fails if dark-theme `.crm-input` tokens (`var(--ink)` on `var(--paper)`) win on the light forms
- Does not touch marketing or listing-package chrome

Local Playwright run: 10 page/theme pairs passed. A forced `--ink` leak on login fails contrast 1.00.

Does not touch #369 listing chrome, #370 email chrome, or PR 371.

## Screenshots

Login, document theme dark, after typing:

[Login in dark document theme with typed email and password](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-login-dark-typed.png)

Login, document theme light, after typing:

[Login in light document theme with typed email and password](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-login-light-typed.png)

Register, document theme dark:

[Register in dark document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-register-dark-typed.png)

Register, document theme light:

[Register in light document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-register-light-typed.png)

Forgot password, document theme dark:

[Forgot password in dark document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-forgot-password-dark-typed.png)

Forgot password, document theme light:

[Forgot password in light document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-forgot-password-light-typed.png)

Reset password, document theme dark:

[Reset password in dark document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-reset-password-dark-typed.png)

Reset password, document theme light:

[Reset password in light document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-reset-password-light-typed.png)

Accept invite, document theme dark:

[Accept invite in dark document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-accept-invite-dark-typed.png)

Accept invite, document theme light:

[Accept invite in light document theme](https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth-accept-invite-light-typed.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ed3702-5098-42f6-8de5-e9c326ea2351?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ed3702-5098-42f6-8de5-e9c326ea2351&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

