### PR TITLE
copy: five in-app blurbs (8/31)

### DIFF
--- a/templates/action_plan.html
+++ b/templates/action_plan.html
@@ -504,7 +504,7 @@
                                 <label class="block text-sm font-semibold text-slate-700 mb-1">
                                     How comfortable are you initiating conversations with strangers? <span class="text-orange-500">*</span>
                                 </label>
-                                <p class="text-sm text-slate-500 mb-4">Be honest — there's no wrong answer here.</p>
+                                <p class="text-sm text-slate-500 mb-4">Pick the option that matches how comfortable you are starting conversations with strangers.</p>
                                 <div class="space-y-3">
                                     <label class="premium-radio-card flex items-center p-4 rounded-xl border-2 border-slate-200 bg-white hover:border-orange-300 cursor-pointer has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50">
                                         <input type="radio" name="stranger_comfort" value="Very comfortable" required class="h-4 w-4 text-orange-600 focus:ring-orange-500">
@@ -530,7 +530,7 @@
                                 <label class="block text-sm font-semibold text-slate-700 mb-1">
                                     Which phrase sounds most like you? <span class="text-orange-500">*</span>
                                 </label>
-                                <p class="text-sm text-slate-500 mb-4">Select all that resonate with you.</p>
+                                <p class="text-sm text-slate-500 mb-4">Select every phrase that sounds like you.</p>
                                 <div class="space-y-3">
                                     <label class="premium-radio-card flex items-center p-4 rounded-xl border-2 border-slate-200 bg-white hover:border-orange-300 cursor-pointer has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50">
                                         <input type="checkbox" name="self_description" value="I thrive at events or meeting people out and about" class="h-4 w-4 text-orange-600 rounded focus:ring-orange-500">

--- a/templates/organization/upgrade.html
+++ b/templates/organization/upgrade.html
@@ -126,7 +126,7 @@
                 <div class="min-w-0">
                     <p class="crm-eyebrow" style="color: var(--accent);">Interested in Pro?</p>
                     <h3 class="mt-2 crm-serif" style="font-size: 24px; line-height: 1.1; color: var(--paper);">
-                        We&rsquo;re finalizing pricing — and we&rsquo;d love to hear from you.
+                        We&rsquo;re still setting Pro pricing. Use Contact us to ask about early-access pricing or to get a note when Pro launches.
                     </h3>
                     <p class="mt-2 text-sm max-w-xl" style="color: oklch(78% 0.004 75);">
                         Reach out to learn more, lock in early-access pricing, or get notified when Pro launches.

--- a/templates/transactions/_seller_workspace.html
+++ b/templates/transactions/_seller_workspace.html
@@ -8,7 +8,7 @@
                     <div class="crm-surface-header">
                         <div>
                             {{ section_header('Seller workspace') }}
-                            <p class="mt-1 text-xs text-slate-500">All documents for this file live here — listing paperwork, offers, and the contract.</p>
+                            <p class="mt-1 text-xs text-slate-500">All documents for this file live here: listing paperwork, offers, and the contract.</p>
                             {% if urgent_seller_offer and urgent_seller_offer.response_deadline_at %}
                             {% set urgent_state = offer_urgency(urgent_seller_offer) %}
                             <p class="mt-1 text-xs font-medium {% if urgent_state.state in ['critical', 'strong_warning'] %}text-red-700{% else %}text-orange-700{% endif %}">

--- a/templates/transactions/bootstrap_inbox.html
+++ b/templates/transactions/bootstrap_inbox.html
@@ -107,7 +107,7 @@
                             <span class="mt-0.5 text-sm font-semibold text-[color:var(--ink-3)]">03</span>
                             <div>
                                 <p class="text-sm font-semibold text-[color:var(--ink)]">Open the right workspace</p>
-                                <p class="mt-1 text-sm leading-5 text-[color:var(--ink-2)]">Listing, offers, or contract coordination — based on what you filed.</p>
+                                <p class="mt-1 text-sm leading-5 text-[color:var(--ink-2)]">Listing, offers, or contract coordination, based on what you filed.</p>
                             </div>
                         </li>
                     </ol>

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -125,3 +125,48 @@ class TestLockedOpenHouseDescription:
 
     def test_python_definition_has_locked_description(self):
         assert st.definition("open_house")["description"] == self.LOCKED
