### PR TITLE
seo: SoftwareApplication.image on five public pages

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -36,6 +36,7 @@
           },
           "description": "Comparing AgentFlow with Follow Up Boss? See pricing, features and where each CRM fits. AgentFlow includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
           "url": "{{ app_base_url }}/follow-up-boss-alternative",
+          "image": "{{ app_base_url }}/static/images/og-share.png",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
         {

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -36,6 +36,7 @@
           },
           "description": "Built for agents, by agents. The free tier stays free. No card. About two minutes.",
           "url": "{{ app_base_url }}/free-real-estate-crm",
+          "image": "{{ app_base_url }}/static/images/og-share.png",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
         {

--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -36,6 +36,7 @@
           },
           "description": "kvCORE is now BoldTrail. See how AgentFlow compares: a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
           "url": "{{ app_base_url }}/kvcore-alternative",
+          "image": "{{ app_base_url }}/static/images/og-share.png",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
         {

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -44,6 +44,7 @@
           },
           "description": "Free real estate CRM for agents. No credit card. Set up in about 2 minutes.",
           "url": "{{ app_base_url }}/",
+          "image": "{{ app_base_url }}/static/images/og-share.png",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
         {

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -36,6 +36,7 @@
           },
           "description": "Comparing AgentFlow with Wise Agent? See pricing, features and where each CRM fits. AgentFlow includes a free plan with up to 10,000 contacts and B.O.B., its built-in AI assistant.",
           "url": "{{ app_base_url }}/wise-agent-alternative",
+          "image": "{{ app_base_url }}/static/images/og-share.png",
           "publisher": { "@id": "{{ app_base_url }}/#organization" }
         },
         {

--- a/tests/test_software_application_image.py
+++ b/tests/test_software_application_image.py
@@ -1,0 +1,60 @@
+"""Pin SoftwareApplication.image on the five public schema pages."""
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES = (
+    ("/", "templates/landing.html"),
+    ("/free-real-estate-crm", "templates/free_real_estate_crm.html"),
+    ("/follow-up-boss-alternative", "templates/follow_up_boss_alternative.html"),
+    ("/wise-agent-alternative", "templates/wise_agent_alternative.html"),
+    ("/kvcore-alternative", "templates/kvcore_alternative.html"),
+)
+IMAGE_KEY = '"image": "{{ app_base_url }}/static/images/og-share.png"'
+
+
+def _app_base_url(app):
+    return (app.config.get("APP_BASE_URL") or "https://agentflow.origentechnolog.com").rstrip("/")
+
+
+def _json_ld_graph(html):
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', html, flags=re.S)
+    assert match is not None
+    data = json.loads(match.group(1))
+    assert data.get("@context") == "https://schema.org"
+    return data["@graph"]
+
+
+def _software_node(graph):
+    software = [node for node in graph if node.get("@type") == "SoftwareApplication"]
+    assert len(software) == 1
+    return software[0]
+
+
+def test_software_application_image_on_five_public_pages(app, client):
+    base = _app_base_url(app)
+    expected = f"{base}/static/images/og-share.png"
+
+    for path, template in PAGES:
+        source = (ROOT / template).read_text()
+        assert IMAGE_KEY in source, template
+        source_graph = _json_ld_graph(
+            source.replace("{{ app_base_url }}", "https://schema-pin.test")
+        )
+        source_software = _software_node(source_graph)
+        assert source_software["image"] == "https://schema-pin.test/static/images/og-share.png"
+        for node in source_graph:
+            if node.get("@type") != "SoftwareApplication":
+                assert "image" not in node, (template, node.get("@type"))
+
+        html = client.get(path).get_data(as_text=True)
+        graph = _json_ld_graph(html)
+        software = _software_node(graph)
+        assert software["image"] == expected, path
+        assert "/static/images/og-share.png" in software["image"]
+        assert software["image"].startswith("http")
+        for node in graph:
+            if node.get("@type") != "SoftwareApplication":
+                assert "image" not in node, (path, node.get("@type"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HOLD. Schema only. Do not merge unless someone says to.

Adds `SoftwareApplication.image` on the five public pages that already have that node. The URL is the existing share image from PR 361.

```
"image": "{{ app_base_url }}/static/images/og-share.png"
```

Once rendered that is an absolute `og-share.png` URL, same host pattern as the other JSON-LD URLs on these nodes.

**Pages.** `/`, `/free-real-estate-crm`, `/follow-up-boss-alternative`, `/wise-agent-alternative`, `/kvcore-alternative`.

**Left alone.** Visible copy, H1s, titles, meta, FAQPage, BreadcrumbList, Organization, login/register, sitemap, robots, `llms.txt`, and `og:image` in `seo_meta.html`. No screenshot, aggregateRating, review, featureList, LocalBusiness, SearchAction, or sameAs.

`tests/test_software_application_image.py` pins the `image` key on each SoftwareApplication node and checks the rendered URL is the `og-share.png` path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf858040-6eb5-4bf4-a2c6-4fa596e7190c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf858040-6eb5-4bf4-a2c6-4fa596e7190c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

