### PR TITLE
seo: comparison links in public footer

### DIFF
--- a/templates/follow_up_boss_alternative.html
+++ b/templates/follow_up_boss_alternative.html
@@ -555,6 +555,9 @@
                     <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
                     <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
                     <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                    <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="hover:text-white transition-colors">Follow Up Boss</a>
+                    <a href="{{ url_for('main.wise_agent_alternative') }}" class="hover:text-white transition-colors">Wise Agent</a>
+                    <a href="{{ url_for('main.kvcore_alternative') }}" class="hover:text-white transition-colors">kvCORE</a>
                 </div>
 
                 <div class="text-brand-500 text-sm">

--- a/templates/free_real_estate_crm.html
+++ b/templates/free_real_estate_crm.html
@@ -367,6 +367,9 @@
                     <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
                     <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
                     <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                    <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="hover:text-white transition-colors">Follow Up Boss</a>
+                    <a href="{{ url_for('main.wise_agent_alternative') }}" class="hover:text-white transition-colors">Wise Agent</a>
+                    <a href="{{ url_for('main.kvcore_alternative') }}" class="hover:text-white transition-colors">kvCORE</a>
                 </div>
 
                 <div class="text-brand-500 text-sm">

--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -545,6 +545,9 @@
                     <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
                     <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
                     <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                    <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="hover:text-white transition-colors">Follow Up Boss</a>
+                    <a href="{{ url_for('main.wise_agent_alternative') }}" class="hover:text-white transition-colors">Wise Agent</a>
+                    <a href="{{ url_for('main.kvcore_alternative') }}" class="hover:text-white transition-colors">kvCORE</a>
                 </div>
 
                 <div class="text-brand-500 text-sm">

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1127,6 +1127,9 @@
                     <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
                     <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
                     <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                    <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="hover:text-white transition-colors">Follow Up Boss</a>
+                    <a href="{{ url_for('main.wise_agent_alternative') }}" class="hover:text-white transition-colors">Wise Agent</a>
+                    <a href="{{ url_for('main.kvcore_alternative') }}" class="hover:text-white transition-colors">kvCORE</a>
                 </div>
                 
                 <!-- Copyright -->

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -535,6 +535,9 @@
                     <a href="{{ url_for('auth.register') }}" class="hover:text-white transition-colors">Register</a>
                     <a href="{{ url_for('auth.terms_privacy') }}" class="hover:text-white transition-colors">Terms & Privacy</a>
                     <a href="#" onclick="openContactUsModal('landing'); return false;" class="hover:text-white transition-colors">Contact</a>
+                    <a href="{{ url_for('main.follow_up_boss_alternative') }}" class="hover:text-white transition-colors">Follow Up Boss</a>
+                    <a href="{{ url_for('main.wise_agent_alternative') }}" class="hover:text-white transition-colors">Wise Agent</a>
+                    <a href="{{ url_for('main.kvcore_alternative') }}" class="hover:text-white transition-colors">kvCORE</a>
                 </div>
 
                 <div class="text-brand-500 text-sm">

--- a/tests/test_free_real_estate_crm.py
+++ b/tests/test_free_real_estate_crm.py
@@ -380,9 +380,9 @@ class TestFreeRealEstateCrmOtherCrmLinks:
                 paragraph,
             )
             assert f"url_for('{endpoint}')" in PAGE
-        assert PAGE.count("url_for('main.follow_up_boss_alternative')") == 1
-        assert PAGE.count("url_for('main.wise_agent_alternative')") == 1
-        assert PAGE.count("url_for('main.kvcore_alternative')") == 1
+        assert PAGE.count("url_for('main.follow_up_boss_alternative')") == 2
+        assert PAGE.count("url_for('main.wise_agent_alternative')") == 2
+        assert PAGE.count("url_for('main.kvcore_alternative')") == 2
 
     def test_sierra_and_lofty_are_not_wrapped(self, client):
         html = client.get(PAGE_PATH).get_data(as_text=True)
@@ -397,7 +397,7 @@ class TestFreeRealEstateCrmOtherCrmLinks:
         html = client.get(PAGE_PATH).get_data(as_text=True)
         section = _other_crms_section(html)
         visible = _visible_copy(section).strip()
-        assert "kvCORE" not in html
+        assert "kvCORE" not in section
         assert "kvcore" not in visible.lower()
         assert "alternative" not in visible.lower()
         assert visible == f"{OTHER_CRMS_HEADING} {OTHER_CRMS_PARAGRAPH}"

