### PR TITLE
seo: sitemap lastmod 2026-09-03 for terms-privacy

### DIFF
--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/terms-privacy</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-09-03</lastmod>
   </url>
   <url>
     <loc>https://agentflow.origentechnolog.com/free-real-estate-crm</loc>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 394 shipped the marketing footer on `/terms-privacy`. Live lastmod is still 2026-08-18.

This sets that one lastmod to 2026-09-03.

Left alone:
- `/`, `/free-real-estate-crm`, `/follow-up-boss-alternative`, `/wise-agent-alternative`, `/kvcore-alternative` stay 2026-09-02
- `/register` and `/login` stay 2026-08-31

Same eight locs. Same host. No robots, llms.txt, templates, titles, H1s, or FAQ.

No test pins the terms-privacy lastmod date, so none changed.

Parsed `static/sitemap.xml` and Flask `GET /sitemap.xml`. Eight locs. Only `/terms-privacy` is 2026-09-03. `pytest -k sitemap` on the canonical and public SEO files: 6 passed.

HOLD. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-869bbd75-8d7a-4d75-bba5-0e776b16c1c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-869bbd75-8d7a-4d75-bba5-0e776b16c1c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

