### PR TITLE
seo: link CRM names on free-CRM page

### DIFF
--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -312,7 +312,7 @@
                 <div>
                     <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 mb-4">What other CRMs publish</h2>
                     <p class="text-lg text-brand-600 leading-relaxed">
-                        Follow Up Boss is $69 per user after a trial. Wise Agent is $49 after a trial. Sierra is $299.95 and up. BoldTrail and Lofty are quote-only. Here it's $0 to start, and you don't need a card.
+                        <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">Follow Up Boss</a> is $69 per user after a trial. <a href="{{ url_for('main.wise_agent_alternative') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">Wise Agent</a> is $49 after a trial. Sierra is $299.95 and up. <a href="{{ url_for('main.kvcore_alternative') }}" class="text-brand-800 underline underline-offset-2 hover:text-accent-600">BoldTrail</a> and Lofty are quote-only. Here it's $0 to start, and you don't need a card.
                     </p>
                 </div>
 

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -396,7 +396,7 @@ class TestFreeRealEstateCrmOtherCrmLinks:
     def test_no_kvcore_or_alternative_added_to_sentence(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
         section = _other_crms_section(html)
-        visible = _visible_copy(section)
+        visible = _visible_copy(section).strip()
         assert "kvCORE" not in html
         assert "kvcore" not in visible.lower()
         assert "alternative" not in visible.lower()

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -333,3 +333,71 @@ class TestFreeRealEstateCrmCopy:
         assert "until you say yes" not in answer
         assert "in the CRM or on Telegram" not in answer
         assert "same 25" not in PAGE.lower()
+
+
+OTHER_CRMS_HEADING = "What other CRMs publish"
+OTHER_CRMS_PARAGRAPH = (
+    "Follow Up Boss is $69 per user after a trial. "
+    "Wise Agent is $49 after a trial. "
+    "Sierra is $299.95 and up. "
+    "BoldTrail and Lofty are quote-only. "
+    "Here it's $0 to start, and you don't need a card."
+)
+OTHER_CRM_LINKS = (
+    ("Follow Up Boss", "/follow-up-boss-alternative", "main.follow_up_boss_alternative"),
+    ("Wise Agent", "/wise-agent-alternative", "main.wise_agent_alternative"),
+    ("BoldTrail", "/kvcore-alternative", "main.kvcore_alternative"),
+)
+
+
+def _other_crms_section(html):
+    match = re.search(
+        r"<h2[^>]*>What other CRMs publish</h2>\s*<p\b[^>]*>.*?</p>",
+        html,
+        flags=re.S,
+    )
+    assert match is not None
+    return match.group(0)
+
+
+class TestFreeRealEstateCrmOtherCrmLinks:
+    def test_paragraph_words_unchanged(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        section = _other_crms_section(html)
+        visible = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", section)).strip()
+        assert visible == f"{OTHER_CRMS_HEADING} {OTHER_CRMS_PARAGRAPH}"
+        assert OTHER_CRMS_PARAGRAPH in _visible_copy(html)
+
+    def test_three_names_link_once_to_existing_paths(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        section = _other_crms_section(html)
+        paragraph = re.search(r"<p\b[^>]*>(.*?)</p>", section, flags=re.S).group(1)
+        assert paragraph.count("<a ") == 3
+        for name, path, endpoint in OTHER_CRM_LINKS:
+            assert paragraph.count(f'href="{path}"') == 1
+            assert re.search(
+                rf'<a href="{re.escape(path)}"[^>]*>{re.escape(name)}</a>',
+                paragraph,
+            )
+            assert f"url_for('{endpoint}')" in PAGE
+        assert PAGE.count("url_for('main.follow_up_boss_alternative')") == 1
+        assert PAGE.count("url_for('main.wise_agent_alternative')") == 1
+        assert PAGE.count("url_for('main.kvcore_alternative')") == 1
+
+    def test_sierra_and_lofty_are_not_wrapped(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        section = _other_crms_section(html)
+        paragraph = re.search(r"<p\b[^>]*>(.*?)</p>", section, flags=re.S).group(1)
+        assert re.search(r"<a\b[^>]*>Sierra</a>", paragraph) is None
+        assert re.search(r"<a\b[^>]*>Lofty</a>", paragraph) is None
+        assert "Sierra is $299.95 and up." in _visible_copy(section)
+        assert "BoldTrail and Lofty are quote-only." in _visible_copy(section)
+
+    def test_no_kvcore_or_alternative_added_to_sentence(self, client):
+        html = client.get(PAGE_PATH).get_data(as_text=True)
+        section = _other_crms_section(html)
+        visible = _visible_copy(section)
+        assert "kvCORE" not in html
+        assert "kvcore" not in visible.lower()
+        assert "alternative" not in visible.lower()
+        assert visible == f"{OTHER_CRMS_HEADING} {OTHER_CRMS_PARAGRAPH}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HOLD ON MERGE.

Wraps Follow Up Boss, Wise Agent, and BoldTrail on `/free-real-estate-crm` in the "What other CRMs publish" paragraph. Same sentence. Links use `url_for` to the existing alternative routes.

- Follow Up Boss → `/follow-up-boss-alternative`
- Wise Agent → `/wise-agent-alternative`
- BoldTrail → `/kvcore-alternative`

Sierra and Lofty stay plain text. The sentence does not add kvCORE or "alternative". Title, H1, FAQ, FAQPage, and meta are unchanged. Footer is untouched.

Not part of PR 373.

Tests pin the three wraps, leave Sierra and Lofty unlinked, and keep the paragraph words the same.

[What other CRMs publish paragraph with three name wraps](https://cursor.com/agents/bc-358cd66a-6a6f-4ba8-b5dc-49845f3e7159/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffree_crm_other_crms_linked_names.webp)
[free_crm_competitor_name_links.mp4](https://cursor.com/agents/bc-358cd66a-6a6f-4ba8-b5dc-49845f3e7159/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffree_crm_competitor_name_links.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-358cd66a-6a6f-4ba8-b5dc-49845f3e7159?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-358cd66a-6a6f-4ba8-b5dc-49845f3e7159&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

