### PR TITLE
copy: stop calling competitors a real product

### DIFF
--- a/templates/kvcore_alternative.html
+++ b/templates/kvcore_alternative.html
@@ -318,7 +318,7 @@
                     Looking for a kvCORE alternative?
                 </h1>
                 <p class="text-lg sm:text-xl text-brand-600 mb-6">
-                    kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. That is a real product, and it is built for a lot more than a solo agent's daily CRM work.
+                    kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. It is built for a lot more than a solo agent's daily CRM work.
                 </p>
                 <p class="text-lg sm:text-xl text-brand-600 mb-6">
                     AgentFlow gives individual agents a simpler place to manage contacts, tasks, follow-ups, with a free plan you can keep using.

--- a/templates/wise_agent_alternative.html
+++ b/templates/wise_agent_alternative.html
@@ -310,7 +310,7 @@
                     Looking for a Wise Agent alternative?
                 </h1>
                 <p class="text-lg sm:text-xl text-brand-600 mb-6">
-                    Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. That is a real product, and a lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.
+                    Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. A lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.
                 </p>
                 <p class="text-lg sm:text-xl text-brand-600 mb-6">
                     AgentFlow gives individual real estate agents a simpler place to do that work, with a free plan you can keep using.
@@ -337,7 +337,7 @@
                         These products aren't identical, and they shouldn't be presented as though they are.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed mb-4">
-                        Wise Agent has published pricing, team logins and add-ons such as WiseText and WiseSocial. That is a real product, and a lot of agents use it.
+                        Wise Agent has published pricing, team logins and add-ons such as WiseText and WiseSocial. A lot of agents use it.
                     </p>
                     <p class="text-lg text-brand-600 leading-relaxed">
                         AgentFlow is aimed at agents who want the core CRM work handled without starting with another monthly software bill.

--- a/tests/test_kvcore_alternative.py
+++ b/tests/test_kvcore_alternative.py
@@ -133,7 +133,7 @@ SECTION_HEADINGS = (
     "Common questions",
 )
 HERO_LINES = (
-    "kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. That is a real product, and it is built for a lot more than a solo agent's daily CRM work.",
+    "kvCORE is now BoldTrail, from Inside Real Estate. It is a large real estate platform for agents, teams and brokerages. Pricing is quote-only. There is no published free plan. It is built for a lot more than a solo agent's daily CRM work.",
     "AgentFlow gives individual agents a simpler place to manage contacts, tasks, follow-ups, with a free plan you can keep using.",
     "No credit card required.",
     "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",

--- a/tests/test_wise_agent_alternative.py
+++ b/tests/test_wise_agent_alternative.py
@@ -129,7 +129,7 @@ SECTION_HEADINGS = (
     "Common questions",
 )
 HERO_LINES = (
-    "Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. That is a real product, and a lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.",
+    "Wise Agent is a real estate CRM with published pricing and a 14-day trial. It starts at $49 a month on their pricing page. A lot of agents use it. Not every agent wants another monthly bill to manage contacts, tasks and follow-ups.",
     "AgentFlow gives individual real estate agents a simpler place to do that work, with a free plan you can keep using.",
     "No credit card required.",
     "Free plan · 1 user · Up to 10,000 contacts · 25 B.O.B. messages per day",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Calling kvCORE and Wise Agent "a real product" undercuts AgentFlow. AgentFlow is a real free CRM for solo agents. This drops that framing and keeps the competitor facts.

Sentence changes:
- kvCORE hero: "That is a real product, and it is built for a lot more than a solo agent's daily CRM work." is now "It is built for a lot more than a solo agent's daily CRM work."
- Wise Agent hero: "That is a real product, and a lot of agents use it." is now "A lot of agents use it."
- Wise Agent body: same cut. "That is a real product, and a lot of agents use it." is now "A lot of agents use it."

Follow Up Boss already had none. Pinned strings in the kvCORE and Wise Agent tests match the new lines. H1s, titles, meta, FAQ, robots, sitemap, and llms.txt are untouched.

[kvCORE hero after the copy fix](https://cursor.com/agents/bc-022f3619-abc7-436a-ba72-0047e18a55e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkvcore_hero_copy.webp)
[Wise Agent hero after the copy fix](https://cursor.com/agents/bc-022f3619-abc7-436a-ba72-0047e18a55e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwise_agent_hero_copy.webp)
[Wise Agent body paragraph after the copy fix](https://cursor.com/agents/bc-022f3619-abc7-436a-ba72-0047e18a55e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwise_agent_body_copy.webp)
[comparison_pages_real_product_copy.mp4](https://cursor.com/agents/bc-022f3619-abc7-436a-ba72-0047e18a55e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomparison_pages_real_product_copy.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-022f3619-abc7-436a-ba72-0047e18a55e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-022f3619-abc7-436a-ba72-0047e18a55e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