+
+
+class TestLockedCopyPairs831:
+    def test_action_plan_stranger_comfort_helper(self):
+        text = _read("templates", "action_plan.html")
+        assert (
+            "Pick the option that matches how comfortable you are "
+            "starting conversations with strangers."
+        ) in text
+        assert "Be honest — there's no wrong answer here." not in text
+        assert "Be honest &mdash; there's no wrong answer here." not in text
+
+    def test_action_plan_self_description_helper(self):
+        text = _read("templates", "action_plan.html")
+        assert "Select every phrase that sounds like you." in text
+        assert "Select all that resonate with you." not in text
+
+    def test_upgrade_pro_contact_heading(self):
+        text = _read("templates", "organization", "upgrade.html")
+        assert (
+            "We&rsquo;re still setting Pro pricing. Use Contact us to ask "
+            "about early-access pricing or to get a note when Pro launches."
+        ) in text
+        assert "We&rsquo;re finalizing pricing — and we&rsquo;d love to hear from you." not in text
+        assert "We're finalizing pricing — and we'd love to hear from you." not in text
+
+    def test_seller_workspace_helper(self):
+        text = _read("templates", "transactions", "_seller_workspace.html")
+        assert (
+            "All documents for this file live here: listing paperwork, "
+            "offers, and the contract."
+        ) in text
+        assert (
+            "All documents for this file live here — listing paperwork, "
+            "offers, and the contract."
+        ) not in text
+
+    def test_bootstrap_inbox_step_03(self):
+        text = _read("templates", "transactions", "bootstrap_inbox.html")
+        assert (
+            "Listing, offers, or contract coordination, based on what you filed."
+        ) in text
+        assert (
+            "Listing, offers, or contract coordination — based on what you filed."
+        ) not in text

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -170,3 +170,66 @@ class TestLockedCopyPairs831:
         assert (
             "Listing, offers, or contract coordination — based on what you filed."
         ) not in text
+
+
+class TestLockedCopyPairs831Rendered:
+    def test_action_plan_page_renders_helpers(self, owner_a_client):
+        resp = owner_a_client.get("/action-plan")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert (
+            "Pick the option that matches how comfortable you are "
+            "starting conversations with strangers."
+        ) in html
+        assert "Select every phrase that sounds like you." in html
+        assert "Be honest — there's no wrong answer here." not in html
+        assert "Select all that resonate with you." not in html
+
+    def test_upgrade_page_renders_heading(self, owner_b_client):
+        resp = owner_b_client.get("/org/upgrade")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert (
+            "We&rsquo;re still setting Pro pricing. Use Contact us to ask "
+            "about early-access pricing or to get a note when Pro launches."
+        ) in html
+        assert "finalizing pricing" not in html
+
+    def test_seller_workspace_page_renders_helper(self, owner_a_client, seed):
+        resp = owner_a_client.get(f"/transactions/{seed['tx_a']}")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert (
+            "All documents for this file live here: listing paperwork, "
+            "offers, and the contract."
+        ) in html
+        assert (
+            "All documents for this file live here — listing paperwork, "
+            "offers, and the contract."
+        ) not in html
+
+    def test_bootstrap_inbox_page_renders_step_03(self, app, owner_a_client, seed):
+        from models import Organization, db
+
+        with app.app_context():
+            org = db.session.get(Organization, seed["org_a"])
+            previous = dict(org.feature_flags or {})
+            flags = dict(previous)
+            flags["BOB_VTC_PILOT"] = True
+            org.feature_flags = flags
+            db.session.commit()
+        try:
+            resp = owner_a_client.get("/transactions/bootstrap/inbox")
+            assert resp.status_code == 200
+            html = resp.get_data(as_text=True)
+            assert (
+                "Listing, offers, or contract coordination, based on what you filed."
+            ) in html
+            assert (
+                "Listing, offers, or contract coordination — based on what you filed."
+            ) not in html
+        finally:
+            with app.app_context():
+                org = db.session.get(Organization, seed["org_a"])
+                org.feature_flags = previous
+                db.session.commit()

--- a/tests/test_locked_app_copy.py
+++ b/tests/test_locked_app_copy.py
@@ -213,8 +213,8 @@ class TestLockedCopyPairs831Rendered:
 
         with app.app_context():
             org = db.session.get(Organization, seed["org_a"])
-            previous = dict(org.feature_flags or {})
-            flags = dict(previous)
+            previous = org.feature_flags
+            flags = dict(previous or {})
             flags["BOB_VTC_PILOT"] = True
             org.feature_flags = flags
             db.session.commit()


### PR DESCRIPTION
Copy-originated. Christopher already approved the five AFTER strings and lifted the merge hold.

Today's five in-app pairs only. AFTER strings shipped as written. No rewrite. No public-site copy. No CSS, JS, or layout changes.

Merge when QA PASS, green CI, and Copilot requested and JARVIS-reviewed.

## Pairs

1. `templates/action_plan.html` (stranger_comfort helper)
   - AFTER: Pick the option that matches how comfortable you are starting conversations with strangers.

2. `templates/action_plan.html` (self_description helper)
   - AFTER: Select every phrase that sounds like you.

3. `templates/organization/upgrade.html` (Pro contact CTA heading)
   - AFTER: We're still setting Pro pricing. Use Contact us to ask about early-access pricing or to get a note when Pro launches.
   - Template form uses `We’re`.

4. `templates/transactions/_seller_workspace.html` (Seller workspace helper)
   - AFTER: All documents for this file live here: listing paperwork, offers, and the contract.

5. `templates/transactions/bootstrap_inbox.html` (What happens next, step 03)
   - AFTER: Listing, offers, or contract coordination, based on what you filed.

## Tests

`tests/test_locked_app_copy.py` pins each AFTER in the template source and on the rendered action plan, upgrade, seller workspace, and bootstrap inbox pages. The old BEFORE strings fail the test if they return.

Based on main `d5e6a34`.