### PR TITLE
seo: noindex utility pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,16 @@ from routes.mcp_oauth import mcp_oauth_bp
 
 SLOW_REQUEST_WARNING_MS = 2000
 
+# Utility URLs that stay out of the index. robots.txt already Disallows these;
+# GSC still followed /reset_password without a robots meta or X-Robots-Tag.
+NOINDEX_UTILITY_PATHS = frozenset((
+    '/reset_password',
+    '/health',
+    '/health/ui',
+    '/registration-status',
+))
+X_ROBOTS_TAG_NOINDEX = 'noindex, nofollow'
+
 
 class _MaxLevelFilter(logging.Filter):
     def __init__(self, exclusive_upper_bound):
@@ -107,6 +117,14 @@ def _current_rss_mb():
         return round(process.memory_info().rss / 1024 / 1024, 1)
     except Exception:
         return None
+
+
+def apply_noindex_utility_headers(response, path=None):
+    """Attach X-Robots-Tag on utility URLs only. Leaves marketing pages alone."""
+    check_path = request.path if path is None else path
+    if check_path in NOINDEX_UTILITY_PATHS:
+        response.headers['X-Robots-Tag'] = X_ROBOTS_TAG_NOINDEX
+    return response
 
 def create_app():
     app = Flask(__name__)
@@ -420,6 +438,10 @@ def create_app():
                 record_daily_session(current_user, surface=surface)
         except Exception:
             pass
+
+    @app.after_request
+    def noindex_utility_pages(response):
+        return apply_noindex_utility_headers(response)
 
     @app.after_request
     def record_session_creation(response):

--- a/templates/auth/reset_request.html
+++ b/templates/auth/reset_request.html
@@ -2,6 +2,9 @@
 {% from "components/ui.html" import brand_logo %}
 
 {% block title %}Forgot password | AgentFlow{% endblock %}
+{% block seo_head %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
 
 {% block content %}
 {% include "auth/_styles.html" %}

--- a/templates/health.html
+++ b/templates/health.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
     <title>OG Telemetry // AgentFlow</title>
     <link rel="icon" href="{{ url_for('static', filename='images/favicon.svg') }}" type="image/svg+xml">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='images/favicon.png') }}">

