### PR TITLE
seo: fix llms.txt paid-plan wording

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -2,7 +2,7 @@
 
 Free real estate CRM for agents. No credit card. Set up in about 2 minutes.
 
-AgentFlow is a free CRM for real estate agents. Use it to organize contacts, manage tasks, and keep follow-ups from slipping. There is no paid plan for sale.
+AgentFlow is a free CRM for real estate agents. Use it to organize contacts, manage tasks, and keep follow-ups from slipping. Paid features come later. Nothing paid is for sale today. Pro is coming soon.
 
 ## Facts
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/llms.txt` still said "There is no paid plan for sale." Crawlers can read that as never-paid.

Replaced that sentence with the same later-paid wording already on public pages:

Paid features come later. Nothing paid is for sale today. Pro is coming soon.

Limits, H1, FAQ, title, meta, robots, and sitemap lastmods are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1a791bb-88ce-499b-a06f-b9027ba5c3ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1a791bb-88ce-499b-a06f-b9027ba5c3ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

