### PR TITLE
feat: add AgentFlow GA4 tag G-H05PW4JXBN

### DIFF
--- a/app.py
+++ b/app.py
@@ -237,6 +237,15 @@ def create_app():
             app_base_url=(app.config.get('APP_BASE_URL') or DEFAULT_APP_BASE_URL).rstrip('/'),
         )
 
+    @app.context_processor
+    def inject_ga4():
+        from services.ga4 import measurement_id, should_load_gtag
+
+        return dict(
+            ga4_measurement_id=measurement_id(),
+            ga4_load_gtag=should_load_gtag(),
+        )
+
     # Initialize Flask-Mail
     mail = Mail()
     mail.init_app(app)

--- a/config.py
+++ b/config.py
@@ -114,6 +114,11 @@ class Config:
         os.getenv('MARKETING_BOUNCE_PAUSE_MIN', '50')
     )
 
+    # GA4 web stream for AgentFlow (property 551941222, G-H05PW4JXBN).
+    # Set GA4_MEASUREMENT_ID="" on Railway to disable. Tests and localhost
+    # still receive the ID in HTML but do not load gtag.js.
+    GA4_MEASUREMENT_ID = os.getenv('GA4_MEASUREMENT_ID', 'G-H05PW4JXBN')
+
     # Product analytics. The project token is intentionally public-safe; never
     # expose a PostHog personal API key to the application or browser.
     POSTHOG_PROJECT_TOKEN = os.getenv('POSTHOG_PROJECT_TOKEN')

--- a/services/ga4.py
+++ b/services/ga4.py
@@ -12,6 +12,25 @@ def measurement_id():
     return (current_app.config.get('GA4_MEASUREMENT_ID') or '').strip()
 
 
+def hostname_from_host_header(host):
+    """Hostname from a Host header, including IPv6 loopback.
+
+    `127.0.0.1:5011` -> `127.0.0.1`
+    `[::1]:5011` -> `::1`
+    `[::1]` -> `::1`
+    `::1` -> `::1`
+    """
+    raw = (host or '').strip().lower()
+    if raw.startswith('['):
+        end = raw.find(']')
+        if end != -1:
+            return raw[1:end]
+        return raw
+    if raw.count(':') > 1:
+        return raw
+    return raw.split(':', 1)[0]
+
+
 def should_load_gtag():
     """True only when a real browser on a non-local host should load gtag.js."""
     if current_app.config.get('TESTING'):
@@ -20,5 +39,8 @@ def should_load_gtag():
         return False
     if not has_request_context():
         return False
-    host = (request.host or '').split(':', 1)[0].lower()
+    # Werkzeug's request.host splits on the first colon, so a Host of
+    # `::1` becomes empty. Read the raw header first.
+    raw = request.environ.get('HTTP_HOST') or request.host
+    host = hostname_from_host_header(raw)
     return host not in LOCAL_HOSTS

--- a/services/ga4.py
+++ b/services/ga4.py
@@ -1,0 +1,24 @@
+"""Decide when the GA4 page tag may load gtag.js.
+
+The measurement ID is public. Pytest and localhost never fetch Google.
+"""
+
+from flask import current_app, has_request_context, request
+
+LOCAL_HOSTS = frozenset({'localhost', '127.0.0.1', '::1', '0.0.0.0'})
+
+
+def measurement_id():
+    return (current_app.config.get('GA4_MEASUREMENT_ID') or '').strip()
+
+
+def should_load_gtag():
+    """True only when a real browser on a non-local host should load gtag.js."""
+    if current_app.config.get('TESTING'):
+        return False
+    if not measurement_id():
+        return False
+    if not has_request_context():
+        return False
+    host = (request.host or '').split(':', 1)[0].lower()
+    return host not in LOCAL_HOSTS

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    {% include "components/ga4.html" %}
     <title>{% block title %}AgentFlow{% endblock %}</title>
     {% block seo_head %}{% endblock %}
     <!-- Theme guard: applies stored theme before any paint to avoid FOUC.

--- a/templates/components/ga4.html
+++ b/templates/components/ga4.html
@@ -1,0 +1,15 @@
+{% if ga4_measurement_id %}
+{% if ga4_load_gtag %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_measurement_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ ga4_measurement_id }}');
+</script>
+{% else %}
+<meta name="ga4-measurement-id" content="{{ ga4_measurement_id }}">
+{% endif %}
+{% endif %}

--- a/templates/components/ga4.html
+++ b/templates/components/ga4.html
@@ -1,5 +1,5 @@
-{% if ga4_measurement_id %}
-{% if ga4_load_gtag %}
+{%- if ga4_measurement_id -%}
+{%- if ga4_load_gtag %}
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_measurement_id }}"></script>
 <script>
@@ -9,7 +9,7 @@
 
   gtag('config', '{{ ga4_measurement_id }}');
 </script>
-{% else %}
+{%- else -%}
 <meta name="ga4-measurement-id" content="{{ ga4_measurement_id }}">
-{% endif %}
-{% endif %}
+{%- endif -%}
+{%- endif %}

