### PR TITLE
seo: robots.txt disallow thin utility URLs

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,10 @@
 User-agent: *
 Allow: /
 Disallow: /dashboard
+Disallow: /reset_password
+Disallow: /registration-status
+Disallow: /health
+Disallow: /health/ui
 
 User-agent: GPTBot
 Allow: /


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HOLD ON MERGE until SEO PASS + QA PASS + green CI + Copilot requested and JARVIS-reviewed.

Adds four `Disallow` rules under `User-agent: *` in `static/robots.txt` so crawlers skip thin public utility URLs:

- `/reset_password`
- `/registration-status`
- `/health`
- `/health/ui`

`Allow: /` and `Disallow: /dashboard` stay. AI-bot Allow blocks and the Sitemap line at `https://agentflow.origentechnolog.com/sitemap.xml` are unchanged.

Production serves this file from `/robots.txt` via `send_from_directory` in `app.py`. Live prod still only disallows `/dashboard`. This is the source of truth that deploy will ship.

No sitemap, llms.txt, template, title, H1, FAQ, or marketing copy changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99be7055-0549-421c-bab9-0107c5cb7813?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99be7055-0549-421c-bab9-0107c5cb7813&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