--- a/tests/test_public_footer_comparison_links.py
+++ b/tests/test_public_footer_comparison_links.py
@@ -1,0 +1,79 @@
+"""Pin comparison links in the five public footers."""
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PUBLIC_PAGES = (
+    ("/", "templates/landing.html"),
+    ("/free-real-estate-crm", "templates/free_real_estate_crm.html"),
+    ("/follow-up-boss-alternative", "templates/follow_up_boss_alternative.html"),
+    ("/wise-agent-alternative", "templates/wise_agent_alternative.html"),
+    ("/kvcore-alternative", "templates/kvcore_alternative.html"),
+)
+
+FOOTER_COMPARISON_LINKS = (
+    ("Follow Up Boss", "/follow-up-boss-alternative", "main.follow_up_boss_alternative"),
+    ("Wise Agent", "/wise-agent-alternative", "main.wise_agent_alternative"),
+    ("kvCORE", "/kvcore-alternative", "main.kvcore_alternative"),
+)
+
+KEPT_FOOTER_LABELS = ("Login", "Register", "Terms & Privacy", "Contact")
+
+_FOOTER = re.compile(r"<footer\b[^>]*>.*?</footer>", re.S)
+_LINK_LABEL = re.compile(r"<a\b[^>]*>(.*?)</a>", re.S)
+
+
+def _footer(html):
+    match = _FOOTER.search(html)
+    assert match is not None
+    return match.group(0)
+
+
+def _footer_labels(footer):
+    labels = []
+    for raw in _LINK_LABEL.findall(footer):
+        text = re.sub(r"<[^>]+>", "", raw)
+        text = re.sub(r"\s+", " ", text).strip()
+        if text:
+            labels.append(text)
+    return labels
+
+
+def _template_link(endpoint, label):
+    return (
+        f'<a href="{{{{ url_for(\'{endpoint}\') }}}}" '
+        f'class="hover:text-white transition-colors">{label}</a>'
+    )
+
+
+class TestPublicFooterComparisonLinks:
+    def test_each_template_footer_has_exact_labels_and_endpoints(self):
+        for _path, relpath in PUBLIC_PAGES:
+            source = (ROOT / relpath).read_text()
+            footer = _footer(source)
+            labels = _footer_labels(footer)
+            for kept in KEPT_FOOTER_LABELS:
+                assert kept in labels
+            for label, _href, endpoint in FOOTER_COMPARISON_LINKS:
+                assert _template_link(endpoint, label) in footer
+                assert label in labels
+            for label in labels:
+                assert "alternative" not in label.lower()
+
+    def test_each_rendered_footer_has_exact_hrefs_and_labels(self, client):
+        for path, _relpath in PUBLIC_PAGES:
+            html = client.get(path).get_data(as_text=True)
+            footer = _footer(html)
+            labels = _footer_labels(footer)
+            for kept in KEPT_FOOTER_LABELS:
+                assert kept in labels
+            for label, href, _endpoint in FOOTER_COMPARISON_LINKS:
+                assert label in labels
+                assert (
+                    f'<a href="{href}" class="hover:text-white transition-colors">'
+                    f"{label}</a>"
+                ) in footer
+            for label in labels:
+                assert "alternative" not in label.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Follow Up Boss, Wise Agent, and kvCORE to the public footer on all five public pages. Same row and same link class as Login, Register, Terms & Privacy, and Contact. Labels use the existing product names. The word alternative is not in the labels.

Footer markup is still duplicated in each template. No shared include.

H1, FAQ, FAQPage, titles, and meta are unchanged.

Tests pin the three footer hrefs and labels on each page, and that alternative is not in those labels. The free CRM page still pins the "What other CRMs publish" sentence; page-level url_for counts now allow the extra footer links.

[Homepage footer with comparison links](https://cursor.com/agents/bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_footer_desktop.webp)
[Follow Up Boss page footer](https://cursor.com/agents/bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffollow_up_boss_footer_desktop.webp)
[Homepage footer at phone width](https://cursor.com/agents/bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_footer_mobile.webp)
[public_footer_comparison_links_demo.mp4](https://cursor.com/agents/bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_footer_comparison_links_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fcd57ef-427a-4f24-b75f-3ec4e397be71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

