### PR TITLE
seo: free-CRM sentence on login

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -59,6 +59,9 @@
     background: var(--brand-orange);
   }
   .left-muted{ color: hsla(0, 0%, 100%, 0.56); }
+  .left p.text-brand-600{ color: hsla(0, 0%, 100%, 0.56); }
+  .left a.text-brand-800{ color: #fb923c; }
+  .left a.text-brand-800:hover{ color: #f97316; }
   .left-title{
     color: hsla(0, 0%, 100%, 0.92);
     font-weight: 800;
@@ -341,6 +344,9 @@
 
               <p class="mt-3 text-sm lg:text-[15px] left-muted leading-relaxed">
                 Keep your contacts, tasks, and follow-ups in one place.
+              </p>
+              <p class="mt-8 text-brand-600">
+                More on what's included is on <a href="{{ url_for('main.free_real_estate_crm') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">the free real estate CRM page</a>.
               </p>
             </div>
 

--- a/tests/auth_family_contrast.py
+++ b/tests/auth_family_contrast.py
@@ -47,7 +47,12 @@ def auth_family_page_specs(reset_path: str, invite_path: str) -> list[dict]:
             "path": "/login",
             "form_kind": "light",
             "scope": ".login-page",
-            "expect_text": ("Sign in", "Forgot password?"),
+            "expect_text": (
+                "Sign in",
+                "Forgot password?",
+                "More on what's included is on",
+                "the free real estate CRM page",
+            ),
             "copy": list(_LIGHT_COPY),
             "fill": (
                 ("input[name='username']", "agent@example.com"),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -197,6 +197,12 @@ class TestAuthPagesRender:
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert "Keep your contacts, tasks, and follow-ups in one place." in html
+        assert "More on what's included is on" in html
+        assert "the free real estate CRM page" in html
+        assert 'href="/free-real-estate-crm"' in html
+        assert html.count("More on what's included is on") == 1
+        assert html.count("the free real estate CRM page") == 1
+        assert html.count('href="/free-real-estate-crm"') == 1
         assert "Sign in to your contacts and tasks." not in html
         assert (
             "Use your account credentials to access contacts, tasks, "

--- a/tests/test_auth_family_css.py
+++ b/tests/test_auth_family_css.py
@@ -50,6 +50,14 @@ class TestPublicAuthDropsCrmInputLeak:
         assert "crm-input" not in reset_password
         assert "crm-input" not in invite
 
+    def test_login_keeps_free_crm_sentence(self):
+        login = _read("templates", "auth", "login.html")
+        assert "More on what's included is on" in login
+        assert "the free real estate CRM page" in login
+        assert "url_for('main.free_real_estate_crm')" in login
+        assert login.count("url_for('main.free_real_estate_crm')") == 1
+        assert login.count("the free real estate CRM page") == 1
+
     def test_register_keeps_free_crm_sentence(self):
         register = _read("templates", "auth", "register.html")
         assert "More on what's included is on" in register

--- a/tests/test_auth_family_ui.py
+++ b/tests/test_auth_family_ui.py
@@ -2,7 +2,7 @@
 
 Browser contrast lives in tests/run_tests.py. This file is the Flask-client
 half: all five public screens stay off crm-input / t-input, keep
-auth-family.css, and register still has the #368 free-CRM sentence.
+auth-family.css, and login/register have the free-CRM sentence.
 
 Do not point these checks at marketing or listing-package chrome.
 Do not weaken tests/test_landing_copy.py TestRegisterLeftoverCopy.
@@ -53,7 +53,16 @@ def _assert_public_auth_lock(html, *must_have):
 class TestPublicAuthPagesStayLocked:
     def test_login_page(self, client, seed):
         html = _html(client.get("/login"))
-        _assert_public_auth_lock(html, "Sign in", "Forgot password?")
+        _assert_public_auth_lock(
+            html,
+            "Sign in",
+            "Forgot password?",
+            "More on what's included is on",
+            "the free real estate CRM page",
+            'href="/free-real-estate-crm"',
+        )
+        assert html.count("the free real estate CRM page") == 1
+        assert html.count('href="/free-real-estate-crm"') == 1
 
     def test_register_page_keeps_368_sentence(self, client, seed):
         html = _html(client.get("/register"))
@@ -109,3 +118,13 @@ def test_register_368_source_contract_is_untouched():
     assert 'assert REGISTER.count("url_for(\'main.free_real_estate_crm\')") == 1' in source
     assert 'assert REGISTER.count("the free real estate CRM page") == 1' in source
     assert '"More on what\'s included is on" in REGISTER' in source
+
+
+def test_login_source_contract_pins_free_crm_sentence():
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parent.joinpath("test_landing_copy.py").read_text()
+    assert "class TestLoginLeftoverCopy" in source
+    assert 'assert LOGIN.count("url_for(\'main.free_real_estate_crm\')") == 1' in source
+    assert 'assert LOGIN.count("the free real estate CRM page") == 1' in source
+    assert '"More on what\'s included is on" in LOGIN' in source

--- a/tests/test_landing_copy.py
+++ b/tests/test_landing_copy.py
@@ -323,6 +323,16 @@ class TestLandingProductClaims:
         assert "power users" not in LANDING.lower()
 
 
+class TestLoginLeftoverCopy:
+    def test_keeps_login_h1(self):
+        assert "Sign in to continue." in LOGIN
+
+    def test_one_human_link_to_free_real_estate_crm(self):
+        assert LOGIN.count("url_for('main.free_real_estate_crm')") == 1
+        assert LOGIN.count("the free real estate CRM page") == 1
+        assert "More on what's included is on" in LOGIN
+
+
 class TestRegisterLeftoverCopy:
     def test_keeps_register_h1(self):
         assert "Create your account." in REGISTER


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Login is a sitemap 200 with no path to the query page.

More on what's included is on the free real estate CRM page.

Same markup and left-rail contrast CSS as #368 on register. H1 stays Sign in to continue. Title stays Log in | AgentFlow. Fields stay `class="input"` from #372. Register is untouched.

Hold on merge.

[Login desktop with the free-CRM sentence on the dark rail](https://cursor.com/agents/bc-7a59ff57-e609-4770-a228-ac5c531d0423/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_desktop_free_crm_link.png)
[Login phone width with the same sentence above the feature list](https://cursor.com/agents/bc-7a59ff57-e609-4770-a228-ac5c531d0423/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_mobile_free_crm_link.png)
[login_free_crm_sentence_walkthrough.mp4](https://cursor.com/agents/bc-7a59ff57-e609-4770-a228-ac5c531d0423/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_free_crm_sentence_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a59ff57-e609-4770-a228-ac5c531d0423?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a59ff57-e609-4770-a228-ac5c531d0423&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