--- a/tests/test_utility_noindex.py
+++ b/tests/test_utility_noindex.py
@@ -1,0 +1,138 @@
+"""Utility URLs stay out of the index via robots meta and X-Robots-Tag.
+
+Does not rewrite robots.txt, sitemap.xml, marketing copy, or gold FAQ/H1s.
+"""
+from pathlib import Path
+
+from app import NOINDEX_UTILITY_PATHS, X_ROBOTS_TAG_NOINDEX
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROBOTS = ROOT / "static" / "robots.txt"
+SITEMAP = ROOT / "static" / "sitemap.xml"
+
+ROBOTS_META = '<meta name="robots" content="noindex, nofollow">'
+
+NOINDEX_PATHS = (
+    "/reset_password",
+    "/health",
+    "/health/ui",
+    "/registration-status",
+)
+
+HTML_NOINDEX_PATHS = (
+    "/reset_password",
+    "/health/ui",
+)
+
+INDEXABLE_PUBLIC_PATHS = (
+    "/",
+    "/login",
+    "/register",
+    "/terms-privacy",
+)
+
+PINNED_ROBOTS = """\
+User-agent: *
+Allow: /
+Disallow: /dashboard
+Disallow: /reset_password
+Disallow: /registration-status
+Disallow: /health
+Disallow: /health/ui
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://agentflow.origentechnolog.com/sitemap.xml
+"""
+
+PINNED_SITEMAP_LASTMODS = {
+    "https://agentflow.origentechnolog.com/": "2026-09-02",
+    "https://agentflow.origentechnolog.com/register": "2026-08-31",
+    "https://agentflow.origentechnolog.com/login": "2026-08-31",
+    "https://agentflow.origentechnolog.com/terms-privacy": "2026-09-03",
+    "https://agentflow.origentechnolog.com/free-real-estate-crm": "2026-09-02",
+    "https://agentflow.origentechnolog.com/follow-up-boss-alternative": "2026-09-02",
+    "https://agentflow.origentechnolog.com/wise-agent-alternative": "2026-09-02",
+    "https://agentflow.origentechnolog.com/kvcore-alternative": "2026-09-02",
+}
+
+
+def _head(html):
+    close = html.lower().find("</head>")
+    assert close != -1
+    return html[:close]
+
+
+class TestUtilityNoindexHtml:
+    def test_reset_password_html_has_robots_meta(self, client, seed):
+        resp = client.get("/reset_password")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert ROBOTS_META in _head(html)
+
+    def test_health_ui_html_has_robots_meta(self, client, seed):
+        resp = client.get("/health/ui")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert ROBOTS_META in _head(html)
+
+    def test_public_marketing_pages_stay_indexable(self, client, seed):
+        for path in INDEXABLE_PUBLIC_PATHS:
+            html = client.get(path).get_data(as_text=True)
+            assert "noindex" not in html.lower(), path
+
+
+class TestUtilityNoindexHeaders:
+    def test_utility_paths_send_x_robots_tag(self, client, seed):
+        assert frozenset(NOINDEX_PATHS) == NOINDEX_UTILITY_PATHS
+        for path in NOINDEX_PATHS:
+            resp = client.get(path)
+            assert resp.headers.get("X-Robots-Tag") == X_ROBOTS_TAG_NOINDEX, path
+
+    def test_public_pages_do_not_send_x_robots_tag(self, client, seed):
+        for path in INDEXABLE_PUBLIC_PATHS:
+            resp = client.get(path)
+            assert resp.headers.get("X-Robots-Tag") is None, path
+
+
+class TestRobotsAndSitemapUntouched:
+    def test_robots_txt_file_matches_pin(self):
+        assert ROBOTS.read_text() == PINNED_ROBOTS
+
+    def test_served_robots_txt_matches_pin(self, client):
+        resp = client.get("/robots.txt")
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == PINNED_ROBOTS
+
+    def test_sitemap_file_lastmods_and_locs_unchanged(self):
+        from xml.etree import ElementTree as ET
+
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = ET.parse(SITEMAP).getroot().findall("sm:url", ns)
+        found = {}
+        for url in urls:
+            loc = (url.findtext("sm:loc", default="", namespaces=ns) or "").strip()
+            lastmod = (url.findtext("sm:lastmod", default="", namespaces=ns) or "").strip()
+            found[loc] = lastmod
+        assert found == PINNED_SITEMAP_LASTMODS
+        for path in NOINDEX_PATHS:
+            assert all(path not in loc for loc in found), path
+
+    def test_served_sitemap_matches_static_file(self, client):
+        resp = client.get("/sitemap.xml")
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == SITEMAP.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HOLD ON MERGE. Do not merge.

robots.txt already Disallows `/reset_password`, `/health`, `/health/ui`, and `/registration-status` (PR 393). Those URLs still returned indexable HTML/JSON with no robots meta and no `X-Robots-Tag`. GSC still showed `/reset_password` as a referring page to the homepage.

This PR adds the missing signals only. No robots.txt, sitemap, marketing copy, gold FAQ/H1, or lastmod edits.

## What changed

- `/reset_password` and `/health/ui` HTML now include `<meta name="robots" content="noindex, nofollow">` in `<head>`.
- Flask responses for `/reset_password`, `/health`, `/health/ui`, and `/registration-status` send `X-Robots-Tag: noindex, nofollow` from one `after_request` helper scoped to those paths.

## Tests

`pytest tests/test_utility_noindex.py` plus nearby auth/nav/SEO tests: 128 passed.

Live Flask on port 5011 confirmed the same headers and meta. Login stays indexable. `robots.txt` and sitemap lastmods are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-685d9023-98ad-47cb-a684-531fe26ebc6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-685d9023-98ad-47cb-a684-531fe26ebc6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