--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% include "components/ga4.html" %}
     <title>Follow Up Boss Alternative for Real Estate Agents | AgentFlow</title>
     {{ public_seo(
         title="Follow Up Boss Alternative for Real Estate Agents | AgentFlow",

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% include "components/ga4.html" %}
     <title>Free real estate CRM | AgentFlow</title>
     {{ public_seo(
         title="Free real estate CRM | AgentFlow",

--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% include "components/ga4.html" %}
     <title>kvCORE Alternative for Real Estate Agents | AgentFlow</title>
     {{ public_seo(
         title="kvCORE Alternative for Real Estate Agents | AgentFlow",

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% include "components/ga4.html" %}
     <title>Free Real Estate CRM | AgentFlow</title>
     {{ public_seo(
         title="Free Real Estate CRM | AgentFlow",

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    {% include "components/ga4.html" %}
     <meta name="theme-color" content="#f4f5f7">
     <meta name="robots" content="noindex, nofollow">
     <title>{% block title %}Your listing{% endblock %}</title>

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% include "components/ga4.html" %}
     <title>Wise Agent Alternative for Real Estate Agents | AgentFlow</title>
     {{ public_seo(
         title="Wise Agent Alternative for Real Estate Agents | AgentFlow",

--- a/tests/test_ga4.py
+++ b/tests/test_ga4.py
@@ -1,0 +1,108 @@
+"""GA4 head tag: present once, no live Google fetch under pytest."""
+from pathlib import Path
+
+from flask import render_template_string
+
+from config import Config
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GTAG_SRC = 'googletagmanager.com/gtag/js?id=G-H05PW4JXBN'
+GTAG_CONFIG = "gtag('config', 'G-H05PW4JXBN')"
+MARKER = 'name="ga4-measurement-id"'
+DEFAULT_ID = 'G-H05PW4JXBN'
+
+DOCUMENT_HEADS = (
+    'templates/base.html',
+    'templates/landing.html',
+    'templates/free_real_estate_crm.html',
+    'templates/follow_up_boss_alternative.html',
+    'templates/kvcore_alternative.html',
+    'templates/wise_agent_alternative.html',
+    'templates/portal/base.html',
+)
+
+
+def _html(resp):
+    assert resp.status_code == 200, resp.status_code
+    return resp.get_data(as_text=True)
+
+
+def _assert_test_safe_once(html):
+    head = html.split('</head>', 1)[0]
+    assert head.count(MARKER) == 1
+    assert f'content="{DEFAULT_ID}"' in head
+    assert 'googletagmanager.com/gtag/js' not in html
+    assert html.lower().count('<head') == 1
+
+
+class TestGa4Config:
+    def test_production_default_is_agentflow_web_stream(self):
+        assert Config.GA4_MEASUREMENT_ID == DEFAULT_ID
+
+
+class TestGa4DocumentHeads:
+    def test_user_facing_roots_include_the_partial_once(self):
+        for rel in DOCUMENT_HEADS:
+            text = (ROOT / rel).read_text()
+            assert text.count('{% include "components/ga4.html" %}') == 1, rel
+
+    def test_auth_templates_do_not_add_a_second_tag(self):
+        auth_dir = ROOT / 'templates' / 'auth'
+        for path in auth_dir.glob('*.html'):
+            assert 'components/ga4.html' not in path.read_text(), path.name
+            assert 'googletagmanager.com/gtag/js' not in path.read_text(), path.name
+
+
+class TestGa4RenderedPages:
+    def test_public_landing(self, client):
+        _assert_test_safe_once(_html(client.get('/')))
+
+    def test_login(self, client, seed):
+        _assert_test_safe_once(_html(client.get('/login')))
+
+    def test_authed_dashboard(self, owner_a_client, seed):
+        _assert_test_safe_once(_html(owner_a_client.get('/dashboard')))
+
+    def test_pytest_does_not_load_gtag_js(self, client, owner_a_client, seed):
+        pages = (
+            client.get('/'),
+            client.get('/login'),
+            owner_a_client.get('/dashboard'),
+        )
+        for resp in pages:
+            html = _html(resp)
+            assert 'googletagmanager.com' not in html
+            assert MARKER in html
+
+
+class TestGa4SnippetSwitch:
+    def test_production_host_emits_standard_snippet_once(self, app):
+        app.config['TESTING'] = False
+        try:
+            with app.test_request_context(
+                '/',
+                base_url='https://www.origentechnolog.com',
+            ):
+                html = render_template_string('{% include "components/ga4.html" %}')
+        finally:
+            app.config['TESTING'] = True
+
+        assert html.count(GTAG_SRC) == 1
+        assert html.count(GTAG_CONFIG) == 1
+        assert html.count("gtag('js', new Date())") == 1
+        assert MARKER not in html
+        assert 'GTM-' not in html
+
+    def test_empty_id_emits_nothing(self, app):
+        previous = app.config['GA4_MEASUREMENT_ID']
+        app.config['GA4_MEASUREMENT_ID'] = ''
+        try:
+            with app.test_request_context('/'):
+                html = render_template_string('{% include "components/ga4.html" %}')
+        finally:
+            app.config['GA4_MEASUREMENT_ID'] = previous
+
+        assert not html.strip()
+        assert 'googletagmanager.com' not in html
+        assert MARKER not in html

--- a/tests/test_ga4.py
+++ b/tests/test_ga4.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from flask import render_template_string
 
 from config import Config
+from services.ga4 import hostname_from_host_header, should_load_gtag
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -77,8 +78,30 @@ class TestGa4RenderedPages:
             assert MARKER in html
 
 
+class TestGa4HostParsing:
+    def test_ipv6_loopback_forms_are_local(self):
+        assert hostname_from_host_header('::1') == '::1'
+        assert hostname_from_host_header('[::1]') == '::1'
+        assert hostname_from_host_header('[::1]:5011') == '::1'
+        assert hostname_from_host_header('127.0.0.1:5011') == '127.0.0.1'
+        assert hostname_from_host_header('localhost:5011') == 'localhost'
+
+    def test_ipv6_loopback_does_not_load_gtag(self, app):
+        previous = app.config['TESTING']
+        app.config['TESTING'] = False
+        try:
+            for host in ('::1', '[::1]', '[::1]:5011'):
+                with app.test_request_context('/', headers={'Host': host}):
+                    assert should_load_gtag() is False, host
+            with app.test_request_context('/', base_url='http://[::1]:5011'):
+                assert should_load_gtag() is False
+        finally:
+            app.config['TESTING'] = previous
+
+
 class TestGa4SnippetSwitch:
     def test_production_host_emits_standard_snippet_once(self, app):
+        previous = app.config['TESTING']
         app.config['TESTING'] = False
         try:
             with app.test_request_context(
@@ -87,7 +110,7 @@ class TestGa4SnippetSwitch:
             ):
                 html = render_template_string('{% include "components/ga4.html" %}')
         finally:
-            app.config['TESTING'] = True
+            app.config['TESTING'] = previous
 
         assert html.count(GTAG_SRC) == 1
         assert html.count(GTAG_CONFIG) == 1

--- a/tests/test_ga4.py
+++ b/tests/test_ga4.py
@@ -29,11 +29,12 @@ def _html(resp):
 
 
 def _assert_test_safe_once(html):
+    assert '</head>' in html
     head = html.split('</head>', 1)[0]
     assert head.count(MARKER) == 1
     assert f'content="{DEFAULT_ID}"' in head
+    assert html.count(MARKER) == 1
     assert 'googletagmanager.com/gtag/js' not in html
-    assert html.lower().count('<head') == 1
 
 
 class TestGa4Config:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the AgentFlow GA4 web stream `G-H05PW4JXBN` (property 551941222, stream AgentFlow web) to every user-facing HTML document head. One include. No GTM container, no extra events, no cookie banner.

Public marketing pages have their own document. Auth and the logged-in app inherit `base.html`. Client portal uses `portal/base.html`. Auth templates from PR 372 were not restyled and did not get `crm-input` or `t-input` back.

Do not merge until QA PASS and green CI on the Copilot fix. I will merge.

## How it loads

`{% include "components/ga4.html" %}` sits in each document `<head>`. Production hosts get the standard gtag.js snippet. Pytest (`TESTING=True`) and localhost, including IPv6 `::1` and `[::1]`, get a `<meta name="ga4-measurement-id">` marker instead, so nothing fetches `googletagmanager.com`.

## Railway

Optional variable: `GA4_MEASUREMENT_ID`

Default in `config.py` is `G-H05PW4JXBN`. Leave it unset on Railway. Set `GA4_MEASUREMENT_ID` to an empty string if you need the tag off.

## Copilot fixes

`should_load_gtag()` reads the raw Host header and treats `::1` and `[::1]` as local. Tests that flip `TESTING` restore the previous value.

## Tests

`tests/test_ga4.py` checks the marker on `/`, `/login`, and `/dashboard`, once per page, with no live Google request. A separate render checks the real snippet on `www.origentechnolog.com` without executing it. IPv6 loopback is covered.

## Painted frames

Live pages on `127.0.0.1:5011`. Login has typed username visible, no orange input slabs, no cookie banner. PR 372 lock holds.

[Public home /](https://cursor.com/agents/bc-ec4171df-9f4a-44bb-800d-88f128da16fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fga4_public_home.webp)

[Login with visible typed username](https://cursor.com/agents/bc-ec4171df-9f4a-44bb-800d-88f128da16fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fga4_login.webp)

[Logged-in dashboard](https://cursor.com/agents/bc-ec4171df-9f4a-44bb-800d-88f128da16fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fga4_dashboard.webp)

## Head dump

Localhost / pytest emits the meta marker once and does not mention `googletagmanager.com`. A `www.origentechnolog.com` render emits the standard gtag.js snippet for `G-H05PW4JXBN` exactly once.

Head SHA: `fcf83df49fb85f7903a81fe0d3831c5d3a5d58a2`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec4171df-9f4a-44bb-800d-88f128da16fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec4171df-9f4a-44bb-800d-88f128da16fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

